### PR TITLE
Fix deleted items on dashboard

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -101,7 +101,10 @@ export class CouchService {
   bulkGet(db: string, ids: string[], opts?: any) {
     const docs = ids.map(id => ({ id }));
     return this.post(db + '/_bulk_get', { docs }, opts).pipe(
-      map((response: any) => response.results.map((result: any) => result.docs[0].ok))
+      map((response: any) => response.results
+        .map((result: any) => result.docs[0].ok)
+        .filter((doc: any) => doc._deleted !== true)
+      )
     );
   }
 


### PR DESCRIPTION
Quick fix to solve the issue of deleted items showing up on the dashboard.

We may also need to clean up the documents on the shelf database after an item is deleted.  Not sure what the best way to do that is because it may make deleting documents from other databases very slow.