### PR TITLE
Changing pswd on normal user message fixes (fixes #3091)

### DIFF
--- a/src/app/shared/dialogs/change-password.directive.ts
+++ b/src/app/shared/dialogs/change-password.directive.ts
@@ -104,7 +104,7 @@ export class ChangePasswordDirective {
       if (isUserAdmin) {
         return forkJoin([ of(res), this.updateAdminPassword(userData), this.updatePasswordOnParent(userData) ]);
       }
-      return of(res);
+      return of([ res ]);
     }));
   }
 


### PR DESCRIPTION
A normal user gets an error message on changing the password since an array is expected for the map(). 

Couldn't replicate the same error message as in the issue #3091