### PR TITLE
Fixing date.ValueToJson() bug in achievement-update (Fixes #3342)

### DIFF
--- a/src/app/users/users-achievements/users-achievements-update.component.ts
+++ b/src/app/users/users-achievements/users-achievements-update.component.ts
@@ -131,7 +131,7 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy {
         date: [ achievement.date, null, ac => this.validatorService.notDateInFuture$(ac) ]
       }),
       { onSubmit: (formValue, formGroup) => {
-        formGroup.controls.date.setValue(formGroup.controls.date.value && formGroup.controls.date.value.toJSON());
+        formGroup.controls.date.setValue(formGroup.controls.date.value);
         this.onDialogSubmit(this.achievements, index)(formValue, formGroup);
       }, closeOnSubmit: true }
     );


### PR DESCRIPTION
formGroup.controls.date.setValue() accepts an object that matches the structure of the group.

[https://angular.io/api/forms/FormGroup#setValue](https://angular.io/api/forms/FormGroup#setValue)