### PR TITLE
Multiarch support for planet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ _prepare_deploy: &_prepare_deploy
     - docker pull $PLANET_TEST
     - docker pull $DOCKER_DB_INIT_TEST
 _prepare_multiarch: &_prepare_multiarch
-  before_script:
-    - sudo snap install yq
+  before_script:    
     - source ./.travis/travis_utils.sh
     - login_docker
     - prepare_everything    
@@ -119,6 +118,7 @@ jobs:
     - stage: multiarch-release
       <<: *_prepare_multiarch
       script: #Pushing multiarch
+        - sudo snap install yq
         - set -e
         - create_multiarch_manifest_planet $PLANET_RPI_LATEST $PLANET_LATEST $PLANET_RPI_VERSIONED $PLANET_VERSIONED
         - create_multiarch_manifest_dbinit $DOCKER_DB_INIT_RPI_LATEST $DOCKER_DB_INIT_LATEST $DOCKER_DB_INIT_RPI_VERSIONED $DOCKER_DB_INIT_VERSIONED

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ _prepare_multiarch: &_prepare_multiarch
   before_script:    
     - source ./.travis/travis_utils.sh
     - login_docker
-    - prepare_everything    
+    - prepare_everything
+    - prepare_yq
     - prepare_multiarch_manifest_tool
     - prepare_db_init_rpi
     - prepare_planet_rpi
@@ -118,12 +119,10 @@ jobs:
     - stage: multiarch-release
       <<: *_prepare_multiarch
       script: #Pushing multiarch
-        - sudo snap install yq
         - set -e
         - create_multiarch_manifest_planet $PLANET_RPI_LATEST $PLANET_LATEST $PLANET_RPI_VERSIONED $PLANET_VERSIONED
         - create_multiarch_manifest_dbinit $DOCKER_DB_INIT_RPI_LATEST $DOCKER_DB_INIT_LATEST $DOCKER_DB_INIT_RPI_VERSIONED $DOCKER_DB_INIT_VERSIONED
         - push_multiarch_manifests
-
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ _prepare_deploy: &_prepare_deploy
     - docker pull $DOCKER_DB_INIT_TEST
 _prepare_multiarch: &_prepare_multiarch
   before_script:
-    - snap install yq
+    - sudo snap install yq
     - source ./.travis/travis_utils.sh
     - login_docker
     - prepare_everything    

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ _prepare_deploy: &_prepare_deploy
     - prepare_everything
     - docker pull $PLANET_TEST
     - docker pull $DOCKER_DB_INIT_TEST
+_prepare_multiarch: &_prepare_multiarch
+  before_script:
+    - snap install yq
+    - source ./.travis/travis_utils.sh
+    - login_docker
+    - prepare_everything    
+    - prepare_multiarch_manifest_tool
+    - prepare_db_init_rpi
+    - prepare_planet_rpi
 _use_chrome: &_use_chrome
   addons:
     apt:
@@ -42,6 +51,7 @@ stages:
   - docker-creation
   - automated-test
   - docker-release
+  - multiarch-release
 
 jobs:
   include:
@@ -105,6 +115,14 @@ jobs:
       script: #arm image building planet
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         - travis_wait 45 bash ./.travis/deploy_rpi.sh --branch="$TRAVIS_BRANCH" --commit="$TRAVIS_COMMIT" --pull="$TRAVIS_PULL_REQUEST" --duser="$DOCKER_USER" --dpass="$DOCKER_PASS" --gtag="$TRAVIS_TAG" --image=db-init
+        
+    - stage: multiarch-release
+      <<: *_prepare_multiarch
+      script: #Pushing multiarch
+        - set -e
+        - create_multiarch_manifest_planet $PLANET_RPI_LATEST $PLANET_LATEST $PLANET_RPI_VERSIONED $PLANET_VERSIONED
+        - create_multiarch_manifest_dbinit $DOCKER_DB_INIT_RPI_LATEST $DOCKER_DB_INIT_LATEST $DOCKER_DB_INIT_RPI_VERSIONED $DOCKER_DB_INIT_VERSIONED
+        - push_multiarch_manifests
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ addons:
   apt:
     packages:
       - docker-ce
-      - snapd
 env:
   global:
     # DOCKER_USER

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
   apt:
     packages:
       - docker-ce
+      - snapd
 env:
   global:
     # DOCKER_USER

--- a/.travis/deploy_rpi.sh
+++ b/.travis/deploy_rpi.sh
@@ -56,7 +56,7 @@ prepare_var(){
     DOCKER_PASS="$dpass"
     RANDOM_FINGERPRINT=$(random_generator)
     DOCKER_ORG=treehouses
-    DOCKER_REPO=planet
+    DOCKER_REPO=planet-tags
     DOCKER_REPO_DEV=planet-dev
     BRANCH=$branch
     COMMIT=${commit::8}

--- a/.travis/deploy_rpi.sh
+++ b/.travis/deploy_rpi.sh
@@ -47,31 +47,9 @@ build_message(){
     echo
 }
 
-random_generator(){
-    awk -v min=10000000 -v max=99999999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'
-}
-
-prepare_var(){
-    DOCKER_USER="$duser"
-    DOCKER_PASS="$dpass"
-    RANDOM_FINGERPRINT=$(random_generator)
-    DOCKER_ORG=treehouses
-    DOCKER_REPO=planet-tags
-    DOCKER_REPO_DEV=planet-dev
-    BRANCH=$branch
-    COMMIT=${commit::8}
-}
-
-prepare_var_post_clone(){
-    VERSION=$(cat package.json | grep version | awk '{print$2}' | awk '{print substr($0, 2, length($0) - 3)}')
-    FILENAME=$VERSION-$BRANCH-$COMMIT
-}
-
 echo "The current directory is: $(pwd)"
-prepare_var
-prepare_var_post_clone
-
 source ./.travis/travis_utils.sh
+prepare_ci
 
 if [[ $image = db-init ]]
   then

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -76,9 +76,15 @@ prepare_db_init_test(){
 
 prepare_multiarch_manifest_tool(){
   build_message Prepare Manifest tool
-  wget -O /tmp/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
-  chmod +x /tmp/manifest_tool
+  sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
+  sudo chmod +x /usr/local/bin/manifest_tool
   mkdir -p /tmp/MA_manifests
+}
+
+prepare_yq(){
+  build_message Prepare yq
+  sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/1.14.1/yq_linux_amd64
+  sudo chmod +x /usr/local/bin/yq
 }
 
 prepare_everything(){
@@ -241,10 +247,10 @@ push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
     if [ "$BRANCH" = "master" ]
     then
-        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
-        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml
-        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml
-        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_db_init_versioned.yaml
+        manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
+        manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml
+        manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml
+        manifest_tool push from-spec /tmp/MA_manifests/MA_db_init_versioned.yaml
         build_message Successfully Pushed Multiarch Manifests to cloud
     else
          build_message Branch is Not master so no need to Push Multiarch Manifests to cloud

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -167,12 +167,12 @@ bell() {
 
 create_multiarch_manifest_planet(){
     build_message Creating Planet Multiarch Manifests
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet-test:latest | \
+        yq n image treehouses/planet:latest | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -187,7 +187,7 @@ create_multiarch_manifest_planet(){
             build_message Creating Planet Multiarch Manifest for Versioned
             # $3: versioned arm
             # $4: versioned amd64
-            yq n image treehouses/planet-test:$VERSION | \
+            yq n image treehouses/planet:$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -203,12 +203,12 @@ create_multiarch_manifest_planet(){
 
 create_multiarch_manifest_dbinit(){
     build_message Creating db init Multiarch Manifests
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         build_message Creating Multiarch Manifest for db-init
         # $1: db-init arm
         # $2: db-init amd64        
-        yq n image treehouses/planet-test:db-init | \
+        yq n image treehouses/planet:db-init | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -223,7 +223,7 @@ create_multiarch_manifest_dbinit(){
             build_message Creating Multiarch Manifest for db-init Versioned
             # $3: db-init versioned arm
             # $4: db-init versioned amd64
-            yq n image treehouses/planet-test:db-init-$VERSION | \
+            yq n image treehouses/planet:db-init-$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -239,7 +239,7 @@ create_multiarch_manifest_dbinit(){
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
         /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -173,12 +173,12 @@ bell() {
 
 create_multiarch_manifest_planet(){
     build_message Creating Planet Multiarch Manifests
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet-test:latest | \
+        yq n image treehouses/planet-test:multi | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -193,7 +193,7 @@ create_multiarch_manifest_planet(){
             build_message Creating Planet Multiarch Manifest for Versioned
             # $3: versioned arm
             # $4: versioned amd64
-            yq n image treehouses/planet-test:$VERSION | \
+            yq n image treehouses/planet-multi:$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -209,12 +209,12 @@ create_multiarch_manifest_planet(){
 
 create_multiarch_manifest_dbinit(){
     build_message Creating db init Multiarch Manifests
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         build_message Creating Multiarch Manifest for db-init
         # $1: db-init arm
         # $2: db-init amd64        
-        yq n image treehouses/planet-test:db-init | \
+        yq n image treehouses/planet-multi:db-init | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -229,7 +229,7 @@ create_multiarch_manifest_dbinit(){
             build_message Creating Multiarch Manifest for db-init Versioned
             # $3: db-init versioned arm
             # $4: db-init versioned amd64
-            yq n image treehouses/planet-test:db-init-$VERSION | \
+            yq n image treehouses/planet-multi:db-init-$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -245,7 +245,7 @@ create_multiarch_manifest_dbinit(){
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
         manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml        

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -74,6 +74,12 @@ prepare_db_init_test(){
   DOCKER_DB_INIT_TEST_LATEST=$DOCKER_ORG/$DOCKER_REPO_TEST:db-init
 }
 
+prepare_multiarch_manifest_tool(){
+  build_message Prepare Manifest tool
+  wget -O /tmp/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
+  chmod +x /tmp/manifest_tool
+}
+
 prepare_everything(){
   prepare_ci
   prepare_planet

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -167,12 +167,12 @@ bell() {
 
 create_multiarch_manifest_planet(){
     build_message Creating Planet Multiarch Manifests
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet:latest | \
+        yq n image treehouses/planet-test:latest | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -187,7 +187,7 @@ create_multiarch_manifest_planet(){
             build_message Creating Planet Multiarch Manifest for Versioned
             # $3: versioned arm
             # $4: versioned amd64
-            yq n image treehouses/planet:$VERSION | \
+            yq n image treehouses/planet-test:$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -203,12 +203,12 @@ create_multiarch_manifest_planet(){
 
 create_multiarch_manifest_dbinit(){
     build_message Creating db init Multiarch Manifests
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         build_message Creating Multiarch Manifest for db-init
         # $1: db-init arm
         # $2: db-init amd64        
-        yq n image treehouses/planet:db-init | \
+        yq n image treehouses/planet-test:db-init | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -223,7 +223,7 @@ create_multiarch_manifest_dbinit(){
             build_message Creating Multiarch Manifest for db-init Versioned
             # $3: db-init versioned arm
             # $4: db-init versioned amd64
-            yq n image treehouses/planet:db-init-$VERSION | \
+            yq n image treehouses/planet-test:db-init-$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -239,7 +239,7 @@ create_multiarch_manifest_dbinit(){
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
         /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -178,7 +178,7 @@ create_multiarch_manifest_planet(){
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet-test:multi | \
+        yq n image treehouses/planet-multi:latest | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -173,12 +173,12 @@ bell() {
 
 create_multiarch_manifest_planet(){
     build_message Creating Planet Multiarch Manifests
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet-test:latest | \
+        yq n image treehouses/planet:latest | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -193,7 +193,7 @@ create_multiarch_manifest_planet(){
             build_message Creating Planet Multiarch Manifest for Versioned
             # $3: versioned arm
             # $4: versioned amd64
-            yq n image treehouses/planet-test:$VERSION | \
+            yq n image treehouses/planet:$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -209,12 +209,12 @@ create_multiarch_manifest_planet(){
 
 create_multiarch_manifest_dbinit(){
     build_message Creating db init Multiarch Manifests
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         build_message Creating Multiarch Manifest for db-init
         # $1: db-init arm
         # $2: db-init amd64        
-        yq n image treehouses/planet-test:db-init | \
+        yq n image treehouses/planet:db-init | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -229,7 +229,7 @@ create_multiarch_manifest_dbinit(){
             build_message Creating Multiarch Manifest for db-init Versioned
             # $3: db-init versioned arm
             # $4: db-init versioned amd64
-            yq n image treehouses/planet-test:db-init-$VERSION | \
+            yq n image treehouses/planet:db-init-$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -245,7 +245,7 @@ create_multiarch_manifest_dbinit(){
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    if [ "$BRANCH" = "multiarch_suport" ]
+    if [ "$BRANCH" = "master" ]
     then
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -173,12 +173,12 @@ bell() {
 
 create_multiarch_manifest_planet(){
     build_message Creating Planet Multiarch Manifests
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet:latest | \
+        yq n image treehouses/planet-test:latest | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -193,7 +193,7 @@ create_multiarch_manifest_planet(){
             build_message Creating Planet Multiarch Manifest for Versioned
             # $3: versioned arm
             # $4: versioned amd64
-            yq n image treehouses/planet:$VERSION | \
+            yq n image treehouses/planet-test:$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -209,12 +209,12 @@ create_multiarch_manifest_planet(){
 
 create_multiarch_manifest_dbinit(){
     build_message Creating db init Multiarch Manifests
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         build_message Creating Multiarch Manifest for db-init
         # $1: db-init arm
         # $2: db-init amd64        
-        yq n image treehouses/planet:db-init | \
+        yq n image treehouses/planet-test:db-init | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -229,7 +229,7 @@ create_multiarch_manifest_dbinit(){
             build_message Creating Multiarch Manifest for db-init Versioned
             # $3: db-init versioned arm
             # $4: db-init versioned amd64
-            yq n image treehouses/planet:db-init-$VERSION | \
+            yq n image treehouses/planet-test:db-init-$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -245,7 +245,7 @@ create_multiarch_manifest_dbinit(){
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -248,9 +248,13 @@ push_multiarch_manifests(){
     if [ "$BRANCH" = "master" ]
     then
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
-        manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml
-        manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml
-        manifest_tool push from-spec /tmp/MA_manifests/MA_db_init_versioned.yaml
+        manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml        
+        #Building for versioned
+        if [[ ! -z $gtag ]] || [[ ! -z $TRAVIS_TAG  ]]
+        then
+             manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml
+             manifest_tool push from-spec /tmp/MA_manifests/MA_db_init_versioned.yaml
+        fi
         build_message Successfully Pushed Multiarch Manifests to cloud
     else
          build_message Branch is Not master so no need to Push Multiarch Manifests to cloud

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -15,7 +15,7 @@ login_docker(){
 
 prepare_ci(){
   DOCKER_ORG=treehouses
-  DOCKER_REPO=planet
+  DOCKER_REPO=planet-tags
   DOCKER_REPO_TEST=planet-test
   VERSION=$(cat package.json | grep version | awk '{print$2}' | awk '{print substr($0, 2, length($0) - 3)}')
   BRANCH=$TRAVIS_BRANCH

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -173,12 +173,12 @@ bell() {
 
 create_multiarch_manifest_planet(){
     build_message Creating Planet Multiarch Manifests
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         build_message Creating Planet Multiarch Manifest for Latest
         # $1: latest arm
         # $2: latest amd64        
-        yq n image treehouses/planet:latest | \
+        yq n image treehouses/planet-test:latest | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -193,7 +193,7 @@ create_multiarch_manifest_planet(){
             build_message Creating Planet Multiarch Manifest for Versioned
             # $3: versioned arm
             # $4: versioned amd64
-            yq n image treehouses/planet:$VERSION | \
+            yq n image treehouses/planet-test:$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -209,12 +209,12 @@ create_multiarch_manifest_planet(){
 
 create_multiarch_manifest_dbinit(){
     build_message Creating db init Multiarch Manifests
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         build_message Creating Multiarch Manifest for db-init
         # $1: db-init arm
         # $2: db-init amd64        
-        yq n image treehouses/planet:db-init | \
+        yq n image treehouses/planet-test:db-init | \
         yq w - manifests[0].image $1 | \
         yq w - manifests[0].platform.architecture arm | \
         yq w - manifests[0].platform.os linux | \
@@ -229,7 +229,7 @@ create_multiarch_manifest_dbinit(){
             build_message Creating Multiarch Manifest for db-init Versioned
             # $3: db-init versioned arm
             # $4: db-init versioned amd64
-            yq n image treehouses/planet:db-init-$VERSION | \
+            yq n image treehouses/planet-test:db-init-$VERSION | \
             yq w - manifests[0].image $3 | \
             yq w - manifests[0].platform.architecture arm | \
             yq w - manifests[0].platform.os linux | \
@@ -245,7 +245,7 @@ create_multiarch_manifest_dbinit(){
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    if [ "$BRANCH" = "master" ]
+    if [ "$BRANCH" = "multiarch_suport" ]
     then
         manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
         manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml        

--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -197,7 +197,8 @@ create_multiarch_manifest_planet(){
             tee /tmp/MA_manifests/MA_planet_versioned.yaml
         fi
     else
-        build_message Branch is Not master so no need to create Multiarch manifests for planet. 
+        build_message Branch is Not master so no need to create Multiarch manifests for planet.
+    fi
 }
 
 create_multiarch_manifest_dbinit(){
@@ -232,14 +233,20 @@ create_multiarch_manifest_dbinit(){
             tee /tmp/MA_manifests/MA_db_init_versioned.yaml
         fi
     else
-        build_message Branch is Not master so no need to create Multiarch manifests for db-init. 
+        build_message Branch is Not master so no need to create Multiarch manifests for db-init.
+    fi
 }
 
 push_multiarch_manifests(){
     build_message Pushing Multiarch Manifests to cloud
-    /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
-    /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml
-    /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml
-    /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_db_init_versioned.yaml
-    build_message Successfully Pushed Multiarch Manifests to cloud
+    if [ "$BRANCH" = "master" ]
+    then
+        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_latest.yaml
+        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_planet_versioned.yaml
+        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_db_init.yaml
+        /tmp/manifest_tool push from-spec /tmp/MA_manifests/MA_db_init_versioned.yaml
+        build_message Successfully Pushed Multiarch Manifests to cloud
+    else
+         build_message Branch is Not master so no need to Push Multiarch Manifests to cloud
+    fi  
 }


### PR DESCRIPTION
## 1. What this PR does
* Pushes all commits to `treehouses/planet-tags`
* Makes `treehouses/planet` multiarch compatible **(only when merged with master)**

## 2. Structure for `treehouses/planet` (`latest` tag)
* For `amd64`, `treehouses/planet:latest` points to `treehouses/planet-tags:latest`
* For `arm`, `treehouses/planet:latest` points to `treehouses/planet-tags:rpi-latest`

## 3. Structure for `treehouses/planet` (`version` tag)
* For `amd64`, `treehouses/planet:0.1.7` points to `treehouses/planet-tags:0.1.7`
* For `arm`, `treehouses/planet:0.1.7` points to `treehouses/planet-tags:rpi-0.1.7`

There is similar structure for `db-init`
