### PR TITLE
[#2611] CourseProgress: Prevent showing of the button during loading time

### DIFF
--- a/src/app/courses/progress-courses/courses-progress-leader.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-leader.component.ts
@@ -35,7 +35,6 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
     });
     this.coursesService.courseUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ course }) => {
       this.course = course;
-      this.selectedStep = course.steps[0];
       this.setProgress(course);
     });
     this.submissionsService.submissionsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe((submissions: any[]) => {


### PR DESCRIPTION
fixes #2611

## Description
I removed initialization of `selectedStep` variable inside ngOnInit(). Thus, "Show full course" button is not visible during loading. 
Not sure if it is a good practice to remove initialization from ngOnInit(). But it seems that the variable is initialized successfully inside functions of the component.