### PR TITLE
Survey/Exam: fix long title (fixes #3512)

### DIFF
--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -6,8 +6,9 @@
 
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1">
+    <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
     <span>
-      <span>{{title ? title + ': ' : ''}}<ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}</span>
+      <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
       <span i18n *ngIf="mode === 'grade' || mode === 'view'"> By{{' ' + submittedBy}}<span i18n *ngIf="!submittedBy">Unknown</span> on {{(updatedOn | date: 'short') || '--'}}</span>
     </span>
     <span class="toolbar-fill"></span>


### PR DESCRIPTION
I've fixed long title in Exam and Survey view:
![Screen Shot 2019-04-08 at 1 09 16 PM](https://user-images.githubusercontent.com/35533801/55753577-8c7c4e00-59ff-11e9-9624-978eaf238344.png)


However, I'm not sure if I should fix long title in MySurveys and Surveys views (list of surveys). Maybe better to keep full titles here.

![Screen Shot 2019-04-08 at 12 46 23 PM](https://user-images.githubusercontent.com/35533801/55753524-69519e80-59ff-11e9-8dd3-36b933851788.png)

vs

![Screen Shot 2019-04-08 at 12 47 13 PM](https://user-images.githubusercontent.com/35533801/55753532-7078ac80-59ff-11e9-9eaa-0153580240a5.png)
