### PR TITLE
Fix CoursesAdd collections error (fixes #3830)

### DIFF
--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -29,7 +29,7 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
     return this._value;
   }
   set value(tags: string[]) {
-    this._value = tags;
+    this._value = tags || [];
     this.onChange(tags);
     this.stateChanges.next();
   }


### PR DESCRIPTION
Was unable to replicate in dev environment, but the errors in production led me to believe it's related to `value` somehow being set to `undefined` in the PlanetTagsInputComponent

Since it already uses a getter/setter, made a change to the setter to fallback to an empty array if something tries to set it to undefined.