### PR TITLE
Refactor MeetupsService - not used in template

### DIFF
--- a/src/app/meetups/meetups.service.ts
+++ b/src/app/meetups/meetups.service.ts
@@ -22,8 +22,7 @@ export class MeetupService {
   constructor(
     private couchService: CouchService,
     private userService: UserService,
-    private router: Router,
-    private planetMessageService: PlanetMessageService
+    private router: Router
   ) {
     this.userService.shelfChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe(() => {
@@ -68,13 +67,12 @@ export class MeetupService {
   attendMeetup(meetupId, participate) {
     participate ? this.userShelf.meetupIds.splice(meetupId, 1)
       : this.userShelf.meetupIds.push(meetupId);
-    this.couchService.put('shelf/' + this.userService.get()._id, this.userShelf)
-      .subscribe((res) => {
-        this.userShelf._rev = res.rev;
+    return this.couchService.put('shelf/' + this.userService.get()._id, this.userShelf)
+      .pipe(map((response) => {
+        this.userShelf._rev = response.rev;
         this.userService.setShelf(this.userShelf);
-        const msg = participate ? 'left' : 'joined';
-        this.planetMessageService.showMessage('You have ' + msg + ' selected meetup.');
-    }, (error) => (error));
+        return { response, participate };
+    }));
   }
 
 }

--- a/src/app/meetups/meetups.service.ts
+++ b/src/app/meetups/meetups.service.ts
@@ -8,7 +8,6 @@ import { of } from 'rxjs/observable/of';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 import { switchMap, catchError, map, takeUntil } from 'rxjs/operators';
 import { PlanetMessageService } from '../shared/planet-message.service';
-import { Router } from '@angular/router';
 
 @Injectable()
 export class MeetupService {
@@ -22,7 +21,6 @@ export class MeetupService {
   constructor(
     private couchService: CouchService,
     private userService: UserService,
-    private router: Router
   ) {
     this.userService.shelfChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe(() => {

--- a/src/app/meetups/view-meetups/meetups-view.component.html
+++ b/src/app/meetups/view-meetups/meetups-view.component.html
@@ -5,10 +5,10 @@
   <mat-toolbar class="primary-color font-size-1">
     <span class="margin-lr-3"><h3>{{meetupDetail.title}}</h3></span>
     <span class="toolbar-fill"></span>
-    <button mat-button class="margin-lr-3" (click)="meetupService.attendMeetup(meetupDetail._id, meetupDetail.participate)">
+    <button mat-button class="margin-lr-3" (click)="joinMeetup()">
       <span *ngIf="!parent">
-        <span *ngIf="meetupDetail.participate; else joinMeetup" i18n>Leave</span>
-        <ng-template #joinMeetup><span i18n>Join</span></ng-template>
+        <span *ngIf="meetupDetail.participate; else joinMeetupText" i18n>Leave</span>
+        <ng-template #joinMeetupText><span i18n>Join</span></ng-template>
       </span>
     </button>
   </mat-toolbar>

--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -6,6 +6,7 @@ import { DatePipe } from '@angular/common';
 import { MeetupService } from '../meetups.service';
 import { Subject } from 'rxjs/Subject';
 import { UserService } from '../../shared/user.service';
+import { PlanetMessageService } from '../../shared/planet-message.service';
 
 @Component({
   templateUrl: './meetups-view.component.html'
@@ -18,9 +19,9 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   constructor(
     private couchService: CouchService,
     private route: ActivatedRoute,
-    // meetupService made public because of error Property is private and only accessible within class during prod build
-    public meetupService: MeetupService,
-    private userService: UserService
+    private meetupService: MeetupService,
+    private userService: UserService,
+    private planetMessageService: PlanetMessageService
   ) { }
 
   ngOnInit() {
@@ -44,6 +45,13 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.onDestroy$.next();
     this.onDestroy$.complete();
+  }
+
+  joinMeetup() {
+    this.meetupService.attendMeetup(this.meetupDetail._id, this.meetupDetail.participate).subscribe((res) => {
+      const msg = res.participate ? 'left' : 'joined';
+      this.planetMessageService.showMessage('You have ' + msg + ' selected meetup.');
+    });
   }
 
 }


### PR DESCRIPTION
As a reminder, we should not use services directly in a template.  Services should be written so they are independent of the components that use them.  This allows them to be more easily used across many components.