### PR TITLE
No attachment hide resource button (fixes #2304)

### DIFF
--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -45,10 +45,12 @@
             </mat-expansion-panel-header>
             <td-markdown [content]="step.description"></td-markdown>
             <mat-action-row>
-              <a *ngIf="step?.resources?.length === 1" mat-raised-button color="accent" class="margin-lr-10" [href]="resourceUrl(step.resources[0])" target="_blank" i18n>View Resource</a>
+              <a *ngIf="step?.resources?.length === 1 && step.resources[0]._attachments" mat-raised-button color="accent" class="margin-lr-10" [href]="resourceUrl(step.resources[0])" target="_blank" i18n>View Resource</a>
               <button *ngIf="step?.resources?.length > 1 && step?.resources?.length" mat-raised-button color="accent" class="margin-lr-10" [matMenuTriggerFor]="resourceList" i18n>View Resource</button>
               <mat-menu #resourceList="matMenu">
-                <a *ngFor="let resource of step.resources;" mat-menu-item [href]="resourceUrl(resource)" target="_blank">{{resource.title}}</a>
+                <ng-container *ngFor="let resource of step.resources;">
+                  <a *ngIf="resource._attachments" mat-menu-item [href]="resourceUrl(resource)" target="_blank">{{resource.title}}</a>
+                </ng-container>
               </mat-menu>
               <a mat-raised-button color="accent" class="margin-lr-10" *ngIf="step?.exam?.questions.length && isUserEnrolled" (click)="goToExam(step, stepNum)" i18n>Take exam</a>
             </mat-action-row>

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -45,12 +45,10 @@
             </mat-expansion-panel-header>
             <td-markdown [content]="step.description"></td-markdown>
             <mat-action-row>
-              <a *ngIf="step?.resources?.length === 1 && step.resources[0]._attachments" mat-raised-button color="accent" class="margin-lr-10" [href]="resourceUrl(step.resources[0])" target="_blank" i18n>View Resource</a>
+              <a *ngIf="step?.resources?.length === 1" mat-raised-button color="accent" class="margin-lr-10" [href]="resourceUrl(step.resources[0])" target="_blank" i18n>View Resource</a>
               <button *ngIf="step?.resources?.length > 1 && step?.resources?.length" mat-raised-button color="accent" class="margin-lr-10" [matMenuTriggerFor]="resourceList" i18n>View Resource</button>
               <mat-menu #resourceList="matMenu">
-                <ng-container *ngFor="let resource of step.resources;">
-                  <a *ngIf="resource._attachments" mat-menu-item [href]="resourceUrl(resource)" target="_blank">{{resource.title}}</a>
-                </ng-container>
+                <a *ngFor="let resource of step.resources;" mat-menu-item [href]="resourceUrl(resource)" target="_blank">{{resource.title}}</a>
               </mat-menu>
               <a mat-raised-button color="accent" class="margin-lr-10" *ngIf="step?.exam?.questions.length && isUserEnrolled" (click)="goToExam(step, stepNum)" i18n>Take exam</a>
             </mat-action-row>

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -66,7 +66,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   resourceUrl(resource) {
-      if (resource._attachments && Object.keys(resource._attachments)[0]) {
+    if (resource._attachments && Object.keys(resource._attachments)[0]) {
       const filename = resource.openWhichFile || Object.keys(resource._attachments)[0];
       return environment.couchAddress + '/resources/' + resource._id + '/' + filename;
     }

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -15,6 +15,7 @@ import { PlanetMessageService } from '../../shared/planet-message.service';
 })
 
 export class CoursesViewComponent implements OnInit, OnDestroy {
+
   onDestroy$ = new Subject<void>();
   courseDetail: any = { steps: [] };
   parent = this.route.snapshot.data.parent;
@@ -35,6 +36,10 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     .pipe(takeUntil(this.onDestroy$))
     .subscribe(({ course, progress = { stepNum: 0 } }: { course: any, progress: any }) => {
       this.courseDetail = course;
+      this.courseDetail.steps = this.courseDetail.steps.map(step => {
+        step.resources = step.resources.filter(res => res._attachments);
+        return step;
+      });
       this.progress = progress;
       this.isUserEnrolled = this.checkMyCourses(course._id);
     });

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -67,7 +67,11 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   resourceUrl(resource) {
-    if (resource._attachments && Object.keys(resource._attachments)[0]) {
+      // redirect to the same page if resource doesn't have file in it
+      if (resource._attachments === undefined) return 'courses/view/' + this.route.snapshot.url[1];
+      //redirect to the homepage; also can create a variable in environment for window.location.origin
+      // if (resource._attachments === undefined) return '/';
+      if (resource._attachments && Object.keys(resource._attachments)[0]) {
       const filename = resource.openWhichFile || Object.keys(resource._attachments)[0];
       return environment.couchAddress + '/resources/' + resource._id + '/' + filename;
     }

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -15,7 +15,6 @@ import { PlanetMessageService } from '../../shared/planet-message.service';
 })
 
 export class CoursesViewComponent implements OnInit, OnDestroy {
-
   onDestroy$ = new Subject<void>();
   courseDetail: any = { steps: [] };
   parent = this.route.snapshot.data.parent;
@@ -67,10 +66,6 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   resourceUrl(resource) {
-      // redirect to the same page if resource doesn't have file in it
-      if (resource._attachments === undefined) return 'courses/view/' + this.route.snapshot.url[1];
-      //redirect to the homepage; also can create a variable in environment for window.location.origin
-      // if (resource._attachments === undefined) return '/';
       if (resource._attachments && Object.keys(resource._attachments)[0]) {
       const filename = resource.openWhichFile || Object.keys(resource._attachments)[0];
       return environment.couchAddress + '/resources/' + resource._id + '/' + filename;


### PR DESCRIPTION
Fixes #2304 

## Description
I adjusted courses-view.component.html file to hide a button for resources which don't have attachments or to exclude those resources from the list of resources.

## Screenshots
When a step has only 1 resource with no attachments in it:
![screen shot 2018-10-25 at 12 07 45 am](https://user-images.githubusercontent.com/35533801/47476265-8eee4100-d7ed-11e8-80c4-4b6acb2bc689.png)

When a step has 2 resources and one doesn't have attachments:
![screen shot 2018-10-25 at 12 08 42 am](https://user-images.githubusercontent.com/35533801/47476332-d2e14600-d7ed-11e8-8e8f-b3edab577b76.png)

Only resource with an attachment will appear in the list.
![screen shot 2018-10-25 at 12 08 10 am](https://user-images.githubusercontent.com/35533801/47476335-d4ab0980-d7ed-11e8-8362-6e606130243a.png)

