### PR TITLE
Add margin for "Show main conversation"(Fix #4038)

### DIFF
--- a/src/app/news/news-list.component.html
+++ b/src/app/news/news-list.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="replyViewing._id!=='root'">
   <div class="action-buttons">
-    <button mat-stroked-button type="button" (click)="showReplies({_id:'root'})" i18n>Show main conversation</button>
+    <button mat-stroked-button style="margin-top: 0.5rem" type="button" (click)="showReplies({_id:'root'})" i18n>Show main conversation</button>
     <button mat-stroked-button type="button" *ngIf="replyViewing.replyTo && replyViewing.replyTo !== 'root'" (click)="showPreviousReplies()" i18n>Show previous replies</button>
   </div>
   <p i18n>Viewing replies for:</p>

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -28,7 +28,6 @@ $label-height: 1rem;
 
   .mat-button, .mat-stroked-button {
     min-width: auto;
-    margin-top: 0.5rem;
   }
 
   .column {

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -28,6 +28,7 @@ $label-height: 1rem;
 
   .mat-button, .mat-stroked-button {
     min-width: auto;
+    margin-top: 0.5rem;
   }
 
   .column {


### PR DESCRIPTION
In news, when replying to reply of messages, a margin of 0.5rem was added to the "Show main conversation" button