### PR TITLE
CoursesAdd: Save as draft locally

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -44,7 +44,7 @@
     </div>
     <div>
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-      <button type="button" mat-raised-button color="warn" (click)="navigateBack()" i18n>Cancel</button>
+      <button type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
       <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
     </div>
   </div>

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -152,7 +152,6 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   }
 
   updateCourse(courseInfo, shouldNavigate) {
-    this.deleteStepIdProperty();
     this.couchService.updateDocument(
       this.dbName,
       { ...courseInfo, steps: this.steps, updatedDate: this.couchService.datePlaceholder, ...this.documentInfo }
@@ -187,15 +186,8 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     this.planetMessageService.showMessage(message);
   }
 
-  deleteStepIdProperty() {
-    this.steps.forEach(step => {
-      delete step.id;
-    });
-  }
-
   addStep() {
     this.steps.push({
-      id: uniqueId(),
       stepTitle: '',
       description: '',
       resources: []

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -179,6 +179,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   }
 
   courseChangeComplete(message, response: any, shouldNavigate) {
+    this.pouchService.deleteDocEditing(this.dbName, this.courseId);
     if (shouldNavigate) {
       this.navigateBack();
     }
@@ -203,6 +204,11 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     });
     this.planetStepListService.addStep(this.steps.length - 1);
     this.saveDraftLocally();
+  }
+
+  cancel() {
+    this.pouchService.deleteDocEditing(this.dbName, this.courseId);
+    this.navigateBack();
   }
 
   navigateBack() {

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-import { Subject, interval, forkJoin, of, combineLatest } from 'rxjs';
-import { takeUntil, debounceTime, switchMap, catchError, throttleTime } from 'rxjs/operators';
+import { Subject, forkJoin, of, combineLatest } from 'rxjs';
+import { takeUntil, debounceTime, catchError } from 'rxjs/operators';
 
 import { CouchService } from '../../shared/couchdb.service';
 import { CustomValidators } from '../../validators/custom-validators';
@@ -11,8 +11,6 @@ import * as constants from '../constants';
 import { PlanetMessageService } from '../../shared/planet-message.service';
 import { CoursesService } from '../courses.service';
 import { UserService } from '../../shared/user.service';
-import { uniqueId } from '../../shared/utils';
-import { ConfigurationService } from '../../configuration/configuration.service';
 import { StateService } from '../../shared/state.service';
 import { PlanetStepListService } from '../../shared/forms/planet-step-list.component';
 import { PouchService } from '../../shared/database';

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -101,6 +101,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     ]).subscribe(([ draft, saved ]: [ any, any ]) => {
       if (saved.error !== 'not_found') {
         this.documentInfo = { _rev: saved._rev, _id: saved._id };
+        this.pageType = 'Update';
       }
       const doc = draft === undefined ? saved : draft;
       if (this.route.snapshot.params.continue !== 'true') {

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -179,6 +179,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       this.navigateBack();
     }
     this.courseForm.get('courseTitle').setAsyncValidators(this.courseTitleValidator(response.id));
+    this.courseId = response.id;
     this.documentInfo = { '_id': response.id, '_rev': response.rev };
     this.coursesService.course = { ...this.documentInfo };
     this.planetMessageService.showMessage(message);

--- a/src/app/shared/database/pouch.service.ts
+++ b/src/app/shared/database/pouch.service.ts
@@ -3,7 +3,7 @@ import PouchDB from 'pouchdb';
 import PouchDBAuth from 'pouchdb-authentication';
 import PouchDBFind from 'pouchdb-find';
 import { throwError, from } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 
 PouchDB.plugin(PouchDBAuth);
@@ -12,7 +12,7 @@ PouchDB.plugin(PouchDBFind);
 @Injectable()
 export class PouchService {
   private baseUrl = environment.couchAddress + '/';
-  private localDBs;
+  private localDBs = {};
   private authDB;
   private databases = [];
 
@@ -81,4 +81,24 @@ export class PouchService {
     console.error('An error occurred in PouchDB', err);
     return throwError(err.message || err);
   }
+
+  private docEditingDB(db, id) {
+    const name = `${db}_${id}`;
+    return this.localDBs[name] !== undefined ? this.localDBs[name] : new PouchDB(name);
+  }
+
+  getDocEditing(db, id = 'new') {
+    return from(this.docEditingDB(db, id).allDocs({ include_docs: true }))
+      .pipe(map((res: any) => {
+        const row = res.rows.find((r: any) => r.id === id);
+        return row && row.doc;
+      }));
+  }
+
+  saveDocEditing(doc, db, id = 'new') {
+    this.getDocEditing(db, id).subscribe((oldDoc: any) => {
+      this.docEditingDB(db, id).put({ ...doc, '_id': id, '_rev': oldDoc && oldDoc._rev });
+    });
+  }
+
 }

--- a/src/app/shared/database/pouch.service.ts
+++ b/src/app/shared/database/pouch.service.ts
@@ -101,4 +101,8 @@ export class PouchService {
     });
   }
 
+  deleteDocEditing(db, id = 'new') {
+    this.docEditingDB(db, id).destroy();
+  }
+
 }


### PR DESCRIPTION
With this change courses will now save locally with PouchDB as a "draft".  Three actions will remove the draft:

1. Clicking "Submit" will save the course to CouchDB and delete PouchDB draft
2. Clicking "Cancel" will delete PouchDB draft
3. Adding an exam or survey will save the course to CouchDB and delete PouchDB draft

Note I also removed the `id` field for course steps because it is no longer used (we no longer use a `trackBy` function in CoursesAdd)