### PR TITLE
Fix Course Progress's course chart label (fixes #3590)

### DIFF
--- a/src/app/courses/progress-courses/courses-progress-chart.component.html
+++ b/src/app/courses/progress-courses/courses-progress-chart.component.html
@@ -13,7 +13,7 @@
   </ng-container>
 </div>
 <div class="errors errors-index" #errorsIndex>
-  <div class="anchor-label" i18n>Steps</div>
+  <div class="anchor-label" i18n>{{label}}</div>
   <div
     class="border-bottom"
     matTooltip="Click to see test detail"

--- a/src/app/courses/progress-courses/courses-progress-chart.component.html
+++ b/src/app/courses/progress-courses/courses-progress-chart.component.html
@@ -13,7 +13,7 @@
   </ng-container>
 </div>
 <div class="errors errors-index" #errorsIndex>
-  <div class="anchor-label" i18n>{{label}}</div>
+  <div class="anchor-label" i18n>{label, select, Steps {Steps} Quest. {Quest.}}</div>
   <div
     class="border-bottom"
     matTooltip="Click to see test detail"

--- a/src/app/courses/progress-courses/courses-progress-chart.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-chart.component.ts
@@ -15,6 +15,7 @@ import { Component, Input, Output, EventEmitter, OnChanges, ViewChildren, ViewCh
 export class CoursesProgressChartComponent implements OnChanges {
 
   @Input() inputs = [];
+  @Input() label = '';
   @Input() height = 0;
   @Input() showTotals = true;
   @Output() changeData = new EventEmitter<{ set, index }>();

--- a/src/app/courses/progress-courses/courses-progress-chart.scss
+++ b/src/app/courses/progress-courses/courses-progress-chart.scss
@@ -2,7 +2,7 @@
 
 :host {
 
-  $cell-size: 71px;
+  $cell-size: 45px;
   $column-gap: 4px;
 
   grid-template-areas:

--- a/src/app/courses/progress-courses/courses-progress-chart.scss
+++ b/src/app/courses/progress-courses/courses-progress-chart.scss
@@ -2,7 +2,7 @@
 
 :host {
 
-  $cell-size: 45px;
+  $cell-size: 71px;
   $column-gap: 4px;
 
   grid-template-areas:

--- a/src/app/courses/progress-courses/courses-progress-leader.component.html
+++ b/src/app/courses/progress-courses/courses-progress-leader.component.html
@@ -20,7 +20,7 @@
     </mat-form-field>
   </mat-toolbar>
   <div class="view-container view-full-height">
-    <planet-courses-progress-chart *ngIf="chartData?.length; else noProgress" [inputs]="chartData" [height]="yAxisLength" (changeData)="changeData($event)">
+    <planet-courses-progress-chart *ngIf="chartData?.length; else noProgress" [label]="chartLabel" [inputs]="chartData" [height]="yAxisLength" (changeData)="changeData($event)">
     </planet-courses-progress-chart>
     <ng-template #noProgress i18n>No Progress record available</ng-template>
   </div>

--- a/src/app/courses/progress-courses/courses-progress-leader.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-leader.component.ts
@@ -16,6 +16,7 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
   course: any;
   // Need to define this variable for template which is shared with CoursesProgressLearner
   headingStart = '';
+  chartLabel = '';
   selectedStep: any;
   chartData: any[];
   submissions: any[] = [];
@@ -48,6 +49,7 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
       this.filterSubmittedExamSteps(submissions);
       this.dialogsLoadingService.stop();
     });
+    this.chartLabel = 'Steps';
   }
 
   ngOnDestroy() {
@@ -142,10 +144,12 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
       this.selectedStep = this.course.steps[courseIndex];
       this.setSingleStep(this.submissions);
     }
+    this.chartLabel = 'Questions';
   }
 
   resetToFullCourse() {
     this.setFullCourse(this.submissions);
+    this.chartLabel = 'Steps';
   }
 
   userProgress(user) {

--- a/src/app/courses/progress-courses/courses-progress-leader.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-leader.component.ts
@@ -16,7 +16,7 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
   course: any;
   // Need to define this variable for template which is shared with CoursesProgressLearner
   headingStart = '';
-  chartLabel = '';
+  chartLabel = 'Steps';
   selectedStep: any;
   chartData: any[];
   submissions: any[] = [];
@@ -49,7 +49,6 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
       this.filterSubmittedExamSteps(submissions);
       this.dialogsLoadingService.stop();
     });
-    this.chartLabel = 'Steps';
   }
 
   ngOnDestroy() {
@@ -144,7 +143,7 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
       this.selectedStep = this.course.steps[courseIndex];
       this.setSingleStep(this.submissions);
     }
-    this.chartLabel = 'Questions';
+    this.chartLabel = 'Quest.';
   }
 
   resetToFullCourse() {


### PR DESCRIPTION
I fixed Course Progress's chart so the label says 'Questions' instead of 'Steps' when the use navigates to the chart for specific questions.