### PR TITLE
Fix add label changing selected labels (fixes #2813)

### DIFF
--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -37,7 +37,7 @@ export class PlanetTagInputDialogComponent {
     this.selectMany = this.mode === 'add' || this.data.initSelectMany;
     this.data.startingTags
       .filter((tag: string) => tag)
-      .forEach(tag => this.tagChange({ value: [ tag ], selected: true }, !this.data.initSelectMany));
+      .forEach(tag => this.tagChange({ value: [ tag ], selected: true }, !this.selectMany));
     this.addTagForm = this.fb.group({
       name: [ '', Validators.required, ac => this.validatorService.isUnique$('tags', 'name', ac) ],
       attachedTo: [ [] ]


### PR DESCRIPTION
To test create/modify a resource to have many labels.  Try to edit the resource again and click "Add Labels", but don't change any.  The selected labels in the "Hover" list should still match what was previously selected.

To see the difference, do the same with the master branch.  You should see the error where only one label is selected after clicking "Add Labels".

#2813