### PR TITLE
[#1229] Buttons in dialog moved to the right, and correct order of them (fixes #1229)

### DIFF
--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -41,7 +41,7 @@
     </div>
   </mat-dialog-content>
   <mat-dialog-actions>
-    <button color="warn" type="button" mat-raised-button (click)="dialogRef.close()" i18n>Cancel</button>&nbsp;
     <button type="submit" color="primary" mat-raised-button i18n>Submit</button>
+    <button color="warn" type="button" mat-raised-button (click)="dialogRef.close()" i18n>Cancel</button>&nbsp;
   </mat-dialog-actions>
 </form>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -327,4 +327,7 @@ body {
     filter: brightness(0) invert(1);
   }
 
+  mat-dialog-actions {
+    justify-content: flex-end;
+  }
 }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/2650479/41184096-59502294-6b54-11e8-90b3-2a3f0ecc5e48.png)


after:
![image](https://user-images.githubusercontent.com/2650479/41184065-35188d8a-6b54-11e8-8e32-f60882fcb090.png)
