### PR TITLE
Achievements: Rearrange to include title & date (fixes #3232)

### DIFF
--- a/src/app/resources/view-resources/resources-menu.component.ts
+++ b/src/app/resources/view-resources/resources-menu.component.ts
@@ -6,7 +6,7 @@ import { MatMenuTrigger } from '@angular/material';
 @Component({
   selector: 'planet-resources-menu',
   template: `
-    <button mat-raised-button color="accent" class="margin-lr-10" [matMenuTriggerFor]="resourceList" (click)="buttonClick(resources)">
+    <button mat-raised-button [color]="color" class="margin-lr-10" [matMenuTriggerFor]="resourceList" (click)="buttonClick(resources)">
       <ng-content></ng-content>
     </button>
     <mat-menu #resourceList="matMenu">
@@ -17,6 +17,7 @@ import { MatMenuTrigger } from '@angular/material';
 export class ResourcesMenuComponent {
 
   @Input() resources: any[] = [];
+  @Input() color = 'accent';
   @ViewChild(MatMenuTrigger) resourceButton: MatMenuTrigger;
 
   constructor() {}

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -29,12 +29,13 @@
         <h3 i18n>My Achievements</h3>
         <td-markdown [content]="achievements.achievementsHeader"></td-markdown>
         <mat-list>
-          <mat-list-item class="mat-list-item-word-wrap" *ngFor="let achievement of achievements.achievements">
-            <mat-icon mat-list-icon>done_outline</mat-icon>
-            <p mat-line [ngClass]="{ 'no-attachment': !achievement.resources?.length }">
-              <span class="achievement-text">{{achievement.description || achievement}}</span>
-              <span class="achievement-button"><planet-resources-menu [resources]="achievement.resources" i18n>View Attachment</planet-resources-menu></span>
+          <mat-list-item class="mat-list-item-word-wrap cursor-pointer" *ngFor="let achievement of achievements.achievements; index as i" (click)="toggleOpenAchievementIndex(i)">
+            <p mat-line>
+              <span class="achievement-text">{{achievement.title || achievement}}</span>
+              <span class="achievement-date">{{achievement.date | date: medium}}</span>
             </p>
+            <p mat-line *ngIf="openAchievementIndex === i">{{achievement.description}}</p>
+            <span mat-line class="achievement-buttons" *ngIf="openAchievementIndex === i"><planet-resources-menu [resources]="achievement.resources" i18n>View Attachment</planet-resources-menu></span>
           </mat-list-item>
         </mat-list>
       </div>

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -30,12 +30,16 @@
         <td-markdown [content]="achievements.achievementsHeader"></td-markdown>
         <mat-list>
           <mat-list-item class="mat-list-item-word-wrap cursor-pointer" *ngFor="let achievement of achievements.achievements; index as i" (click)="toggleOpenAchievementIndex(i)">
-            <p mat-line>
+            <p class="achievement-header" mat-line>
               <span class="achievement-text">{{achievement.title || achievement}}</span>
               <span class="achievement-date">{{achievement.date | date: medium}}</span>
             </p>
             <p mat-line *ngIf="openAchievementIndex === i">{{achievement.description}}</p>
-            <span mat-line class="achievement-buttons" *ngIf="openAchievementIndex === i"><planet-resources-menu [resources]="achievement.resources" i18n>View Attachment</planet-resources-menu></span>
+            <span mat-line class="achievement-buttons" *ngIf="openAchievementIndex === i">
+              <ng-container *ngFor="let resource of achievement.resources">
+                <planet-resources-menu [resources]="[ resource ]" color="primary" (click)="$event.stopPropagation()">{{resource.title}}</planet-resources-menu>
+              </ng-container>
+            </span>
           </mat-list-item>
         </mat-list>
       </div>

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -19,6 +19,7 @@ export class UsersAchievementsComponent implements OnInit {
   achievementNotFound = false;
   ownAchievements = false;
   redirectUrl = '/';
+  openAchievementIndex = -1;
 
   constructor(
     private couchService: CouchService,
@@ -78,6 +79,10 @@ export class UsersAchievementsComponent implements OnInit {
 
   goBack() {
     this.router.navigate([ this.redirectUrl ]);
+  }
+
+  toggleOpenAchievementIndex(index) {
+    this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
   }
 
 }

--- a/src/app/users/users-achievements/users-achievements.scss
+++ b/src/app/users/users-achievements/users-achievements.scss
@@ -11,28 +11,25 @@
 
     &.mat-list-item-word-wrap {
       height: initial;
+      margin: 0.75rem 0;
     }
 
     .mat-line {
       word-wrap: break-word;
       white-space: pre-wrap;
       display: grid;
-      grid-template-areas: "txt btn";
-      grid-template-columns: auto min-content;
+      grid-template-areas: "txt dt";
+      grid-template-columns: auto max-content;
       align-items: center;
 
       .achievement-text {
         grid-area: txt;
       }
 
-      .achievement-button {
-        grid-area: btn;
-        margin: 0.25rem 0;
+      .achievement-date {
+        grid-area: dt;
       }
 
-      &.no-attachment {
-        grid-template-columns: auto 0;
-      }
     }
 
   }

--- a/src/app/users/users-achievements/users-achievements.scss
+++ b/src/app/users/users-achievements/users-achievements.scss
@@ -17,6 +17,9 @@
     .mat-line {
       word-wrap: break-word;
       white-space: pre-wrap;
+    }
+
+    .achievement-header {
       display: grid;
       grid-template-areas: "txt dt";
       grid-template-columns: auto max-content;
@@ -30,6 +33,14 @@
         grid-area: dt;
       }
 
+    }
+
+    .achievement-buttons button {
+      margin: 0.25rem 0.5rem 0.25rem 0;
+
+      &:last-child {
+        margin-right: 0;
+      }
     }
 
   }


### PR DESCRIPTION
#3232 editing the achievements view to include the new fields.

Click on an achievement to show description and a button for each resource.  Clicking again closes the achievement.  Only on achievement should be open at a time.