### PR TITLE
Fix user defined beta toggle (fixes #3532)

### DIFF
--- a/src/app/shared/beta.directive.ts
+++ b/src/app/shared/beta.directive.ts
@@ -29,8 +29,9 @@ export class PlanetBetaDirective implements OnInit {
     }
   }
 
-  isBetaEnabled() {
-    return this.configuration.betaEnabled === 'on' || this.configuration.betaEnabled === 'user' && this.userService.get().betaEnabled;
+  isBetaEnabled(): boolean {
+    return this.configuration.betaEnabled === 'on' ||
+      this.configuration.betaEnabled === 'user' && this.userService.get().betaEnabled === true;
   }
 
 }


### PR DESCRIPTION
User defined beta functionality (set in configuration) won't work until users explicitly set their own beta functionality in their profile.  This resulted in the dashboard, which has one version for beta and one for non-beta, not showing any content for that setting.

This fixes that issue by making sure the `isBetaEnabled()` function returns a boolean value so its type matches the type of `planetBeta`