### PR TITLE
Submissions: save last question (fixes #3674)

### DIFF
--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -60,7 +60,7 @@
         *ngIf="mode !== 'view'"
         mat-raised-button
         color="primary"
-        (click)="submit()"
+        (click)="examComplete()"
         [planetSubmit]="spinnerOn"
         [disabled]="!answer.valid || grade === undefined || grade === null">
         <ng-container *ngIf="isComplete" i18n>Complete</ng-container>

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -60,7 +60,7 @@
         *ngIf="mode !== 'view'"
         mat-raised-button
         color="primary"
-        (click)="nextQuestion()"
+        (click)="submit()"
         [planetSubmit]="spinnerOn"
         [disabled]="!answer.valid || grade === undefined || grade === null">
         <ng-container *ngIf="isComplete" i18n>Complete</ng-container>

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -90,9 +90,13 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     });
   }
 
-  submit() {
+  examComplete() {
     this.nextQuestion();
-    this.examComplete();
+    if (this.route.snapshot.data.newUser === true) {
+      this.router.navigate([ '/users/submission', { id: this.submissionId } ]);
+    } else {
+      this.goBack();
+    }
     if (this.examType === 'surveys') {
       this.submissionsService.sendSubmissionNotification(this.route.snapshot.data.newUser);
     }
@@ -119,14 +123,6 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
 
   resetCheckboxes() {
     this.question.choices.forEach((choice: any) => this.checkboxState[choice.id] = false);
-  }
-
-  examComplete() {
-    if (this.route.snapshot.data.newUser === true) {
-      this.router.navigate([ '/users/submission', { id: this.submissionId } ]);
-    } else {
-      this.goBack();
-    }
   }
 
   goBack() {

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -89,7 +89,7 @@ export class SubmissionsService {
     });
   }
 
-  submitAnswer(answer, correct: boolean, index: number) {
+  submitAnswer(answer, correct: boolean, index: number, nextClicked?: boolean) {
     const submission = { ...this.submission, answers: [ ...this.submission.answers ], lastUpdateTime: this.couchService.datePlaceholder };
     const oldAnswer = submission.answers[index];
     submission.answers[index] = this.newAnswer(answer, oldAnswer, correct);
@@ -97,7 +97,7 @@ export class SubmissionsService {
     if (correct !== undefined) {
       this.updateGrade(submission, correct ? 1 : 0, index);
     }
-    return this.updateSubmission(submission, this.submission.type === 'exam', nextQuestion);
+    return this.updateSubmission(submission, this.submission.type === 'exam', nextQuestion, nextClicked);
   }
 
   newAnswer(answer, oldAnswer, correct) {
@@ -108,11 +108,11 @@ export class SubmissionsService {
     });
   }
 
-  submitGrade(grade, index: number) {
+  submitGrade(grade, index: number, nextClicked?: boolean) {
     const submission = { ...this.submission, answers: [ ...this.submission.answers ], gradeTime: this.couchService.datePlaceholder };
     this.updateGrade(submission, grade, index);
     const nextQuestion = this.nextQuestion(submission, index, 'grade');
-    return this.updateSubmission(submission, false, nextQuestion);
+    return this.updateSubmission(submission, false, nextQuestion, nextClicked);
   }
 
   nextQuestion(submission, index, field) {
@@ -137,8 +137,8 @@ export class SubmissionsService {
       total + (submission.parent.questions[index].marks * (answer.grade || 0)), 0);
   }
 
-  updateSubmission(submission: any, takingExam: boolean, nextQuestion: number) {
-    submission.status = nextQuestion === -1 ? this.updateStatus(submission) : submission.status;
+  updateSubmission(submission: any, takingExam: boolean, nextQuestion: number, nextClicked?: boolean) {
+    submission.status = nextClicked === false ? this.updateStatus(submission) : submission.status;
     return this.couchService.updateDocument('submissions', submission).pipe(map((res) => {
       let attempts = this.submissionAttempts;
       if (submission.status === 'complete' && takingExam) {


### PR DESCRIPTION
#### Done:
* The last question can be saved to the DB without clicking on 'Submit/Complete' button. 
* Prevent updating submission status and opening new submission even if all questions have been saved to the DB. A user has to click on 'Submit/Complete' button to be able to change submission status.

#### Todo:
* Fix a console error `Cannot read property 'totalMarks' of undefined` which appears after submitting completed exam/survey;