### PR TITLE
[Fixes#3932] Markdown Textbox: Full screen not expanding fully

### DIFF
--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -32,5 +32,6 @@ planet-markdown-textbox {
 
   .CodeMirror.CodeMirror-fullscreen, .CodeMirror-fullscreen .CodeMirror-scroll {
     height: 100%;
+    max-height: 100%;
   }
 }


### PR DESCRIPTION
[Fixes#3932] Markdown Textbox: Full screen not expanding fully

![issue-3932](https://user-images.githubusercontent.com/41846764/58998896-c03ddf00-87c8-11e9-8e3e-054d6be05637.PNG)
