### PR TITLE
Fix user creation on production vagrant (fixes #3869)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,8 @@ Vagrant.configure(2) do |config|
         docker-compose -f planet.yml -f volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d
       else
         docker-compose -f planet.yml -f volumes.yml -p planet up -d
+        docker wait planet_db-init_1
+        docker start planet_db-init_1
       fi
     SHELL
   end

--- a/docker/planet/nginx/credentials.sh
+++ b/docker/planet/nginx/credentials.sh
@@ -3,13 +3,19 @@ echo "HTTP/1.0 200 OK"
 echo "Content-type: text/plain"
 echo ""
 
+YML_PATH=credentials/credentials.yml
 PLANET_USER=${PLANET_CREDENTIALS%%,*}
 PLANET_PASS=${PLANET_CREDENTIALS##*,}
+if [ -f "$YML_PATH" ]; then
+  OLD_USER=$(grep COUCHDB_USER $YML_PATH | sed -e 's/.*=//')
+fi
 
-rm credentials/credentials.yml
-echo "services:
-  db-init:
-    environment:
-      - COUCHDB_USER=$PLANET_USER
-      - COUCHDB_PASS=$PLANET_PASS
-version: \"2\"" >> credentials/credentials.yml
+if [ -z "$OLD_USER" ] || [ "$PLANET_USER" == "$OLD_USER" ]; then
+  rm credentials/credentials.yml
+  echo "services:
+    db-init:
+      environment:
+        - COUCHDB_USER=$PLANET_USER
+        - COUCHDB_PASS=$PLANET_PASS
+  version: \"2\"" >> $YML_PATH
+fi

--- a/src/app/configuration/configuration.service.ts
+++ b/src/app/configuration/configuration.service.ts
@@ -140,6 +140,8 @@ export class ConfigurationService {
           this.createUser(credentials.name, userDetail),
           // then add a shelf for that user
           this.couchService.put('shelf/org.couchdb.user:' + credentials.name, {}),
+          // and add credentials.yml for that user
+          this.managerService.updateCredentialsYml(credentials),
           // then post configuration to parent planet's registration requests
           this.addPlanetToParent({ ...configuration, _id: conf.id }, true, userDetail)
         ]);

--- a/src/app/manager-dashboard/manager.service.ts
+++ b/src/app/manager-dashboard/manager.service.ts
@@ -10,6 +10,7 @@ import { debug } from '../debug-operator';
 import { StateService } from '../shared/state.service';
 import { ReportsService } from './reports/reports.service';
 import { findDocuments } from '../shared/mangoQueries';
+import { environment } from '../../environments/environment.test';
 
 const passwordFormFields = [
   {
@@ -115,6 +116,18 @@ export class ManagerService {
       { '_id': { '$gt': null } };
     return this.couchService.findAll('communityregistrationrequests',
       findDocuments(selector, 0, [ { 'createdDate': 'desc' } ] ));
+  }
+
+  updateCredentialsYml({ name, password }) {
+    if (environment.production === true) {
+      const opts = {
+        responseType: 'text',
+        withCredentials: false,
+        headers: { 'Content-Type': 'text/plain' }
+      };
+      return this.couchService.getUrl('updateyml?u=' + name + ',' + password, opts);
+    }
+    return of({});
   }
 
 }

--- a/src/app/shared/dialogs/change-password.directive.ts
+++ b/src/app/shared/dialogs/change-password.directive.ts
@@ -10,6 +10,7 @@ import { CustomValidators } from '../../validators/custom-validators';
 import { ValidatorService } from '../../validators/validator.service';
 import { StateService } from '../state.service';
 import { DialogsLoadingService } from './dialogs-loading.service';
+import { ManagerService } from '../../manager-dashboard/manager.service';
 
 const changePasswordFields = [
   {
@@ -76,7 +77,8 @@ export class ChangePasswordDirective {
     private planetMessageService: PlanetMessageService,
     private validatorService: ValidatorService,
     private stateService: StateService,
-    private dialogsLoadingService: DialogsLoadingService
+    private dialogsLoadingService: DialogsLoadingService,
+    private managerService: ManagerService
   ) {}
 
   @HostListener('click')
@@ -119,7 +121,10 @@ export class ChangePasswordDirective {
     const isUserAdmin = (this.userService.get().isUserAdmin && !this.userService.get().roles.length);
     return this.couchService.put(this.dbName + '/' + userData._id, userData).pipe(switchMap((res) => {
       if (isUserAdmin) {
-        return forkJoin([ of(res), this.updateAdminPassword(userData), this.updatePasswordOnParent(userData) ]);
+        return forkJoin([
+          of(res), this.updateAdminPassword(userData), this.updatePasswordOnParent(userData),
+          this.managerService.updateCredentialsYml(userData)
+        ]);
       }
       return of([ res ]);
     }));

--- a/src/app/upgrade/upgrade.component.ts
+++ b/src/app/upgrade/upgrade.component.ts
@@ -58,7 +58,7 @@ export class UpgradeComponent {
         parentVersion = pVersion;
         return this.managerService.openPasswordConfirmation();
       }),
-      switchMap(credentials => this.postAdminCredentials(credentials)),
+      switchMap(credentials => this.managerService.updateCredentialsYml(credentials)),
       switchMap(() => this.managerService.addAdminLog('upgrade')),
       switchMap(() => {
         this.start();
@@ -150,15 +150,6 @@ export class UpgradeComponent {
       headers: { 'Content-Type': 'text/plain' }
     };
     return this.couchService.getUrl('version', opts).pipe(catchError(() => of('N/A')));
-  }
-
-  postAdminCredentials({ name, password }) {
-    const opts = {
-      responseType: 'text',
-      withCredentials: false,
-      headers: { 'Content-Type': 'text/plain' }
-    };
-    return this.couchService.getUrl('updateyml?u=' + name + ',' + password, opts);
   }
 
   upgradeMyPlanet() {


### PR DESCRIPTION
In my testing I found that the production vagrant was resetting the `_users` design doc during the initial setup and every subsequent halt/up cycle after configuration if the `credentials.yml` file was not set.

Since this was only set before an upgrade, I modified this to also run the script to create/modify that file during the initial configuration and on changing passwords.  In case we add the ability to set and remove admins, I limited the script to change the yml file only if the user name matches what is in the file.  We'll need to make sure that the first admin cannot be removed.