### PR TITLE
Fix center.media.mit.edu admin

### DIFF
--- a/src/app/login/login-form.component.ts
+++ b/src/app/login/login-form.component.ts
@@ -99,6 +99,12 @@ export class LoginFormComponent {
     }, error => this.planetMessageService.showAlert('An error occurred please try again'));
   }
 
+  createParentSession({ name, password }) {
+    return this.couchService.post('_session',
+      { 'name': name, 'password': password },
+      { withCredentials: true, domain: this.userService.getConfig().parentDomain });
+  }
+
   login({ name, password }: {name: string, password: string}, isCreate: boolean) {
     this.couchService.post('_session', { 'name': name, 'password': password }, { withCredentials: true })
       .pipe(switchMap((data) => {
@@ -115,9 +121,7 @@ export class LoginFormComponent {
         const localAdminName = localConfig.adminName.split('@')[0];
         // If not in e2e test or on a center, also add session to parent domain
         if (!environment.test && localAdminName === name && localConfig.planet_type !== 'center') {
-          obsArr.push(this.couchService.post('_session',
-            { 'name': this.userService.getConfig().adminName, 'password': password },
-            { withCredentials: true, domain: this.userService.getConfig().parentDomain }));
+          obsArr.push(this.createParentSession({ 'name': this.userService.getConfig().adminName, 'password': password }));
         }
         return forkJoin(obsArr).pipe(catchError(error => {
           // 401 is for Unauthorized

--- a/src/app/login/login-form.component.ts
+++ b/src/app/login/login-form.component.ts
@@ -111,9 +111,10 @@ export class LoginFormComponent {
       }), switchMap((routeSuccess) => {
         // Post new session info to login_activity
         const obsArr = [ this.userService.newSessionLog() ];
-        const localAdminName = this.userService.getConfig().adminName.split('@')[0];
-        // If not in e2e test, also add session to parent domain
-        if (!environment.test && localAdminName === name) {
+        const localConfig = this.userService.getConfig();
+        const localAdminName = localConfig.adminName.split('@')[0];
+        // If not in e2e test or on a center, also add session to parent domain
+        if (!environment.test && localAdminName === name && localConfig.planet_type !== 'center') {
           obsArr.push(this.couchService.post('_session',
             { 'name': this.userService.getConfig().adminName, 'password': password },
             { withCredentials: true, domain: this.userService.getConfig().parentDomain }));


### PR DESCRIPTION
Since center tries to log into the "parent" and fails, it loses the session immediately pushing you back to the login screen on every route change.