### PR TITLE
Adds button margins to "add course", "update course", and "add meetups" (Fixes #3985)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -40,7 +40,7 @@
     </div>
     <div class="actions-container">
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-      <button type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
+      <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
       <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
     </div>
   </div>

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -1,5 +1,4 @@
 @import '../../variables';
-@import '../../../styles.scss';
 
 :host {
   .view-container {

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -1,4 +1,5 @@
 @import '../../variables';
+@import '../../../styles.scss';
 
 :host {
   .view-container {

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -73,7 +73,7 @@
         </mat-form-field>
       </div>
       <button mat-raised-button type="submit" color="primary" [planetSubmit]="meetupForm.valid" [disabled]="!meetupForm.dirty" i18n>Save</button>
-      <button mat-raised-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
+      <button class="margin-lr-2" mat-raised-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
     </form>
   </div>
 </div>


### PR DESCRIPTION
Fixes Issue #3985.

Adds 2px button margins to "add course", "update course", and "add meetups".

![Capture](https://user-images.githubusercontent.com/22685147/59147443-a15a6b00-89c9-11e9-98f3-6742ce922d4a.PNG)