### PR TITLE
Fix label filter (fixes #2652)

### DIFF
--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -31,7 +31,7 @@ export class TagsService {
   }
 
   filterTags(tags: any[], filterString: string): string[] {
-    return tags.filter((tag: any) => tag.key.toLowerCase().indexOf(filterString.toLowerCase()) > -1);
+    return tags.filter((tag: any) => tag.name.toLowerCase().indexOf(filterString.toLowerCase()) > -1);
   }
 
   newTag({ name, attachedTo }) {


### PR DESCRIPTION
Had referenced the incorrect property of the tag object in the filtering function.

To test try typing into the "Filter labels" input and see if the label list is filtered.  Also there should not be errors in the console as you type.