### PR TITLE
Refactor DialogsForm (fixes #1527)

### DIFF
--- a/src/app/shared/dialogs/change-password.directive.ts
+++ b/src/app/shared/dialogs/change-password.directive.ts
@@ -91,8 +91,8 @@ export class ChangePasswordDirective {
       } else {
         this.planetMessageService.showAlert(errors.map(e => e.reason).join(' & '));
       }
-    }, (error) => {
-      if (error.reason === 'Name or password is incorrect.') {
+    }, (err) => {
+      if (err.error.reason === 'Name or password is incorrect.') {
         this.dialogsFormService.showErrorMessage('Old password isn\'t valid');
       }
       this.planetMessageService.showAlert('Error changing password');
@@ -119,7 +119,7 @@ export class ChangePasswordDirective {
 
   passwordError(reason: string) {
     return () => {
-      return of({ ok: false, reason: reason });
+      return of({ error: { ok: false, reason: reason } });
     };
   }
 

--- a/src/app/shared/dialogs/change-password.directive.ts
+++ b/src/app/shared/dialogs/change-password.directive.ts
@@ -92,6 +92,9 @@ export class ChangePasswordDirective {
         this.planetMessageService.showAlert(errors.map(e => e.reason).join(' & '));
       }
     }, (error) => {
+      if (error.reason === 'Name or password is incorrect.') {
+        this.dialogsFormService.showErrorMessage('Old password isn\'t valid');
+      }
       this.planetMessageService.showAlert('Error changing password');
     });
   }

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -50,6 +50,7 @@
     </div>
   </mat-dialog-content>
   <mat-dialog-actions>
+    <span i18n class="mat-caption warn-text-color margin-lr-8">{{errorMessage}}</span>
     <button type="submit" [planetSubmit]="modalForm.valid && isSpinnerOk" color="primary" mat-raised-button i18n>Submit</button>
     <button color="warn" type="button" mat-raised-button (click)="dialogRef.close()" i18n>Cancel</button>
   </mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -50,7 +50,7 @@
     </div>
   </mat-dialog-content>
   <mat-dialog-actions>
-    <button type="submit" [planetSubmit]="modalForm.valid" color="primary" mat-raised-button i18n>Submit</button>
+    <button type="submit" [planetSubmit]="modalForm.valid && isSpinnerOk" color="primary" mat-raised-button i18n>Submit</button>
     <button color="warn" type="button" mat-raised-button (click)="dialogRef.close()" i18n>Cancel</button>
   </mat-dialog-actions>
 </form>

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef } from '@angular/material';
-import { FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { FormGroup, FormBuilder } from '@angular/forms';
+import { DialogsLoadingService } from './dialogs-loading.service';
 
 @Component({
   templateUrl: './dialogs-form.component.html'
@@ -11,6 +12,7 @@ export class DialogsFormComponent {
   public fields: any;
   public modalForm: any;
   passwordVisibility = new Map();
+  isSpinnerOk = true;
 
   private markFormAsTouched (formGroup: FormGroup) {
     (<any>Object).values(formGroup.controls).forEach(control => {
@@ -21,13 +23,30 @@ export class DialogsFormComponent {
     });
   }
 
-  constructor(public dialogRef: MatDialogRef<DialogsFormComponent>) { }
+  constructor(
+    public dialogRef: MatDialogRef<DialogsFormComponent>,
+    private fb: FormBuilder,
+    @Inject(MAT_DIALOG_DATA) public data,
+    private dialogsLoadingService: DialogsLoadingService
+  ) {
+    if (this.data.formGroup) {
+      this.modalForm = this.data.formGroup instanceof FormGroup ? this.data.formGroup : this.fb.group(this.data.formGroup);
+      this.title = this.data.title;
+      this.fields = this.data.fields;
+      this.isSpinnerOk = false;
+    }
+  }
 
   onSubmit(mForm, dialog) {
-    if (mForm.valid) {
-      dialog.close(mForm.value);
-    } else {
+    if (!mForm.valid) {
       this.markFormAsTouched(mForm);
+      return;
+    }
+    this.dialogsLoadingService.start();
+    if (this.data.onSubmit) {
+      this.data.onSubmit(mForm.value);
+    } else {
+      dialog.close(mForm.value);
     }
   }
 

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -13,6 +13,7 @@ export class DialogsFormComponent {
   public modalForm: any;
   passwordVisibility = new Map();
   isSpinnerOk = true;
+  errorMessage = '';
 
   private markFormAsTouched (formGroup: FormGroup) {
     (<any>Object).values(formGroup.controls).forEach(control => {

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -31,10 +31,6 @@ export class DialogsFormComponent {
     }
   }
 
-  onRatingChange(fieldName: string) {
-    console.log(fieldName);
-  }
-
   togglePasswordVisibility(fieldName) {
     const visibility = this.passwordVisibility.get(fieldName) || false;
     this.passwordVisibility.set(fieldName, !visibility);

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -30,7 +30,7 @@ export class DialogsFormComponent {
     @Inject(MAT_DIALOG_DATA) public data,
     private dialogsLoadingService: DialogsLoadingService
   ) {
-    if (this.data.formGroup) {
+    if (this.data && this.data.formGroup) {
       this.modalForm = this.data.formGroup instanceof FormGroup ? this.data.formGroup : this.fb.group(this.data.formGroup);
       this.title = this.data.title;
       this.fields = this.data.fields;
@@ -43,8 +43,8 @@ export class DialogsFormComponent {
       this.markFormAsTouched(mForm);
       return;
     }
-    this.dialogsLoadingService.start();
-    if (this.data.onSubmit) {
+    if (this.data && this.data.onSubmit) {
+      this.dialogsLoadingService.start();
       this.data.onSubmit(mForm.value);
     } else {
       dialog.close(mForm.value);

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -42,4 +42,8 @@ export class DialogsFormService {
     this.dialogRef.close();
   }
 
+  showErrorMessage(errorMessage: string) {
+    this.dialogRef.componentInstance.errorMessage = errorMessage;
+  }
+
 }

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { DialogsFormComponent } from './dialogs-form.component';
-import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material';
+import { MatDialogRef, MatDialog } from '@angular/material';
 import { Injectable } from '@angular/core';
 import {
   FormBuilder,
@@ -9,6 +9,9 @@ import {
 
 @Injectable()
 export class DialogsFormService {
+
+  private dialogRef: MatDialogRef<DialogsFormComponent>;
+
   constructor(private dialog: MatDialog, private fb: FormBuilder) { }
 
   public confirm(title: string, fields: any, formGroup: any, autoFocus = false): Observable<boolean> {
@@ -25,6 +28,18 @@ export class DialogsFormService {
     dialogRef.componentInstance.title = title;
     dialogRef.componentInstance.fields = fields;
     return dialogRef.afterClosed();
+  }
+
+  openDialogsForm(title: string, fields: any[], formGroup: any, options: any) {
+    this.dialogRef = this.dialog.open(DialogsFormComponent, {
+      width: '600px',
+      autoFocus: options.autoFocus,
+      data: { title, formGroup, fields, ...options }
+    });
+  }
+
+  closeDialogsForm() {
+    this.dialogRef.close();
   }
 
 }


### PR DESCRIPTION
Changes DialogsForm so the dialog does not close automatically when the form is submitted.

This allows us to receive a response from the server before closing the form in case of errors.

Implemented for changing passwords so far, will need to implement for other forms as well.  Note the change password error requires #3042 so I will put this on hold.

#1527 