### PR TITLE
Fix upgrade script

### DIFF
--- a/docker/planet/Dockerfile
+++ b/docker/planet/Dockerfile
@@ -26,7 +26,8 @@ RUN apk add --update \
     fcgiwrap \
     spawn-fcgi \
     nano \
-    curl
+    curl \
+    bash
 COPY docker/planet/scripts/docker-entrypoint.sh ./
 COPY docker/planet/upgrade.sh /usr/share/nginx/html
 


### PR DESCRIPTION
The x86 docker didn't have bash which is required for the use of an array in the script.