### PR TITLE
Compose file for docker development environment

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -2,7 +2,7 @@ services:
   couchdb:
     expose:
       - 5984
-    image: treehouses/couchdb:2.1.2
+    image: treehouses/couchdb:2.3.0
     ports:
       - "5984:5984"
   db-init:
@@ -23,7 +23,7 @@ services:
       - HOST_PROTOCOL=http
       - DB_HOST=127.0.0.1
       - DB_PORT=2200
-      - CENTER_ADDRESS=earth.ole.org:2200
+      - CENTER_ADDRESS=planet.earth.ole.org/db
     depends_on:
       - couchdb
 version: "2"

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -1,0 +1,29 @@
+services:
+  couchdb:
+    expose:
+      - 5984
+    image: treehouses/couchdb:2.1.2
+    ports:
+      - "5984:5984"
+  db-init:
+    image: treehouses/planet:db-init-latest
+    depends_on:
+      - couchdb
+    environment:
+      - COUCHDB_HOST=http://couchdb:5984
+  planet:
+    image: treehouses/planet:latest
+    ports:
+      - "3000:80"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/vagrant/dist:/usr/share/nginx/html/eng:ro"
+    environment:
+      - MULTIPLE_IPS=true
+      - HOST_PROTOCOL=http
+      - DB_HOST=127.0.0.1
+      - DB_PORT=2200
+      - CENTER_ADDRESS=earth.ole.org:2200
+    depends_on:
+      - couchdb
+version: "2"


### PR DESCRIPTION
Just a thought to move development a little closer to production.

Use `ng build --source-map --watch` instead of `ng serve`.  The downside of this approach is that there is no live reload, so leaving `ng serve` as the default.

Useful for working on the upgrade script.