### PR TITLE
Add dash between courseName and tryNumber(fixes #3746)

### DIFF
--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -185,7 +185,7 @@ export class ExamsAddComponent implements OnInit {
 
   newExamName(existingExams: any[], namePrefix, nameNumber = 0) {
     const tryNumber = nameNumber || existingExams.length;
-    const name = `${namePrefix} ${tryNumber + 1}`;
+    const name = `${namePrefix} - ${tryNumber + 1}`;
     if (existingExams.findIndex((exam: any) => exam.name === name) === -1) {
       return name;
     }


### PR DESCRIPTION
(fixes #3746) add a dash to separate course name and tryNumber after submit the course survey.


![issue#3746](https://user-images.githubusercontent.com/31773567/57351535-20ccf400-7117-11e9-9e72-464f87b9b08a.jpg)
