### PR TITLE
Fix child total resources & courses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
       script:
         - set -e
         - echo  "Waiting for couchdb to start"; WAIT_TIME=0; until curl http://127.0.0.1:5984/_all_dbs || [ $WAIT_TIME -eq 180 ]; do echo "..."; sleep 5; WAIT_TIME=$(expr $WAIT_TIME + 5); done
-        - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 25 ]; then exit 1; fi
+        - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 26 ]; then exit 1; fi
         - ng e2e
     - stage: docker-release
       <<: *_prepare_deploy

--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -121,6 +121,7 @@ curl -X PUT $COUCHURL/tablet_users
 curl -X PUT $COUCHURL/child_users
 curl -X PUT $COUCHURL/replicator_users
 curl -X PUT $COUCHURL/admin_activities
+curl -X PUT $COUCHURL/child_statistics
 
 # Create design documents
 node ./design/create-design-docs.js

--- a/src/app/manager-dashboard/manager-sync.component.ts
+++ b/src/app/manager-dashboard/manager-sync.component.ts
@@ -8,6 +8,7 @@ import { SyncService } from '../shared/sync.service';
 import { findDocuments } from '../shared/mangoQueries';
 import { ManagerService } from './manager.service';
 import { StateService } from '../shared/state.service';
+import { ReportsService } from './reports/reports.service';
 
 @Component({
   templateUrl: './manager-sync.component.html'
@@ -24,7 +25,8 @@ export class ManagerSyncComponent implements OnInit {
     private syncService: SyncService,
     private planetMessageService: PlanetMessageService,
     private managerService: ManagerService,
-    private stateService: StateService
+    private stateService: StateService,
+    private reportsService: ReportsService
   ) {}
 
   ngOnInit() {
@@ -51,6 +53,9 @@ export class ManagerSyncComponent implements OnInit {
       return { ...rep, _deleted: true };
     });
     this.syncService.deleteReplicators(deleteArray).pipe(
+      switchMap(data => {
+        return this.sendStatsToParent();
+      }),
       switchMap(data => {
         return this.syncService.confirmPasswordAndRunReplicators(this.replicatorList());
       }),
@@ -114,6 +119,18 @@ export class ManagerSyncComponent implements OnInit {
         planetCode: planetCode
       };
     });
+  }
+
+  sendStatsToParent() {
+    const domain = this.planetConfiguration.parentDomain;
+    return forkJoin([
+      this.reportsService.getDatabaseCount('resources'),
+      this.reportsService.getDatabaseCount('courses'),
+      this.couchService.get('child_statistics/' + this.planetConfiguration.code, { domain })
+    ]).pipe(switchMap(([ totalResources, totalCourses, stats ]) => {
+      const { error, reason, ...statsDoc } = stats;
+      return this.couchService.post('child_statistics', { ...stats, totalCourses, totalResources }, { domain });
+    }));
   }
 
 }

--- a/src/app/manager-dashboard/manager-sync.component.ts
+++ b/src/app/manager-dashboard/manager-sync.component.ts
@@ -122,14 +122,14 @@ export class ManagerSyncComponent implements OnInit {
   }
 
   sendStatsToParent() {
-    const domain = this.planetConfiguration.parentDomain;
+    const { code, parentDomain: domain } = this.planetConfiguration;
     return forkJoin([
       this.reportsService.getDatabaseCount('resources'),
       this.reportsService.getDatabaseCount('courses'),
-      this.couchService.get('child_statistics/' + this.planetConfiguration.code, { domain })
+      this.couchService.get('child_statistics/' + code, { domain })
     ]).pipe(switchMap(([ totalResources, totalCourses, stats ]) => {
-      const { error, reason, ...statsDoc } = stats;
-      return this.couchService.post('child_statistics', { ...stats, totalCourses, totalResources }, { domain });
+      const { error, reason, docs, rows, ...statsDoc } = stats;
+      return this.couchService.post('child_statistics', { _id: code, ...statsDoc, totalCourses, totalResources }, { domain });
     }));
   }
 

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -35,7 +35,7 @@ export class ReportsDetailComponent {
       this.getLoginActivities();
       this.getRatingInfo();
       this.getResourceVisits();
-      this.getPlanetCounts();
+      this.getPlanetCounts(local);
     });
   }
 
@@ -70,9 +70,16 @@ export class ReportsDetailComponent {
     });
   }
 
-  getPlanetCounts() {
-    this.activityService.getDatabaseCount('resources').subscribe(count => this.reports.totalResources = count);
-    this.activityService.getDatabaseCount('courses').subscribe(count => this.reports.totalCourses = count);
+  getPlanetCounts(local: boolean) {
+    if (local) {
+      this.activityService.getDatabaseCount('resources').subscribe(count => this.reports.totalResources = count);
+      this.activityService.getDatabaseCount('courses').subscribe(count => this.reports.totalCourses = count);
+    } else {
+      this.activityService.getChildDatabaseCounts(this.planetCode).subscribe((response: any) => {
+        this.reports.totalResources = response.totalResources;
+        this.reports.totalCourses = response.totalCourses;
+      });
+    }
   }
 
   xyChartData(data, unique) {

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -104,6 +104,10 @@ export class ReportsService {
     }));
   }
 
+  getChildDatabaseCounts(code: string) {
+    return this.couchService.get('child_statistics/' + code);
+  }
+
   getAdminActivities(planetCode?: string) {
     return this.couchService.findAll('admin_activities', this.selector(planetCode)).pipe(map(adminActivities => {
       return this.groupBy(adminActivities, [ 'parentCode', 'createdOn', 'type' ], { maxField: 'time' });


### PR DESCRIPTION
Adds a `child_statistics` database to store the count of resources & courses from child planets (communities) so when they are offline the data will still show in reports.