### PR TITLE
[Fixes #3432] Add Edit Date To News Post

### DIFF
--- a/src/app/news/news.component.html
+++ b/src/app/news/news.component.html
@@ -24,7 +24,8 @@
                 item.user.name}}
             </a>
           </mat-card-title>
-          <mat-card-subtitle><ng-container i18n>wrote on</ng-container> {{item.time | date: medium }}</mat-card-subtitle>
+          <mat-card-subtitle><ng-container i18n>wrote on</ng-container> {{item.time | date: medium}}</mat-card-subtitle>
+          <mat-card-subtitle *ngIf="item.updateDate"><ng-container i18n>edited on</ng-container> {{item.updateDate | date: medium}}</mat-card-subtitle>
         </mat-card-header>
         <mat-card-content>
           <p>{{item.message}}</p>

--- a/src/app/news/news.component.ts
+++ b/src/app/news/news.component.ts
@@ -55,7 +55,7 @@ export class NewsComponent implements OnInit {
       createdOn: this.configuration.code,
       parentCode: this.configuration.parentCode,
       user: this.userService.get(),
-      viewableBy: 'community'
+      viewableBy: 'community',
     };
     this.postNews(news);
   }
@@ -106,6 +106,7 @@ export class NewsComponent implements OnInit {
     this.dialogsFormService.confirm(title, fields, formGroup)
       .subscribe((response: any) => {
         if (response !== undefined) {
+          news.updateDate = this.couchService.datePlaceholder;
           this.postNews({ ...news, ...response });
         }
       });


### PR DESCRIPTION
Fixes #3432 
Displays edit date 

![newsPostDates](https://user-images.githubusercontent.com/21087353/54717391-0cf90e80-4b26-11e9-9fdf-2d58a931a008.PNG)
