### PR TITLE
Fix missing doc causing no items in dashboard (fixes #3096)

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -115,7 +115,7 @@ export class CouchService {
     return this.post(db + '/_bulk_get', { docs }, opts).pipe(
       map((response: any) => response.results
         .map((result: any) => result.docs[0].ok)
-        .filter((doc: any) => doc._deleted !== true)
+        .filter((doc: any) => doc !== undefined && doc._deleted !== true)
       )
     );
   }


### PR DESCRIPTION
To test add some documents to the shelf and then modify the shelf document of one of your users to include a string which does not correspond to a document id in the database (`"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"` in the image below).  On master there will be no items on the dashboard, but on this branch they will appear.

![image](https://user-images.githubusercontent.com/9203229/52756436-560dee00-2fcf-11e9-9f26-57d08182b846.png)
