### PR TITLE
[#972] update meetup created date field shows in timestamp format (connect #972)

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -15,6 +15,9 @@
       "tsconfig": "tsconfig.app.json",
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
+      "scripts":[
+        "../node_modules/moment/min/moment.min.js"
+      ],
       "styles": [
         "../node_modules/material-design-icons/iconfont/material-icons.css",
         "styles.scss"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "material-design-icons": "^3.0.1",
     "material-icons": "^0.1.0",
     "mime-types": "^2.1.17",
+    "moment": "^2.22.1",
     "ngx-img": "^10.15.0",
     "rxjs": "5.5.2",
     "zone.js": "^0.8.18"

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -11,6 +11,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import * as constants from '../constants';
 import { CustomValidators } from '../../validators/custom-validators';
 import { UserService } from '../../shared/user.service';
+import * as moment from 'moment';
 
 @Component({
   templateUrl: './meetups-add.component.html'
@@ -40,6 +41,7 @@ export class MeetupsAddComponent implements OnInit {
     if (this.route.snapshot.url[0].path === 'update') {
       this.couchService.get('meetups/' + this.route.snapshot.paramMap.get('id'))
       .subscribe((data) => {
+        data.createdDate = moment(data.createdDate).format('YYYY-MM-DD');
         this.pageType = 'Update';
         this.revision = data._rev;
         this.id = data._id;


### PR DESCRIPTION
@lmmrssa @paulbert @Rupesh87 Time stamp appears on created date only if a user creates a new meet up. So I use a moment library to convert time stamp to planet date format 