### PR TITLE
[Fixes#3956] Markdown Textbox: adjust bottom margin

### DIFF
--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -33,4 +33,8 @@ planet-markdown-textbox {
   .CodeMirror.CodeMirror-fullscreen, .CodeMirror-fullscreen .CodeMirror-scroll {
     height: 100%;
   }
+
+  .editor-statusbar {
+    margin-bottom: -25px;
+  }
 }

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -35,6 +35,6 @@ planet-markdown-textbox {
   }
 
   .editor-statusbar {
-    margin-bottom: -25px;
+    margin-bottom: -2.75em;
   }
 }


### PR DESCRIPTION
[Fixes#3956] Markdown Textbox: adjust bottom margin

![issue-3956](https://user-images.githubusercontent.com/41846764/58998400-283ef600-87c6-11e9-98cd-6d69787755e4.PNG)
