### PR TITLE
Run build command in parallel (#1833)

### DIFF
--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -4,10 +4,12 @@ build_multi(){
   {
     "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng
     "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-    "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
   } &
   {
+    "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
     "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
+  } &
+  {
     "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
     "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
   } &

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env sh
 
 build_multi(){
-  "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng &
-  "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf &
-  "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf &
-  "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf &
-  "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf &
-  "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf &
+  {
+    "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng
+    "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
+    "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
+  } &
+  {
+    "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
+    "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
+    "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
+  } &
   wait
 }
 

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -4,12 +4,10 @@ build_multi(){
   {
     "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng
     "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-  } &
-  {
     "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
-    "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
   } &
   {
+    "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
     "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
     "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
   } &

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env sh
 
 build_multi(){
-  "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng
-  "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-  "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
-  "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
-  "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
-  "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
+  "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng &
+  "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf &
+  "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf &
+  "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf &
+  "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf &
+  "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf &
+  wait
 }
 
 build_single(){


### PR DESCRIPTION
Fixes #1833

Not sure if its working or not. But please check these builds

* [build with tag](https://travis-ci.org/open-learning-exchange/planet/builds/418297179?utm_source=github_status&utm_medium=notification) --> takes 19 minutes
* [build without tag](https://travis-ci.org/open-learning-exchange/planet/builds/418295245) --> takes 6 minutes (no changes, expected)

Comparison:

* [previous build with tag](https://travis-ci.org/open-learning-exchange/planet/builds/416729956) --> takes 20 minutes
* [previous build without tag](https://travis-ci.org/open-learning-exchange/planet/builds/418191589) --> takes 6 minutes (no changes, expected)

---
From my chat with @paulbert 
>the old setup run all translation build in 20+ minutes
>and new parallel takes 19 minutes
>I guess with new language added, the the time we save will be much higher
>however, I don't know how much `ng build` travis can handle one at a time.