### PR TITLE
Fix fillSubTags error (fixes #3085)

### DIFF
--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -46,7 +46,7 @@ export class TagsService {
   }
 
   fillSubTags(tag: any, index: number, tags: any[]) {
-    return { ...tag, subTags: tags.filter(t => t.attachedTo.indexOf(tag._id) > -1) };
+    return { ...tag, subTags: tags.filter(({ attachedTo = [] }) => attachedTo.indexOf(tag._id) > -1) };
   }
 
 }


### PR DESCRIPTION
Gives `attachedTo` a default value of an empty array to prevent error.  I think it was caused by an older version of a document in the `tags` database, but it can't hurt to include this in case somehow documents get changed in a bad way.