### PR TITLE
[Fixes #3879] Course: selected collection tag can be made similar to resource 

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -3,7 +3,7 @@
   <span i18n>Courses</span>
   <span class="toolbar-fill"></span>
   <mat-form-field class="font-size-1 margin-lr-4 mat-form-field-type-no-underline mat-form-field-dynamic-width collections-search">
-    <planet-tag-input [formControl]="tagFilter" [db]="dbName" [parent]="parent" [filteredData]="courses.filteredData"></planet-tag-input>
+    <planet-tag-input #tagInput [formControl]="tagFilter" [db]="dbName" [parent]="parent" [filteredData]="courses.filteredData" [helperText]="false"></planet-tag-input>
   </mat-form-field>
   <mat-form-field class="font-size-1 margin-lr-3">
     <mat-select placeholder="Grade Level" [value]="filter['doc.gradeLevel'] || 'All'" (selectionChange)="onFilterChange($event.value, 'doc.gradeLevel')">
@@ -20,13 +20,16 @@
   <mat-form-field class="font-size-1 margin-lr-3">
     <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">
   </mat-form-field>
-  <button mat-raised-button color="primary" i18n (click)="resetSearch()" [disabled]="courses.filter === ''"><span>Reset</span></button>
+  <button mat-raised-button color="primary" i18n (click)="resetSearch()" [disabled]="courses.filter === ''"><span>Clear</span></button>
 </mat-toolbar>
 <div class="space-container primary-link-hover">
   <mat-toolbar class="primary-color font-size-1">
     <ng-container *ngIf="isAuthorized">
       <button *ngIf="!parent" mat-mini-fab routerLink="add" ><mat-icon>add</mat-icon></button>
-      <planet-filtered-amount [table]="courses" labelFor="courses"></planet-filtered-amount>
+      <div class="column margin-lr-5">
+        <planet-filtered-amount [table]="courses" labelFor="courses"></planet-filtered-amount>
+        <planet-tag-selected-input [selectedIds]="tagFilter.value" [allTags]="tagInput.tags"></planet-tag-selected-input>
+      </div>
       <span class="toolbar-fill"></span>
       <ng-container *ngIf="parent">
         <button mat-button [disabled]="!selection.selected.length" (click)="shareCourse('pull', selection.selected)">

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -35,6 +35,13 @@ import { PlanetTagInputComponent } from '../shared/forms/planet-tag-input.compon
     .mat-column-info, .mat-column-rating {
       max-width: 225px;
     }
+    .column {
+      display: flex;
+      flex-direction: column;
+    }
+    .column > * {
+      line-height: normal;
+    }
   ` ]
 })
 


### PR DESCRIPTION
[Fixes #3879] Course: selected collection tag can be made similar to resource 

![issue-3879-library](https://user-images.githubusercontent.com/41846764/58364864-66f8b600-7e80-11e9-8940-88438991e371.PNG)
![issue-3879-courses](https://user-images.githubusercontent.com/41846764/58430923-1dbb8880-8071-11e9-8587-f6a8c6e74582.PNG)

