### PR TITLE
Show/hide beta features

### DIFF
--- a/src/app/configuration/configuration.component.html
+++ b/src/app/configuration/configuration.component.html
@@ -59,12 +59,17 @@
             <input matInput i18n-placeholder placeholder="Local URL" formControlName="localDomain" (keyup)="localDomainChange($event)">
           </mat-form-field>
           <mat-slide-toggle formControlName="autoAccept" i18n>Auto accept Members</mat-slide-toggle>
-          <mat-slide-toggle
-            formControlName="betaEnabled"
-            i18n
-            matTooltip="Beta features may not work as intended. It's recommended to leave this off">
-            Enable Beta features
-          </mat-slide-toggle>
+          <mat-form-field>
+            <mat-select
+              formControlName="betaEnabled"
+              i18n-placeholder
+              placeholder="Beta features"
+              matTooltip="Beta features may not work as intended. It's recommended to leave this off">
+              <mat-option value="off" i18n>Always off</mat-option>
+              <mat-option value="on" i18n>Always on</mat-option>
+              <mat-option value="user" i18n>User preferences</mat-option>
+            </mat-select>
+          </mat-form-field>
         </ng-container>
       </div>
     </form>

--- a/src/app/configuration/configuration.component.html
+++ b/src/app/configuration/configuration.component.html
@@ -59,6 +59,12 @@
             <input matInput i18n-placeholder placeholder="Local URL" formControlName="localDomain" (keyup)="localDomainChange($event)">
           </mat-form-field>
           <mat-slide-toggle formControlName="autoAccept" i18n>Auto accept Members</mat-slide-toggle>
+          <mat-slide-toggle
+            formControlName="betaEnabled"
+            i18n
+            matTooltip="Beta features may not work as intended. It's recommended to leave this off">
+            Enable Beta features
+          </mat-slide-toggle>
         </ng-container>
       </div>
     </form>

--- a/src/app/configuration/configuration.component.ts
+++ b/src/app/configuration/configuration.component.ts
@@ -105,7 +105,8 @@ export class ConfigurationComponent implements OnInit {
         this.parentUniqueValidator('code')
       ],
       createdDate: this.couchService.datePlaceholder,
-      autoAccept: true
+      autoAccept: true,
+      betaEnabled: false
     });
     this.contactFormGroup = this.formBuilder.group({
       firstName: [ '', CustomValidators.required ],

--- a/src/app/configuration/configuration.component.ts
+++ b/src/app/configuration/configuration.component.ts
@@ -106,7 +106,7 @@ export class ConfigurationComponent implements OnInit {
       ],
       createdDate: this.couchService.datePlaceholder,
       autoAccept: true,
-      betaEnabled: false
+      betaEnabled: 'off'
     });
     this.contactFormGroup = this.formBuilder.group({
       firstName: [ '', CustomValidators.required ],

--- a/src/app/shared/beta.directive.ts
+++ b/src/app/shared/beta.directive.ts
@@ -7,6 +7,8 @@ import { UserService } from './user.service';
 })
 export class PlanetBetaDirective implements OnInit {
 
+  configuration = this.stateService.configuration;
+
   constructor(
     private stateService: StateService,
     private userService: UserService,
@@ -15,7 +17,7 @@ export class PlanetBetaDirective implements OnInit {
   ) {}
 
   ngOnInit() {
-    if (this.userService.get().betaEnabled) {
+    if (this.configuration.betaEnabled === 'on' || this.configuration.betaEnabled === 'user' && this.userService.get().betaEnabled) {
       this.viewContainer.createEmbeddedView(this.templateRef);
     } else {
       this.viewContainer.clear();

--- a/src/app/shared/beta.directive.ts
+++ b/src/app/shared/beta.directive.ts
@@ -1,0 +1,23 @@
+import { Directive, TemplateRef, ViewContainerRef, OnInit } from '@angular/core';
+import { StateService } from './state.service';
+
+@Directive({
+  selector: '[planetBeta]'
+})
+export class PlanetBetaDirective implements OnInit {
+
+  constructor(
+    private stateService: StateService,
+    private templateRef: TemplateRef<any>,
+    private viewContainer: ViewContainerRef
+  ) {}
+
+  ngOnInit() {
+    if (this.stateService.configuration.betaEnabled) {
+      this.viewContainer.createEmbeddedView(this.templateRef);
+    } else {
+      this.viewContainer.clear();
+    }
+  }
+
+}

--- a/src/app/shared/beta.directive.ts
+++ b/src/app/shared/beta.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, TemplateRef, ViewContainerRef, OnInit } from '@angular/core';
 import { StateService } from './state.service';
+import { UserService } from './user.service';
 
 @Directive({
   selector: '[planetBeta]'
@@ -8,12 +9,13 @@ export class PlanetBetaDirective implements OnInit {
 
   constructor(
     private stateService: StateService,
+    private userService: UserService,
     private templateRef: TemplateRef<any>,
     private viewContainer: ViewContainerRef
   ) {}
 
   ngOnInit() {
-    if (this.stateService.configuration.betaEnabled) {
+    if (this.userService.get().betaEnabled) {
       this.viewContainer.createEmbeddedView(this.templateRef);
     } else {
       this.viewContainer.clear();

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -7,6 +7,7 @@ import { LowercaseDirective } from '../shared/lowercase.directive';
 import { PlanetLanguageComponent } from './planet-language.component';
 import { ResourcesMenuComponent } from '../resources/view-resources/resources-menu.component';
 import { AuthorizedRolesDirective } from './authorized-roles.directive';
+import { PlanetBetaDirective } from './beta.directive';
 
 @NgModule({
   imports: [
@@ -18,7 +19,8 @@ import { AuthorizedRolesDirective } from './authorized-roles.directive';
     PlanetLanguageComponent,
     ResourcesMenuComponent,
     LowercaseDirective,
-    AuthorizedRolesDirective
+    AuthorizedRolesDirective,
+    PlanetBetaDirective
   ],
   declarations: [
     PlanetLocalStatusComponent,
@@ -26,7 +28,8 @@ import { AuthorizedRolesDirective } from './authorized-roles.directive';
     PlanetLanguageComponent,
     ResourcesMenuComponent,
     LowercaseDirective,
-    AuthorizedRolesDirective
+    AuthorizedRolesDirective,
+    PlanetBetaDirective
   ]
 })
 export class SharedComponentsModule {}

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -66,6 +66,13 @@
               <mat-icon svgIcon="female" class="female-icon accent-text-color margin-lr-3"></mat-icon><span i18n>Female</span>
             </div>
           </mat-radio-button>
+          <mat-slide-toggle
+            *ngIf="!submissionMode"
+            formControlName="betaEnabled"
+            i18n
+            matTooltip="Beta features may not work as intended. It's recommended to leave this off">
+            Enable Beta features
+          </mat-slide-toggle>
           <mat-error><planet-form-error-messages [control]="editForm.controls.gender"></planet-form-error-messages></mat-error>
         </mat-radio-group>
         <div>

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -99,7 +99,8 @@ export class UsersUpdateComponent implements OnInit {
         ac => this.validatorService.notDateInFuture$(ac)
       ],
       gender: [ '', this.conditionalValidator(Validators.required).bind(this) ],
-      level: [ '', this.conditionalValidator(Validators.required).bind(this) ]
+      level: [ '', this.conditionalValidator(Validators.required).bind(this) ],
+      betaEnabled: false
     });
   }
 


### PR DESCRIPTION
Need to make sure that we fit this feature to our use cases.  From a discussion today we think:

1. Set toggle in configuration that allows members to turn on beta features.  Members would then have to change this in their profile.  This will allow us to have different accounts for demos that have features turned on or off depending on the audience.
2. Managers will always have the option to turn on beta features in their profile.  This will allow us to have beta features enabled on our own accounts in the field to show to tech geniuses.

Other options would be to just have beta broadly turned on/off based on the configuration or to allow each member decide regardless of the configuration.

On user profile:
![image](https://user-images.githubusercontent.com/9203229/52507734-6897ba00-2bc0-11e9-9225-b3744b11c26c.png)

On configuration:
![image](https://user-images.githubusercontent.com/9203229/52508060-4eaaa700-2bc1-11e9-90d7-ed347e5d9c26.png)

@lmmrssa Thoughts?  Currently this branch enables/disables on a per user basis if you want to check it out (you will need to set an HTML element as beta with `*planetBeta`).  Once we have a little more direction I can finish this up.