### PR TITLE
Fix planet setup configuration error

### DIFF
--- a/src/app/shared/state.service.ts
+++ b/src/app/shared/state.service.ts
@@ -13,7 +13,7 @@ export class StateService {
   private stateUpdated = new Subject<any>();
 
   get configuration(): any {
-    return this.state.local.configurations.docs[0];
+    return this.state.local.configurations.docs[0] || {};
   }
 
   constructor(


### PR DESCRIPTION
In 0.5.0 an error was introduced which breaks the initial configuration setup.  This fixes that error allowing the initial setup of a planet again.