### PR TITLE
Courses, Resources & Meetups: Selection aligned with title (fixes #3662)

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -68,7 +68,7 @@
           [indeterminate]="selection.hasValue() && !isAllSelected()">
           </mat-checkbox>
         </mat-header-cell>
-        <mat-cell *matCellDef="let row">
+        <mat-cell *matCellDef="let row" class="table-selection-top">
           <mat-checkbox (change)="$event ? selection.toggle(row._id) : null"
             [checked]="selection.isSelected(row._id)">
           </mat-checkbox>

--- a/src/app/meetups/meetups.component.html
+++ b/src/app/meetups/meetups.component.html
@@ -41,7 +41,7 @@
           <mat-checkbox (change)="$event ? masterToggle() : null" [checked]="selection.hasValue() && isAllSelected()" [indeterminate]="selection.hasValue() && !isAllSelected()">
           </mat-checkbox>
         </mat-header-cell>
-        <mat-cell *matCellDef="let row">
+        <mat-cell *matCellDef="let row" class="table-selection-top">
           <mat-checkbox (change)="$event ? selection.toggle(row._id) : null" [checked]="selection.isSelected(row._id)">
           </mat-checkbox>
         </mat-cell>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -72,7 +72,7 @@
           [indeterminate]="selection.hasValue() && !isAllSelected()">
           </mat-checkbox>
         </mat-header-cell>
-        <mat-cell *matCellDef="let row">
+        <mat-cell *matCellDef="let row" class="table-selection-top">
           <mat-checkbox (change)="$event ? selection.toggle(row._id) : null"
             [checked]="selection.isSelected(row._id)">
           </mat-checkbox>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -109,14 +109,27 @@ body {
     margin: 0 3px;
   }
 
+  $list-title-height: 36px;
+
+  .list-content-menu, .table-selection-top {
+    align-self: start;
+  }
+
+  .table-selection-top {
+    height: $list-title-height;
+    min-height: $list-title-height;
+  }
+
   // Style which places menu icon in upper right corner of table cell
   .list-content-menu {
+
     display: grid;
     grid-template-areas:
       'hd mn'
       'cn .'
-      'tags tags';
+      'tags .';
     grid-template-columns: auto 50px;
+    grid-template-rows: $list-title-height 1fr min-content;
 
     .header {
       grid-area: hd;
@@ -135,9 +148,9 @@ body {
       grid-area: mn;
     }
 
-    .tags-list {
+    .tags-list, .course-progress {
       grid-area: tags;
-      margin-bottom: 0.5rem;
+      margin: 0.5rem 0;
     }
 
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -122,7 +122,6 @@ body {
 
   // Style which places menu icon in upper right corner of table cell
   .list-content-menu {
-
     display: grid;
     grid-template-areas:
       'hd mn'


### PR DESCRIPTION
In addition to Courses & Resources as included in #3662, I also updated Meetups since it uses a similar layout for the title & description.