### PR TITLE
Resource attachment fix (connects #1858)

### DIFF
--- a/docker/planet/default.conf
+++ b/docker/planet/default.conf
@@ -85,5 +85,6 @@ server {
     proxy_pass       http://couchdb:5984/;
     proxy_set_header Host      $host;
     proxy_set_header X-Real-IP $remote_addr;
+    client_max_body_size 1024M;
   }
 }


### PR DESCRIPTION
Added `client_max_body_size` to `location /db/`.  Not sure if this will fix the problem, but it was quick to add to get a build started.