### PR TITLE
Fix translations

### DIFF
--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -12,8 +12,7 @@
       color="accent"
       class="margin-lr-10"
       *ngIf="stepDetail?.exam?.questions.length && showExamButton"
-      (click)="goToExam()"
-      i18n>
+      (click)="goToExam()">
       {{examStart === 1 ? "Take Exam" : "Continue Exam"}}
     </a>
     <a

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -16,7 +16,7 @@ import { debug } from '../debug-operator';
       <span *ngIf="planetType !== 'community'">
         <a routerLink="/requests" i18n mat-raised-button>Requests</a>
         <a routerLink="/associated/{{ planetType === 'center' ? 'nation' : 'community' }}"
-          i18n mat-raised-button>{{ planetType === 'center' ? 'Nation' : 'Community' }}</a>
+          mat-raised-button>{{ planetType === 'center' ? 'Nation' : 'Community' }}</a>
       </span>
       <button *ngIf="planetType !== center && showResendConfiguration"
         (click)="resendConfig()" i18n mat-raised-button>Resend Registration Request</button>

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -18,7 +18,7 @@
 
       <!-- radio button -->
       <section *ngIf="field.type === 'radio'">
-        <label i18n>{{field.label}}</label>
+        <label>{{field.label}}</label>
         <div class="planet-radio-group">
           <mat-radio-group formControlName="{{field.name}}" required="{{field.required}}" >
             <mat-radio-button class="planet-radio-button" *ngFor="let option of field.options" [value]="option" >{{option}}</mat-radio-button>

--- a/src/app/users/users.component.html
+++ b/src/app/users/users.component.html
@@ -103,10 +103,7 @@
           <a
             *ngIf="element.doc.roles.length > 0 && !filterAssociated"
             (click)="setRoles(element.doc, element.doc.isUserAdmin ? element.doc.oldRoles : ['manager'])"
-            mat-raised-button color="primary" i18n>
-            <!--Convert boolean to number for i18n-->
-            {+element.doc.isUserAdmin, select, 1 {Demote} 0 {Promote}}
-          </a>
+            mat-raised-button color="primary" i18n>{+element.doc.isUserAdmin, select, 1 {Demote} 0 {Promote}}</a>
         </span>
         <ng-container *ngIf="!filterAssociated">
           <button mat-raised-button color="primary" *ngIf="!element.myTeamInfo else addTeam" (click)="addTeams([element.doc._id])">Add Team</button>

--- a/src/i18n/messages.ar.xlf
+++ b/src/i18n/messages.ar.xlf
@@ -52,7 +52,7 @@
         </context-group>
         <target xml:lang="ar" state="needs-translation">Are you sure you want to <x id="ICU" equiv-text="{data.changeType, select, accept {...} reject {...} unlink {...} delete {...}}"/>
       the <x id="ICU_1" equiv-text="{data.amount, select, single {...} many {...}}"/>
-  
+
   </target>
       </trans-unit>
       <trans-unit id="b3b7b0b5d0a6b1dbab492e6d68ae1fa227d7bb58" datatype="html">
@@ -951,15 +951,6 @@
         </context-group>
         <target xml:lang="ar" state="needs-translation">Step</target>
       </trans-unit>
-      <trans-unit id="13c270db76cb28d7e1945a454ed60a5d5e5752df" datatype="html">
-        <source>
-          <x id="INTERPOLATION" equiv-text="{{examStart === 1 ? &quot;Take Exam&quot; : &quot;Continue Exam&quot;}}"/>
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/courses/step-view-courses/courses-step-view.component.ts</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="b1a045c8850fc0b5e3db079bc60c13ae01167c72" datatype="html">
         <source>
       Open resource new tab
@@ -1011,15 +1002,6 @@
           <context context-type="linenumber">2</context>
         </context-group>
         <target xml:lang="ar" state="needs-translation">{VAR_SELECT, select, required {This field is required} min {The number cannot be below <x id="INTERPOLATION" equiv-text="{{number}}"/>} max {The number cannot exceed <x id="INTERPOLATION" equiv-text="{{number}}"/>} duplicate {Value already exists} email {Please enter a valid email} matchPassword {Passwords must match} invalidInt {Please enter a number} invalidPositive {The number cannot be negative} invalidHex {Hex is not valid} invalidTime {Time is invalid} invalidDateFormat {Date is in incorrect format} invalidDate {Date is invalid} invalidEndDate {End date cannot be before start date} invalidEndTime {End time cannot be before start time} dateInPast {Cannot be before current date} invalidOldPassword {Old password isn't valid} pattern {Invalid input. Hover for more info} invalidFirstCharacter {Must start with letter or number} }</target>
-      </trans-unit>
-      <trans-unit id="f7503283354cce9f5bc0e058da5eb75f906b290c" datatype="html">
-        <source>
-          <x id="INTERPOLATION" equiv-text="{{field.label}}"/>
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/dialogs/dialogs-form.component.ts</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="6ee2b6d3a08e9e94b5203fdb22deffc8508f282e" datatype="html">
         <source>Name: <x id="INTERPOLATION" equiv-text="{{data.allData.name}}"/> </source>
@@ -1620,15 +1602,6 @@
         </context-group>
         <target xml:lang="ar" state="needs-translation">Requests</target>
       </trans-unit>
-      <trans-unit id="763183703a8c602e394c9705c4e8f79895e5dde3" datatype="html">
-        <source>
-          <x id="INTERPOLATION" equiv-text="{{ planetType === 'center' ? 'Nation' : 'Community' }}"/>
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/manager-dashboard/manager-dashboard.component.ts</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="ff83038b9d1b00416aa6a76ebaa2d9b7b8c5cdb1" datatype="html">
         <source>Resend Registration Request</source>
         <context-group purpose="location">
@@ -1668,18 +1641,6 @@
           <context context-type="linenumber">16</context>
         </context-group>
         <target xml:lang="ar" state="needs-translation">List Meetups</target>
-      </trans-unit>
-      <trans-unit id="d65fd97877969344d3a07afec5d0389b7aeea1aa" datatype="html">
-        <source>
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/meetups/meetups.component.ts</context>
-          <context context-type="linenumber">31</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/resources/resources.component.ts</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="884535df42a54a2c00582c299326273b3eaa8c3d" datatype="html">
         <source><x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon&gt;"/>clear<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon&gt;"/>Leave</source>
@@ -2212,15 +2173,6 @@
         </context-group>
         <target xml:lang="ar" state="needs-translation">Action</target>
       </trans-unit>
-      <trans-unit id="9effd84e2122d49dba889d3e03fa25c19589e06d" datatype="html">
-        <source>
-          <x id="ICU" equiv-text="{+element.doc.isUserAdmin, select, 0 {...} 1 {...}}"/>
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/users/users.component.ts</context>
-          <context context-type="linenumber">93</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="506bcfcdbb95044d7597c7f0833f25a68d37738a" datatype="html">
         <source>{VAR_SELECT, select, 0 {Promote} 1 {Demote} }</source>
         <context-group purpose="location">
@@ -2237,9 +2189,9 @@
           <context context-type="linenumber">100</context>
         </context-group>
         <target xml:lang="ar" state="needs-translation">
-          
+
           <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon&gt;"/>folder_open<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon&gt;"/>View Profile
-        
+
         </target>
       </trans-unit>
       <trans-unit id="761e7bc19e9488ae4447d0cd58a9c83b4d1844e2" datatype="html">

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -932,36 +932,27 @@
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="13c270db76cb28d7e1945a454ed60a5d5e5752df" datatype="html">
-        <source>
-      <x id="INTERPOLATION" equiv-text="{{examStart === 1 ? &quot;Take Exam&quot; : &quot;Continue Exam&quot;}}"/>
-    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/courses/step-view-courses/courses-step-view.component.ts</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="b1a045c8850fc0b5e3db079bc60c13ae01167c72" datatype="html">
         <source>
       Open resource new tab
     </source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/courses/step-view-courses/courses-step-view.component.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b46c766f5745fbe4d967d14eaf20391606a0c28d" datatype="html">
         <source>List of Resources</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/courses/step-view-courses/courses-step-view.component.ts</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb56b817ae1c5fbe2b34a7e74031be3b4dc8de3a" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{stepNum}}"/>/<x id="INTERPOLATION_1" equiv-text="{{maxStep}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/courses/step-view-courses/courses-step-view.component.ts</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c87fc952938382700c1d2c56bdb02b8a55b4941d" datatype="html">
@@ -1020,13 +1011,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/form-error-messages.component.ts</context>
           <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="f7503283354cce9f5bc0e058da5eb75f906b290c" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{field.label}}"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/dialogs/dialogs-form.component.ts</context>
-          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d7039076b24be09bd64cbfd5b38bb95363a89931" datatype="html">
@@ -1694,13 +1678,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/manager-dashboard/manager-dashboard.component.ts</context>
           <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="763183703a8c602e394c9705c4e8f79895e5dde3" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ planetType === &apos;center&apos; ? &apos;Nation&apos; : &apos;Community&apos; }}"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/manager-dashboard/manager-dashboard.component.ts</context>
-          <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ff83038b9d1b00416aa6a76ebaa2d9b7b8c5cdb1" datatype="html">

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -2048,21 +2048,11 @@
           <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9effd84e2122d49dba889d3e03fa25c19589e06d" datatype="html">
-        <source>
-            
-            <x id="ICU" equiv-text="{+element.doc.isUserAdmin, select, 0 {...} 1 {...}}"/>
-          </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/users/users.component.ts</context>
-          <context context-type="linenumber">106</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="506bcfcdbb95044d7597c7f0833f25a68d37738a" datatype="html">
         <source>{VAR_SELECT, select, 0 {Promote} 1 {Demote} }</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/users/users.component.ts</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="436d4f2b6d175f1deeb91d14618542f63567bd7d" datatype="html">
@@ -2071,7 +2061,7 @@
         </source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/users/users.component.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="761e7bc19e9488ae4447d0cd58a9c83b4d1844e2" datatype="html">


### PR DESCRIPTION
Fixing situations where `i18n` tags were used for elements with only interpolation (which should not be translated & causes errors).