### PR TITLE
Fix getting list for "Fetch Items"

### DIFF
--- a/src/app/manager-dashboard/manager.service.ts
+++ b/src/app/manager-dashboard/manager.service.ts
@@ -95,8 +95,8 @@ export class ManagerService {
   }
 
   getPushedList() {
-    return this.couchService.post(
-      `send_items/_find`,
+    return this.couchService.findAll(
+      'send_items',
       findDocuments({ 'sendTo': this.configuration.code }),
       { domain: this.configuration.parentDomain }
     );


### PR DESCRIPTION
Before this change it would only get 25 of the docs in the `send_items` database.