### PR TITLE
[#4117] Stops spinner on changing collection

### DIFF
--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -8,6 +8,7 @@ import { DialogsFormService } from '../dialogs/dialogs-form.service';
 import { UserService } from '../user.service';
 import { CustomValidators } from '../../validators/custom-validators';
 import { mapToArray, isInMap } from '../utils';
+import { DialogsLoadingService } from '../../shared/dialogs/dialogs-loading.service';
 
 @Component({
   'templateUrl': 'planet-tag-input-dialog.component.html',
@@ -55,7 +56,8 @@ export class PlanetTagInputDialogComponent {
     private planetMessageService: PlanetMessageService,
     private validatorService: ValidatorService,
     private dialogsFormService: DialogsFormService,
-    private userService: UserService
+    private userService: UserService,
+    private dialogsLoadingService: DialogsLoadingService
   ) {
     this.dataInit();
     // April 17, 2019: Removing selectMany toggle, but may revisit later
@@ -145,6 +147,7 @@ export class PlanetTagInputDialogComponent {
         this.indeterminate.set(newTagId, this.indeterminate.get(tag._id));
         this.data.initTags(this.mode === 'add' ? newTagId : undefined);
         this.dialogsFormService.closeDialogsForm();
+        this.dialogsLoadingService.stop();
       });
     }).bind(this);
     event.stopPropagation();


### PR DESCRIPTION
Issue #4117 

Editing subcollection status no longer has an infinite spinner.