### PR TITLE
Fix adding new message to feedback (fixes #2790)

### DIFF
--- a/src/app/feedback/feedback-view.component.ts
+++ b/src/app/feedback/feedback-view.component.ts
@@ -71,7 +71,7 @@ export class FeedbackViewComponent implements OnInit, OnDestroy {
       this.feedback.messages,
       { message: this.newMessage, user: this.user.name, time: this.couchService.datePlaceholder }
     );
-    this.couchService.updateDocument(this.dbName + '/' + this.feedback._id, newFeedback)
+    this.couchService.updateDocument(this.dbName, newFeedback)
       .pipe(switchMap((res) => {
         this.newMessage = '';
         return this.getFeedback(res.id);


### PR DESCRIPTION
New messages can be added to feedback conversations without error now.

#2790 