### PR TITLE
Courses progress database change (fixes #2554)

### DIFF
--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -116,7 +116,7 @@ export class CoursesService {
       if (addProgress) {
         courses = courses.map(course => ({
           ...course,
-          progress: progress.find((p: any) => p.courseId === course._id && p.userId === this.userService.get()._id) || { stepNum: 0 }
+          progress: progress.filter((p: any) => p.courseId === course._id && p.userId === this.userService.get()._id) || []
         }));
       }
       this.courses = courses;

--- a/src/app/courses/progress-courses/courses-progress-bar.component.html
+++ b/src/app/courses/progress-courses/courses-progress-bar.component.html
@@ -1,6 +1,6 @@
 <div
-  *ngFor="let step of course?.steps; index as i"
+  *ngFor="let step of steps; index as i"
   [matTooltip]="step.stepTitle || 'Step ' + (i+1)"
-  [ngClass]="{ 'completed': completed || ((i+1) < courseProgress?.stepNum), 'not-started': (i+1) > courseProgress?.stepNum, 'cursor-pointer': i < courseProgress?.stepNum }"
-  (click)="routing(courseProgress?.stepNum,i)">
+  [ngClass]="{ 'completed': step.status === 'completed', 'not-started': step.status === 'not started', 'cursor-pointer': step.status !== 'not started' }"
+  (click)="routing(step.status,i)">
 </div>

--- a/src/app/courses/progress-courses/courses-progress-bar.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-bar.component.ts
@@ -9,20 +9,32 @@ import { Router } from '@angular/router';
 export class CoursesProgressBarComponent implements OnChanges {
 
   @Input() course: any = { steps: [] };
-  @Input() courseProgress: any = { stepNum: 0 };
-  completed = false;
+  @Input() courseProgress: any[] = [];
+  steps: any[] = [];
 
   constructor(
     private router: Router
   ) { }
 
   ngOnChanges() {
-    this.completed = this.course.steps.length === this.courseProgress.stepNum && this.courseProgress.passed;
+    this.steps = this.course.steps.map((step: any, index: number) => {
+      const progress = this.courseProgress.find((p: any) => p.stepNum === (index + 1));
+      const status = this.progressStatus(progress);
+      return { stepTitle: step.stepTitle, status };
+    });
   }
 
-  routing(completedStepNum, i) {
-    if (i < completedStepNum) {
+  routing(status, i) {
+    if (status !== 'not started') {
       this.router.navigate([ '/courses/view', this.course._id, 'step', i + 1 ]);
     }
   }
+
+  progressStatus(progress: any) {
+    if (progress === undefined) {
+      return 'not started';
+    }
+    return progress.passed ? 'completed' : 'pending';
+  }
+
 }

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -38,12 +38,12 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.coursesService.courseUpdated$
     .pipe(takeUntil(this.onDestroy$))
-    .subscribe(({ course, progress = { stepNum: 0 } }: { course: any, progress: any }) => {
+    .subscribe(({ course, progress = { stepNum: 0, passed: false } }: { course: any, progress: any }) => {
       // To be readable by non-technical people stepNum param will start at 1
       this.stepDetail = course.steps[this.stepNum - 1];
       this.progress = progress;
       if (!this.parent && this.stepNum > progress.stepNum) {
-        this.coursesService.updateProgress({ courseId: course._id, stepNum: this.stepNum, progress });
+        this.coursesService.updateProgress({ courseId: course._id, stepNum: this.stepNum, progress, passed: this.stepDetail === undefined });
       }
       this.maxStep = course.steps.length;
       this.attempts = 0;
@@ -56,18 +56,18 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
           type: 'exam' });
       }
       this.resource = this.stepDetail.resources ? this.stepDetail.resources[0] : undefined;
-      this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$))
-      .subscribe(({ submission, attempts, bestAttempt = { grade: 0 } }) => {
-        this.examStart = submission.answers.reduce((totalPassed, answer) => totalPassed + (answer.passed ? 1 : 0), 0) + 1;
-        this.attempts = attempts;
-        const examPercent = (bestAttempt.grade / this.stepDetail.exam.totalMarks) * 100;
-        this.examPassed = examPercent >= this.stepDetail.exam.passingPercentage;
-        if (!this.parent && this.progress.passed !== this.examPassed) {
-          this.coursesService.updateProgress({
-            courseId: this.courseId, stepNum: this.stepNum, passed: this.examPassed, progress: this.progress
-          });
-        }
-      });
+    });
+    this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$))
+    .subscribe(({ submission, attempts, bestAttempt = { grade: 0 } }) => {
+      this.examStart = submission.answers.reduce((totalPassed, answer) => totalPassed + (answer.passed ? 1 : 0), 0) + 1;
+      this.attempts = attempts;
+      const examPercent = (bestAttempt.grade / this.stepDetail.exam.totalMarks) * 100;
+      this.examPassed = examPercent >= this.stepDetail.exam.passingPercentage;
+      if (!this.parent && this.progress.passed !== this.examPassed) {
+        this.coursesService.updateProgress({
+          courseId: this.courseId, stepNum: this.stepNum, passed: this.examPassed, progress: this.progress
+        });
+      }
     });
     this.route.paramMap.pipe(takeUntil(this.onDestroy$)).subscribe((params: ParamMap) => {
       this.parent = this.route.snapshot.data.parent;

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -38,12 +38,12 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.coursesService.courseUpdated$
     .pipe(takeUntil(this.onDestroy$))
-    .subscribe(({ course, progress = { stepNum: 0, passed: false } }: { course: any, progress: any }) => {
+    .subscribe(({ course, progress = [] }: { course: any, progress: any }) => {
       // To be readable by non-technical people stepNum param will start at 1
       this.stepDetail = course.steps[this.stepNum - 1];
-      this.progress = progress;
-      if (!this.parent && this.stepNum > progress.stepNum) {
-        this.coursesService.updateProgress({ courseId: course._id, stepNum: this.stepNum, progress, passed: this.stepDetail === undefined });
+      this.progress = progress.find((p: any) => p.stepNum === this.stepNum) || { passed: false };
+      if (!this.parent && this.progress.stepNum === undefined) {
+        this.coursesService.updateProgress({ courseId: course._id, stepNum: this.stepNum, passed: this.stepDetail.exam === undefined });
       }
       this.maxStep = course.steps.length;
       this.attempts = 0;
@@ -65,7 +65,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
       this.examPassed = examPercent >= this.stepDetail.exam.passingPercentage;
       if (!this.parent && this.progress.passed !== this.examPassed) {
         this.coursesService.updateProgress({
-          courseId: this.courseId, stepNum: this.stepNum, passed: this.examPassed, progress: this.progress
+          courseId: this.courseId, stepNum: this.stepNum, passed: this.examPassed
         });
       }
     });


### PR DESCRIPTION
Adds one document per user per step to the `courses_progress` database so we can track when the user starts & completes each step.

To test: take course and check to make sure one and only one document is created on database for each step.  Confirm course progress bar (on CoursesComponent & CoursesViewComponent) look as they did before for this PR (grey for step not started, blue for in progress, and green for completed).

Note that any progress from previous versions will look different (all but one step will be grey).

#2554 