### PR TITLE
[#1550] Removing meetup from dashboard (connects #1550)

### DIFF
--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -34,6 +34,7 @@ export class DashboardTileComponent implements OnInit {
     event.stopPropagation();
     const newIds = this.userService.shelf[this.shelfName].filter((shelfId) => shelfId !== item._id);
     this.userService.updateShelf(newIds, this.shelfName).subscribe(() => {
+      this.itemData.length--;
       this.planetMessageService.showMessage(item.title + ' removed from ' + this.cardTitle);
     });
   }

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -34,7 +34,6 @@ export class DashboardTileComponent implements OnInit {
     event.stopPropagation();
     const newIds = this.userService.shelf[this.shelfName].filter((shelfId) => shelfId !== item._id);
     this.userService.updateShelf(newIds, this.shelfName).subscribe(() => {
-      this.itemData.length--;
       this.planetMessageService.showMessage(item.title + ' removed from ' + this.cardTitle);
     });
   }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -34,6 +34,7 @@ export class DashboardComponent implements OnInit {
     const userShelf = this.userService.shelf;
 
     if (this.isEmptyShelf(userShelf)) {
+      this.data = { resources: [], courses: [], meetups: [], myTeams: [] };
       return;
     }
 


### PR DESCRIPTION
The error happens if we remove the last one item from the dashboard, it can’t  update the list. Because the last one item may appear in the myLibrary, myCourses, myMeetups or myTeams, so this error may happen in in the myLibrary, myCourses, myMeetups and myTeams.
<img width="716" alt="dashboard" src="https://user-images.githubusercontent.com/25615945/42236227-ea31643e-7ebf-11e8-833c-d8189c362a13.png">
