### PR TITLE
Collections: Update layout

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -100,9 +100,14 @@
             <mat-icon>more_vert</mat-icon>
           </button>
           <mat-chip-list #tagsList class="tags-list">
-            <mat-chip *ngFor="let tag of element.tags" (click)="addTag(tag._id)">
-              {{tag.name}}
-            </mat-chip>
+            <ng-container *ngFor="let tag of element.tags">
+              <mat-chip *ngIf="tag.isMainTag" (click)="addTag(tag._id)" color="primary" selected>
+                {{tag.name}}
+              </mat-chip>
+              <mat-chip *ngFor="let subTag of tag.subTags" (click)="addTag(subTag._id)">
+                {{subTag.name}}
+              </mat-chip>
+            </ng-container>
           </mat-chip-list>
           <div class="course-progress" *ngIf="element.admission && element.doc.steps.length && !parent">
             <span i18n>Your progress:</span>

--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -68,6 +68,7 @@ export class CoursesService {
   }
 
   mergeData({ courses, courses_progress, ratings, tags }, planetField = 'local', parent = false) {
+    tags = tags.map(this.tagsService.fillSubTags);
     const data = courses.map((course: any) => ({
       doc: course,
       _id: course._id,

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -95,9 +95,14 @@
           </h3>
           <td-markdown class="content" [content]="element.doc.description"></td-markdown>
           <mat-chip-list #tagsList class="tags-list">
-            <mat-chip *ngFor="let tag of element.tags" (click)="addTag(tag._id)">
-              {{tag.name}}
-            </mat-chip>
+            <ng-container *ngFor="let tag of element.tags">
+              <mat-chip *ngIf="tag.isMainTag" (click)="addTag(tag._id)" color="primary" selected>
+                {{tag.name}}
+              </mat-chip>
+              <mat-chip *ngFor="let subTag of tag.subTags" (click)="addTag(subTag._id)">
+                {{subTag.name}}
+              </mat-chip>
+            </ng-container>
           </mat-chip-list>
           <planet-local-status [status]="element.localStatus"></planet-local-status>
           <button *ngIf="!parent && !isDialog" class="menu" mat-icon-button [matMenuTriggerFor]="resourceMenu">

--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -42,8 +42,8 @@ export class ResourcesService {
     });
     this.stateService.couchStateListener('tags').subscribe(response => {
       if (response !== undefined) {
-        this.tags[response.planetField] = response.newData;
-        this.setTags(this.resources[response.planetField], response.newData, response.planetField);
+        this.tags[response.planetField] = response.newData.map(this.tagsService.fillSubTags);
+        this.setTags(this.resources[response.planetField], this.tags[response.planetField], response.planetField);
       }
     });
   }

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -20,6 +20,7 @@
       <!-- selectbox -->
       <mat-form-field *ngIf="field.type === 'selectbox'" class="full-width">
         <mat-select placeholder="{{field.placeholder}}" formControlName="{{field.name}}" required="{{field.required}}" [multiple]="field.multiple">
+          <mat-option *ngIf="field.reset">None</mat-option>
           <mat-option *ngFor="let option of field.options" [value]="option.value">{{option.name}}</mat-option>
         </mat-select>
         <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -14,6 +14,7 @@ import { PlanetStepListComponent, PlanetStepListFormDirective, PlanetStepListIte
   PlanetStepListActionsDirective, PlanetStepListNumberDirective } from './planet-step-list.component';
 import { PlanetMarkdownTextboxComponent } from './planet-markdown-textbox.component';
 import { PlanetTagInputDialogComponent, PlanetTagInputToggleIconComponent } from './planet-tag-input-dialog.component';
+import { SharedComponentsModule } from '../shared-components.module';
 
 @NgModule({
   imports: [
@@ -21,7 +22,8 @@ import { PlanetTagInputDialogComponent, PlanetTagInputToggleIconComponent } from
     FormsModule,
     ReactiveFormsModule,
     MaterialModule,
-    CovalentTextEditorModule
+    CovalentTextEditorModule,
+    SharedComponentsModule
   ],
   exports: [
     FormErrorMessagesComponent,

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -26,7 +26,7 @@
   </mat-expansion-panel>
   <mat-action-list *ngIf="selectMany">
     <ng-container *ngFor="let tag of tags">
-      <mat-list-item (click)="tagChange([ tag._id || tag.name ])" class="cursor-pointer">
+      <mat-list-item (click)="tagChange([ tag._id || tag.name ].concat(subTagIds(tag.subTags)), { deselectSubs: true })" class="cursor-pointer">
         <p matLine>
           <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)"></mat-checkbox>
           <span [ngClass]="{ 'mat-body-2': tag.subTags.length > 0, 'mat-body-1': tag.subTags.length === 0 }">{{tag.name + ' (' + (tag.count || 0) + ')'}}</span>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -13,7 +13,8 @@
         <mat-error><planet-form-error-messages [control]="addTagForm.controls.name"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
-        <mat-select i18n-placeholder placeholder="Subcollection of..." formControlName="attachedTo" multiple>
+        <mat-select i18n-placeholder placeholder="Subcollection of..." formControlName="attachedTo">
+          <mat-option>None</mat-option>
           <mat-option *ngFor="let tag of tags" [value]="tag._id || tag.name">{{tag.name}}</mat-option>
         </mat-select>
       </mat-form-field>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -24,23 +24,21 @@
   <mat-action-list *ngIf="selectMany">
     <ng-container *ngFor="let tag of tags">
       <mat-list-item (click)="tagChange([ tag._id || tag.name ])" [ngClass]="{ 'mat-body-2': tag.subTags.length > 0 }" class="cursor-pointer">
-        <span>
+        <p mat-line>
+          <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)"></mat-checkbox>
           {{tag.name + ' (' + (tag.count || 0) + ')'}}
           <planet-tag-input-toggle-icon *ngIf="tag.subTags.length > 0" (click)="toggleSubcollection($event,tag._id)" [isOpen]="subcollectionIsOpen.get(tag._id)"></planet-tag-input-toggle-icon>
           <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)" class="margin-lr-5">Edit</button>
-        </span>
-        <span class="toolbar-fill"></span>
-        <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)"></mat-checkbox>
+        </p>
       </mat-list-item>
       <ng-container *ngIf="subcollectionIsOpen.get(tag._id)">
         <mat-list-item *ngFor="let subTag of tag.subTags" (click)="tagChange([ subTag._id || subTag.name, tag._id || tag.name ])" class="cursor-pointer">
           <mat-icon mat-list-icon>subdirectory_arrow_right</mat-icon>
-          <span>
+          <p matLine>
+            <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)"></mat-checkbox>
             {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
             <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,subTag)">Edit</button>
-          </span>
-          <span class="toolbar-fill"></span>
-          <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)"></mat-checkbox>
+          </p>
         </mat-list-item>
       </ng-container>
       <mat-divider></mat-divider>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -1,7 +1,10 @@
-<h3>Collections</h3>
+<ng-container [ngSwitch]="mode">
+  <span mat-dialog-title i18n *ngSwitchCase="'filter'">Collections</span>
+  <span mat-dialog-title i18n *ngSwitchCase="'add'">Change Collections</span>
+</ng-container>
 <mat-dialog-content>
   <mat-form-field class="full-width">
-    <input matInput i18n-placeholder placeholder="Filter Collections" [ngModel]="filterValue" (ngModelChange)="updateFilter($event)">
+    <input matInput i18n-placeholder placeholder="Filter by Collection Name" [ngModel]="filterValue" (ngModelChange)="updateFilter($event)">
   </mat-form-field>
   <mat-expansion-panel *planetAuthorizedRoles>
     <mat-expansion-panel-header>
@@ -23,12 +26,12 @@
   </mat-expansion-panel>
   <mat-action-list *ngIf="selectMany">
     <ng-container *ngFor="let tag of tags">
-      <mat-list-item (click)="tagChange([ tag._id || tag.name ])" [ngClass]="{ 'mat-body-2': tag.subTags.length > 0 }" class="cursor-pointer">
-        <p mat-line>
+      <mat-list-item (click)="tagChange([ tag._id || tag.name ])" class="cursor-pointer">
+        <p matLine>
           <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)"></mat-checkbox>
-          {{tag.name + ' (' + (tag.count || 0) + ')'}}
+          <span [ngClass]="{ 'mat-body-2': tag.subTags.length > 0, 'mat-body-1': tag.subTags.length === 0 }">{{tag.name + ' (' + (tag.count || 0) + ')'}}</span>
           <planet-tag-input-toggle-icon *ngIf="tag.subTags.length > 0" (click)="toggleSubcollection($event,tag._id)" [isOpen]="subcollectionIsOpen.get(tag._id)"></planet-tag-input-toggle-icon>
-          <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)" class="margin-lr-5">Edit</button>
+          <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,tag)">Edit</button>
         </p>
       </mat-list-item>
       <ng-container *ngIf="subcollectionIsOpen.get(tag._id)">
@@ -36,7 +39,7 @@
           <mat-icon mat-list-icon>subdirectory_arrow_right</mat-icon>
           <p matLine>
             <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)"></mat-checkbox>
-            {{subTag.name + ' (' + (subTag.count || 0) + ')'}}
+            <span class="mat-body-1">{{subTag.name + ' (' + (subTag.count || 0) + ')'}}</span>
             <button mat-stroked-button *ngIf="isUserAdmin" (click)="editTagClick($event,subTag)">Edit</button>
           </p>
         </mat-list-item>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -1,8 +1,9 @@
+<h3>Collections</h3>
 <mat-dialog-content>
-  <mat-form-field>
+  <mat-form-field class="full-width">
     <input matInput i18n-placeholder placeholder="Filter Collections" [ngModel]="filterValue" (ngModelChange)="updateFilter($event)">
   </mat-form-field>
-  <mat-expansion-panel *ngIf="mode==='add'">
+  <mat-expansion-panel *planetAuthorizedRoles>
     <mat-expansion-panel-header>
       <mat-panel-title i18n>Create New Collection</mat-panel-title>
     </mat-expansion-panel-header>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -70,10 +70,10 @@ export class PlanetTagInputDialogComponent {
   dataInit() {
     this.tags = this.filterTags(this.filterValue);
     this.mode = this.data.mode;
-    if (this.newTagId !== undefined) {
+    if (this.newTagId !== undefined && this.mode === 'add') {
       this.tagChange([ this.newTagId ]);
-      this.newTagId = undefined;
     }
+    this.newTagId = undefined;
   }
 
   tagChange(tags, tagOne = false) {
@@ -168,7 +168,9 @@ export class PlanetTagInputDialogComponent {
 
   toggleSubcollection(event, tagId) {
     event.stopPropagation();
-    this.subcollectionIsOpen.set(tagId, !this.subcollectionIsOpen.get(tagId));
+    const newState = !this.subcollectionIsOpen.get(tagId)
+    this.subcollectionIsOpen.clear();
+    this.subcollectionIsOpen.set(tagId, newState);
   }
 
 }

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -63,7 +63,7 @@ export class PlanetTagInputDialogComponent {
     this.data.startingTags
       .filter((tag: any) => tag)
       .forEach(tag => {
-        this.tagChange([ tag.tagId || tag ], !this.selectMany);
+        this.tagChange([ tag.tagId || tag ], { tagOne: !this.selectMany });
         this.indeterminate.set(tag.tagId || tag, tag.indeterminate || false);
       });
     this.addTagForm = this.fb.group({
@@ -82,16 +82,21 @@ export class PlanetTagInputDialogComponent {
     this.newTagId = undefined;
   }
 
-  tagChange(tags, tagOne = false) {
+  tagChange(tags, { tagOne = false, deselectSubs = false }: { tagOne?, deselectSubs? } = {}) {
     const newState = !this.selected.get(tags[0]);
+    const setAllTags = newState !== deselectSubs;
     tags.forEach((tag, index) => {
-      if (index === 0 || newState) {
+      if (index === 0 || setAllTags) {
         this.selected.set(tag, newState || this.indeterminate.get(tag));
         this.indeterminate.set(tag, false);
 
         this.data.tagUpdate(tag, this.selected.get(tag), tagOne);
       }
     });
+  }
+
+  subTagIds(subTags: any[]) {
+    return subTags.map(subTag => subTag._id || subTag.name);
   }
 
   updateFilter(value) {

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -15,6 +15,12 @@ import { mapToArray, isInMap } from '../utils';
     :host .mat-list-option span {
       font-weight: inherit;
     }
+    :host p[matLine] * {
+      margin-right: 0.25rem;
+    }
+    :host p[matLine] *:last-child {
+      margin-right: 0;
+    }
   ` ]
 })
 export class PlanetTagInputDialogComponent {

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -169,7 +169,7 @@ export class PlanetTagInputDialogComponent {
 
   toggleSubcollection(event, tagId) {
     event.stopPropagation();
-    const newState = !this.subcollectionIsOpen.get(tagId)
+    const newState = !this.subcollectionIsOpen.get(tagId);
     this.subcollectionIsOpen.clear();
     this.subcollectionIsOpen.set(tagId, newState);
   }

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -137,10 +137,11 @@ export class PlanetTagInputDialogComponent {
       });
     }).bind(this);
     event.stopPropagation();
-    const options = this.tags.map((t: any) => ({ name: t.name, value: t._id || t.name })).filter((t: any) => t.name !== tag.name);
+    const options = this.tags.filter((t: any) => t.name !== tag.name && (t.attachedTo === undefined || t.attachedTo.length === 0))
+      .map((t: any) => ({ name: t.name, value: t._id || t.name }));
     this.dialogsFormService.openDialogsForm('Edit Collection', [
       { placeholder: 'Name', name: 'name', required: true, type: 'textbox' },
-      { placeholder: 'Subcollection of...', name: 'attachedTo', type: 'selectbox', options, required: false, multiple: true }
+      { placeholder: 'Subcollection of...', name: 'attachedTo', type: 'selectbox', options, required: false, reset: true }
     ], this.tagForm(tag), { onSubmit });
   }
 

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -145,8 +145,9 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
   openPresetDialog() {
     this.initTags();
     this.dialogRef = this.dialog.open(PlanetTagInputDialogComponent, {
-      width: '80vw',
-      height: '80vh',
+      minWidth: '25vw',
+      maxWidth: '90vw',
+      maxHeight: '80vh',
       autoFocus: false,
       data: this.dialogData(true)
     });

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -9,6 +9,7 @@ import { Subject } from 'rxjs';
 import { TagsService } from './tags.service';
 import { PlanetTagInputDialogComponent } from './planet-tag-input-dialog.component';
 import { dedupeShelfReduce } from '../utils';
+import { UserService } from '../user.service';
 
 @Component({
   'selector': 'planet-tag-input',
@@ -78,7 +79,8 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
     private focusMonitor: FocusMonitor,
     private elementRef: ElementRef,
     private tagsService: TagsService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private userService: UserService
   ) {
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
@@ -143,8 +145,8 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
   openPresetDialog() {
     this.initTags();
     this.dialogRef = this.dialog.open(PlanetTagInputDialogComponent, {
-      maxWidth: '80vw',
-      maxHeight: '80vh',
+      width: '80vw',
+      height: '80vh',
       autoFocus: false,
       data: this.dialogData(true)
     });
@@ -204,7 +206,7 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
           0
         )
       });
-    }).filter((tag: any) => tag.count > 0);
+    }).filter((tag: any) => tag.count > 0 || this.userService.doesUserHaveRole([ '_admin', 'manager' ]));
   }
 
   dialogTagUpdate(tag, isSelected, tagOne = false) {

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -171,7 +171,7 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
       initTags: this.initTags.bind(this),
       reset: this.resetDialogData.bind(this),
       startingTags,
-      tags: this.filterTags(this.tags, this.selectMany),
+      tags: this.filterTags(this.tags.filter((tag: any) => tag.attachedTo === undefined || tag.attachedTo.length === 0), this.selectMany),
       mode: this.mode,
       initSelectMany: this.selectMany,
       db: this.db

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -171,7 +171,7 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
       initTags: this.initTags.bind(this),
       reset: this.resetDialogData.bind(this),
       startingTags,
-      tags: this.filterTags(this.tags.filter((tag: any) => tag.attachedTo === undefined || tag.attachedTo.length === 0), this.selectMany),
+      tags: this.filterTags(this.tags.filter(this.tagsService.filterOutSubTags), this.selectMany),
       mode: this.mode,
       initSelectMany: this.selectMany,
       db: this.db

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -36,7 +36,7 @@ export class TagsService {
 
   updateTag(tag) {
     const { count, subTags, ...tagData } = tag;
-    const newId = `${tagData.db}${tagData.attachedTo.length === 0 ? '' : '_' + tagData.attachedTo}_${tagData.name.toLowerCase()}`;
+    const newId = `${tagData.attachedTo.length === 0 ? tagData.db : tagData.attachedTo}_${tagData.name.toLowerCase()}`;
     if (newId === tag._id) {
       return this.couchService.updateDocument('tags', tagData).pipe(
         switchMap(res => of([ res ]))

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -70,10 +70,17 @@ export class TagsService {
       const tag = { ...this.findTag(tagLink.tagId, tags), tagLink };
       return ({ ...obj, [tagLink.linkId]: obj[tagLink.linkId] ? [ ...obj[tagLink.linkId], tag ] : [ tag ] });
     }, {});
-    return docs.map((doc: any) => ({
-      ...doc,
-      tags: tagsObj[doc._id] || []
-    }));
+    return docs.map((doc: any) => {
+      const docTags = tagsObj[doc._id] || [];
+      return {
+        ...doc,
+        tags: docTags.map(tag => ({
+          ...tag,
+          subTags: tag.subTags.filter(subTag => docTags.some(docTag => docTag._id === subTag._id)),
+          isMainTag: this.filterOutSubTags(tag)
+        }))
+      };
+    });
   }
 
   tagBulkDocs(linkId: string, db: string, newTagIds: string[], currentTags: any[] = []) {
@@ -96,6 +103,10 @@ export class TagsService {
       )
     ).flat();
     return this.couchService.bulkDocs('tags', newTags);
+  }
+
+  filterOutSubTags(tag: any) {
+    return tag.attachedTo === undefined || tag.attachedTo.length === 0;
   }
 
 }

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -23,7 +23,8 @@ export class TagsService {
         return tags
           .map((tag: any) => ({ ...tag, count: tagCounts[tag._id] || 0 }))
           .filter((tag: any) => tag.db === db && tag.docType === 'definition')
-          .map(this.fillSubTags);
+          .map(this.fillSubTags)
+          .filter(tag => tag.attachedTo === undefined || tag.attachedTo.length === 0);
       })
     );
   }
@@ -35,7 +36,7 @@ export class TagsService {
 
   updateTag(tag) {
     const { count, subTags, ...tagData } = tag;
-    const newId = `${tagData.db}_${tagData.name.toLowerCase()}`;
+    const newId = `${tagData.db}${tagData.attachedTo.length === 0 ? '' : '_' + tagData.attachedTo}_${tagData.name.toLowerCase()}`;
     if (newId === tag._id) {
       return this.couchService.updateDocument('tags', tagData).pipe(
         switchMap(res => of([ res ]))

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -23,8 +23,7 @@ export class TagsService {
         return tags
           .map((tag: any) => ({ ...tag, count: tagCounts[tag._id] || 0 }))
           .filter((tag: any) => tag.db === db && tag.docType === 'definition')
-          .map(this.fillSubTags)
-          .filter(tag => tag.attachedTo === undefined || tag.attachedTo.length === 0);
+          .map(this.fillSubTags);
       })
     );
   }


### PR DESCRIPTION
Updates layout & subcollections

Subcollections are now unique to the attached collection.  The upside is that this is less confusing: clicking on a subcollection doesn't mark the checkbox for a bunch of items in the list.  The downside is that this will require more collections on each planet and will likely end up with some duplication.

TODOs:
- Fix subcollection showing id instead of name
- Better UI for subcollection in list of resources/courses