### PR TITLE
Spinner added on re-open (Fixes #4061)

### DIFF
--- a/src/app/feedback/feedback-view.component.ts
+++ b/src/app/feedback/feedback-view.component.ts
@@ -120,8 +120,10 @@ export class FeedbackViewComponent implements OnInit, OnDestroy {
 
   openFeedback(feedback) {
     this.dialogsLoadingService.start();
-    this.feedbackServive.openFeedback(feedback).subscribe(() => this.getFeedback(feedback.id));
-    this.dialogsLoadingService.stop();
+    this.feedbackServive.openFeedback(feedback).subscribe(() => {
+      this.getFeedback(feedback.id);
+      this.dialogsLoadingService.stop();
+    });
   }
 
   scrollToBottom() {

--- a/src/app/feedback/feedback-view.component.ts
+++ b/src/app/feedback/feedback-view.component.ts
@@ -10,6 +10,7 @@ import { PlanetMessageService } from '../shared/planet-message.service';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { debug } from '../debug-operator';
 import { FeedbackService } from './feedback.service';
+import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 
 @Component({
   templateUrl: './feedback-view.component.html',
@@ -32,7 +33,8 @@ export class FeedbackViewComponent implements OnInit, OnDestroy {
     private dialogsFormService: DialogsFormService,
     private planetMessageService: PlanetMessageService,
     private feedbackServive: FeedbackService,
-    private router: Router
+    private router: Router,
+    private dialogsLoadingService: DialogsLoadingService
   ) {}
 
   ngOnInit() {
@@ -117,7 +119,9 @@ export class FeedbackViewComponent implements OnInit, OnDestroy {
   }
 
   openFeedback(feedback) {
+    this.dialogsLoadingService.start();
     this.feedbackServive.openFeedback(feedback).subscribe(() => this.getFeedback(feedback.id));
+    this.dialogsLoadingService.stop();
   }
 
   scrollToBottom() {


### PR DESCRIPTION
Fixes Issue #4061 

It is now impossible to click the Re-Open button twice on a Feedback while it is loading due to the spinner being active.