### PR TITLE
[#1171] Fix unable to logout due to error (fixes #1171)

### DIFF
--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -160,6 +160,9 @@ export class UserService {
     }
     return newObs.pipe(switchMap(() => {
       return this.couchService.put(this.logsDb + '/' + this.sessionId, this.logObj(Date.now()));
+    }), map((res) => {
+      this.sessionRev = res.rev;
+      return res;
     }));
   }
 


### PR DESCRIPTION
After the successful update of login_activities this updates the sessionRev so if the routing to the login page is unsuccessful there will not be a conflict error on the next logout click.