### PR TITLE
Fix course overwrite (fixes #3600)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -176,11 +176,14 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     if (shouldNavigate) {
       this.navigateBack();
     }
+    this.planetMessageService.showMessage(message);
+    if (this.isDestroyed) {
+      return;
+    }
     this.courseForm.get('courseTitle').setAsyncValidators(this.courseTitleValidator(response.id));
     this.courseId = response.id;
     this.documentInfo = { '_id': response.id, '_rev': response.rev };
     this.coursesService.course = { ...this.documentInfo };
-    this.planetMessageService.showMessage(message);
   }
 
   addStep() {


### PR DESCRIPTION
It's still hard to pin down the exact issue, but I think the _id was being saved on CoursesService even after it should have been reset.  Note that courses were not overwritten every time, but only occasionally.

To test create a lot of courses one after another each with one test.  If any of them are overwritten please try to document exactly what happened and I'll attempt another fix.