### PR TITLE
Initial configuration error (fixes #2040)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,7 +118,7 @@ Vagrant.configure(2) do |config|
 
     # Add initial Couch databases here
     chmod +x couchdb-setup.sh
-    ./couchdb-setup.sh -p 5984
+    ./couchdb-setup.sh -p 5984 -i
     # End Couch database addition
 
   SHELL

--- a/src/app/configuration/configuration.service.ts
+++ b/src/app/configuration/configuration.service.ts
@@ -110,6 +110,7 @@ export class ConfigurationService {
 
   updateAutoAccept(autoAccept) {
     return this.couchService.get('_users/_security').pipe(switchMap((security) => {
+      security.admins = security.admins === undefined ? { roles: [] } : security.admins;
       security.admins.roles = autoAccept ?
         security.admins.roles.concat([ 'openlearner' ]).reduce(dedupeShelfReduce, []) :
         security.admins.roles.filter(role => role !== 'openlearner');


### PR DESCRIPTION
The error was because the `_users` security object was not set when db-init ran which led to us trying to access properties of undefined for auto accept.

We should also update treehouses to make sure `db-init` runs the first time with:
```
    environment:
      - INSTALL=1
```