### PR TITLE
Add configuration for serving languages in dev environment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,6 +54,12 @@
                   "with": "src/environments/environment.test.ts"
                 }
               ]
+            },
+            "language": {
+              "i18nFile": "src/i18n/messages.som.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "so",
+              "aot": true
             }
           }
         },
@@ -70,6 +76,9 @@
             },
             "test": {
               "browserTarget": "ang-bell-app:build:test"
+            },
+            "language": {
+              "browserTarget": "ang-bell-app:build:language"
             }
           }
         },


### PR DESCRIPTION
Command to serve with different language in development: `ng serve --configuration=language`

As it is written to change language you need to change the `angular.json` file.  There might be a way to do that with another custom flag which would be better.