### PR TITLE
ExamsAdd: Add question opens menu and move type

### DIFF
--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -14,7 +14,13 @@
     <form [formGroup]="examForm" (ngSubmit)="onSubmit()" novalidate>
       <div class="exam-buttons">
         <button mat-raised-button color="primary" type="submit" [planetSubmit]="examForm.valid" i18n>{{pageType}} {examType, select, exam {Exam} survey {Survey}}</button>
-        <button mat-raised-button color="accent" type="button" (click)="addQuestion()" i18n class="margin-lr-5">Add Question</button>
+        <button mat-raised-button color="accent" type="button" [matMenuTriggerFor]="questionMenu" i18n class="margin-lr-5">Add Question</button>
+        <mat-menu #questionMenu>
+          <button mat-menu-item type="button" (click)="addQuestion('input')" i18n>Text - Short answer</button>
+          <button mat-menu-item type="button" (click)="addQuestion('textarea')" i18n>Text - Long answer</button>
+          <button mat-menu-item type="button" (click)="addQuestion('select')" i18n>Multiple Choice - single answer</button>
+          <button mat-menu-item type="button" (click)="addQuestion('selectMultiple')" i18n>Multiple Choice - multiple answer</button>
+        </mat-menu>
         <span *ngIf="showFormError" i18n class="mat-caption warn-text-color">Some required fields are missing.</span>
       </div>
       <div class="exam-inputs">

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -149,9 +149,9 @@ export class ExamsAddComponent implements OnInit {
     });
   }
 
-  addQuestion() {
+  addQuestion(type: string) {
     const questions = (<FormArray>this.examForm.get('questions'));
-    questions.push(this.examsService.newQuestionForm(this.examType === 'exam'));
+    questions.push(this.examsService.newQuestionForm(this.examType === 'exam', { type }));
     questions.updateValueAndValidity();
     this.planetStepListService.addStep(questions.length - 1);
     this.stepClick(questions.length - 1);

--- a/src/app/exams/exams-question.component.html
+++ b/src/app/exams/exams-question.component.html
@@ -1,13 +1,9 @@
 <form class="vertical-form" [formGroup]="questionForm">
-  <mat-form-field class="full-width">
-    <input matInput class="full-width" placeholder="Question Title" [formControl]="questionForm.controls.title">
-    <mat-error><planet-form-error-messages [control]="questionForm.controls.title"></planet-form-error-messages></mat-error>
-  </mat-form-field>
-  <mat-form-field class="full-width mat-form-field-type-no-underline">
-    <planet-markdown-textbox class="full-width" required="true" placeholder="Question Detail" [formControl]="questionForm.controls.body"></planet-markdown-textbox>
-    <mat-error><planet-form-error-messages [control]="questionForm.controls.body"></planet-form-error-messages></mat-error>
-  </mat-form-field>
-  <div>
+  <div class="type-title-container">
+    <mat-form-field class="full-width">
+      <input matInput class="full-width" placeholder="Question Title" [formControl]="questionForm.controls.title">
+      <mat-error><planet-form-error-messages [control]="questionForm.controls.title"></planet-form-error-messages></mat-error>
+    </mat-form-field>
     <mat-form-field>
       <mat-select i18n-placeholder placeholder="Type" formControlName="type" (selectionChange)="clearChoices()">
         <mat-option value="input" i18n>Text - Short answer</mat-option>
@@ -16,6 +12,12 @@
         <mat-option value="selectMultiple" i18n>Multiple Choice - multiple answer</mat-option>
       </mat-select>
     </mat-form-field>
+  </div>
+  <mat-form-field class="full-width mat-form-field-type-no-underline">
+    <planet-markdown-textbox class="full-width" required="true" placeholder="Question Detail" [formControl]="questionForm.controls.body"></planet-markdown-textbox>
+    <mat-error><planet-form-error-messages [control]="questionForm.controls.body"></planet-form-error-messages></mat-error>
+  </mat-form-field>
+  <div>
     <button type="button" mat-button (click)="addChoice()" class="margin-lr-5" *ngIf="questionForm.controls.type.value.includes('select')">Add Choice</button>
   </div>
   <div i18n class="mat-caption warn-text-color" *ngIf="!questionForm.controls.correctChoice.valid && questionForm.controls.correctChoice.touched">

--- a/src/app/exams/exams-question.component.ts
+++ b/src/app/exams/exams-question.component.ts
@@ -12,19 +12,7 @@ import { CustomValidators } from '../validators/custom-validators';
 @Component({
   selector: 'planet-exam-question',
   templateUrl: 'exams-question.component.html',
-  styles: [ `
-    .question-choices {
-      display: flex;
-      align-items: baseline;
-      flex-wrap: wrap;
-    }
-    .question-choices > div {
-      margin-right: 0.5rem;
-    }
-    .question-choices > div > mat-checkbox {
-      margin-left: 0.5rem;
-    }
-  ` ]
+  styleUrls: [ 'exams-question.scss' ]
 })
 export class ExamsQuestionComponent implements OnInit, OnChanges {
 

--- a/src/app/exams/exams-question.scss
+++ b/src/app/exams/exams-question.scss
@@ -1,0 +1,21 @@
+@import '../variables';
+
+.question-choices {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.question-choices > div {
+  margin-right: 0.5rem;
+}
+
+.question-choices > div > mat-checkbox {
+  margin-left: 0.5rem;
+}
+
+.type-title-container {
+  display: grid;
+  grid-template-columns: 1fr $form-width-1;
+  grid-column-gap: 0.5rem;
+}

--- a/src/app/exams/exams.service.ts
+++ b/src/app/exams/exams.service.ts
@@ -36,7 +36,7 @@ export class ExamsService {
 
   setInitalFormValue(formGroup, initialValue?) {
     if (initialValue !== undefined) {
-      formGroup.setValue(initialValue);
+      formGroup.patchValue(initialValue);
     }
     return formGroup;
   }


### PR DESCRIPTION
Two changes:
- "Add Question" opens a menu to select the type of question to add
- Type is moved to the same line as title so this can be changed later, but to move it out of the way of the form fields that have not been filled.