### PR TITLE
Edit label in dialog (connects #2869)

### DIFF
--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -10,7 +10,7 @@
 
       <!-- selectbox -->
       <mat-form-field *ngIf="field.type === 'selectbox'" class="full-width">
-        <mat-select placeholder="{{field.placeholder}}" formControlName="{{field.name}}" required="{{field.required}}">
+        <mat-select placeholder="{{field.placeholder}}" formControlName="{{field.name}}" required="{{field.required}}" [multiple]="field.multiple">
           <mat-option *ngFor="let option of field.options" [value]="option.value">{{option.name}}</mat-option>
         </mat-select>
         <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -22,19 +22,33 @@
   </mat-expansion-panel>
   <mat-selection-list (selectionChange)="tagChange($event.option)" *ngIf="selectMany">
     <ng-container *ngFor="let tag of tags">
-      <mat-list-option [selected]="isSelected(tag._id || tag.name)" [value]="[ tag._id || tag.name ]">{{tag.name + ' (' + (tag.count || 0) + ')'}}</mat-list-option>
+      <mat-list-option [selected]="isSelected(tag._id || tag.name)" [value]="[ tag._id || tag.name ]">
+        <span>
+          {{tag.name + ' (' + (tag.count || 0) + ')'}}
+          <button mat-stroked-button (click)="editTagClick($event,tag)" class="margin-lr-5">Edit</button>
+        </span>
+      </mat-list-option>
       <mat-list-option *ngFor="let subTag of tag.subTags" [value]="[ subTag._id || subTag.name, tag._id || tag.name ]" [selected]="isSelected(subTag._id || subTag.name)">
         <mat-icon mat-list-icon>subdirectory_arrow_right</mat-icon>
-        {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
+        <span>
+          {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
+          <button mat-stroked-button (click)="editTagClick($event,tag)">Edit</button>
+        </span>
       </mat-list-option>
     </ng-container>
   </mat-selection-list>
   <mat-nav-list *ngIf="!selectMany">
     <ng-container *ngFor="let tag of tags">
-      <a mat-list-item (click)="selectOne(tag._id || tag.name)" mat-dialog-close>{{tag.name + ' (' + (tag.count || 0) + ')'}}</a>
+      <a mat-list-item (click)="selectOne(tag._id || tag.name)" mat-dialog-close>
+        {{tag.name + ' (' + (tag.count || 0) + ')'}}
+        <span class="toolbar-fill"></span>
+        <button mat-stroked-button (click)="editTagClick($event,tag)">Edit</button>
+      </a>
       <a mat-list-item *ngFor="let subTag of tag.subTags" (click)="selectOne(tag._id || tag.name, subTag._id || subTag.name)" mat-dialog-close>
         <mat-icon>subdirectory_arrow_right</mat-icon>
         {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
+        <span class="toolbar-fill"></span>
+        <button mat-stroked-button (click)="editTagClick($event,tag)">Edit</button>
       </a>
       <mat-divider></mat-divider>
     </ng-container>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -25,14 +25,14 @@
       <mat-list-option [selected]="isSelected(tag._id || tag.name)" [value]="[ tag._id || tag.name ]">
         <span>
           {{tag.name + ' (' + (tag.count || 0) + ')'}}
-          <button mat-stroked-button (click)="editTagClick($event,tag)" class="margin-lr-5">Edit</button>
+          <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)" class="margin-lr-5">Edit</button>
         </span>
       </mat-list-option>
       <mat-list-option *ngFor="let subTag of tag.subTags" [value]="[ subTag._id || subTag.name, tag._id || tag.name ]" [selected]="isSelected(subTag._id || subTag.name)">
         <mat-icon mat-list-icon>subdirectory_arrow_right</mat-icon>
         <span>
           {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
-          <button mat-stroked-button (click)="editTagClick($event,tag)">Edit</button>
+          <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)">Edit</button>
         </span>
       </mat-list-option>
     </ng-container>
@@ -42,13 +42,13 @@
       <a mat-list-item (click)="selectOne(tag._id || tag.name)" mat-dialog-close>
         {{tag.name + ' (' + (tag.count || 0) + ')'}}
         <span class="toolbar-fill"></span>
-        <button mat-stroked-button (click)="editTagClick($event,tag)">Edit</button>
+        <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)">Edit</button>
       </a>
       <a mat-list-item *ngFor="let subTag of tag.subTags" (click)="selectOne(tag._id || tag.name, subTag._id || subTag.name)" mat-dialog-close>
         <mat-icon>subdirectory_arrow_right</mat-icon>
         {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
         <span class="toolbar-fill"></span>
-        <button mat-stroked-button (click)="editTagClick($event,tag)">Edit</button>
+        <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)">Edit</button>
       </a>
       <mat-divider></mat-divider>
     </ng-container>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -6,6 +6,7 @@ import { switchMap } from 'rxjs/operators';
 import { PlanetMessageService } from '../planet-message.service';
 import { ValidatorService } from '../../validators/validator.service';
 import { DialogsFormService } from '../dialogs/dialogs-form.service';
+import { UserService } from '../user.service';
 
 @Component({
   'templateUrl': 'planet-tag-input-dialog.component.html'
@@ -26,6 +27,7 @@ export class PlanetTagInputDialogComponent {
   }
   addTagForm: FormGroup;
   newTagId: string;
+  isUserAdmin = false;
 
   constructor(
     public dialogRef: MatDialogRef<PlanetTagInputDialogComponent>,
@@ -34,7 +36,8 @@ export class PlanetTagInputDialogComponent {
     private fb: FormBuilder,
     private planetMessageService: PlanetMessageService,
     private validatorService: ValidatorService,
-    private dialogsFormService: DialogsFormService
+    private dialogsFormService: DialogsFormService,
+    private userService: UserService
   ) {
     this.dataInit();
     this.selectMany = this.mode === 'add' || this.data.initSelectMany;
@@ -45,6 +48,7 @@ export class PlanetTagInputDialogComponent {
       name: [ '', Validators.required, ac => this.validatorService.isUnique$('tags', 'name', ac) ],
       attachedTo: [ [] ]
     });
+    this.isUserAdmin = this.userService.get().isUserAdmin;
   }
 
   dataInit() {
@@ -114,7 +118,6 @@ export class PlanetTagInputDialogComponent {
       this.planetMessageService.showMessage('Label updated');
       this.data.initTags();
     });
-
   }
 
   tagForm(tag: any = {}) {

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -2,8 +2,10 @@ import { Component, Inject } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { TagsService } from './tags.service';
+import { switchMap } from 'rxjs/operators';
 import { PlanetMessageService } from '../planet-message.service';
 import { ValidatorService } from '../../validators/validator.service';
+import { DialogsFormService } from '../dialogs/dialogs-form.service';
 
 @Component({
   'templateUrl': 'planet-tag-input-dialog.component.html'
@@ -31,7 +33,8 @@ export class PlanetTagInputDialogComponent {
     private tagsService: TagsService,
     private fb: FormBuilder,
     private planetMessageService: PlanetMessageService,
-    private validatorService: ValidatorService
+    private validatorService: ValidatorService,
+    private dialogsFormService: DialogsFormService
   ) {
     this.dataInit();
     this.selectMany = this.mode === 'add' || this.data.initSelectMany;
@@ -87,7 +90,7 @@ export class PlanetTagInputDialogComponent {
   addLabel() {
     const onAllFormControls = (func: any) => Object.entries(this.addTagForm.controls).forEach(func);
     if (this.addTagForm.valid) {
-      this.tagsService.newTag(this.addTagForm.value).subscribe((res) => {
+      this.tagsService.updateTag(this.addTagForm.value).subscribe((res) => {
         this.newTagId = res.id;
         this.planetMessageService.showMessage('New label added');
         onAllFormControls(([ key, value ]) => value.updateValueAndValidity());
@@ -99,6 +102,30 @@ export class PlanetTagInputDialogComponent {
     } else {
       onAllFormControls(([ key, value ]) => value.markAsTouched({ onlySelf: true }));
     }
+  }
+
+  editTagClick(event, tag) {
+    event.stopPropagation();
+    const options = this.tags.map((t: any) => ({ name: t.name, value: t._id || t.name })).filter((t: any) => t.name !== tag.name);
+    this.dialogsFormService.confirm('Edit tag', [
+      { placeholder: 'Name', name: 'name', required: true, type: 'textbox' },
+      { placeholder: 'Sublabel of...', name: 'attachedTo', type: 'selectbox', options, required: false, multiple: true }
+    ], this.tagForm(tag), false).pipe(switchMap((newTag: any) => this.tagsService.updateTag({ ...tag, ...newTag }))).subscribe(() => {
+      this.planetMessageService.showMessage('Label updated');
+      this.data.initTags();
+    });
+
+  }
+
+  tagForm(tag: any = {}) {
+    return this.fb.group({
+      name: [
+        tag.name || '',
+        Validators.required,
+        ac => this.validatorService.isUnique$('tags', 'name', ac, { exceptions: [ tag.name ] })
+      ],
+      attachedTo: [ tag.attachedTo || [] ]
+    });
   }
 
 }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -41,8 +41,8 @@ export class TagsService {
     return (tag: any) => (checkSubTags && tag.subTags.length > 0) || tag.name.toLowerCase().indexOf(filterString.toLowerCase()) > -1;
   }
 
-  newTag({ name, attachedTo }) {
-    return this.couchService.post('tags', { name, attachedTo });
+  updateTag(tag) {
+    return this.couchService.post('tags', tag);
   }
 
   findTag(tagKey: any, fullTags: any[]) {


### PR DESCRIPTION
Initial part of #2869.  Currently editing a label is restricted to admins, but I think we can make a change later to allow the creator of the label to edit it.

I think a management page to delete labels in the manager dashboard could be another next step.  Since that is not a trivial task for the DB (each resource with that label will need to be updated), deletion should be restricted to admins only.