### PR TITLE
[#3410] Prevent joining old meetup

### DIFF
--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -84,12 +84,16 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   }
 
   joinMeetup() {
-    this.meetupService.attendMeetup(this.meetupDetail._id, this.meetupDetail.participate).subscribe((res) => {
-      const msg = res.participate ? 'left' : 'joined';
-      this.meetupDetail.participate = !res.participate;
-      this.planetMessageService.showMessage('You have ' + msg + ' meetup.');
-      this.fixEnrolledList(res.participate, this.userService.get().name);
-    });
+    if(this.meetupDetail.endDate > Date.now() || this.meetupDetail.participate) {
+      this.meetupService.attendMeetup(this.meetupDetail._id, this.meetupDetail.participate).subscribe((res) => {
+        const msg = res.participate ? 'left' : 'joined';
+        this.meetupDetail.participate = !res.participate;
+        this.planetMessageService.showMessage('You have ' + msg + ' meetup.');
+        this.fixEnrolledList(res.participate, this.userService.get().name);
+      });
+    } else {
+      this.planetMessageService.showMessage('You cannot join this meetup.');
+    }
   }
 
   openInviteMemberDialog() {

--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -84,7 +84,7 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   }
 
   joinMeetup() {
-    if(this.meetupDetail.endDate > Date.now() || this.meetupDetail.participate) {
+    if (this.meetupDetail.endDate > Date.now() || this.meetupDetail.participate) {
       this.meetupService.attendMeetup(this.meetupDetail._id, this.meetupDetail.participate).subscribe((res) => {
         const msg = res.participate ? 'left' : 'joined';
         this.meetupDetail.participate = !res.participate;


### PR DESCRIPTION
Partially fixes #3410 
I've modified joinMeetup() to ensure that user cannot join an old meetup. But this only works when the user tries to join from the meetups view page. If they try to join from the meetups page, where they can select multiple meetups and click on 'join selected', they are still able to join old meetups. I will modify meetupsToggle() to ensure that the user is prevented from joining. Or I will make the changes in ```meetups.component.html``` within ```[disabled]="selectedNotJoined === 0"``` if possible. I tried making these changes through attendMeetups() so that I would not have to make these changes in two separate functions, but that didn't seem to work. Any suggestions are helpful. 