### PR TITLE
Return all documents from _find query (connects #1241)

### DIFF
--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -80,10 +80,10 @@ export class CommunityComponent implements OnInit, AfterViewInit {
   }
 
   getCommunityList() {
-    this.couchService.post('communityregistrationrequests/_find',
+    this.couchService.findAll('communityregistrationrequests',
       findDocuments({ '_id': { '$gt': null } }, 0, [ { 'createdDate': 'desc' } ] ))
       .subscribe((data) => {
-        this.communities.data = data.docs;
+        this.communities.data = data;
         this.requestListFilter('');
       }, (error) => this.message = 'There was a problem getting Communities');
   }

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -108,14 +108,14 @@ export class UsersComponent implements OnInit, AfterViewInit {
   }
 
   getUsers() {
-    return this.couchService.post(this.dbName + '/_find', { 'selector': {} });
+    return this.couchService.findAll(this.dbName, { 'selector': {}, 'limit': 3 });
   }
 
   initializeData() {
     const currentLoginUser = this.userService.get().name;
     this.selection.clear();
     this.getUsers().pipe(debug('Getting user list')).subscribe((users: any) => {
-      users = users.docs.filter((user: any) => {
+      users = users.filter((user: any) => {
         // Removes current user from list.  Users should not be able to change their own roles,
         // so this protects from that.  May need to unhide in the future.
         if (currentLoginUser !== user.name) {


### PR DESCRIPTION
Uses the bookmark returned from a _find query to recursively find all documents that match.  Implemented for UsersComponent and CommunityComponent as examples to test.

Will need to be implemented across more of the app if working (which we should do in other PRs).