### PR TITLE
Default user for android

### DIFF
--- a/src/app/configuration/configuration.component.ts
+++ b/src/app/configuration/configuration.component.ts
@@ -279,7 +279,7 @@ export class ConfigurationComponent implements OnInit {
       // then add user to parent planet with id of configuration and isUserAdmin set to false
       userDetail['requestId'] = data.id;
       userDetail['isUserAdmin'] = false;
-      return this.couchService.put('_users/org.couchdb.user:' + adminName, { ...userDetail,
+      return this.createUser(adminName, { ...userDetail,
         name: adminName
       }, {
         domain: configuration.parentDomain
@@ -296,10 +296,15 @@ export class ConfigurationComponent implements OnInit {
   }
 
   createReplicator(feedbackSyncUp, feedbackSyncDown, credentials, configuration, adminName, userDetail) {
+    const pin = this.createPin();
     // create replicator at first as we do not have session
     this.couchService.post('_replicator', feedbackSyncUp)
       .pipe(
         debug('Creating replicator'),
+        switchMap(() => forkJoin([
+          this.createUser('satellite', { 'name': 'satellite', 'password': pin, roles: [ 'learner' ], 'type': 'user' }),
+          this.couchService.put('_node/nonode@nohost/_config/satellite/pin', pin)
+        ])),
         switchMap(res => {
           return this.couchService.post('_replicator', feedbackSyncDown);
         }),
@@ -309,7 +314,7 @@ export class ConfigurationComponent implements OnInit {
             // When creating a planet, add admin
             this.couchService.put('_node/nonode@nohost/_config/admins/' + credentials.name, credentials.password),
             // then add user with same credentials
-            this.couchService.put('_users/org.couchdb.user:' + credentials.name, userDetail),
+            this.createUser(credentials.name, userDetail),
             // then add a shelf for that user
             this.couchService.put('shelf/org.couchdb.user:' + credentials.name, {}),
             // then add configuration
@@ -363,6 +368,14 @@ export class ConfigurationComponent implements OnInit {
         console.log(err);
       });
     }
+  }
+
+  createUser(name, details, opts?) {
+    return this.couchService.put('_users/org.couchdb.user:' + name, details, opts);
+  }
+
+  createPin() {
+    return Array(4).fill(0).map(() => Math.floor(Math.random() * 10)).join('');
   }
 
 }

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -28,4 +28,5 @@
     <p *ngSwitchDefault i18n>Your request has not been accepted by parent</p>
   </ng-container>
 </div>
+<div *ngIf="pin" i18n>Your tablet pin number is: {{pin}}</div>
 <div>{{message}}</div>

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -94,8 +94,15 @@ export class ManagerDashboardComponent implements OnInit {
   }
 
   deleteCommunity() {
-     return () => {
-      this.couchService.allDocs('_replicator').pipe(switchMap((docs: any) => {
+    return () => {
+      this.couchService.get('_users/org.couchdb.user:satellite').pipe(switchMap((res) =>
+        forkJoin([
+          this.couchService.delete('_users/org.couchdb.user:satellite?rev=' + res._rev),
+          this.couchService.delete('_node/nonode@nohost/_config/satellite/pin')
+        ])
+      ),
+      switchMap(() => this.couchService.allDocs('_replicator')),
+      switchMap((docs: any) => {
         const replicators = docs.map(doc => {
           return { _id: doc._id, _rev: doc._rev, _deleted: true };
         });

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -25,6 +25,7 @@ export class ManagerDashboardComponent implements OnInit {
   devMode = isDevMode();
   deleteCommunityDialog: any;
   pushedItems = { course: [], resource: [] };
+  pin: string;
 
   constructor(
     private userService: UserService,
@@ -46,6 +47,7 @@ export class ManagerDashboardComponent implements OnInit {
       this.displayDashboard = false;
       this.message = 'Access restricted to admins';
     }
+    this.couchService.get('_node/nonode@nohost/_config/satellite/pin').subscribe((res) => this.pin = res);
   }
 
   resendConfig() {

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -116,11 +116,9 @@ export class UsersComponent implements OnInit, AfterViewInit {
     this.selection.clear();
     this.getUsers().pipe(debug('Getting user list')).subscribe((users: any) => {
       users = users.filter((user: any) => {
-        // Removes current user from list.  Users should not be able to change their own roles,
+        // Removes current user and special satellite user from list.  Users should not be able to change their own roles,
         // so this protects from that.  May need to unhide in the future.
-        if (currentLoginUser !== user.name) {
-          return user;
-        }
+        return currentLoginUser !== user.name && user.name !== 'satellite';
       }).map((user: any) => {
         const userInfo = { doc: user, imageSrc: '', myTeamInfo: true };
         if (user._attachments) {


### PR DESCRIPTION
On community configuration creates a `satellite` user with the learner role and a 4 digit pin for its password that is also stored on the database configuration.  That pin is displayed on the manager dashboard.

In addition as part of cleanup when deleting the community the satellite user & the configuration pin value are deleted.