### PR TITLE
Add script to convert js to json for design docs (fixes #79)

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -114,6 +114,8 @@ curl -X PUT $COUCHURL/courses_progress
 curl -X PUT $COUCHURL/attachments
 curl -X PUT $COUCHURL/send_items
 
+# Create design documents
+node ./design/create-design-docs.js
 # Update version number in configurations database
 upsert_doc configurations version $(jq -c '{version: .version}' package.json)
 # Add or update design docs

--- a/design/create-design-docs.js
+++ b/design/create-design-docs.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const mime = require('mime');
+const basePath = require('path').basename(__dirname) + '/';
+
+const readDirectories = (err, directories) => {
+  directories.forEach((dir) => {
+    fs.stat(basePath + dir, (err, stat) => {
+      if (stat.isDirectory()) {
+        readDir(dir, readFiles(dir));
+      }
+    });
+  });
+};
+
+const readFiles = (dirPath) => (err, files) => {
+  files.forEach((file) => {
+    const filePath = basePath + dirPath + '/' + file;
+    fs.stat(filePath, (err, stat) => {
+      if (mime.getType(file) === 'application/javascript' && file !== 'create-design-docs.js') {
+        fs.readFile(filePath, 'utf8', writeDesignDoc(filePath));
+      }
+    });
+  });
+};
+
+const readDir = (dirPath, callback) => {
+  fs.readdir(basePath + dirPath, callback);
+};
+
+const writeDesignDoc = (filePath) => (err, data) => {
+  fs.writeFile(filePath + 'on', JSON.stringify({ 'validate_doc_update': data.split(/\r?\n/).join('\n') }), (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+};
+
+readDir('', readDirectories);


### PR DESCRIPTION
Right now only creates `validate_doc_update` function, but currently that is the only one we are adding so it should be OK.