### PR TITLE
Disable submit button upon submission (fixes #1200)

### DIFF
--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -106,7 +106,7 @@
       <div *ngIf="pageType==='Update'">
         <mat-checkbox (change)="deleteAttachmentToggle($event)" i18n>Delete File</mat-checkbox>
       </div>
-      <button mat-raised-button type="submit" color="primary" i18n>Submit</button>
+      <button mat-raised-button type="submit" color="primary" [disabled]="isSubmitted" i18n>Submit</button>
       <button mat-raised-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
     </form>
   </div>

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -33,6 +33,7 @@ export class ResourcesAddComponent implements OnInit {
   userDetail: any = {};
   pageType = 'Add new';
   disableDownload = true;
+  isSubmitted = false;
 
   constructor(
     private router: Router,
@@ -128,6 +129,7 @@ export class ResourcesAddComponent implements OnInit {
 
   onSubmit() {
     if (this.resourceForm.valid) {
+      this.isSubmitted = true;
       const fileObs: Observable<any> = this.createFileObs();
       fileObs.pipe(debug('Preparing file for upload')).subscribe((resource) => {
         const { _id, _rev } = this.existingResource;


### PR DESCRIPTION
### Current state
Added `isSubmitted` variable and bound the `disabled` attribute of the `Submit` button to it. Now it should be impossible to add a resource multiple times.

### Next step
As suggested by @lmmrssa in #1200
> as some request will take a while to return response we should have some indicator showing action being carried on.

So next step is to add some kind of loading sign. What type of loading signal do we use in other parts of the app?
