### PR TITLE
Replicate tags for "Get Resources" & "Get Courses"

### DIFF
--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -335,7 +335,10 @@ export class CoursesComponent implements OnInit, AfterViewInit, OnDestroy {
   shareCourse(type, courseIds) {
     const courses = courseIds.map(courseId => ({ item: findByIdInArray(this.courses.data, courseId), db: this.dbName }));
     const msg = (type === 'pull' ? 'fetch' : 'send');
-    this.syncService.confirmPasswordAndRunReplicators(this.syncService.createReplicatorsArray(courses, type)).subscribe(() => {
+    const parentType = type === 'pull' ? 'parent' : 'local';
+    this.syncService.replicatorsArrayWithTags(courses, type, parentType).pipe(switchMap(replicators =>
+      this.syncService.confirmPasswordAndRunReplicators(replicators)
+    )).subscribe(() => {
       this.planetMessageService.showMessage(courses.length + ' ' + this.dbName + ' ' + 'queued to ' + msg);
     }, () => error => this.planetMessageService.showMessage(error));
   }


### PR DESCRIPTION
Replicates the tags along with the resources or courses object.  When replicating courses, does not replicate the tags of the resources attached to the courses.  I specifically worked on the "Get Resources" & "Get Courses" (child pull), but this might work in other replication scenarios.

Requires #3837 & #3841 to see this on courses.