### PR TITLE
Fix learner progress view (fixes #3575)

### DIFF
--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -160,9 +160,9 @@ export class CoursesService {
   }
 
   getUsersCourses(userId) {
-    this.couchService.post('courses_progress/_find', findDocuments({ 'userId': userId }, [ 'courseId' ])).subscribe(response => {
+    this.couchService.findAll('courses_progress', findDocuments({ 'userId': userId }, [ 'courseId' ])).subscribe(response => {
       // Added [ 0 ] as when no record it will return all records
-      const courseIds = response.docs.map(c => c.courseId).concat([ '0' ]);
+      const courseIds = response.map((c: any) => c.courseId).concat([ '0' ]);
       this.getCourses({ ids: courseIds });
     });
   }


### PR DESCRIPTION
In the view for learner progress (navigated to via the **My Progress** link on dashboard) there were only a set of courses shown.  This is because the request to the `courses_progress` database was still using the `_find` endpoint, which defaults to a limit of 25.

Replaces that request with our `findAll` method which returns all items that match the query.