### PR TITLE
Fix console error on resources page (fixes #2278)

### DIFF
--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -33,7 +33,7 @@ export class CoursesService {
     private stateService: StateService
   ) {
     this.ratingService.ratingsUpdated$.pipe(switchMap(() => {
-      const { ids, opts } = this.currentParams;
+      const { ids, opts } = this.currentParams || { ids: [], opts: {} };
       return this.findRatings(ids, opts);
     })).subscribe((ratings) => {
       this.updateCourses(this.createCourseList(this.courses, ratings.docs));


### PR DESCRIPTION
To test: load resources or parent resources from manager dashboard before loading courses.  There should not be new errors in the console.