### PR TITLE
Travis "build fail" fix

### DIFF
--- a/docker/db-init/crosscompile_db-init.sh
+++ b/docker/db-init/crosscompile_db-init.sh
@@ -23,7 +23,7 @@ echo "Building db-init for ${ARCH}"
 
 if [[ "${ACT}" == "install" ]]; then
   apt-get update -qq
-  apt-get install -y curl
+  apt-get install -y curl gnupg
   curl -sL https://deb.nodesource.com/setup_6.x | bash -
   apt-get install -y nodejs build-essential ${PACKAGES}
   npm install "--arch=${TRIPLE}" -g add-cors-to-couchdb

--- a/docker/db-init/rpi-Dockerfile
+++ b/docker/db-init/rpi-Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as builder
+FROM ubuntu:xenial as builder
 LABEL maintainer="sahil@ole.org,mappuji@ole.org"
 
 COPY docker/db-init/crosscompile_db-init.sh .

--- a/docker/planet/crosscompile_planet.sh
+++ b/docker/planet/crosscompile_planet.sh
@@ -24,7 +24,7 @@ echo "Building Planet for ${ARCH}"
 if [[ "${ACT}" == "install"  ]]; then
    echo "Install stage"
    apt-get update -qq
-   apt-get install -y curl
+   apt-get install -y curl gnupg
    curl -sL https://deb.nodesource.com/setup_6.x | bash -
    apt-get install -y nodejs build-essential ${PACKAGES}
    npm install "--arch=${TRIPLE}"

--- a/docker/planet/rpi-Dockerfile
+++ b/docker/planet/rpi-Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as builder
+FROM ubuntu:xenial as builder
 LABEL maintainer="sahil@ole.org,mappuji@ole.org"
 
 WORKDIR /ng-app


### PR DESCRIPTION
This is a quick fix for the current travis build fail issue. It was caused due to the removal of the pre-installed GNU privacy guard package.

I wouldn't consider this as a permanent fix, but should be used for the time being.

I will work on making a builder image with everything pre-installed, so that these problems will not occur in future.