### PR TITLE
Development serve for different languages (fixes #2363)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,6 +55,30 @@
                   "with": "src/environments/environment.test.ts"
                 }
               ]
+            },
+            "somali": {
+              "aot": true,
+              "i18nFile": "src/i18n/messages.som.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "so"
+            },
+            "french": {
+              "aot": true,
+              "i18nFile": "src/i18n/messages.fra.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "fr"
+            },
+            "nepali": {
+              "aot": true,
+              "i18nFile": "src/i18n/messages.nep.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "ne"
+            },
+            "arabic": {
+              "aot": true,
+              "i18nFile": "src/i18n/messages.ara.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "ar"
             }
           }
         },
@@ -71,6 +95,18 @@
             },
             "test": {
               "browserTarget": "planet-app:build:test"
+            },
+            "somali": {
+              "browserTarget": "planet-app:build:somali"
+            },
+            "french": {
+              "browserTarget": "planet-app:build:french"
+            },
+            "nepali": {
+              "browserTarget": "planet-app:build:nepali"
+            },
+            "arabic": {
+              "browserTarget": "planet-app:build:arabic"
             }
           }
         },


### PR DESCRIPTION
Allows for viewing some of the different language files in the development server with one of the following commands:

```
ng serve --configuration=somali
ng serve --configuration=french
ng serve --configuration=nepali
ng serve --configuration=arabic
```

Made the change to review another PR anyway, so figure I can share so others can use this.