### PR TITLE
CoursesProgress: Fix spacing for fewer rows (fixes #3586)

### DIFF
--- a/src/app/courses/progress-courses/courses-progress-chart.scss
+++ b/src/app/courses/progress-courses/courses-progress-chart.scss
@@ -9,7 +9,7 @@
     "total index user"
     ". . usertotal";
   grid-template-columns: fit-content($cell-size) $cell-size 1fr;
-  grid-template-rows: calc(#{$view-container-height} - 2rem - (#{$cell-size} * 2)) calc(#{$cell-size} * 2);
+  grid-template-rows: fit-content(calc(#{$view-container-height} - 2rem - (#{$cell-size} * 2))) calc(#{$cell-size} * 2);
 
   &, .errors-container {
     display: grid;

--- a/src/app/courses/progress-courses/courses-progress-leader.component.html
+++ b/src/app/courses/progress-courses/courses-progress-leader.component.html
@@ -19,7 +19,7 @@
       </mat-select>
     </mat-form-field>
   </mat-toolbar>
-  <div class="view-container">
+  <div class="view-container view-full-height">
     <planet-courses-progress-chart *ngIf="chartData?.length; else noProgress" [inputs]="chartData" [height]="yAxisLength" (changeData)="changeData($event)">
     </planet-courses-progress-chart>
     <ng-template #noProgress i18n>No Progress record available</ng-template>

--- a/src/app/courses/progress-courses/courses-progress-learner.component.html
+++ b/src/app/courses/progress-courses/courses-progress-learner.component.html
@@ -6,7 +6,7 @@
   <mat-toolbar class="primary-color font-size-1">
     <span i18n>{{headingStart ? headingStart + ' ' : ''}}Course Progress</span>
   </mat-toolbar>
-  <div class="view-container">
+  <div class="view-container view-full-height">
     <planet-courses-progress-chart *ngIf="chartData?.length; else noProgress" [inputs]="chartData" [height]="yAxisLength" [showTotals]="false" (changeData)="changeData($event)">
     </planet-courses-progress-chart>
     <ng-template #noProgress i18n>No Progress record available</ng-template>


### PR DESCRIPTION
When there are fewer rows than the height of the available space, the final label rows now move up to align better with the rest of the CoursesProgress table.