### PR TITLE
[#1343] Only get data for non-empty shelf (connects #1343)

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -50,7 +50,7 @@ export class DashboardComponent implements OnInit {
         })
       ).subscribe((res: any) => {
         this.visits = res.docs.length;
-    });
+      });
   }
 
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -74,10 +74,9 @@ export class DashboardComponent implements OnInit {
   }
 
   isEmptyShelf(shelf) {
-    let isEmpty = shelf.courseIds.length === 0
+    return shelf.courseIds.length === 0
       && shelf.meetupIds.length === 0
       && shelf.myTeamIds.length === 0
       && shelf.resourceIds.length === 0;
-    return isEmpty;
   }
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -26,6 +26,11 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit() {
     const userShelf = this.userService.shelf;
+
+    if (this.isEmptyShelf(userShelf)) {
+      return;
+    }
+
     forkJoin([
       this.getData('resources', userShelf.resourceIds, { linkPrefix: 'resources/view/', addId: true }),
       this.getData('courses', userShelf.courseIds, { titleField: 'courseTitle', linkPrefix: 'courses/view/', addId: true }),
@@ -37,6 +42,7 @@ export class DashboardComponent implements OnInit {
       this.data.meetups = dashboardItems[2];
       this.data.myTeams = dashboardItems[3];
     });
+
     this.couchService.post('login_activities/_find', findDocuments({ 'user': this.userService.get().name }, [ 'user' ], [], 1000))
       .pipe(
         catchError(() => {
@@ -44,7 +50,7 @@ export class DashboardComponent implements OnInit {
         })
       ).subscribe((res: any) => {
         this.visits = res.docs.length;
-      });
+    });
   }
 
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {
@@ -65,5 +71,13 @@ export class DashboardComponent implements OnInit {
       return this.urlPrefix + Object.keys(attachments)[0];
     }
     return 'assets/image.png';
+  }
+
+  isEmptyShelf(shelf) {
+    let isEmpty = shelf.courseIds.length === 0
+      && shelf.meetupIds.length === 0
+      && shelf.myTeamIds.length === 0
+      && shelf.resourceIds.length === 0;
+    return isEmpty;
   }
 }


### PR DESCRIPTION
### Changes
Added small function to check if shelf is empty, and a condition that exits from `ngOnInit` if the shelf is empty. This is meant to fix the problem where new users would make a request that they don't have permission for and thus get an error message.

### Question
I decided to exit the ngOnInit instead of wrapping its contents in an if statement because it's generally considered [better style](https://softwareengineering.stackexchange.com/questions/18454/should-i-return-from-a-function-early-or-use-an-if-statement). However, I was unsure if the call `this.couch.service.post...` does something of value even for an empty shelf, so if that's the case the solution will have to be changed.