### PR TITLE
Add new label (fixes #2501)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
       script:
         - set -e
         - echo  "Waiting for couchdb to start"; WAIT_TIME=0; until curl http://127.0.0.1:5984/_all_dbs || [ $WAIT_TIME -eq 180 ]; do echo "..."; sleep 5; WAIT_TIME=$(expr $WAIT_TIME + 5); done
-        - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 26 ]; then exit 1; fi
+        - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 27 ]; then exit 1; fi
         - ng e2e
     - stage: docker-release
       <<: *_prepare_deploy

--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -122,6 +122,7 @@ curl -X PUT $COUCHURL/child_users
 curl -X PUT $COUCHURL/replicator_users
 curl -X PUT $COUCHURL/admin_activities
 curl -X PUT $COUCHURL/child_statistics
+curl -X PUT $COUCHURL/tags
 
 # Create design documents
 node ./design/create-design-docs.js

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -64,7 +64,7 @@
           </h3>
           <td-markdown class="content" [content]="element.description"></td-markdown>
           <mat-chip-list #tagsList class="tags-list">
-            <mat-chip *ngFor="let tag of element.tags" (click)="addTag(tag)">
+            <mat-chip *ngFor="let tag of element.tagNames" (click)="addTag(tag)">
               {{tag}}
             </mat-chip>
           </mat-chip-list>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -110,7 +110,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
           return sortNumberOrString(item, property);
       }
     };
-
+    this.stateService.requestData('tags', this.parent ? 'parent' : 'local');
     this.userService.shelfChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe((shelf: any) => {
         this.resources.data = this.setupList(this.resources.data, shelf.resourceIds);

--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -36,6 +36,7 @@ export class ResourcesService {
     });
     this.stateService.couchStateListener('tags').subscribe(response => {
       if (response !== undefined) {
+        this.tags[response.planetField] = response.newData;
         this.setTags(this.resources[response.planetField], response.newData, response.planetField);
       }
     });
@@ -64,7 +65,7 @@ export class ResourcesService {
   setTags(resources, tags, planetField) {
     this.resources[planetField] = resources.map((resource: any) => resource.tags === undefined ? resource : ({
       ...resource,
-      tags: resource.tags.map(tag => {
+      tagNames: resource.tags.map(tag => {
         const tagInfo = tags.find((t: any) => t._id === tag);
         return tagInfo ? tagInfo.name : tag;
       })

--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -5,6 +5,7 @@ import { RatingService } from '../shared/forms/rating.service';
 import { UserService } from '../shared/user.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { StateService } from '../shared/state.service';
+import { TagsService } from '../shared/forms/tags.service';
 
 @Injectable()
 export class ResourcesService {
@@ -19,7 +20,8 @@ export class ResourcesService {
     private ratingService: RatingService,
     private userService: UserService,
     private planetMessageService: PlanetMessageService,
-    private stateService: StateService
+    private stateService: StateService,
+    private tagsService: TagsService
   ) {
     this.ratingService.ratingsUpdated$.subscribe((res: any) => {
       const planetField = res.parent ? 'parent' : 'local';
@@ -65,10 +67,7 @@ export class ResourcesService {
   setTags(resources, tags, planetField) {
     this.resources[planetField] = resources.map((resource: any) => resource.tags === undefined ? resource : ({
       ...resource,
-      tagNames: resource.tags.map(tag => {
-        const tagInfo = tags.find((t: any) => t._id === tag);
-        return tagInfo ? tagInfo.name : tag;
-      })
+      tagNames: resource.tags.map(tag => this.tagsService.findTag(tag, tags).name)
     }));
   }
 

--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -69,6 +69,7 @@ export class ResourcesService {
       ...resource,
       tagNames: resource.tags.map(tag => this.tagsService.findTag(tag, tags).name)
     }));
+    this.resourcesUpdated.next(this.resources);
   }
 
   getRatings(resourceIds: string[], opts: any) {

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -3,7 +3,7 @@
     <input matInput i18n-placeholder placeholder="Filter Labels" [ngModel]="filterValue" (ngModelChange)="updateFilter($event)">
   </mat-form-field>
   <mat-slide-toggle i18n [(ngModel)]="selectMany" class="margin-lr-5" *ngIf="mode==='filter'">Select Many Labels</mat-slide-toggle>
-  <mat-expansion-panel>
+  <mat-expansion-panel *ngIf="mode==='add'">
     <mat-expansion-panel-header>
       <mat-panel-title i18n>Create New Label</mat-panel-title>
     </mat-expansion-panel-header>
@@ -12,7 +12,7 @@
         <input matInput i18n-placeholder placeholder="Label" formControlName="name">
       </mat-form-field>
       <mat-form-field>
-        <mat-select i18n-placeholder placeholder="Sublevel of..." formControlName="parents" multiple>
+        <mat-select i18n-placeholder placeholder="Sublevel of..." formControlName="attachedTo" multiple>
           <mat-option value="Mathematics">Mathematics</mat-option>
           <mat-option>Early Education</mat-option>
         </mat-select>
@@ -21,10 +21,10 @@
     </form>
   </mat-expansion-panel>
   <mat-selection-list (selectionChange)="tagChange($event.option)" *ngIf="selectMany">
-    <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.key)" [value]="tag.key">{{tag.key + ' (' + tag.value + ')'}}</mat-list-option>
+    <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.name)" [value]="tag.name">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
   </mat-selection-list>
   <mat-nav-list *ngIf="!selectMany">
-    <a mat-list-item *ngFor="let tag of tags" (click)="selectOne(tag.key)" mat-dialog-close>{{tag.key + ' (' + tag.value + ')'}}</a>
+    <a mat-list-item *ngFor="let tag of tags" (click)="selectOne(tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>
   </mat-nav-list>
 </mat-dialog-content>
 <mat-dialog-actions *ngIf="selectMany">

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -13,9 +13,8 @@
         <mat-error><planet-form-error-messages [control]="addTagForm.controls.name"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
-        <mat-select i18n-placeholder placeholder="Sublevel of..." formControlName="attachedTo" multiple>
-          <mat-option value="Mathematics">Mathematics</mat-option>
-          <mat-option>Early Education</mat-option>
+        <mat-select i18n-placeholder placeholder="Sublabel of..." formControlName="attachedTo" multiple>
+          <mat-option *ngFor="let tag of tags" value="tag._id || tag.name">{{tag.name}}</mat-option>
         </mat-select>
       </mat-form-field>
       <span><button type="submit" i18n mat-raised-button color="primary">Add Label</button></span>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -21,10 +21,10 @@
     </form>
   </mat-expansion-panel>
   <mat-selection-list (selectionChange)="tagChange($event.option)" *ngIf="selectMany">
-    <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.name)" [value]="tag._id || tag.name">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
+    <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag._id || tag.name)" [value]="tag._id || tag.name">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
   </mat-selection-list>
   <mat-nav-list *ngIf="!selectMany">
-    <a mat-list-item *ngFor="let tag of tags" (click)="selectOne(tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>
+    <a mat-list-item *ngFor="let tag of tags" (click)="selectOne(tag._id || tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>
   </mat-nav-list>
 </mat-dialog-content>
 <mat-dialog-actions *ngIf="selectMany">

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -22,7 +22,7 @@
     </form>
   </mat-expansion-panel>
   <mat-selection-list (selectionChange)="tagChange($event.option)" *ngIf="selectMany">
-    <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.name)" [value]="tag.name">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
+    <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.name)" [value]="tag._id || tag.name">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
   </mat-selection-list>
   <mat-nav-list *ngIf="!selectMany">
     <a mat-list-item *ngFor="let tag of tags" (click)="selectOne(tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -7,15 +7,18 @@
     <mat-expansion-panel-header>
       <mat-panel-title i18n>Create New Label</mat-panel-title>
     </mat-expansion-panel-header>
-    <mat-form-field>
-      <input matInput placeholder="Label">
-    </mat-form-field>
-    <mat-form-field>
-      <mat-select placeholder="Attached to...">
-        <mat-option>Mathematics</mat-option>
-        <mat-option>Early Education</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <form class="form-spacing" (ngSubmit)="addLabel()" [formGroup]="addTagForm">
+      <mat-form-field>
+        <input matInput i18n-placeholder placeholder="Label" formControlName="name">
+      </mat-form-field>
+      <mat-form-field>
+        <mat-select i18n-placeholder placeholder="Sublevel of..." formControlName="parents" multiple>
+          <mat-option value="Mathematics">Mathematics</mat-option>
+          <mat-option>Early Education</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <span><button type="submit" i18n mat-raised-button color="primary">Add Label</button></span>
+    </form>
   </mat-expansion-panel>
   <mat-selection-list (selectionChange)="tagChange($event.option)" *ngIf="selectMany">
     <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.key)" [value]="tag.key">{{tag.key + ' (' + tag.value + ')'}}</mat-list-option>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -9,7 +9,8 @@
     </mat-expansion-panel-header>
     <form class="form-spacing" (ngSubmit)="addLabel()" [formGroup]="addTagForm">
       <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Label" formControlName="name">
+        <input matInput i18n-placeholder placeholder="Label" formControlName="name" required>
+        <mat-error><planet-form-error-messages [control]="addTagForm.controls.name"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
         <mat-select i18n-placeholder placeholder="Sublevel of..." formControlName="attachedTo" multiple>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -14,7 +14,7 @@
       </mat-form-field>
       <mat-form-field>
         <mat-select i18n-placeholder placeholder="Sublabel of..." formControlName="attachedTo" multiple>
-          <mat-option *ngFor="let tag of tags" value="tag._id || tag.name">{{tag.name}}</mat-option>
+          <mat-option *ngFor="let tag of tags" [value]="tag._id || tag.name">{{tag.name}}</mat-option>
         </mat-select>
       </mat-form-field>
       <span><button type="submit" i18n mat-raised-button color="primary">Add Label</button></span>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -3,6 +3,20 @@
     <input matInput i18n-placeholder placeholder="Filter Labels" [ngModel]="filterValue" (ngModelChange)="updateFilter($event)">
   </mat-form-field>
   <mat-slide-toggle i18n [(ngModel)]="selectMany" class="margin-lr-5" *ngIf="mode==='filter'">Select Many Labels</mat-slide-toggle>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title i18n>Create New Label</mat-panel-title>
+    </mat-expansion-panel-header>
+    <mat-form-field>
+      <input matInput placeholder="Label">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-select placeholder="Attached to...">
+        <mat-option>Mathematics</mat-option>
+        <mat-option>Early Education</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </mat-expansion-panel>
   <mat-selection-list (selectionChange)="tagChange($event.option)" *ngIf="selectMany">
     <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag.key)" [value]="tag.key">{{tag.key + ' (' + tag.value + ')'}}</mat-list-option>
   </mat-selection-list>

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -1,7 +1,7 @@
 import {
   Component, Input, Optional, Self, OnInit, OnDestroy, HostBinding, EventEmitter, Output, ElementRef, Inject
 } from '@angular/core';
-import { ControlValueAccessor, NgControl, FormControl } from '@angular/forms';
+import { ControlValueAccessor, NgControl, FormControl, FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { MatFormFieldControl, MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { Subject } from 'rxjs';
@@ -17,11 +17,13 @@ export class PlanetTagInputDialogComponent {
   filterValue = '';
   mode = 'filter';
   selectMany = false;
+  addTagForm: FormGroup;
 
   constructor(
     public dialogRef: MatDialogRef<PlanetTagInputDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any,
-    private tagsService: TagsService
+    private tagsService: TagsService,
+    private fb: FormBuilder
   ) {
     this.tags = this.data.tags;
     this.mode = this.data.mode;
@@ -29,6 +31,10 @@ export class PlanetTagInputDialogComponent {
     this.data.startingTags
       .filter((tag: string) => tag)
       .forEach(tag => this.tagChange({ value: tag, selected: true }));
+    this.addTagForm = this.fb.group({
+      name: [ '', Validators.required ],
+      parents: [ [] ]
+    });
   }
 
   tagChange(option) {
@@ -48,6 +54,10 @@ export class PlanetTagInputDialogComponent {
   selectOne(tag) {
     this.data.tagUpdate(tag, true, true);
     this.dialogRef.close();
+  }
+
+  addLabel() {
+    console.log(this.addTagForm.value);
   }
 
 }

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -165,7 +165,8 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
 
   writeValue(tags) {
     this.value = tags;
-    this.tooltipLabels = tags.join(', ');
+    const tagsNames = tags.map((tag: any) => this.tagsService.findTag(tag, this.tags).name);
+    this.tooltipLabels = tagsNames.join(', ');
   }
 
   registerOnChange(fn: (_: any) => void) {

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -61,11 +61,17 @@ export class PlanetTagInputDialogComponent {
   }
 
   addLabel() {
-    this.tagsService.newTag(this.addTagForm.value).subscribe(() => {
-      this.planetMessageService.showMessage('New label added');
-      this.data.initTags();
-      this.dialogRef.close();
-    });
+    if (this.addTagForm.valid) {
+      this.tagsService.newTag(this.addTagForm.value).subscribe(() => {
+        this.planetMessageService.showMessage('New label added');
+        this.data.initTags();
+        this.dialogRef.close();
+      });
+    } else {
+      Object.entries(this.addTagForm.controls).forEach(([ key, value ]) => {
+        value.markAsTouched({ onlySelf: true });
+      });
+    }
   }
 
 }

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -7,6 +7,7 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { Subject } from 'rxjs';
 import { TagsService } from './tags.service';
 import { PlanetMessageService } from '../planet-message.service';
+import { ValidatorService } from '../../validators/validator.service';
 
 @Component({
   'templateUrl': 'planet-tag-input-dialog.component.html'
@@ -25,7 +26,8 @@ export class PlanetTagInputDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: any,
     private tagsService: TagsService,
     private fb: FormBuilder,
-    private planetMessageService: PlanetMessageService
+    private planetMessageService: PlanetMessageService,
+    private validatorService: ValidatorService
   ) {
     this.tags = this.data.tags;
     this.mode = this.data.mode;
@@ -34,7 +36,7 @@ export class PlanetTagInputDialogComponent {
       .filter((tag: string) => tag)
       .forEach(tag => this.tagChange({ value: tag, selected: true }));
     this.addTagForm = this.fb.group({
-      name: [ '', Validators.required ],
+      name: [ '', Validators.required, ac => this.validatorService.isUnique$('tags', 'name', ac) ],
       attachedTo: [ [] ]
     });
   }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -19,14 +19,13 @@ export class TagsService {
       this.stateService.getCouchState('tags', parent ? 'parent' : 'local')
     ]).pipe(
       map(([ existingTags, dbTags ]: [ any, any ]) => {
-        const findDbTag = (tag: any) => {
-          const fullTag = dbTags.find((dbTag: any) => dbTag._id === tag.key);
-          return { count: tag.value, ...(fullTag ? fullTag : { name: tag.key }) };
-        };
         const unusedTags = dbTags.filter((dbTag: any) => {
           return existingTags.rows.find((tag: any) => tag.key === dbTag._id) === undefined
         });
-        return existingTags.rows.sort((a, b) => b.value - a.value).map((tag: any) => findDbTag(tag)).concat(unusedTags);
+        return existingTags.rows.sort((a, b) => b.value - a.value).map((tag: any) => ({
+          count: tag.value,
+          ...this.findTag(tag.key, dbTags)
+        })).concat(unusedTags);
       })
     );
   }
@@ -37,6 +36,11 @@ export class TagsService {
 
   newTag({ name, attachedTo }) {
     return this.couchService.post('tags', { name, attachedTo });
+  }
+
+  findTag(tagKey: any, fullTags: any[]) {
+    const fullTag = fullTags.find((dbTag: any) => dbTag._id === tagKey);
+    return { ...(fullTag ? fullTag : { name: tagKey }) };
   }
 
 }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -20,7 +20,7 @@ export class TagsService {
     ]).pipe(
       map(([ existingTags, dbTags ]: [ any, any ]) => {
         const unusedTags = dbTags.filter((dbTag: any) => {
-          return existingTags.rows.find((tag: any) => tag.key === dbTag._id) === undefined
+          return existingTags.rows.find((tag: any) => tag.key === dbTag._id) === undefined;
         });
         return existingTags.rows.sort((a, b) => b.value - a.value).map((tag: any) => ({
           count: tag.value,

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -16,15 +16,15 @@ export class TagsService {
     const opts = parent ? { domain: this.stateService.configuration.parentDomain } : {};
     return forkJoin([
       this.couchService.get('resources/_design/resources/_view/count_tags?group=true', opts),
-      this.couchService.findAll('tags', undefined, opts)
+      this.stateService.getCouchState('tags', parent ? 'parent' : 'local')
     ]).pipe(
       map(([ existingTags, dbTags ]: [ any, any ]) => {
         const findDbTag = (tag: any) => {
-          const fullTag = dbTags.find((dbTag: any) => dbTag.name === tag.key);
+          const fullTag = dbTags.find((dbTag: any) => dbTag._id === tag.key);
           return { count: tag.value, ...(fullTag ? fullTag : { name: tag.key }) };
         };
         const unusedTags = dbTags.filter((dbTag: any) => {
-          return existingTags.rows.find((tag: any) => tag.key === dbTag.name) === undefined
+          return existingTags.rows.find((tag: any) => tag.key === dbTag._id) === undefined
         });
         return existingTags.rows.sort((a, b) => b.value - a.value).map((tag: any) => findDbTag(tag)).concat(unusedTags);
       })

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CouchService } from '../couchdb.service';
+import { forkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { StateService } from '../state.service';
 
@@ -13,13 +14,29 @@ export class TagsService {
 
   getTags(parent: boolean) {
     const opts = parent ? { domain: this.stateService.configuration.parentDomain } : {};
-    return this.couchService.get('resources/_design/resources/_view/count_tags?group=true', opts).pipe(
-      map((response: any) => response.rows.sort((a, b) => b.value - a.value))
+    return forkJoin([
+      this.couchService.get('resources/_design/resources/_view/count_tags?group=true', opts),
+      this.couchService.findAll('tags', undefined, opts)
+    ]).pipe(
+      map(([ existingTags, dbTags ]: [ any, any ]) => {
+        const findDbTag = (tag: any) => {
+          const fullTag = dbTags.find((dbTag: any) => dbTag.name === tag.key);
+          return { count: tag.value, ...(fullTag ? fullTag : { name: tag.key }) };
+        };
+        const unusedTags = dbTags.filter((dbTag: any) => {
+          return existingTags.rows.find((tag: any) => tag.key === dbTag.name) === undefined
+        });
+        return existingTags.rows.sort((a, b) => b.value - a.value).map((tag: any) => findDbTag(tag)).concat(unusedTags);
+      })
     );
   }
 
   filterTags(tags: any[], filterString: string): string[] {
     return tags.filter((tag: any) => tag.key.toLowerCase().indexOf(filterString.toLowerCase()) > -1);
+  }
+
+  newTag({ name, attachedTo }) {
+    return this.couchService.post('tags', { name, attachedTo });
   }
 
 }


### PR DESCRIPTION
Allows adding new labels from the dialog in the resource page.

Please test to make sure you can create a label and assign it to resources.

Next TODOs:
- Adding a label which is a "sublabel" or attached to other labels doesn't do anything at this moment.  Need to show this in the filter view.
- Tags on the resource list show the id for a split second before changing to the text.  Need to find ways to improve this.
- A manager list view of labels where they can edit them after they have been created.