### PR TITLE
Fix scrolling for markdown editors

### DIFF
--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -19,7 +19,9 @@
   }
 }
 
-planet-markdown-textbox .CodeMirror {
-  height: 15vh;
-  min-height: 15vh;
+planet-markdown-textbox {
+  .CodeMirror, .CodeMirror-scroll {
+    height: 15vh;
+    min-height: 15vh;
+  }
 }


### PR DESCRIPTION
To test go to any page with an editor (resource add, course add) and add enough lines into the description to go beyond the height of the editor.  You should see a scrollbar appear at that point:

![image](https://user-images.githubusercontent.com/9203229/47469648-f4cbd000-d7cf-11e8-9810-a07ed2ed10e1.png)
