### PR TITLE
Add simple markdown editor for course description (fixes #808)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "@angular/platform-server": "6.0.7",
     "@angular/router": "6.0.7",
     "@angular/service-worker": "6.0.7",
+    "@covalent/markdown": "^1.0.1",
+    "@covalent/text-editor": "^1.0.0",
     "@types/cropperjs": "^1.1.2",
     "core-js": "^2.5.1",
     "cropperjs": "^1.3.4",

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -14,7 +14,8 @@
         <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
         <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
       </mat-form-field>
-      <mat-form-field class="full-width">
+      <td-text-editor formControlName="description"></td-text-editor>
+      <!-- <mat-form-field class="full-width">
         <textarea
           matInput
           i18n-placeholder
@@ -26,7 +27,7 @@
           matAutosizeMinRows="4">
         </textarea>
         <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-      </mat-form-field>
+      </mat-form-field> -->
       <mat-form-field>
         <input matInput i18n-placeholder placeholder="Member Limit" type="number" formControlName="memberLimit">
         <mat-error><planet-form-error-messages [control]="courseForm.controls.memberLimit"></planet-form-error-messages></mat-error>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -66,8 +66,8 @@
       <mat-cell  *matCellDef="let element" class="list-content-menu">
         <h3 class="header"><a [routerLink]="['view', element._id]">{{element.courseTitle}}</a>
         </h3>
-        <div class="content"><p>{{ element.description }}</p></div>
-        <planet-local-status [status]="element.localStatus"></planet-local-status>
+        <td-markdown class="content">{{ element.description }}</td-markdown>
+	<planet-local-status [status]="element.localStatus"></planet-local-status>
         <button *ngIf="!parent" class="menu" mat-icon-button [matMenuTriggerFor]="resourceMenu">
           <mat-icon>more_vert</mat-icon>
         </button>

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -21,7 +21,8 @@
         <p i18n><b>Grade Level:</b> {{courseDetail.gradeLevel}}</p>
         <p i18n><b>Language of Instruction:</b> {{courseDetail.languageOfInstruction}}</p>
         <p i18n><b>Method:</b> {{courseDetail.method}}</p>
-        <p i18n><b>Description:</b> {{courseDetail.description}}</p>
+        <p><b i18n>Description:</b></p>
+        <td-markdown [content]="courseDetail.description"></td-markdown>
       </div>
       <div class="course-view">
         <ng-container *ngFor="let step of courseDetail.steps; let stepNum = index;">

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -1,8 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TdTextEditorComponent } from '@covalent/text-editor';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentTextEditorModule } from '@covalent/text-editor';
+import { CovalentMarkdownModule } from '@covalent/markdown';
 import { MaterialModule } from '../material.module';
 import { FormErrorMessagesComponent } from './form-error-messages.component';
 import { PlanetRatingComponent } from './planet-rating.component';
@@ -24,7 +24,9 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetStackedBarComponent,
     PlanetTagInputComponent,
     TdTextEditorComponent,
-    TdMarkdownComponent
+    TdMarkdownComponent,
+    CovalentTextEditorModule,
+    CovalentMarkdownModule
   ],
   declarations: [
     FormErrorMessagesComponent,
@@ -33,7 +35,8 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetStackedBarComponent,
     PlanetTagInputComponent,
     TdTextEditorComponent,
-    TdMarkdownComponent
+    TdMarkdownComponent,
+    PlanetStackedBarComponent
   ]
 })
 export class PlanetFormsModule {}

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TdTextEditorComponent } from '@covalent/text-editor';
+import { TdMarkdownComponent } from '@covalent/markdown';
 import { MaterialModule } from '../material.module';
 import { FormErrorMessagesComponent } from './form-error-messages.component';
 import { PlanetRatingComponent } from './planet-rating.component';
@@ -20,14 +22,18 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetRatingComponent,
     PlanetRatingStarsComponent,
     PlanetStackedBarComponent,
-    PlanetTagInputComponent
+    PlanetTagInputComponent,
+    TdTextEditorComponent,
+    TdMarkdownComponent
   ],
   declarations: [
     FormErrorMessagesComponent,
     PlanetRatingComponent,
     PlanetRatingStarsComponent,
     PlanetStackedBarComponent,
-    PlanetTagInputComponent
+    PlanetTagInputComponent,
+    TdTextEditorComponent,
+    TdMarkdownComponent
   ]
 })
 export class PlanetFormsModule {}

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -23,8 +23,6 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetRatingStarsComponent,
     PlanetStackedBarComponent,
     PlanetTagInputComponent,
-    TdTextEditorComponent,
-    TdMarkdownComponent,
     CovalentTextEditorModule,
     CovalentMarkdownModule
   ],
@@ -34,8 +32,6 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetRatingStarsComponent,
     PlanetStackedBarComponent,
     PlanetTagInputComponent,
-    TdTextEditorComponent,
-    TdMarkdownComponent,
     PlanetStackedBarComponent
   ]
 })


### PR DESCRIPTION
If this editor looks OK let's approve and merge to move on to refining the UX.  

Follow up issue:

We will need to make a custom form element for the editor to use form errors & placeholders.  We should also do sizing of the editor as part of that future issue.
