### PR TITLE
[#770] Add multilevel filter specific fields (connects #770)

### DIFF
--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -9,13 +9,27 @@ const checkFilterItems = (data: any) => ((includeItem: boolean, [ field, val ]) 
 
 export const filterSpecificFields = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
+    let dt = '';
     for (let i = 0; i < filterFields.length; i++) {
-      if (data[filterFields[i]].toLowerCase().indexOf(filter.trim().toLowerCase()) > -1) {
+      const keys = filterFields[i].split('.');
+      dt = testCase(data, keys);
+      if (dt.toLowerCase().indexOf(filter.trim().toLowerCase()) > -1) {
         return true;
       }
     }
   };
 };
+
+function testCase(data: any, filterFields: string[]) {
+  if (filterFields.length > 1 && data[filterFields[0]]) {
+      data = data[filterFields[0]];
+      filterFields.splice(0, 1);
+      return testCase(data, filterFields);
+  } else if (data[filterFields[0]]) {
+      return data[filterFields[0]];
+  }
+  return '';
+}
 
 export const filterDropdowns = (filterObj: any) => {
   return (data: any, filter: string) => {

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -9,26 +9,19 @@ const checkFilterItems = (data: any) => ((includeItem: boolean, [ field, val ]) 
 
 export const filterSpecificFields = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
-    let dt = '';
     for (let i = 0; i < filterFields.length; i++) {
       const keys = filterFields[i].split('.');
-      dt = testCase(data, keys);
-      if (dt.toLowerCase().indexOf(filter.trim().toLowerCase()) > -1) {
+      if (getProperty(data, keys).toLowerCase().indexOf(filter.trim().toLowerCase()) > -1) {
         return true;
       }
     }
   };
 };
 
-function testCase(data: any, filterFields: string[]) {
-  if (filterFields.length > 1 && data[filterFields[0]]) {
-      data = data[filterFields[0]];
-      filterFields.splice(0, 1);
-      return testCase(data, filterFields);
-  } else if (data[filterFields[0]]) {
-      return data[filterFields[0]];
-  }
-  return '';
+// Takes an object and array of property keys.  Returns the nested value of the succession of
+// keys or undefined.
+function getProperty(data: any, propertyArray: string[]) {
+  return propertyArray.reduce((obj, prop) => (obj && obj[prop]) ? obj[prop] : undefined, data);
 }
 
 export const filterDropdowns = (filterObj: any) => {

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -9,6 +9,7 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { Router } from '@angular/router';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { switchMap, catchError, map, takeUntil } from 'rxjs/operators';
+import { filterSpecificFields } from '../shared/table-helpers';
 import { of } from 'rxjs/observable/of';
 import { Subject } from 'rxjs/Subject';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
@@ -105,6 +106,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
         return userInfo;
       });
       this.setMyTeams(users, this.userService.getUserShelf().myTeamIds);
+      this.allUsers.filterPredicate = filterSpecificFields([ 'doc.name' ]);
     }, (error) => {
       // A bit of a placeholder for error handling.  Request will return error if the logged in user is not an admin.
       console.log('Error initializing data!');


### PR DESCRIPTION
`doc` key was introduced to prevent from saving unnecessary data. But our filter only works one level. So introduced multi-level filter where `.` will act as dot separator of keys