### PR TITLE
Show parent labels when viewing parent (connects #2523)

### DIFF
--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -3,7 +3,7 @@
   <span i18n>Library</span>
   <span class="toolbar-fill margin-lr-10"></span>
   <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
-    <planet-tag-input [formControl]="tagFilter"></planet-tag-input>
+    <planet-tag-input [formControl]="tagFilter" [parent]="parent"></planet-tag-input>
   </mat-form-field>
   <mat-form-field class="font-size-1 margin-lr-3">
     <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, Input, Optional, Self, OnDestroy, HostBinding, EventEmitter, Output, ElementRef, Inject
+  Component, Input, Optional, Self, OnInit, OnDestroy, HostBinding, EventEmitter, Output, ElementRef, Inject
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, FormControl } from '@angular/forms';
 import { MatFormFieldControl, MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
@@ -60,7 +60,7 @@ export class PlanetTagInputDialogComponent {
     { provide: MatFormFieldControl, useExisting: PlanetTagInputComponent }
   ]
 })
-export class PlanetTagInputComponent implements ControlValueAccessor, OnDestroy {
+export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, OnDestroy {
 
   static nextId = 0;
 
@@ -87,6 +87,7 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnDestroy 
     this.stateChanges.next();
   }
   @Input() mode = 'filter';
+  @Input() parent = false;
 
   shouldLabelFloat = false;
   onTouched;
@@ -106,7 +107,10 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnDestroy 
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
     }
-    this.tagsService.getTags().subscribe((tags: string[]) => {
+  }
+
+  ngOnInit() {
+    this.tagsService.getTags(this.parent).subscribe((tags: string[]) => {
       this.tags = tags;
     });
   }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -19,7 +19,7 @@ export class TagsService {
   }
 
   filterTags(tags: any[], filterString: string): string[] {
-    return tags.filter((tag: any) => tag.key.indexOf(filterString) > -1);
+    return tags.filter((tag: any) => tag.key.toLowerCase().indexOf(filterString.toLowerCase()) > -1);
   }
 
 }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -1,14 +1,19 @@
 import { Injectable } from '@angular/core';
 import { CouchService } from '../couchdb.service';
 import { map } from 'rxjs/operators';
+import { StateService } from '../state.service';
 
 @Injectable()
 export class TagsService {
 
-  constructor(private couchService: CouchService) {}
+  constructor(
+    private couchService: CouchService,
+    private stateService: StateService
+  ) {}
 
-  getTags() {
-    return this.couchService.get('resources/_design/resources/_view/count_tags?group=true').pipe(
+  getTags(parent: boolean) {
+    const opts = parent ? { domain: this.stateService.configuration.parentDomain } : {};
+    return this.couchService.get('resources/_design/resources/_view/count_tags?group=true', opts).pipe(
       map((response: any) => response.rows.sort((a, b) => b.value - a.value))
     );
   }


### PR DESCRIPTION
To test: go to parent resources and click filter labels.  Should see labels from the parent planet.

Found the issue in testing #2523 