### PR TITLE
Markdown editor component (fixes #1845) (fixes #2045)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -15,10 +15,10 @@
           <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
           <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
         </mat-form-field>
-        <div class="full-width">
+        <mat-form-field class="full-width mat-form-field-type-no-underline">
+          <planet-markdown-textbox class="full-width" placeholder="Description" [formControl]="courseForm.controls.description"></planet-markdown-textbox>
           <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-          <td-text-editor class="full-width" formControlName="description"></td-text-editor>
-        </div>
+        </mat-form-field>
         <mat-form-field>
           <input matInput i18n-placeholder placeholder="Member Limit" type="number" formControlName="memberLimit">
           <mat-error><planet-form-error-messages [control]="courseForm.controls.memberLimit"></planet-form-error-messages></mat-error>

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -13,7 +13,10 @@
       <mat-form-field>
         <input matInput i18n-placeholder placeholder="Step title" formControlName="stepTitle">
       </mat-form-field>
-      <td-text-editor formControlName="description"></td-text-editor>
+      <mat-form-field class="full-width mat-form-field-type-no-underline">
+        <planet-markdown-textbox class="full-width" placeholder="Description" [formControl]="stepForm.controls.description"></planet-markdown-textbox>
+        <mat-error><planet-form-error-messages [control]="stepForm.controls.description"></planet-form-error-messages></mat-error>
+      </mat-form-field>
     </form>
     <div *ngIf="activeStep?.resources?.length"><span i18n>Attached resources: </span><span *ngFor="let resource of activeStep.resources; let isLast= last">{{resource.title}}{{isLast ? '' : ', '}}</span></div>
     <a mat-raised-button color="primary" (click)="addExam()">{{activeStep?.exam ? 'Update' : 'Add' }} Exam</a>

--- a/src/app/exams/exams-question.component.html
+++ b/src/app/exams/exams-question.component.html
@@ -11,8 +11,10 @@
     <mat-form-field>
       <input matInput i18n-placeholder placeholder="Question Title" formControlName="header">
     </mat-form-field>
-    <td-text-editor formControlName="body"></td-text-editor>
-    <mat-error><planet-form-error-messages [control]="questionForm.controls.body"></planet-form-error-messages></mat-error>
+    <mat-form-field class="full-width mat-form-field-type-no-underline">
+      <planet-markdown-textbox class="full-width" placeholder="Question Detail" [formControl]="questionForm.controls.body"></planet-markdown-textbox>
+      <mat-error><planet-form-error-messages [control]="questionForm.controls.body"></planet-form-error-messages></mat-error>
+    </mat-form-field>
     <div>
       <mat-form-field>
         <mat-select i18n-placeholder placeholder="Type" formControlName="type" (selectionChange)="clearChoices()">

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -16,9 +16,10 @@
           </mat-error>
         </mat-form-field>
       </div>
-      <div>
-        <td-text-editor class="full-width" formControlName="description" required></td-text-editor>
-      </div>
+      <mat-form-field class="full-width mat-form-field-type-no-underline">
+        <planet-markdown-textbox class="full-width" placeholder="Description" [formControl]="meetupForm.controls.description"></planet-markdown-textbox>
+        <mat-error><planet-form-error-messages [control]="meetupForm.controls.description"></planet-form-error-messages></mat-error>
+      </mat-form-field>
       <div>
         <mat-form-field>
           <input matInput [matDatepicker]="datepickerStart" i18n-placeholder placeholder="Start Date" formControlName="startDate">

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -16,7 +16,10 @@
       <mat-form-field>
         <input matInput  i18n-placeholder placeholder="Year" formControlName="year">
       </mat-form-field>
-      <td-text-editor class="full-width" formControlName="description" required></td-text-editor>
+      <mat-form-field class="full-width mat-form-field-type-no-underline">
+        <planet-markdown-textbox class="full-width" placeholder="Description" [formControl]="resourceForm.controls.description"></planet-markdown-textbox>
+        <mat-error><planet-form-error-messages [control]="resourceForm.controls.description"></planet-form-error-messages></mat-error>
+      </mat-form-field>
       <mat-form-field class="full-width">
         <planet-tag-input [formControl]="resourceForm.controls.tags" i18n-placeholder placeholder="Labels"></planet-tag-input>
       </mat-form-field>

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -10,13 +10,15 @@ import { PlanetRatingStarsComponent } from './planet-rating-stars.component';
 import { PlanetStackedBarComponent } from './planet-stacked-bar.component';
 import { PlanetTagInputComponent } from './planet-tag-input.component';
 import { PlanetStepListComponent, PlanetStepListFormDirective, PlanetStepListItemComponent } from './planet-step-list.component';
+import { PlanetMarkdownTextboxComponent } from './planet-markdown-textbox.component';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    MaterialModule
+    MaterialModule,
+    CovalentTextEditorModule
   ],
   exports: [
     FormErrorMessagesComponent,
@@ -28,7 +30,8 @@ import { PlanetStepListComponent, PlanetStepListFormDirective, PlanetStepListIte
     CovalentMarkdownModule,
     PlanetStepListComponent,
     PlanetStepListFormDirective,
-    PlanetStepListItemComponent
+    PlanetStepListItemComponent,
+    PlanetMarkdownTextboxComponent
   ],
   declarations: [
     FormErrorMessagesComponent,
@@ -39,7 +42,8 @@ import { PlanetStepListComponent, PlanetStepListFormDirective, PlanetStepListIte
     PlanetStackedBarComponent,
     PlanetStepListComponent,
     PlanetStepListFormDirective,
-    PlanetStepListItemComponent
+    PlanetStepListItemComponent,
+    PlanetMarkdownTextboxComponent
   ]
 })
 export class PlanetFormsModule {}

--- a/src/app/shared/forms/planet-markdown-textbox.component.html
+++ b/src/app/shared/forms/planet-markdown-textbox.component.html
@@ -1,0 +1,7 @@
+
+<td-text-editor
+  [ngClass]="{ 'warn-text-color': errorState }"
+  [ngModel]="value"
+  (ngModelChange)="writeValue($event)"
+  (focusout)="onFocusOut()">
+</td-text-editor>

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -1,0 +1,107 @@
+import {
+  Component, Input, Optional, Self, OnDestroy, HostBinding, EventEmitter, Output, OnInit, ViewEncapsulation, ElementRef
+} from '@angular/core';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
+import { MatFormFieldControl } from '@angular/material';
+import { Subject } from 'rxjs';
+import { FocusMonitor } from '@angular/cdk/a11y';
+
+@Component({
+  'selector': 'planet-markdown-textbox',
+  'templateUrl': './planet-markdown-textbox.component.html',
+  'styleUrls': [ 'planet-markdown-textbox.scss' ],
+  'providers': [
+    { provide: MatFormFieldControl, useExisting: PlanetMarkdownTextboxComponent },
+  ],
+  'encapsulation': ViewEncapsulation.None
+})
+export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, OnInit, OnDestroy {
+
+  static nextId = 0;
+
+  @HostBinding() id = `planet-markdown-textbox-${PlanetMarkdownTextboxComponent.nextId++}`;
+  @HostBinding('attr.aria-describedby') describedBy = '';
+  @Input() _value = '';
+  get value() {
+    return this._value;
+  }
+  set value(text: string) {
+    console.log(text);
+    this._value = text;
+    this.onChange(text);
+    this.stateChanges.next();
+  }
+  @Output() valueChanges = new EventEmitter<string[]>();
+
+  get empty() {
+    return this._value.length === 0;
+  }
+
+  private _placeholder: string;
+  @Input()
+  get placeholder() {
+    return this._placeholder;
+  }
+  set placeholder(text: string) {
+    this._placeholder = text;
+    this.stateChanges.next();
+  }
+
+  get shouldLabelFloat() {
+    return true;
+  }
+
+  onTouched;
+  stateChanges = new Subject<void>();
+  focused = false;
+  errorState = false;
+
+  constructor(
+    @Optional() @Self() public ngControl: NgControl,
+    private focusMonitor: FocusMonitor,
+    private elementRef: ElementRef
+  ) {
+    if (this.ngControl) {
+      this.ngControl.valueAccessor = this;
+    }
+    focusMonitor.monitor(elementRef.nativeElement, true).subscribe(origin => {
+      this.focused = !!origin;
+      this.stateChanges.next();
+    });
+  }
+
+  ngOnInit() {}
+
+  ngOnDestroy() {
+    this.stateChanges.complete();
+  }
+
+  writeValue(val: string) {
+    this.value = val;
+    this.setErrorState();
+  }
+
+  onChange(_: any) {}
+
+  registerOnChange(fn: (_: any) => void) {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any) {
+    this.onTouched = fn;
+  }
+
+  setDescribedByIds(ids: string[]) {
+    this.describedBy = ids.join(' ');
+  }
+
+  setErrorState() {
+    this.errorState = this.ngControl.touched && this.value === '';
+  }
+
+  onFocusOut() {
+    this.ngControl.control.markAsTouched({ onlySelf: true });
+    this.setErrorState();
+  }
+
+}

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -1,0 +1,25 @@
+@import '../../variables';
+
+@mixin editor-border-color($color) {
+  border-top-color: $color;
+  border-left-color: $color;
+  border-right-color: $color;
+  border-bottom-color: $color;
+}
+
+.mat-form-field-invalid planet-markdown-textbox {
+  .editor-toolbar, .CodeMirror {
+    @include editor-border-color($warn);
+  }
+}
+
+.mat-focused.ng-valid planet-markdown-textbox, .mat-focused.ng-untouched planet-markdown-textbox {
+  .editor-toolbar, .CodeMirror {
+    @include editor-border-color($primary);
+  }
+}
+
+planet-markdown-textbox .CodeMirror {
+  height: 15vh;
+  min-height: 15vh;
+}


### PR DESCRIPTION
Sets up the markdown editor as a Material form component.  This improves the visuals for errors and as a side effect fixes the issue where the text doesn't initialize until you click on the editor

#1845 #2045 