### PR TITLE
Changes "Update Team" modal word "Detail" To "Description" and adds autofocus (Issue #4016)

### DIFF
--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -42,7 +42,7 @@ export class TeamsService {
       requests: [ team.requests || [] ],
       teamType: [ team._id ? { value: team.teamType || 'local', disabled: true } : 'local' ]
     };
-    return this.dialogsFormService.confirm(title, [ ...addTeamDialogFields, this.typeFormField(configuration) ], formGroup)
+    return this.dialogsFormService.confirm(title, [ ...addTeamDialogFields, this.typeFormField(configuration) ], formGroup, true)
       .pipe(
         switchMap((response: any) => response !== undefined ?
           this.updateTeam(

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -18,7 +18,7 @@ const addTeamDialogFields = [ {
 }, {
   'type': 'textarea',
   'name': 'description',
-  'placeholder': 'Detail',
+  'placeholder': 'Description',
   'required': false
 } ];
 
@@ -41,7 +41,7 @@ export class TeamsService {
       requests: [ team ? team.requests : [] ]
     };
     return this.dialogsFormService
-      .confirm(title, addTeamDialogFields, formGroup)
+      .confirm(title, addTeamDialogFields, formGroup, true)
       .pipe(
         debug('Dialog confirm'),
         switchMap((response: any) => {


### PR DESCRIPTION
Fixes Issue #4016

The autofocus is on "Name" and not "Description", however. I thought this would be more apt because this "Update Team" modal is used for both editing purposes and adding descriptions, so autofocusing on the Description might not be the most frequent use. In case you do want to change the description, it is just a tab away.