### PR TITLE
Change course add steps to custom panel like list

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -39,14 +39,7 @@
       </form>
     </div>
     <div>
-      <planet-courses-step
-        *ngFor="let step of steps; index as i; trackBy: stepTrackByFn"
-        (stepRemove)="removeStep(i)"
-        (stepOrder)="orderStep(i, $event)"
-        [(stepInfo)]="steps[i]"
-        [stepCount]="steps.length"
-        [stepNum]="i+1"
-        (examClick)="addExam($event)"></planet-courses-step>
+      <planet-courses-step [(steps)]="steps"></planet-courses-step>
     </div>
     <div>
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -1,18 +1,13 @@
-import { Component, OnInit } from '@angular/core';
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  FormArray,
-  Validators
-} from '@angular/forms';
-import { Router, ActivatedRoute, ParamMap } from '@angular/router';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { CouchService } from '../../shared/couchdb.service';
 import { CustomValidators } from '../../validators/custom-validators';
 import { ValidatorService } from '../../validators/validator.service';
 import * as constants from '../constants';
-import { MatFormField, MatFormFieldControl } from '@angular/material';
 import { PlanetMessageService } from '../../shared/planet-message.service';
 import { CoursesService } from '../courses.service';
 import { UserService } from '../../shared/user.service';
@@ -22,14 +17,22 @@ import { uniqueId } from '../../shared/utils';
   templateUrl: 'courses-add.component.html',
   styleUrls: [ './courses-add.scss' ]
 })
-export class CoursesAddComponent implements OnInit {
+export class CoursesAddComponent implements OnInit, OnDestroy {
   // needs member document to implement
   members = [];
   readonly dbName = 'courses'; // make database name a constant
   courseForm: FormGroup;
   documentInfo = { rev: '', id: '' };
   pageType = 'Add new';
-  steps = [];
+  private onDestroy$ = new Subject<void>();
+  private _steps = [];
+  get steps() {
+    return this._steps;
+  }
+  set steps(value: any[]) {
+    this._steps = value;
+    this.coursesService.course = { form: this.courseForm.value, steps: this._steps };
+  }
 
   // from the constants import
   gradeLevels = constants.gradeLevels;
@@ -48,6 +51,7 @@ export class CoursesAddComponent implements OnInit {
     private userService: UserService
   ) {
     this.createForm();
+    this.onFormChanges();
   }
 
   createForm() {
@@ -100,11 +104,27 @@ export class CoursesAddComponent implements OnInit {
     if (storedCourse.form) {
       this.setFormAndSteps(storedCourse);
     }
+    this.coursesService.returnUrl = this.router.url;
+    this.coursesService.course = { form: this.courseForm.value, steps: this.steps };
+  }
+
+  ngOnDestroy() {
+    if (this.coursesService.stepIndex === undefined) {
+      this.coursesService.reset();
+    }
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
   }
 
   setFormAndSteps(course: any) {
     this.courseForm.patchValue(course.form);
     this.steps = course.steps || [];
+  }
+
+  onFormChanges() {
+    this.courseForm.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe(value => {
+      this.coursesService.course = { form: value, steps: this.steps };
+    });
   }
 
   updateCourse(courseInfo) {
@@ -166,19 +186,7 @@ export class CoursesAddComponent implements OnInit {
   }
 
   navigateBack() {
-    this.coursesService.reset();
     this.router.navigate([ '/courses' ]);
-  }
-
-  addExam(stepIndex) {
-    this.coursesService.returnUrl = this.router.url;
-    this.coursesService.course = { form: this.courseForm.value, steps: this.steps };
-    this.coursesService.stepIndex = stepIndex;
-    if (this.steps[stepIndex].exam) {
-      this.router.navigate([ '/courses/update/exam/', this.steps[stepIndex].exam._id ]);
-    } else {
-      this.router.navigate([ '/courses/exam/' ]);
-    }
   }
 
   removeStep(pos) {

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -85,7 +85,6 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    const storedCourse = this.coursesService.course;
     if (this.route.snapshot.url[0].path === 'update') {
       this.couchService.get('courses/' + this.route.snapshot.paramMap.get('id'))
       .subscribe((data) => {
@@ -94,15 +93,15 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
         });
         this.pageType = 'Update';
         this.documentInfo = { rev: data._rev, id: data._id };
-        if (!storedCourse.form) {
+        if (this.route.snapshot.params.continue !== 'true') {
           this.setFormAndSteps({ form: data, steps: data.steps });
         }
       }, (error) => {
         console.log(error);
       });
     }
-    if (storedCourse.form) {
-      this.setFormAndSteps(storedCourse);
+    if (this.route.snapshot.params.continue === 'true') {
+      this.setFormAndSteps(this.coursesService.course);
     }
     this.coursesService.returnUrl = this.router.url;
     this.coursesService.course = { form: this.courseForm.value, steps: this.steps };

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -1,6 +1,6 @@
 <planet-step-list [steps]="steps" [nameProp]="'stepTitle'" (stepClicked)="stepClick($event)">
   <planet-step-list-item *ngFor="let step of steps; index as i; first as isFirst; last as isLast">
-    <span>{{step.stepTitle}}</span>
+    <span>{{step.stepTitle || 'Step ' + (i+1)}}</span>
     <mat-icon *ngIf="step?.resources?.length">attach_file</mat-icon>
     <mat-icon *ngIf="step?.exam?.questions.length">assignment</mat-icon>
     <span class="toolbar-fill"></span>

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -1,35 +1,32 @@
-<mat-expansion-panel>
-  <mat-expansion-panel-header>
-    <mat-panel-title>
-      {{stepInfo.stepTitle || 'Step ' + (stepNum)}}
-    </mat-panel-title>
-    <mat-panel-description>
-      <mat-icon *ngIf="stepInfo?.resources?.length">attach_file</mat-icon>
-      <mat-icon *ngIf="stepInfo?.exam?.questions.length">assignment</mat-icon>
-    </mat-panel-description>
-  </mat-expansion-panel-header>
-  <form class="vertical-form" [formGroup]="stepForm" (change)="stepChange()">
-    <mat-form-field>
-      <input matInput i18n-placeholder placeholder="Step title" formControlName="stepTitle">
-    </mat-form-field>
-    <mat-form-field>
-      <textarea
-        matInput
-        i18n-placeholder
-        placeholder="Description"
-        formControlName="description"
-        matTextareaAutosize
-        matAutosizeMaxRows="5"
-        matAutosizeMinRows="4">
-      </textarea>
-    </mat-form-field>
-  </form>
-  <div *ngIf="resources?.length"><span i18n>Attached resources: </span><span *ngFor="let resource of resources; let isLast= last">{{resource.title}}{{isLast ? '' : ', '}}</span></div>
-  <mat-action-row>
-    <a mat-raised-button color="primary" (click)="addExam(stepNum)">{{stepInfo.exam ? 'Update' : 'Add' }} Exam</a>
+<planet-step-list [steps]="steps" [nameProp]="'stepTitle'" (stepClicked)="stepClick($event)">
+  <planet-step-list-item *ngFor="let step of steps; index as i; first as isFirst; last as isLast">
+    <span>{{step.stepTitle}}</span>
+    <mat-icon *ngIf="step?.resources?.length">attach_file</mat-icon>
+    <mat-icon *ngIf="step?.exam?.questions.length">assignment</mat-icon>
+    <span class="toolbar-fill"></span>
+    <button mat-icon-button *ngIf="!isFirst" (click)="moveStep($event,i,-1)"><mat-icon>arrow_upward</mat-icon></button>
+    <button mat-icon-button *ngIf="!isLast" (click)="moveStep($event,i,1)"><mat-icon>arrow_downward</mat-icon></button>
+    <button mat-icon-button (click)="moveStep($event,i)"><mat-icon>delete</mat-icon></button>
+  </planet-step-list-item>
+  <div planetStepListForm>
+    <form class="vertical-form" [formGroup]="stepForm">
+      <mat-form-field>
+        <input matInput i18n-placeholder placeholder="Step title" formControlName="stepTitle">
+      </mat-form-field>
+      <mat-form-field>
+        <textarea
+          matInput
+          i18n-placeholder
+          placeholder="Description"
+          formControlName="description"
+          matTextareaAutosize
+          matAutosizeMaxRows="5"
+          matAutosizeMinRows="4">
+        </textarea>
+      </mat-form-field>
+    </form>
+    <div *ngIf="activeStep?.resources?.length"><span i18n>Attached resources: </span><span *ngFor="let resource of activeStep.resources; let isLast= last">{{resource.title}}{{isLast ? '' : ', '}}</span></div>
+    <a mat-raised-button color="primary" (click)="addExam()">{{activeStep?.exam ? 'Update' : 'Add' }} Exam</a>
     <button mat-raised-button color="primary" (click)="attachItem('resources')">Add Resource</button>
-    <button mat-icon-button *ngIf="stepNum !== 1" (click)="moveUp()"><mat-icon>arrow_upward</mat-icon></button>
-    <button mat-icon-button *ngIf="stepCount !== stepNum" (click)="moveDown()"><mat-icon>arrow_downward</mat-icon></button>
-    <button mat-icon-button (click)="deleteStep()"><mat-icon>delete</mat-icon></button>
-  </mat-action-row>
-</mat-expansion-panel>
+  </div>
+</planet-step-list>

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -72,7 +72,7 @@ export class CoursesStepComponent implements OnDestroy {
 
   dialogOkClick(db: string) {
     return (selected: any) => {
-      this.activeStep.resources = selected;
+      this.steps[this.activeStepIndex].resources = selected;
       this.stepsChange.emit(this.steps);
       this.dialogRef.close();
     };

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -21,7 +21,7 @@ export class CoursesStepComponent implements OnDestroy {
   stepForm: FormGroup;
   dialogRef: MatDialogRef<DialogsListComponent>;
   activeStep: any;
-  activeStepIndex: number = -1;
+  activeStepIndex = -1;
   private onDestroy$ = new Subject<void>();
 
   constructor(

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -1,64 +1,60 @@
-import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  Validators
-} from '@angular/forms';
+import { Component, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
+import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { DialogsListService } from '../../shared/dialogs/dialogs-list.service';
 import { DialogsListComponent } from '../../shared/dialogs/dialogs-list.component';
 import { filterSpecificFields } from '../../shared/table-helpers';
+import { CoursesService } from '../courses.service';
 
 @Component({
   selector: 'planet-courses-step',
   templateUrl: 'courses-step.component.html'
 })
-export class CoursesStepComponent implements OnChanges {
+export class CoursesStepComponent implements OnDestroy {
 
-  @Input() stepInfo: any = {
-    id: '',
-    stepTitle: '',
-    description: '',
-    resources: []
-  };
-  @Output() stepInfoChange = new EventEmitter<any>();
-  @Input() stepNum: number;
-  @Input() stepCount: number;
-  @Output() examClick = new EventEmitter<any>();
-  @Output() stepOrder = new EventEmitter<any>();
-  @Output() stepRemove = new EventEmitter<any>();
+  @Input() steps: any[];
+  @Output() stepsChange = new EventEmitter<any>();
 
   stepForm: FormGroup;
   dialogRef: MatDialogRef<DialogsListComponent>;
-  resources: any;
+  activeStep: any;
+  activeStepIndex: number = -1;
+  private onDestroy$ = new Subject<void>();
 
   constructor(
+    private router: Router,
     private fb: FormBuilder,
     private dialogsListService: DialogsListService,
-    private dialog: MatDialog
-  ) {}
-
-  ngOnChanges() {
-    const { resources, ...stepForm } = this.stepInfo;
-    this.stepForm = this.fb.group(stepForm);
-    this.resources = resources;
+    private dialog: MatDialog,
+    private coursesService: CoursesService,
+  ) {
+    this.stepForm = this.fb.group({
+      id: '',
+      stepTitle: '',
+      description: ''
+    });
+    this.stepForm.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe(value => {
+      this.steps[this.activeStepIndex] = { ...this.activeStep, ...value };
+      this.stepsChange.emit(this.steps);
+    });
   }
 
-  stepChange() {
-    this.stepInfoChange.emit({ ...this.stepForm.value, resources: this.resources });
+  ngOnDestroy() {
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
   }
 
-  addExam(stepNum: number) {
-    this.examClick.emit(stepNum - 1);
-  }
-
-  deleteStep() {
-    this.stepRemove.emit();
+  stepClick(index: number) {
+    this.activeStep = this.steps[index];
+    this.activeStepIndex = index;
+    this.stepForm.patchValue(this.steps[index]);
   }
 
   attachItem(db: string) {
-    const initialSelection = this.resources.map(resource => resource._id);
+    const initialSelection = this.activeStep.resources.map(resource => resource._id);
     this.dialogsListService.getListAndColumns(db).subscribe((res) => {
       const data = { okClick: this.dialogOkClick(db).bind(this),
         filterPredicate: filterSpecificFields([ 'title' ]),
@@ -76,18 +72,28 @@ export class CoursesStepComponent implements OnChanges {
 
   dialogOkClick(db: string) {
     return (selected: any) => {
-      this.resources = selected;
-      this.stepChange();
+      this.activeStep.resources = selected;
+      this.stepsChange.emit(this.steps);
       this.dialogRef.close();
     };
   }
 
-  moveUp() {
-    this.stepOrder.emit(this.stepNum - 2);
+  addExam() {
+    this.coursesService.stepIndex = this.activeStepIndex;
+    if (this.activeStep.exam) {
+      this.router.navigate([ '/courses/update/exam/', this.activeStep.exam._id ]);
+    } else {
+      this.router.navigate([ '/courses/exam/' ]);
+    }
   }
 
-  moveDown() {
-    this.stepOrder.emit(this.stepNum);
+  moveStep(event, i, direction = 0) {
+    event.stopPropagation();
+    const step = this.steps.splice(i, 1)[0];
+    if (direction !== 0) {
+      this.steps.splice(i + direction, 0, step);
+    }
+    this.stepsChange.emit(this.steps);
   }
 
 }

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -101,7 +101,7 @@ export class ExamsAddComponent implements OnInit {
       this.documentInfo = { _id: res.id, _rev: res.rev };
       const courseExam = { ...this.documentInfo, ...examInfo, totalMarks: this.totalMarks(examInfo) };
       this.coursesService.course.steps[this.coursesService.stepIndex].exam = courseExam;
-      this.router.navigate([ this.coursesService.returnUrl ]);
+      this.router.navigate([ this.coursesService.returnUrl, { 'continue': true } ]);
       this.planetMessageService.showMessage(this.successMessage);
     }, (err) => {
       // Connect to an error display component to show user that an error has occurred

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -9,6 +9,7 @@ import { PlanetRatingComponent } from './planet-rating.component';
 import { PlanetRatingStarsComponent } from './planet-rating-stars.component';
 import { PlanetStackedBarComponent } from './planet-stacked-bar.component';
 import { PlanetTagInputComponent } from './planet-tag-input.component';
+import { PlanetStepListComponent, PlanetStepListFormDirective, PlanetStepListItemComponent } from './planet-step-list.component';
 
 @NgModule({
   imports: [
@@ -24,7 +25,10 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetStackedBarComponent,
     PlanetTagInputComponent,
     CovalentTextEditorModule,
-    CovalentMarkdownModule
+    CovalentMarkdownModule,
+    PlanetStepListComponent,
+    PlanetStepListFormDirective,
+    PlanetStepListItemComponent
   ],
   declarations: [
     FormErrorMessagesComponent,
@@ -32,7 +36,10 @@ import { PlanetTagInputComponent } from './planet-tag-input.component';
     PlanetRatingStarsComponent,
     PlanetStackedBarComponent,
     PlanetTagInputComponent,
-    PlanetStackedBarComponent
+    PlanetStackedBarComponent,
+    PlanetStepListComponent,
+    PlanetStepListFormDirective,
+    PlanetStepListItemComponent
   ]
 })
 export class PlanetFormsModule {}

--- a/src/app/shared/forms/planet-step-list.component.html
+++ b/src/app/shared/forms/planet-step-list.component.html
@@ -1,0 +1,9 @@
+<mat-nav-list *ngIf="listMode">
+  <mat-list-item *ngFor="let stepListItem of stepListItems; index as i" (click)="stepClick(i)">
+    <ng-template [ngTemplateOutlet]="stepListItem.template"></ng-template>
+  </mat-list-item>
+</mat-nav-list>
+<ng-container *ngIf="!listMode">
+  <button class="back-button" (click)="toList()" mat-button><mat-icon>keyboard_arrow_left</mat-icon>Return to List</button>
+  <ng-content selector="planet-step-list-form"></ng-content>
+</ng-container>

--- a/src/app/shared/forms/planet-step-list.component.ts
+++ b/src/app/shared/forms/planet-step-list.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, EventEmitter, Output, Directive, ContentChildren, ViewChild, TemplateRef } from '@angular/core';
+
+@Component({
+  selector: 'planet-step-list-item',
+  template: '<ng-template><ng-content></ng-content></ng-template>'
+})
+export class PlanetStepListItemComponent {
+  @ViewChild(TemplateRef) template: TemplateRef<any>;
+}
+
+@Component({
+  selector: 'planet-step-list',
+  templateUrl: './planet-step-list.component.html',
+  styles: [ `
+    .back-button {
+      padding: 0 0.5rem 0 0;
+      margin: 0.5rem 0;
+    }
+  ` ]
+})
+export class PlanetStepListComponent {
+
+  @Input() steps: any[];
+  @Input() nameProp: string;
+  @Input() defaultName = 'Step';
+  @Output() stepClicked = new EventEmitter<number>();
+  @Output() stepUpdated = new EventEmitter<number>();
+
+  @ContentChildren(PlanetStepListItemComponent) stepListItems;
+
+  listMode = true;
+  openIndex = -1;
+
+  constructor() {}
+
+  stepClick(index: number) {
+    this.listMode = false;
+    this.openIndex = index;
+    this.stepClicked.emit(index);
+  }
+
+  toList() {
+    this.listMode = true;
+    this.stepUpdated.emit(this.openIndex);
+  }
+
+}
+
+@Directive({
+  selector: '[planetStepListForm]'
+})
+export class PlanetStepListFormDirective {}


### PR DESCRIPTION
Using the mat-expansion-panel for the course steps makes it difficult if you needed to scroll to see the add resource/exam buttons.  For courses with ~50 steps it would be very cumbersome trying to scroll to find the one step you have open to edit.

Added a new component which we can reuse for similar lists which opens a form when an item is clicked on to edit that item's attributes.