### PR TITLE
Additional resource filters

### DIFF
--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -71,7 +71,7 @@
     </ng-container>
   </mat-toolbar>
 
-  <div class="view-container view-full-height view-table" *ngIf="!emptyData; else notFoundMessage">
+  <div class="view-container view-full-height view-table" [ngClass]="{'view-with-search':showFilters==='on'}" *ngIf="!emptyData; else notFoundMessage">
     <mat-table #table [dataSource]="resources" matSort>
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -15,7 +15,7 @@
     <button mat-button i18n (click)="resetFilter()"><span>Reset</span></button>
   </mat-toolbar-row>
   <mat-toolbar-row class="search-bar" *ngIf="showFilters==='on'">
-    <planet-resources-search [filteredData]="resources.filteredData" (searchChange)="onSearchChange($event)"></planet-resources-search>
+    <planet-resources-search [filteredData]="resources.filteredData" [startingSelection]="searchSelection" (searchChange)="onSearchChange($event)"></planet-resources-search>
   </mat-toolbar-row>
 </mat-toolbar>
 

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -1,14 +1,39 @@
 <mat-toolbar>
-  <button mat-icon-button (click)="goBack()"><mat-icon>arrow_back</mat-icon></button>
-  <span i18n>Library</span>
-  <span class="toolbar-fill margin-lr-10"></span>
-  <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
-    <planet-tag-input [formControl]="tagFilter" [parent]="parent" [filteredData]="resources.filteredData"></planet-tag-input>
-  </mat-form-field>
-  <mat-form-field class="font-size-1 margin-lr-3">
-    <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">
-  </mat-form-field>
-  <button mat-button i18n (click)="resetFilter()"><span>Reset</span></button>
+  <mat-toolbar-row>
+    <button mat-icon-button (click)="goBack()"><mat-icon>arrow_back</mat-icon></button>
+    <span i18n>Library</span>
+    <span class="toolbar-fill margin-lr-10"></span>
+    <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
+      <planet-tag-input [formControl]="tagFilter" [parent]="parent" [filteredData]="resources.filteredData"></planet-tag-input>
+    </mat-form-field>
+    <mat-form-field class="font-size-1 margin-lr-3">
+      <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">
+    </mat-form-field>
+    <button mat-button i18n (click)="toggleFilters()">
+      { showFilters, select, on {Hide Filters} off {Show Filters} }
+    </button>
+    <button mat-button i18n (click)="resetFilter()"><span>Reset</span></button>
+  </mat-toolbar-row>
+  <mat-toolbar-row class="search-bar" *ngIf="showFilters==='on'">
+    <div>
+      <span class="mat-caption">Subject</span>
+      <mat-selection-list>
+        <mat-list-option *ngFor="let subject of constants.subjectList" [value]="subject">{{subject}}</mat-list-option>
+      </mat-selection-list>
+    </div>
+    <div>
+      <span class="mat-caption">Level</span>
+      <mat-selection-list>
+        <mat-list-option *ngFor="let level of constants.levelList" [value]="level">{{level}}</mat-list-option>
+      </mat-selection-list>
+    </div>
+    <div>
+      <span class="mat-caption">Medium</span>
+      <mat-selection-list>
+        <mat-list-option *ngFor="let medium of constants.media" [value]="medium">{{medium}}</mat-list-option>
+      </mat-selection-list>
+    </div>
+  </mat-toolbar-row>
 </mat-toolbar>
 
 <div class="space-container primary-link-hover">

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -15,24 +15,7 @@
     <button mat-button i18n (click)="resetFilter()"><span>Reset</span></button>
   </mat-toolbar-row>
   <mat-toolbar-row class="search-bar" *ngIf="showFilters==='on'">
-    <div>
-      <span class="mat-caption">Subject</span>
-      <mat-selection-list>
-        <mat-list-option *ngFor="let subject of constants.subjectList" [value]="subject">{{subject}}</mat-list-option>
-      </mat-selection-list>
-    </div>
-    <div>
-      <span class="mat-caption">Level</span>
-      <mat-selection-list>
-        <mat-list-option *ngFor="let level of constants.levelList" [value]="level">{{level}}</mat-list-option>
-      </mat-selection-list>
-    </div>
-    <div>
-      <span class="mat-caption">Medium</span>
-      <mat-selection-list>
-        <mat-list-option *ngFor="let medium of constants.media" [value]="medium">{{medium}}</mat-list-option>
-      </mat-selection-list>
-    </div>
+    <planet-resources-search [filteredData]="resources.filteredData"></planet-resources-search>
   </mat-toolbar-row>
 </mat-toolbar>
 

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -15,7 +15,7 @@
     <button mat-button i18n (click)="resetFilter()"><span>Reset</span></button>
   </mat-toolbar-row>
   <mat-toolbar-row class="search-bar" *ngIf="showFilters==='on'">
-    <planet-resources-search [filteredData]="resources.filteredData"></planet-resources-search>
+    <planet-resources-search [filteredData]="resources.filteredData" (searchChange)="onSearchChange($event)"></planet-resources-search>
   </mat-toolbar-row>
 </mat-toolbar>
 

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -20,7 +20,6 @@ import { DialogsListComponent } from '../shared/dialogs/dialogs-list.component';
 import { findByIdInArray } from '../shared/utils';
 import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
-import * as constants from './resources-constants';
 
 @Component({
   templateUrl: './resources.component.html',
@@ -58,7 +57,6 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   selectedNotAdded = 0;
   selectedAdded = 0;
   isAuthorized = false;
-  constants = constants;
   showFilters = 'off';
 
   @ViewChild(PlanetTagInputComponent)

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -20,25 +20,11 @@ import { DialogsListComponent } from '../shared/dialogs/dialogs-list.component';
 import { findByIdInArray } from '../shared/utils';
 import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
+import * as constants from './resources-constants';
 
 @Component({
   templateUrl: './resources.component.html',
-  styles: [ `
-    /* Column Widths */
-    .mat-column-select {
-      max-width: 44px;
-    }
-    .mat-column-tags {
-      max-width: 125px;
-    }
-    .mat-column-rating {
-      max-width: 225px;
-    }
-    .mat-progress-bar {
-      height: 10px;
-      width: 120px;
-    }
-  ` ]
+  styleUrls: [ './resources.scss' ]
 })
 export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   resources = new MatTableDataSource();
@@ -72,6 +58,8 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   selectedNotAdded = 0;
   selectedAdded = 0;
   isAuthorized = false;
+  constants = constants;
+  showFilters = 'off';
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;
@@ -312,6 +300,10 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     const { inShelf, notInShelf } = this.userService.countInShelf(selected, 'resourceIds');
     this.selectedAdded = inShelf;
     this.selectedNotAdded = notInShelf;
+  }
+
+  toggleFilters() {
+    this.showFilters = this.showFilters === 'off' ? 'on' : 'off';
   }
 
 }

--- a/src/app/resources/resources.module.ts
+++ b/src/app/resources/resources.module.ts
@@ -11,6 +11,7 @@ import { MaterialModule } from '../shared/material.module';
 import { HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
+import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search-resources/resources-search.component';
 
 @NgModule({
   imports: [
@@ -29,7 +30,9 @@ import { SharedComponentsModule } from '../shared/shared-components.module';
     ResourcesComponent,
     ResourcesViewComponent,
     ResourcesViewerComponent,
-    ResourcesAddComponent
+    ResourcesAddComponent,
+    ResourcesSearchComponent,
+    ResourcesSearchListComponent
   ],
   exports: [ ResourcesViewerComponent ]
 })

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -1,5 +1,8 @@
 @import '../variables';
 
+$toolbar-height: 25vh;
+$label-height: 1rem;
+
 /* Column Widths */
 .mat-column-select {
   max-width: 44px;
@@ -15,30 +18,8 @@
   width: 120px;
 }
 
-$toolbar-height: 25vh;
-$label-height: 1rem;
 .search-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
-  grid-template-rows: $toolbar-height;
   height: $toolbar-height;
-  grid-auto-flow: column;
-  align-items: start;
-  grid-column-gap: 0.75rem;
-  padding-bottom: 0.5rem;
-
-  &> div {
-    height: inherit;
-    display: grid;
-    grid-template-rows: $label-height calc(#{$toolbar-height} - #{$label-height});
-
-    .mat-selection-list {
-      height: calc(#{$toolbar-height} - #{$label-height});
-      padding: 0;
-      overflow-y: auto;
-    }
-  }
-
 }
 
 .view-full-height.view-with-search {

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -1,0 +1,40 @@
+/* Column Widths */
+.mat-column-select {
+  max-width: 44px;
+}
+.mat-column-tags {
+  max-width: 125px;
+}
+.mat-column-rating {
+  max-width: 225px;
+}
+.mat-progress-bar {
+  height: 10px;
+  width: 120px;
+}
+
+$toolbar-height: 25vh;
+$label-height: 1rem;
+.search-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
+  grid-template-rows: $toolbar-height;
+  height: $toolbar-height;
+  grid-auto-flow: column;
+  align-items: start;
+  grid-column-gap: 0.75rem;
+  padding-bottom: 0.5rem;
+
+  &> div {
+    height: inherit;
+    display: grid;
+    grid-template-rows: $label-height calc(#{$toolbar-height} - #{$label-height});
+
+    .mat-selection-list {
+      height: calc(#{$toolbar-height} - #{$label-height});
+      padding: 0;
+      overflow-y: auto;
+    }
+  }
+
+}

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -1,3 +1,5 @@
+@import '../variables';
+
 /* Column Widths */
 .mat-column-select {
   max-width: 44px;
@@ -37,4 +39,8 @@ $label-height: 1rem;
     }
   }
 
+}
+
+.view-full-height.view-with-search {
+  height: calc(#{$view-container-height} - #{$toolbar-height});
 }

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -76,6 +76,7 @@ export class ResourcesSearchListComponent {
 export class ResourcesSearchComponent implements OnInit, OnChanges {
 
   @Input() filteredData: any[];
+  @Input() startingSelection: any;
   @Output() searchChange = new EventEmitter<any>();
   @ViewChildren(ResourcesSearchListComponent) searchListComponents: QueryList<ResourcesSearchListComponent>;
 
@@ -86,7 +87,7 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
   constructor () {}
 
   ngOnInit() {
-    this.reset(true);
+    this.reset({ startingSelection: this.startingSelection, isInit: true });
   }
 
   ngOnChanges() {
@@ -95,8 +96,9 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
     }, []);
   }
 
-  reset(isInit = false) {
+  reset({ startingSelection = {}, isInit = false }) {
     this.selected = this.categories.reduce((select, category) => ({ ...select, [category]: [] }), {});
+    this.selected = { ...this.selected, ...startingSelection };
     if (!isInit) {
       this.searchListComponents.forEach((component) => component.reset());
     }

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -96,7 +96,7 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
     }, []);
   }
 
-  reset({ startingSelection = {}, isInit = false }) {
+  reset({ startingSelection = {}, isInit = false } = {}) {
     this.selected = this.categories.reduce((select, category) => ({ ...select, [category]: [] }), {});
     this.selected = { ...this.selected, ...startingSelection };
     if (!isInit) {

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input, ViewEncapsulation, OnChanges } from '@angular/core';
+import { dedupeShelfReduce } from '../../shared/utils';
+
+@Component({
+  template: `
+    <planet-resources-search-list *ngFor="let list of searchLists" [category]="list.category" [items]="list.items">
+    </planet-resources-search-list>
+  `,
+  styleUrls: [ './resources-search.scss' ],
+  selector: 'planet-resources-search',
+  encapsulation: ViewEncapsulation.None
+})
+export class ResourcesSearchComponent {
+
+  @Input() filteredData: any[];
+
+  categories = [ 'subject', 'languages', 'mediaType', 'level' ];
+  searchLists = [];
+
+  constructor () {}
+
+  ngOnChanges() {
+    this.searchLists = this.categories.reduce((lists, category) => {
+      return lists.concat(this.createSearchList(category, this.filteredData));
+    }, []);
+  }
+
+  createSearchList(category, data) {
+    return ({
+      category,
+      items: data.reduce((list, item) => list.concat(item[category]), []).reduce(dedupeShelfReduce, []).filter(item => item)
+    })
+  }
+
+}
+
+@Component({
+  template: `
+    <span class="mat-caption" i18n>{category, select,
+      subject {Subject}
+      languages {Language}
+      mediaType {Medium}
+      level {Level}
+    }
+    </span>
+    <mat-selection-list>
+      <mat-list-option *ngFor="let item of items" [value]="item">{{item}}</mat-list-option>
+    </mat-selection-list>
+  `,
+  selector: 'planet-resources-search-list',
+  styleUrls: [ './resources-search.scss' ],
+  encapsulation: ViewEncapsulation.None
+})
+export class ResourcesSearchListComponent {
+
+  @Input() category;
+  @Input() items;
+
+}

--- a/src/app/resources/search-resources/resources-search.scss
+++ b/src/app/resources/search-resources/resources-search.scss
@@ -1,0 +1,25 @@
+@import '../resources';
+
+planet-resources-search {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
+  grid-template-rows: $toolbar-height;
+  grid-auto-flow: column;
+  align-items: start;
+  grid-column-gap: 0.75rem;
+  padding-bottom: 0.5rem;
+
+  &> planet-resources-search-list {
+    height: inherit;
+    display: grid;
+    grid-template-rows: $label-height calc(#{$toolbar-height} - #{$label-height});
+
+    .mat-selection-list {
+      height: calc(#{$toolbar-height} - #{$label-height});
+      padding: 0;
+      overflow-y: auto;
+    }
+  }
+
+}

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -74,6 +74,15 @@ export const filterTags = (filterField, filterControl: FormControl) => {
   };
 };
 
+export const filterAdvancedSearch = (searchObj: any) => {
+  return (data: any, filter: string) => {
+    return Object.entries(searchObj).reduce(
+      (isMatch, [ field, val ]: any[]) => isMatch && filterArrayField(field, val)(data, filter),
+      true
+    );
+  };
+};
+
 // Takes an array of the above filtering functions and returns true if all match
 export const composeFilterFunctions = (filterFunctions: any[]) => {
   return (data: any, filter: any) => {


### PR DESCRIPTION
A set of filters (click "Show Filters" on resources page to display them) for resource Subject, Level, Medium, and Language.  Populates the list based on currently selected resources.

One known issue: if you select some of these filters and then select a collection it is possible to end up with 0 resources.  This is more an issue with the collection list & I more suitable for a future PR on that feature.

It is possible to end up with no resources left with a selection filter & text search as well, but I don't think that's avoidable.