### PR TITLE
Resources: Filter with sublabels

### DIFF
--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -24,7 +24,14 @@
     <mat-list-option *ngFor="let tag of tags" [selected]="isSelected(tag._id || tag.name)" [value]="tag._id || tag.name">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
   </mat-selection-list>
   <mat-nav-list *ngIf="!selectMany">
-    <a mat-list-item *ngFor="let tag of tags" (click)="selectOne(tag._id || tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>
+    <ng-container *ngFor="let tag of tags">
+      <a mat-list-item (click)="selectOne(tag._id || tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>
+      <a mat-list-item *ngFor="let subTag of tag.subTags" (click)="selectOne(tag._id || tag.name, subTag._id || subTag.name)" mat-dialog-close>
+        <mat-icon>subdirectory_arrow_right</mat-icon>
+        {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
+      </a>
+      <mat-divider></mat-divider>
+    </ng-container>
   </mat-nav-list>
 </mat-dialog-content>
 <mat-dialog-actions *ngIf="selectMany">

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -60,8 +60,11 @@ export class PlanetTagInputDialogComponent {
     this.tags = value ? this.tagsService.filterTags(this.data.tags, value) : this.data.tags;
   }
 
-  selectOne(tag) {
+  selectOne(tag, subTag?) {
     this.data.tagUpdate(tag, true, true);
+    if (subTag !== undefined) {
+      this.data.tagUpdate(subTag, true);
+    }
     this.dialogRef.close();
   }
 

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -25,7 +25,7 @@ export class TagsService {
         return existingTags.rows.sort((a, b) => b.value - a.value).map((tag: any) => ({
           count: tag.value,
           ...this.findTag(tag.key, dbTags)
-        })).concat(unusedTags);
+        })).concat(unusedTags).map(this.fillSubTags);
       })
     );
   }
@@ -40,7 +40,11 @@ export class TagsService {
 
   findTag(tagKey: any, fullTags: any[]) {
     const fullTag = fullTags.find((dbTag: any) => dbTag._id === tagKey);
-    return { ...(fullTag ? fullTag : { name: tagKey }) };
+    return { ...(fullTag ? fullTag : { _id: tagKey, name: tagKey, attachedTo: [] }) };
+  }
+
+  fillSubTags(tag: any, index: number, tags: any[]) {
+    return { ...tag, subTags: tags.filter(t => t.attachedTo.indexOf(tag._id) > -1) };
   }
 
 }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -31,7 +31,7 @@ export class TagsService {
   }
 
   filterTags(tags: any[], filterString: string): string[] {
-    return tags.filter((tag: any) => tag.key.toLowerCase().indexOf(filterString.toLowerCase()) > -1);
+    return tags.filter((tag: any) => tag.name.toLowerCase().indexOf(filterString.toLowerCase()) > -1);
   }
 
   newTag({ name, attachedTo }) {


### PR DESCRIPTION
To test: create a new label and select some values for "Sublabel of...".  Add this label & the parent label to one or many resources.  Back on the resource view click "Filter labels" and you will see a similar view to the below image.  Clicking on a label with an L arrow will filter by both that label and the parent above it.

Note there are still a few more steps for the labels which relate here
#2661 - Would allow us to attach already created labels to new labels
#2662 - Right now if the label & sublabel have no matching resources you could click the sublabel and see no resources