### PR TITLE
Show version of parent & planet (connects #1671)

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -117,8 +117,6 @@ curl -X PUT $COUCHURL/teams
 
 # Create design documents
 node ./design/create-design-docs.js
-# Update version number in configurations database
-upsert_doc configurations version $(jq -c '{version: .version}' package.json)
 # Add or update design docs
 upsert_doc nations _design/nation-validators @./design/nations/nation-validators.json
 # Insert indexes

--- a/src/app/configuration/configuration-guard.service.ts
+++ b/src/app/configuration/configuration-guard.service.ts
@@ -14,10 +14,10 @@ export class ConfigurationGuard {
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     return this.couchService.allDocs('configurations').pipe(map((data: any[]) => {
-      if (data.length > 1) {
+      if (data.length > 0) {
         this.router.navigate([ '/login' ]);
       }
-      return data.length < 2;
+      return data.length === 0;
     }));
   }
 

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -56,8 +56,10 @@ export class ManagerDashboardComponent implements OnInit {
       this.displayDashboard = false;
       this.message = 'Access restricted to admins';
     } else if (this.userService.getConfig().planetType !== 'center') {
-      this.getVersion().subscribe(this.setVersion(this.versionLocal));
-      this.getVersion({ domain: this.userService.getConfig().parentDomain }).subscribe(this.setVersion(this.versionParent));
+      const opts = { responseType: 'text', withCredentials: false, headers: { 'Content-Type': 'text/plain' } };
+      this.getVersion(opts).subscribe((version: string) => this.versionLocal = version);
+      this.getVersion({ domain: this.userService.getConfig().parentDomain, ...opts })
+        .subscribe((version: string) => this.versionParent = version);
     }
     this.getSatellitePin();
   }
@@ -244,11 +246,7 @@ export class ManagerDashboardComponent implements OnInit {
   }
 
   getVersion(opts: any = {}) {
-    return this.couchService.getUrl('version', opts).pipe(catchError((err) => of('N/A')));
-  }
-
-  setVersion(version) {
-    return (newVersion) => version = newVersion;
+    return this.couchService.getUrl('version', opts).pipe(catchError(() => of('N/A')));
   }
 
 }

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -92,4 +92,10 @@ export class CouchService {
     return this.http.request(req);
   }
 
+  getUrl(url: string, reqOpts?: any) {
+    const [ domain = '', protocol, opts ] = this.setOpts(reqOpts);
+    const urlPrefix = domain ? (protocol || environment.parentProtocol) + '://' + domain + '/' : '';
+    return this.http.get(urlPrefix + url, opts);
+  }
+
 }

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -93,9 +93,10 @@ export class CouchService {
   }
 
   getUrl(url: string, reqOpts?: any) {
-    const [ domain = '', protocol, opts ] = this.setOpts(reqOpts);
-    const urlPrefix = domain ? (protocol || environment.parentProtocol) + '://' + domain + '/' : '';
-    return this.http.get(urlPrefix + url, opts);
+    const [ domainWithPort = '', protocol, opts ] = this.setOpts(reqOpts);
+    const domain = domainWithPort ? domainWithPort.split(':')[0] : '';
+    const urlPrefix = domain ? (protocol || environment.parentProtocol) + '://' + domain : window.location.origin;
+    return this.http.get(urlPrefix + '/' + url, opts);
   }
 
 }

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -80,9 +80,7 @@ export class UserService {
       }),
       switchMap(([ configuration, shelf ]: [ any, any ]) => {
         if (configuration.length > 0) {
-          // Config is split into two docs, one with most properties and one with id 'version' and the version
-          const fullConfig = configuration.find((conf: any) => conf._id !== 'version');
-          this.configuration = Object.assign({}, configuration[0], configuration[1], fullConfig);
+          this.configuration = configuration[0];
           this.shelf = shelf;
         }
         return of(true);


### PR DESCRIPTION
Uses the new `/version` endpoint rather than the database.