### PR TITLE
Fix login_activities data (fixes #2814)

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -81,10 +81,16 @@ export class CouchService {
   }
 
   updateDocument(db: string, doc: any, opts?: any) {
-    return this.currentTime().pipe(switchMap((date) => {
-      const docWithDate = this.fillInDateFields(doc, date);
-      return this.post(db, docWithDate, opts);
-    }));
+    let docWithDate: any;
+    return this.currentTime().pipe(
+      switchMap((date) => {
+        docWithDate = this.fillInDateFields(doc, date);
+        return this.post(db, docWithDate, opts);
+      }),
+      map((res: any) => {
+        return ({ ...res, doc: { ...docWithDate, _rev: res.rev, _id: res.id } });
+      })
+    );
   }
 
   localComparison(db: string, parentDocs: any[]) {


### PR DESCRIPTION
Fixes loginTime being overwritten on logout and makes sure to create a new document on the `login_activites` database every login.

To test: Clear your `login_activities` database (except for the document with id starting with `_design`).  Then in the app login, logout, and login again.  You should now have 2 new documents one with `logoutTime` > `loginTime` and another with a positive `loginTime` and `logoutTime` set to 0.

#2814 