### PR TITLE
Center protocol environment variable (fixes #746)

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -17,7 +17,7 @@ export class CouchService {
   }
 
   private couchDBReq(type: string, db: string, [ domain, opts ]: any[], data?: any) {
-    const url = domain ? 'http://' + domain + '/' + db : this.baseUrl + db;
+    const url = domain ? environment.centerProtocol + '://' + domain + '/' + db : this.baseUrl + db;
     let httpReq: Observable<any>;
     if (type === 'post' || type === 'put') {
       httpReq = this.http[type](url, data, opts);

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,5 +3,6 @@ export const environment = {
   test: false,
   // Change this to Docker address
   couchAddress: 'planet-db-host:planet-db-port/',
-  centerAddress: 'planet-center-address'
+  centerAddress: 'planet-center-address',
+  centerProtocol: 'https'
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -2,5 +2,6 @@ export const environment = {
   production: false,
   test: true,
   couchAddress: 'http://127.0.0.1:5984/',
-  centerAddress: 'earth.np.ole.org:5986'
+  centerAddress: 'earth.ole.org:2200',
+  centerProtocol: 'https'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,5 +7,6 @@ export const environment = {
   production: false,
   test: false,
   couchAddress: 'http://127.0.0.1:2200/',
-  centerAddress: 'earth.np.ole.org:5986'
+  centerAddress: 'earth.ole.org:2200',
+  centerProtocol: 'https'
 };


### PR DESCRIPTION
The main problem with using relative protocol (`//`) rather than explicitly setting protocol is that our development environments use http.