### PR TITLE
[#563] Update dashboard view (connects #563)

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -32,6 +32,9 @@ $screen-sm: 780px;
 
 // Maximum full height of view container (avoiding vertical overflow)
 $view-container-height: calc(100vh - 352px);
+// Height of dashboard
+$dashboard-height: calc(100vh - 128px);
+$dashboard-tile-height: calc((#{$dashboard-height} - 3rem) / 4);
 
 /*
  * Old Planet Material Colors

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -16,8 +16,4 @@
         </span>
     </div>
   </div>
-  <div class="dashboard-arrows bg-grey">
-    <button mat-icon-button type="button" (click)="arrowClick(1)" [disabled]="isRightDisabled"><mat-icon>keyboard_arrow_right</mat-icon></button>
-    <button mat-icon-button type="button" (click)="arrowClick(-1)" [disabled]="displayProps.displayIndex===0"><mat-icon>keyboard_arrow_left</mat-icon></button>
-  </div>
 </mat-card>

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -1,17 +1,19 @@
 <mat-card class="dashboard-card">
-  <div class="upper-tile accent-color">
+  <div class="left-tile accent-color">
     <mat-icon svgIcon={{cardTitle}}></mat-icon>
     <span class="margin-lr-5">{{cardTitle}}</span>
   </div>
-  <div class="lower-tile" #items>
-    <mat-list class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}">
-      <mat-list-item *ngFor="let item of itemData;last as last">
-        <a mat-line [routerLink]="item.link">{{item.title}}</a>
-        <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
-      </mat-list-item>
-      <mat-list-item *ngIf="itemData.length === 0" class="dashboard-item cursor-pointer" [routerLink]="[emptyLink]">
+  <div class="right-tile" #items>
+    <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" [ngStyle]="{'transform':itemTranslate()}">
+      <span
+        class="dashboard-item cursor-pointer"
+        *ngFor="let item of itemData;let odd=odd"
+        [ngClass]="{'bg-grey': odd}"
+        [routerLink]="item.link"
+      >{{item.title}}</span>
+      <span *ngIf="itemData.length === 0" class="dashboard-item cursor-pointer" [routerLink]="[emptyLink]">
         Add item to {{cardTitle}}
-      </mat-list-item>
-    </mat-list>
+      </span>
+    </div>
   </div>
 </mat-card>

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -4,16 +4,14 @@
     <span class="margin-lr-5">{{cardTitle}}</span>
   </div>
   <div class="lower-tile" #items>
-    <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" [ngStyle]="{'transform':itemTranslate()}">
-      <span
-        class="dashboard-item cursor-pointer"
-        *ngFor="let item of itemData;let odd=odd"
-        [ngClass]="{'bg-grey': odd}"
-        [routerLink]="item.link"
-        >{{item.title}}</span>
-        <span *ngIf="itemData.length === 0" class="dashboard-item cursor-pointer" [routerLink]="[emptyLink]">
-          Add item to {{cardTitle}}
-        </span>
-    </div>
+    <mat-list class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}">
+      <mat-list-item *ngFor="let item of itemData;last as last">
+        <a mat-line [routerLink]="item.link">{{item.title}}</a>
+        <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
+      </mat-list-item>
+      <mat-list-item *ngIf="itemData.length === 0" class="dashboard-item cursor-pointer" [routerLink]="[emptyLink]">
+        Add item to {{cardTitle}}
+      </mat-list-item>
+    </mat-list>
   </div>
 </mat-card>

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -4,7 +4,7 @@
     <span>{{cardTitle}}</span>
   </div>
   <div class="right-tile" #items>
-    <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" [ngStyle]="{'transform':itemTranslate()}">
+    <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}">
       <span
         class="dashboard-item cursor-pointer"
         *ngFor="let item of itemData;let odd=odd"

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -1,9 +1,9 @@
 <mat-card class="dashboard-card">
-  <div class="left-tile accent-color">
+  <div class="upper-tile accent-color">
     <mat-icon svgIcon={{cardTitle}}></mat-icon>
     <span>{{cardTitle}}</span>
   </div>
-  <div class="right-tile" #items>
+  <div class="lower-tile" #items>
     <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" [ngStyle]="{'transform':itemTranslate()}">
       <span
         class="dashboard-item cursor-pointer"

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -1,7 +1,7 @@
 <mat-card class="dashboard-card">
   <div class="left-tile accent-color">
     <mat-icon svgIcon={{cardTitle}}></mat-icon>
-    <span class="margin-lr-5">{{cardTitle}}</span>
+    <span>{{cardTitle}}</span>
   </div>
   <div class="right-tile" #items>
     <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" [ngStyle]="{'transform':itemTranslate()}">

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -1,7 +1,7 @@
 <mat-card class="dashboard-card">
   <div class="upper-tile accent-color">
     <mat-icon svgIcon={{cardTitle}}></mat-icon>
-    <span>{{cardTitle}}</span>
+    <span class="margin-lr-5">{{cardTitle}}</span>
   </div>
   <div class="lower-tile" #items>
     <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" [ngStyle]="{'transform':itemTranslate()}">

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, AfterViewChecked, HostListener, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, OnInit, ElementRef, ViewChild } from '@angular/core';
 
 // Main page once logged in.  At this stage is more of a placeholder.
 @Component({
@@ -6,7 +6,7 @@ import { Component, Input, OnInit, AfterViewChecked, HostListener, ElementRef, V
   templateUrl: './dashboard-tile.component.html',
   styleUrls: [ './dashboard-tile.scss' ]
 })
-export class DashboardTileComponent implements OnInit, AfterViewChecked {
+export class DashboardTileComponent implements OnInit {
   @Input() cardTitle: string;
   @Input() color: string;
   @Input() itemData;
@@ -16,69 +16,12 @@ export class DashboardTileComponent implements OnInit, AfterViewChecked {
     return { title: 'Item ' + ind, link: '/' };
   });
 
-  private _isRightDisabled = true;
-  get isRightDisabled() {
-    return this._isRightDisabled;
-  }
-  set isRightDisabled(newVal: boolean) {
-    this._isRightDisabled = newVal;
-    // Need to manually tell Angular to run change detection for disabling button
-    this.changeDetectorRef.detectChanges();
-  }
-
-  displayProps = {
-    displayIndex: 0,
-    width: 0,
-    // Tiles are 150px wide, set by css
-    itemWidth: 150
-  };
-
-  constructor(private changeDetectorRef: ChangeDetectorRef) { }
+  constructor() { }
 
   ngOnInit() {
     if (!this.itemData) {
       this.itemData = this.mockItems;
     }
-  }
-
-  ngAfterViewChecked() {
-    this.displayProps.width = this.itemDiv.nativeElement.offsetWidth;
-    this.isRightDisabled = this.checkRightDisable();
-  }
-
-  @HostListener('window:resize', [ '$event' ])
-  onResize(event) {
-    this.displayProps.width = this.itemDiv.nativeElement.offsetWidth;
-    // Recheck max index and slide tiles to adjust if needed.
-    this.displayProps.displayIndex = Math.min(this.displayProps.displayIndex, this.maxIndex());
-    this.isRightDisabled = this.checkRightDisable();
-  }
-
-  itemTranslate() {
-    const { displayIndex, itemWidth } = this.displayProps;
-    return 'translateX(-' + (displayIndex * itemWidth) + 'px)';
-  }
-
-  tilesInView(): number {
-    return Math.floor(this.displayProps.width / this.displayProps.itemWidth);
-  }
-
-  maxIndex(): number {
-    // Minimum index is 0
-    return Math.max(0, this.itemData.length - (this.displayProps.width / this.displayProps.itemWidth));
-  }
-
-  arrowClick(direction: number) {
-    let newIndex = this.displayProps.displayIndex + (direction * this.tilesInView());
-    // Buttons should disable before allowing index out of range,
-    // but keeping this to make sure items are always viewable
-    newIndex = (newIndex < 0 || newIndex > this.itemData.length - 1) ? 0 : newIndex;
-    this.displayProps.displayIndex = Math.min(newIndex, this.maxIndex());
-  }
-
-  // Disable the right button if there is no more content.
-  checkRightDisable() {
-    return this.displayProps.displayIndex > this.itemData.length - this.tilesInView() - 1;
   }
 
 }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -8,19 +8,17 @@
 
   .dashboard-card {
     display: grid;
-    grid-template-areas: "ut" "lt";
-    grid-template-rows: 3rem 1fr;
-    grid-template-columns: 1fr;
+    grid-template-areas: "lt rt";
+    grid-template-rows: 1fr;
+    grid-template-columns: 150px 1fr;
     padding: 0;
-    height: 100%;
+    height: 18vh;
 
-    .upper-tile {
-      grid-area: ut;
+    .left-tile {
       border-radius: 2px 0 0 2px;
       display: flex;
       justify-content: center;
       align-items: center;
-      align-content: center;
       flex-direction: column;
       flex-wrap: wrap;
       font-size: 1.25rem;
@@ -33,17 +31,29 @@
 
     }
 
-    .lower-tile {
-      grid-area: lt;
+    .right-tile {
       display: grid;
-      overflow: hidden;
+      overflow-x: auto;
+      overflow-y: hidden;
 
       .dashboard-items.dashboard-empty {
         grid-auto-columns: auto;
       }
 
       .dashboard-items {
-        overflow: auto;
+        display: grid;
+        grid-auto-columns: 150px;
+        transition: transform 0.5s;
+
+        .dashboard-item {
+          grid-column-end: span 1;
+          grid-row-end: 1;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          text-align: center;
+          padding: 0.5rem;
+        }
       }
     }
   }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -56,14 +56,6 @@
         }
       }
     }
-
-    .dashboard-arrows {
-      grid-area: arrows;
-      display: grid;
-      justify-content: center;
-      align-items: center;
-      grid-auto-rows: 50%;
-    }
   }
 
 }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -18,6 +18,7 @@
       display: flex;
       justify-content: center;
       align-items: center;
+      align-content: center;
       flex-direction: column;
       flex-wrap: wrap;
       font-size: 1.25rem;

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -6,14 +6,14 @@
 
   .dashboard-card {
     display: grid;
-    grid-template-areas: "lt rt arrows";
-    grid-template-columns: 150px 1fr 50px;
-    grid-auto-rows: 1fr;
-    height: 18vh;
-    min-height: 100px;
+    grid-template-areas: "ut" "lt";
+    grid-template-rows: 3rem 1fr;
+    grid-template-columns: 1fr;
     padding: 0;
+    height: 100%;
 
-    .left-tile {
+    .upper-tile {
+      grid-area: ut;
       border-radius: 2px 0 0 2px;
       display: flex;
       justify-content: center;
@@ -30,7 +30,8 @@
 
     }
 
-    .right-tile {
+    .lower-tile {
+      grid-area: lt;
       display: grid;
       overflow: hidden;
 
@@ -40,12 +41,13 @@
       
       .dashboard-items {
         display: grid;
-        grid-auto-columns: 150px;
+        grid-auto-rows: 3rem;
         transition: transform 0.5s;
+        overflow: auto;
 
         .dashboard-item {
-          grid-column-end: span 1;
-          grid-row-end: 1;
+          grid-column-end: 1;
+          grid-row-end: span 1;
           display: flex;
           justify-content: center;
           align-items: center;

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -1,4 +1,5 @@
 @import '../mixins.scss';
+@import '../variables';
 
 :host {
 
@@ -11,7 +12,7 @@
     grid-template-areas: "lt rt";
     grid-template-rows: 1fr;
     grid-template-columns: 150px 1fr;
-    height: 18vh;
+    height: $dashboard-tile-height;
     padding: 0;
 
     .left-tile {

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -11,8 +11,8 @@
     grid-template-areas: "lt rt";
     grid-template-rows: 1fr;
     grid-template-columns: 150px 1fr;
-    padding: 0;
     height: 18vh;
+    padding: 0;
 
     .left-tile {
       border-radius: 2px 0 0 2px;

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -3,6 +3,8 @@
 :host {
 
   @include left-right-grid-areas;
+  // For Firefox.  Otherwise grid tile will expand to fit text.
+  min-width: 0;
 
   .dashboard-card {
     display: grid;
@@ -39,22 +41,9 @@
       .dashboard-items.dashboard-empty {
         grid-auto-columns: auto;
       }
-      
-      .dashboard-items {
-        display: grid;
-        grid-auto-rows: 3rem;
-        transition: transform 0.5s;
-        overflow: auto;
 
-        .dashboard-item {
-          grid-column-end: 1;
-          grid-row-end: span 1;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          text-align: center;
-          padding: 0.5rem;
-        }
+      .dashboard-items {
+        overflow: auto;
       }
     }
   }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -7,7 +7,7 @@
   <div class="lower-list">
     <mat-list>
       <mat-list-item *ngFor="let item of [ 'Submissions', 'Calendar', 'Email', 'Surveys', 'Documents' ]; last as last">
-        <span mat-line>{{item}}</span>
+        <span>{{item}}</span>
         <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
       </mat-list-item>
     </mat-list>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,3 +1,18 @@
+<mat-card>
+  <img [src]="profileImg">
+  <div class="primary-color dashboard-name mat-typography">
+    <h2>{{displayName}}</h2>
+    <p class="caption">{{dateNow | date:'longDate'}}</p>
+  </div>
+  <div class="lower-list">
+    <mat-list>
+      <mat-list-item *ngFor="let item of [ 'Submissions', 'Calendar', 'Email', 'Surveys', 'Documents' ]; last as last">
+        <span mat-line>{{item}}</span>
+        <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
+      </mat-list-item>
+    </mat-list>
+  </div>
+</mat-card>
 <planet-dashboard-tile
   [cardTitle]="'myLibrary'"
   class="planet-library-theme"

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -3,6 +3,7 @@
   <div class="primary-color dashboard-name mat-typography">
     <h2>{{displayName}}</h2>
     <p class="caption">{{dateNow | date:'longDate'}}</p>
+    <p class="caption">{{visits | number}} <ng-container i18n>Visits</ng-container></p>
   </div>
   <div class="lower-list">
     <mat-list>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -7,24 +7,18 @@ import { map, switchMap, catchError } from 'rxjs/operators';
 import { of } from 'rxjs/observable/of';
 import { findDocuments } from '../shared/mangoQueries';
 import { forkJoin } from 'rxjs/observable/forkJoin';
+import { environment } from '../../environments/environment';
 
 // Main page once logged in.  At this stage is more of a placeholder.
 @Component({
   templateUrl: './dashboard.component.html',
-  styles: [ `
-    :host {
-      height: calc(100% - 64px);
-      padding: 2rem;
-      display: grid;
-      grid-auto-columns: 1fr;
-      grid-auto-rows: 100%;
-      grid-auto-flow: column;
-      grid-gap: 1rem;
-    }
-  ` ]
+  styleUrls: [ './dashboard.scss' ]
 })
 export class DashboardComponent implements OnInit {
   data = { resources: [], courses: [], meetups: [], myTeams: [] };
+  urlPrefix = environment.couchAddress + '/_users/org.couchdb.user:' + this.userService.get().name + '/';
+  displayName = this.userService.get().firstName + ' ' + this.userService.get().lastName;
+  dateNow = Date.now();
 
   constructor(
     private userService: UserService,
@@ -56,5 +50,13 @@ export class DashboardComponent implements OnInit {
           return response.docs.map((item) => ({ ...item, title: item[titleField], link: linkPrefix + (addId ? item._id : '') }));
         })
       );
+  }
+
+  get profileImg() {
+    const attachments = this.userService.get()._attachments;
+    if (attachments) {
+      return this.urlPrefix + Object.keys(attachments)[0];
+    }
+    return 'assets/image.png';
   }
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -9,7 +9,6 @@ import { findDocuments } from '../shared/mangoQueries';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 import { environment } from '../../environments/environment';
 
-// Main page once logged in.  At this stage is more of a placeholder.
 @Component({
   templateUrl: './dashboard.component.html',
   styleUrls: [ './dashboard.scss' ]
@@ -19,6 +18,7 @@ export class DashboardComponent implements OnInit {
   urlPrefix = environment.couchAddress + '/_users/org.couchdb.user:' + this.userService.get().name + '/';
   displayName = this.userService.get().firstName + ' ' + this.userService.get().lastName;
   dateNow = Date.now();
+  visits = 0;
 
   constructor(
     private userService: UserService,
@@ -38,6 +38,14 @@ export class DashboardComponent implements OnInit {
       this.data.meetups = dashboardItems[2];
       this.data.myTeams = dashboardItems[3];
     });
+    this.couchService.post('login_activities/_find', findDocuments({ 'user': this.userService.get().name }, [ 'user' ], [], 1000))
+      .pipe(
+        catchError(() => {
+          return of({ docs: [] });
+        })
+      ).subscribe((res: any) => {
+        this.visits = res.docs.length;
+      });
   }
 
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -13,9 +13,12 @@ import { forkJoin } from 'rxjs/observable/forkJoin';
   templateUrl: './dashboard.component.html',
   styles: [ `
     :host {
+      height: calc(100% - 64px);
       padding: 2rem;
       display: grid;
-      grid-auto-columns: 100%;
+      grid-auto-columns: 1fr;
+      grid-auto-rows: 100%;
+      grid-auto-flow: column;
       grid-gap: 1rem;
     }
   ` ]

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -1,0 +1,42 @@
+:host {
+  height: calc(100% - 64px);
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 150px;
+  grid-auto-columns: 1fr;
+  grid-auto-rows: 100%;
+  grid-auto-flow: column;
+  grid-gap: 1rem;
+
+  mat-card {
+    max-width: 150px;
+    padding: 0;
+    display: grid;
+    grid-template-rows: min-content min-content;
+    grid-auto-rows: 1fr;
+    grid-auto-columns: 1fr;
+
+    img {
+      width: 100%;
+      display: block;
+    }
+
+    .lower-list {
+      overflow: auto;
+    }
+
+    .dashboard-name {
+      padding: 0.5rem 1rem;
+
+      h1, h2, h3 {
+        margin: 0;
+      }
+
+      p {
+        margin: 0;
+      }
+    }
+
+  }
+
+}

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -25,7 +25,7 @@
       position: absolute;
       left: 1rem;
       top: 1rem;
-      border: white 3px;
+      border: white 3px solid;
     }
 
     .lower-list {

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -1,11 +1,13 @@
+@import '../variables';
+
 :host {
-  height: calc(100% - 64px);
+  height: $dashboard-height;
   padding: 2rem;
   display: grid;
   grid-template-areas: "card" "card" "card" "card";
   grid-template-columns: 200px;
   grid-auto-columns: 1fr;
-  grid-auto-rows: 1fr;
+  grid-auto-rows: $dashboard-tile-height;
   grid-auto-flow: column;
   grid-gap: 1rem;
 
@@ -14,7 +16,7 @@
     max-width: 200px;
     padding: 0;
     display: grid;
-    grid-template-rows: min-content min-content;
+    grid-template-rows: min-content;
     grid-auto-rows: 1fr;
     grid-auto-columns: 1fr;
     position: relative;

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -2,23 +2,30 @@
   height: calc(100% - 64px);
   padding: 2rem;
   display: grid;
-  grid-template-columns: 150px;
+  grid-template-areas: "card" "card" "card" "card";
+  grid-template-columns: 200px;
   grid-auto-columns: 1fr;
-  grid-auto-rows: 100%;
+  grid-auto-rows: 1fr;
   grid-auto-flow: column;
   grid-gap: 1rem;
 
   mat-card {
-    max-width: 150px;
+    grid-area: card;
+    max-width: 200px;
     padding: 0;
     display: grid;
     grid-template-rows: min-content min-content;
     grid-auto-rows: 1fr;
     grid-auto-columns: 1fr;
+    position: relative;
 
     img {
-      width: 100%;
+      width: 100px;
       display: block;
+      position: absolute;
+      left: 1rem;
+      top: 1rem;
+      border: white 3px;
     }
 
     .lower-list {
@@ -26,7 +33,7 @@
     }
 
     .dashboard-name {
-      padding: 0.5rem 1rem;
+      padding: calc(100px + 2rem) 1rem 0.5rem 1rem;
 
       h1, h2, h3 {
         margin: 0;


### PR DESCRIPTION
I can revert to the white/grey alternating for the lists, but since some of the designs have used small lines to divide instead tried that to see how it looks.

The left menu is just a placeholder for now, and on tablets it doesn't fit (it is also scrollable, however):

![screenshot_2018-04-11-20-32-36](https://user-images.githubusercontent.com/9203229/38650271-edcab628-3dc8-11e8-8015-9e4b51313801.png)
