### PR TITLE
Prevent exam to close with unanswered questions

### DIFF
--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -10,7 +10,7 @@
     <span class="margin-lr-2" i18n *ngIf="mode === 'grade' || mode === 'view'">By {{submittedBy}}<span i18n *ngIf="!submittedBy">Unknown</span> on {{(updatedOn | date: 'short') || '--'}}</span>
     <span class="toolbar-fill"></span>
     <button mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)"><mat-icon>navigate_before</mat-icon></button>
-    <button mat-icon-button [disabled]="questionNum === maxQuestions" (click)="nextQuestion(questionNum)"><mat-icon>navigate_next</mat-icon></button>
+    <button mat-icon-button [disabled]="questionNum === maxQuestions" (click)="nextQuestion(true)"><mat-icon>navigate_next</mat-icon></button>
   </mat-toolbar>
   <div class="view-container">
     <span class="mat-h2">{{question.title}}</span>
@@ -54,7 +54,7 @@
         *ngIf="mode !== 'view'"
         mat-raised-button
         color="primary"
-        (click)="nextQuestion(questionNum)"
+        (click)="nextQuestion()"
         [planetSubmit]="spinnerOn"
         [disabled]="answer === undefined || answer === '' || grade === undefined || grade === null"
         i18n>

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -203,7 +203,7 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
           correctAnswer
         };
       case 'grade':
-        return { obs: this.submissionsService.submitGrade(this.grade, this.questionNum - 1, close), correctAnswer };
+        return { obs: this.submissionsService.submitGrade(this.grade, this.questionNum - 1), correctAnswer };
       default:
         return { obs: of({ nextQuestion: this.questionNum + 1 }), correctAnswer };
     }

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -94,7 +94,7 @@ export class SubmissionsService {
       mistakes: (oldAnswer ? oldAnswer.mistakes : 0) + (correct === false ? 1 : 0),
       passed: correct !== false
     };
-    const close = submission.answers.filter(answer => answer.value).length >= submission.parent.questions.length;
+    const close = this.shouldCloseSubmission(submission, 'value');
     const nextQuestion = close ? -1 : this.nextQuestion(submission, index + 1, 'value');
     if (correct !== undefined) {
       this.updateGrade(submission, correct ? 1 : 0, index);
@@ -102,10 +102,12 @@ export class SubmissionsService {
     return this.updateSubmission(submission, this.submission.type === 'exam', nextQuestion);
   }
 
-  submitGrade(grade, index: number, close) {
+  submitGrade(grade, index: number) {
     const submission = { ...this.submission, answers: [ ...this.submission.answers ], gradeTime: this.couchService.datePlaceholder };
     this.updateGrade(submission, grade, index);
-    return this.updateSubmission(submission, false, close);
+    const close = this.shouldCloseSubmission(submission, 'grade');
+    const nextQuestion = close ? -1 : this.nextQuestion(submission, index + 1, 'grade');
+    return this.updateSubmission(submission, false, nextQuestion);
   }
 
   updateGrade(submission, grade, index) {
@@ -178,6 +180,10 @@ export class SubmissionsService {
 
   submissionName(user) {
     return user.name || ((user.firstName || '') + ' ' + (user.lastName || '')).trim();
+  }
+
+  shouldCloseSubmission(submission, field) {
+    return submission.answers.filter(answer => answer[field] !== undefined).length >= submission.parent.questions.length;
   }
 
   nextQuestion(submission, index, field) {

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -94,8 +94,7 @@ export class SubmissionsService {
       mistakes: (oldAnswer ? oldAnswer.mistakes : 0) + (correct === false ? 1 : 0),
       passed: correct !== false
     };
-    const close = this.shouldCloseSubmission(submission, 'value');
-    const nextQuestion = close ? -1 : this.nextQuestion(submission, index + 1, 'value');
+    const nextQuestion = this.nextQuestion(submission, index, 'value');
     if (correct !== undefined) {
       this.updateGrade(submission, correct ? 1 : 0, index);
     }
@@ -105,9 +104,13 @@ export class SubmissionsService {
   submitGrade(grade, index: number) {
     const submission = { ...this.submission, answers: [ ...this.submission.answers ], gradeTime: this.couchService.datePlaceholder };
     this.updateGrade(submission, grade, index);
-    const close = this.shouldCloseSubmission(submission, 'grade');
-    const nextQuestion = close ? -1 : this.nextQuestion(submission, index + 1, 'grade');
+    const nextQuestion = this.nextQuestion(submission, index, 'grade');
     return this.updateSubmission(submission, false, nextQuestion);
+  }
+
+  nextQuestion(submission, index, field) {
+    const close = this.shouldCloseSubmission(submission, field);
+    return close ? -1 : this.findNextQuestion(submission, index + 1, field);
   }
 
   updateGrade(submission, grade, index) {
@@ -186,12 +189,12 @@ export class SubmissionsService {
     return submission.answers.filter(answer => answer[field] !== undefined).length >= submission.parent.questions.length;
   }
 
-  nextQuestion(submission, index, field) {
+  findNextQuestion(submission, index, field) {
     if (index >= submission.parent.questions.length) {
-      return this.nextQuestion(submission, 0, field);
+      return this.findNextQuestion(submission, 0, field);
     }
     return submission.answers[index] && submission.answers[index][field] !== undefined ?
-      this.nextQuestion(submission, index + 1, field) : index;
+      this.findNextQuestion(submission, index + 1, field) : index;
   }
 
 }


### PR DESCRIPTION
fixes #2570 

The learner can take the exam multiple times, and he is also able to move between questions without answering them, the issue is, if he reaches to the last question and submits the answer, the exam will be closed.
The solution here did the trick by taking track all answers, and not to close the exam until all answers were submitted.

It will be better to persist answers in the textbox of each question so learners can review their answers.