### PR TITLE
[#1419] Error for invalid date (connects#1419)

### DIFF
--- a/src/app/shared/form-error-messages.component.ts
+++ b/src/app/shared/form-error-messages.component.ts
@@ -32,6 +32,7 @@ import { AbstractControl, AbstractControlDirective } from '@angular/forms';
       pattern {Invalid input. Hover for more info}
       invalidFirstCharacter {Must start with letter or number}
       invalidFutureDate {Cannot be after current date}
+      dateRequired {This field is required as valid date}
     }</span>
   `
 })

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -89,7 +89,7 @@ export class UsersUpdateComponent implements OnInit {
       email: [ '', [ Validators.required, Validators.email ] ],
       language: [ '', Validators.required ],
       phoneNumber: [ '', Validators.required ],
-      birthDate: [ '', Validators.compose([ Validators.required, CustomValidators.notDateInFuture ]) ],
+      birthDate: [ '', Validators.compose([ CustomValidators.dateValidRequired, CustomValidators.notDateInFuture ]) ],
       gender: [ '', Validators.required ],
       level: [ '', Validators.required ]
     });

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -197,7 +197,8 @@ export class CustomValidators {
     }
   }
 
-  // for validating whether time is date or not
+  // matDatepicker returns null for date missing or invalid date
+  // Use this validator for special date message
   static dateValidRequired(ac: AbstractControl): ValidationErrors {
     if (!ac.value) {
       return { dateRequired: true };

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -196,4 +196,11 @@ export class CustomValidators {
       return { invalidFutureDate: true };
     }
   }
+
+  // for validating whether time is date or not
+  static dateValidRequired(ac: AbstractControl): ValidationErrors {
+    if (!ac.value) {
+      return { dateRequired: true };
+    }
+  }
 }


### PR DESCRIPTION
If we use datepicker, when we input alphabet (q, w..) or some special characters( @, #..), input will pass null or undefined as birthdate value. 

[Date picker input and change events](https://stackblitz.com/angular/aaledypnmljg?file=app%2Fdatepicker-events-example.ts) can show this situation.
<img width="269" alt="input" src="https://user-images.githubusercontent.com/25615945/41930155-d3d78900-793f-11e8-9c18-54154acc3525.png">

So I revise form-error-message, error message can be suitable to input nothing or to input something not date.
<img width="642" alt="screen shot" src="https://user-images.githubusercontent.com/25615945/41930461-bc9b55f4-7940-11e8-82d3-64bd99b3fdad.png">

