### PR TITLE
Fix collections list & updates

### DIFF
--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -35,6 +35,7 @@ export class PlanetTagInputDialogComponent {
   addTagForm: FormGroup;
   newTagId: string;
   isUserAdmin = false;
+  isInMap = isInMap;
   subcollectionIsOpen = new Map();
   get okClickValue() {
     return { wasOkClicked: true, indeterminate: this.indeterminate ? mapToArray(this.indeterminate, true) : [] };

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -150,6 +150,7 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
   }
 
   openPresetDialog() {
+    this.initTags();
     this.dialogRef = this.dialog.open(PlanetTagInputDialogComponent, {
       maxWidth: '80vw',
       maxHeight: '80vh',


### PR DESCRIPTION
I made an error in the last commit of #3772 where none of the names of the collections were showing up in the list.

This also fixes the "Search Collections" list not updating correctly after editing a collection name by selecting resources/courses & clicking "Change Collections".