### PR TITLE
Fix large resource upload

### DIFF
--- a/src/ngsw-config.json
+++ b/src/ngsw-config.json
@@ -21,7 +21,7 @@
   "dataGroups": [
     {
       "name": "dataGroup1",
-      "urls": ["!resources"]
+      "urls": ["!resources"],
       "cacheConfig": {
         "maxSize": 50,
         "maxAge": "3d12h"

--- a/src/ngsw-config.json
+++ b/src/ngsw-config.json
@@ -17,5 +17,15 @@
         "files": ["/assets/**"]
       }
     }
+  ],
+  "dataGroups": [
+    {
+      "name": "dataGroup1",
+      "urls": ["!resources"]
+      "cacheConfig": {
+        "maxSize": 50,
+        "maxAge": "3d12h"
+      }
+    }
   ]
 }


### PR DESCRIPTION
Large resource upload is working in dev environment, but not production.  Seeing if removing the resources from the service worker manifest will help.