### PR TITLE
Capitalize course in Get Course (fixes #3647)

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -26,7 +26,7 @@
       <span class="toolbar-fill"></span>
       <ng-container *ngIf="parent">
         <button mat-button [disabled]="!selection.selected.length" (click)="shareCourse('pull', selection.selected)">
-          <mat-icon aria-hidden="true" class="margin-lr-3">cloud_download</mat-icon><span i18n>Get course</span>
+          <mat-icon aria-hidden="true" class="margin-lr-3">cloud_download</mat-icon><span i18n>Get Course</span>
         </button>
       </ng-container>
       <ng-container *ngIf="!parent">


### PR DESCRIPTION
Changed "Get course" to "Get Course" in Getting List of Courses page.