### PR TITLE
[#286] Enable multiple admin (connects #286)

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -73,14 +73,20 @@ insert_attachments() {
 multi_db_update() {
   DOC_LOC=$1
   DOC_NAME=$2
-  # Use echo $(<$DOC_LOC) to be able to run in Windows
-  INPUTS=$(echo $(<$DOC_LOC) | jq -c '.[]')
+  INPUTS=$(echo $DOC_LOC | jq -c '.[]')
   for i in $INPUTS
   do
     JSON=$(echo $i | jq -c '. | .json' )
     DB_NAME=$(echo $i | jq -r '. | .dbName')
     upsert_doc $DB_NAME $DOC_NAME $JSON
   done
+}
+
+add_security_admin_roles() {
+  JSON=$1
+  ROLE_NAME=$2
+  NEW_DOCS=$(echo $(<$JSON) | jq '.[].json.admins.roles += ["'$ROLE_NAME'"]')
+  echo $NEW_DOCS | jq -c '.'
 }
 
 # Add CouchDB standard databases
@@ -116,4 +122,5 @@ insert_docs courses ./design/courses/courses-mockup.json
 insert_docs resources ./design/resources/resources-mockup.json
 insert_attachments resources ./design/resources/resources-attachment-mockup.json
 # Add permission in databases
-multi_db_update ./design/security-update/security-update.json _security
+SECURITY=$(add_security_admin_roles ./design/security-update/security-update.json manager)
+multi_db_update $SECURITY _security

--- a/design/security-update/security-update.json
+++ b/design/security-update/security-update.json
@@ -4,7 +4,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -17,7 +17,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -30,7 +30,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -43,7 +43,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -56,7 +56,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -69,7 +69,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -82,7 +82,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -95,7 +95,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -108,7 +108,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -121,7 +121,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -134,7 +134,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -147,7 +147,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],
@@ -160,7 +160,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["manager"]
+				"roles": []
 			},
 			"members": {
 				"names": [],

--- a/design/security-update/security-update.json
+++ b/design/security-update/security-update.json
@@ -1,10 +1,49 @@
 [
 	{
+		"dbName": "_users",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": []
+			}
+		}
+	},
+	{
+		"dbName": "communityregistrationrequests",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": []
+			}
+		}
+	},
+	{
+		"dbName": "configurations",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": []
+			}
+		}
+	},
+	{
 		"dbName": "courses",
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["admin"]
+				"roles": ["manager"]
 			},
 			"members": {
 				"names": [],
@@ -13,11 +52,37 @@
 		}
 	},
 	{
+		"dbName": "feedback",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": []
+			}
+		}
+	},
+	{
+		"dbName": "login_activities",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": []
+			}
+		}
+	},
+	{
 		"dbName": "meetups",
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["admin"]
+				"roles": ["manager"]
 			},
 			"members": {
 				"names": [],
@@ -30,7 +95,7 @@
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["admin"]
+				"roles": ["manager"]
 			},
 			"members": {
 				"names": [],
@@ -39,11 +104,63 @@
 		}
 	},
 	{
+		"dbName": "notifications",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": []
+			}
+		}
+	},
+	{
+		"dbName": "ratings",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": ["intern", "learner", "teacher"]
+			}
+		}
+	},
+	{
+		"dbName": "resource_activities",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": ["intern", "learner", "teacher"]
+			}
+		}
+	},
+	{
 		"dbName": "resources",
 		"json": {
 			"admins": {
 				"names": [],
-				"roles": ["admin"]
+				"roles": ["manager"]
+			},
+			"members": {
+				"names": [],
+				"roles": ["intern", "learner", "teacher"]
+			}
+		}
+	},
+	{
+		"dbName": "shelf",
+		"json": {
+			"admins": {
+				"names": [],
+				"roles": ["manager"]
 			},
 			"members": {
 				"names": [],

--- a/src/app/users/users.component.html
+++ b/src/app/users/users.component.html
@@ -64,7 +64,7 @@
             {{role}}
             <mat-icon matChipRemove *ngIf="!element.doc.isUserAdmin">cancel</mat-icon>
           </mat-chip>
-          <mat-chip *ngIf="element.doc.isUserAdmin">admin</mat-chip>
+          <mat-chip *ngIf="element.doc.isUserAdmin && element.doc.roles.length === 0">admin</mat-chip>
       </mat-chip-list>
       </mat-cell>
     </ng-container>
@@ -78,6 +78,7 @@
           <a routerLink="/users/profile/{{element.doc.name}}" mat-raised-button color="primary" i18n>View Profile
             <mat-icon>folder_open</mat-icon>
           </a>
+          <a *ngIf="element.doc.roles.length > 0" (click)="promote(element.doc, false)" mat-raised-button color="primary" i18n>Demote</a>
         </div>
         <div *ngIf="!element.doc.isUserAdmin">
           <button mat-icon-button *ngIf="element.doc.roles.length === 0" (click)="addRole(element.doc)">
@@ -91,6 +92,7 @@
           <a routerLink="/users/profile/{{element.name}}" mat-raised-button color="primary" i18n>View Profile
             <mat-icon>folder_open</mat-icon>
           </a>
+          <a (click)="promote(element.doc, true)" mat-raised-button color="primary" i18n>Promote</a>
         </div>
       </mat-cell>
     </ng-container>

--- a/src/app/users/users.component.html
+++ b/src/app/users/users.component.html
@@ -71,32 +71,28 @@
     <ng-container matColumnDef="action">
       <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
       <mat-cell  *matCellDef="let element">
-        <div *ngIf="element.doc.isUserAdmin">
-          <mat-icon>&nbsp;</mat-icon>
-          <button mat-raised-button color="primary" *ngIf="!element.myTeamInfo else addAdminAsTeam" (click)="addTeams([{'_id': element.doc._id}])">Add Team</button>
-          <ng-template #addAdminAsTeam><button mat-raised-button color="primary" *ngIf="element.myTeamInfo" (click)="removeTeam(element.doc._id)">Remove Team</button></ng-template>
-          <a routerLink="/users/profile/{{element.doc.name}}" mat-raised-button color="primary" i18n>View Profile
-            <mat-icon>folder_open</mat-icon>
-          </a>
-          <a *ngIf="element.doc.roles.length > 0" (click)="promote(element.doc, false)" mat-raised-button color="primary" i18n>Demote</a>
-        </div>
-        <div *ngIf="!element.doc.isUserAdmin">
-          <button mat-icon-button *ngIf="element.doc.roles.length === 0" (click)="addRole(element.doc)">
+        <span *ngIf="!element.doc.isUserAdmin">
+          <button mat-icon-button *ngIf="element.doc.roles.length === 0" (click)="setRoles(element.doc, element.doc.oldRoles || ['learner'])">
             <mat-icon>lock</mat-icon>
           </button>
-          <button mat-icon-button *ngIf="element.doc.roles.length > 0" (click)="removeRole(element.doc)">
+          <button mat-icon-button *ngIf="element.doc.roles.length > 0" (click)="setRoles(element.doc, [])">
             <mat-icon>lock_open</mat-icon>
           </button>
-          <button mat-raised-button color="primary" *ngIf="!element.myTeamInfo else addTeam" (click)="addTeams([{'_id': element.doc._id}])">Add Team</button>
-          <ng-template #addTeam><button mat-raised-button color="primary" *ngIf="element.myTeamInfo" (click)="removeTeam(element.doc._id)">Remove Team</button></ng-template>
-          <a routerLink="/users/profile/{{element.name}}" mat-raised-button color="primary" i18n>View Profile
-            <mat-icon>folder_open</mat-icon>
-          </a>
-          <a (click)="promote(element.doc, true)" mat-raised-button color="primary" i18n>Promote</a>
-        </div>
+        </span>
+        <button mat-raised-button color="primary" *ngIf="!element.myTeamInfo else addTeam" (click)="addTeams([{'_id': element.doc._id}])">Add Team</button>
+        <ng-template #addTeam><button mat-raised-button color="primary" (click)="removeTeam(element.doc._id)">Remove Team</button></ng-template>
+        <a routerLink="/users/profile/{{element.name}}" mat-raised-button color="primary" i18n>View Profile
+          <mat-icon>folder_open</mat-icon>
+        </a>
+        <a
+          *ngIf="element.doc.roles.length > 0"
+          (click)="setRoles(element.doc, element.doc.isUserAdmin ? element.doc.oldRoles : ['manager'])"
+          mat-raised-button color="primary" i18n>
+          <!--Convert boolean to number for i18n-->
+          {+element.doc.isUserAdmin, select, 1 {Demote} 0 {Promote}}
+        </a>
       </mat-cell>
     </ng-container>
-
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns;" [ngClass]="{highlight:selection.isSelected(row)}" ></mat-row>
   </mat-table>

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -82,7 +82,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
   }
 
   getUsers() {
-    return this.couchService.allDocs('_users');
+    return this.couchService.post(this.dbName + '/_find' { 'selector': { } });
   }
 
   getShelf() {
@@ -99,7 +99,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
     forkJoin([ this.getUsers(), this.getShelf() ])
     .debug('Getting user list').subscribe(([ users, shelfRes ]) => {
       const myTeamIds = shelfRes.docs[0].myTeamIds;
-      this.allUsers.data = users.reduce((newUsers: any[], user: any) => {
+      this.allUsers.data = users.docs.reduce((newUsers: any[], user: any) => {
         const userInfo = { doc: user, imageSrc: '', myTeamInfo: true };
         if (user._attachments) {
           userInfo.imageSrc = this.urlPrefix + 'org.couchdb.user:' + user.name + '/' + Object.keys(user._attachments)[0];
@@ -111,6 +111,18 @@ export class UsersComponent implements OnInit, AfterViewInit {
     }, (error) => {
       // A bit of a placeholder for error handling.  Request will return error if the logged in user is not an admin.
       console.log('Error initializing data!');
+      console.log(error);
+    });
+  }
+
+  promote(user, isAdmin) {
+    // Only add manager role and set isUserAdmin true
+    let selectedRolesArray = isAdmin ? [ 'manager' ] : [ 'learner' ];
+    const tempUser = { ...user, roles: selectedRolesArray, isUserAdmin: isAdmin };
+    this.couchService.put('_users/org.couchdb.user:' + tempUser.name, tempUser).subscribe((response) => {
+      console.log('Success!');
+      this.initializeData();
+    }, (error) => {
       console.log(error);
     });
   }

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -115,10 +115,13 @@ export class UsersComponent implements OnInit, AfterViewInit {
     });
   }
 
-  promote(user, isAdmin) {
-    // Only add manager role and set isUserAdmin true
-    const selectedRolesArray = isAdmin ? [ 'manager' ] : [ 'learner' ];
-    const tempUser = { ...user, roles: selectedRolesArray, isUserAdmin: isAdmin };
+  setRoles(user, roles) {
+    const tempUser = {
+      ...user,
+      roles,
+      oldRoles: [ ...user.roles ] || [ 'learner' ],
+      isUserAdmin: roles.indexOf('manager') > -1
+    };
     this.couchService.put('_users/org.couchdb.user:' + tempUser.name, tempUser).subscribe((response) => {
       console.log('Success!');
       this.initializeData();
@@ -132,7 +135,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
     let tempUser = { ...user, roles: [ ...user.roles ] };
     tempUser.roles.splice(index, 1);
     if (tempUser.roles.length === 0) {
-      tempUser = { ...tempUser, oldRoles: [] };
+      tempUser = { ...tempUser, oldRoles: [ 'learner' ] };
     }
     this.couchService.put('_users/org.couchdb.user:' + tempUser.name, tempUser).subscribe((response) => {
       console.log('Success!');
@@ -142,32 +145,6 @@ export class UsersComponent implements OnInit, AfterViewInit {
     }, (error) => {
       // Placeholder for error handling until we have popups for user notification.
       console.log('Error!');
-      console.log(error);
-    });
-  }
-
-  addRole(user) {
-    let selectedUserRole: string[] = [];
-    if (user.oldRoles === undefined || user.oldRoles.length === 0) {
-      selectedUserRole = [ 'learner' ];
-    } else {
-      selectedUserRole = user.oldRoles;
-    }
-    const tempUser = { ...user, roles: [ ...selectedUserRole ] };
-    this.couchService.put('_users/org.couchdb.user:' + tempUser.name, tempUser).subscribe((response) => {
-      console.log('Success!');
-      this.initializeData();
-    }, (error) => {
-      console.log(error);
-    });
-  }
-
-  removeRole(user) {
-    const tempUser = { ...user, roles: [ ], oldRoles: [ ...user.roles ]  };
-    this.couchService.put('_users/org.couchdb.user:' + tempUser.name, tempUser).subscribe((response) => {
-      console.log('Success!');
-      this.initializeData();
-    }, (error) => {
       console.log(error);
     });
   }

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -82,7 +82,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
   }
 
   getUsers() {
-    return this.couchService.post(this.dbName + '/_find' { 'selector': { } });
+    return this.couchService.post(this.dbName + '/_find', { 'selector': { } });
   }
 
   getShelf() {
@@ -117,7 +117,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
 
   promote(user, isAdmin) {
     // Only add manager role and set isUserAdmin true
-    let selectedRolesArray = isAdmin ? [ 'manager' ] : [ 'learner' ];
+    const selectedRolesArray = isAdmin ? [ 'manager' ] : [ 'learner' ];
     const tempUser = { ...user, roles: selectedRolesArray, isUserAdmin: isAdmin };
     this.couchService.put('_users/org.couchdb.user:' + tempUser.name, tempUser).subscribe((response) => {
       console.log('Success!');


### PR DESCRIPTION
* Updated _users _all_docs to _find as _all_docs is only accessible by system admin
* Added manager role to db as application admin not system admin. So it can be easily promoted/demoted
* Changed admin role in design docs to manager as admin label is displayed for system admin
* Added manager as admin of all databases in design doc
