### PR TITLE
TeamsView: Add resource

### DIFF
--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -5,7 +5,7 @@ import { MatDialog, MatDialogRef } from '@angular/material';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { CoursesService } from '../courses.service';
-import { CoursesAddResourcesComponent } from './courses-add-resources.component';
+import { DialogsAddResourcesComponent } from '../../shared/dialogs/dialogs-add-resources.component';
 
 @Component({
   selector: 'planet-courses-step',
@@ -20,7 +20,7 @@ export class CoursesStepComponent implements OnDestroy {
   @Output() addStepEvent = new EventEmitter<void>();
 
   stepForm: FormGroup;
-  dialogRef: MatDialogRef<CoursesAddResourcesComponent>;
+  dialogRef: MatDialogRef<DialogsAddResourcesComponent>;
   activeStep: any;
   activeStepIndex = -1;
   private onDestroy$ = new Subject<void>();
@@ -56,7 +56,7 @@ export class CoursesStepComponent implements OnDestroy {
   }
 
   addResources() {
-    this.dialogRef = this.dialog.open(CoursesAddResourcesComponent, {
+    this.dialogRef = this.dialog.open(DialogsAddResourcesComponent, {
       width: '80vw',
       data: {
         okClick: this.resourcsDialogOkClick.bind(this),

--- a/src/app/courses/courses.module.ts
+++ b/src/app/courses/courses.module.ts
@@ -18,7 +18,7 @@ import { CoursesProgressBarComponent } from './progress-courses/courses-progress
 import { CoursesProgressChartComponent } from './progress-courses/courses-progress-chart.component';
 import { CoursesProgressLearnerComponent } from './progress-courses/courses-progress-learner.component';
 import { SharedComponentsModule } from '../shared/shared-components.module';
-import { CoursesAddResourcesComponent } from './add-courses/courses-add-resources.component';
+import { DialogsAddResourcesModule } from '../shared/dialogs/dialogs-add-resources.module';
 
 @NgModule({
   imports: [
@@ -31,7 +31,8 @@ import { CoursesAddResourcesComponent } from './add-courses/courses-add-resource
     MaterialModule,
     ResourcesModule,
     ExamsModule,
-    SharedComponentsModule
+    SharedComponentsModule,
+    DialogsAddResourcesModule
   ],
   declarations: [
     CoursesComponent,
@@ -42,9 +43,7 @@ import { CoursesAddResourcesComponent } from './add-courses/courses-add-resource
     CoursesProgressLeaderComponent,
     CoursesProgressLearnerComponent,
     CoursesProgressBarComponent,
-    CoursesProgressChartComponent,
-    CoursesAddResourcesComponent
-  ],
-  entryComponents: [ CoursesAddResourcesComponent ]
+    CoursesProgressChartComponent
+  ]
 })
 export class CoursesModule {}

--- a/src/app/manager-dashboard/sync.directive.ts
+++ b/src/app/manager-dashboard/sync.directive.ts
@@ -53,7 +53,7 @@ export class SyncDirective {
       switchMap(([ achievements, teamResources ]: any[]) =>
         forkJoin(this.achievementResourceReplicator(achievements), this.teamResourcesReplicator(teamResources))
       ),
-      switchMap((replicators: any[]) => {
+      switchMap((replicators: any) => {
         this.dialogsLoadingService.stop();
         return this.syncService.confirmPasswordAndRunReplicators(this.replicatorList().concat(replicators.flat()));
       }),

--- a/src/app/manager-dashboard/sync.directive.ts
+++ b/src/app/manager-dashboard/sync.directive.ts
@@ -49,13 +49,13 @@ export class SyncDirective {
       switchMap((replicators) => this.syncService.deleteReplicators(deleteArray(replicators))),
       switchMap(() => forkJoin(this.sendStatsToParent(), this.getParentUsers())),
       map(([ res, users ]) => this.updateParentUsers(users)),
-      switchMap(() => {
-        return this.couchService.findAll('achievements', findDocuments({ sendToNation: true, createdOn: this.planetConfiguration.code }));
-      }),
-      switchMap(achievements => this.achievementResourceReplicator(achievements)),
-      switchMap(replicators => {
+      switchMap(() => this.getAchievementsAndTeamResources()),
+      switchMap(([ achievements, teamResources ]: any[]) =>
+        forkJoin(this.achievementResourceReplicator(achievements), this.teamResourcesReplicator(teamResources))
+      ),
+      switchMap((replicators: any[]) => {
         this.dialogsLoadingService.stop();
-        return this.syncService.confirmPasswordAndRunReplicators(this.replicatorList().concat(replicators));
+        return this.syncService.confirmPasswordAndRunReplicators(this.replicatorList().concat(replicators.flat()));
       }),
       switchMap(res => this.managerService.addAdminLog('sync'))
     ).subscribe(data => {
@@ -182,6 +182,23 @@ export class SyncDirective {
       const docs = [ ...deleteArray, ...updateArray ].map(({ _attachments, ...doc }) => doc);
       return this.couchService.bulkDocs('parent_users', docs);
     })).subscribe((res) => console.log(res));
+  }
+
+  getAchievementsAndTeamResources() {
+    return forkJoin([
+      this.couchService.findAll('achievements', findDocuments({ sendToNation: true, createdOn: this.planetConfiguration.code })),
+      this.couchService.findAll(
+        'teams', findDocuments({ docType: 'resourceLink', teamType: 'sync', teamPlanetCode: this.planetConfiguration.code })
+      )
+    ]);
+  }
+
+  teamResourcesReplicator(teamResources: any[]) {
+    return this.syncService.replicatorsArrayWithTags(
+      teamResources.map(linkDoc => ({ db: 'resources', item: { _id: linkDoc.resourceId } })),
+      'push',
+      'local'
+    );
   }
 
 }

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -92,6 +92,9 @@
           <ng-container *ngIf="existingResource.doc?._attachments">
             <mat-checkbox [disabled]="disableDelete || this.file" (change)="deleteAttachmentToggle($event)" i18n>Delete File</mat-checkbox>
           </ng-container>
+          <ng-container *ngIf="isDialog">
+            <mat-checkbox formControlName="private" i18n-matTooltip matTooltip="If checked, resource will only be viewable by this team" i18n>Private Resource</mat-checkbox>
+          </ng-container>
         </div>
       </form>
     </div>

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -1,8 +1,8 @@
-<mat-toolbar>
+<mat-toolbar *ngIf="!isDialog">
   <a mat-icon-button routerLink="/resources"><mat-icon>arrow_back</mat-icon></a>
 </mat-toolbar>
 
-<div class="space-container">
+<div [ngClass]="{'space-container':!isDialog}">
   <mat-toolbar class="primary-color font-size-1" i18n>{{pageType}} Resource</mat-toolbar>
   <div class="view-container view-full-height">
     <div class="form-container">
@@ -95,7 +95,7 @@
         </div>
       </form>
     </div>
-    <div class="actions-container inner-gaps by-column">
+    <div class="actions-container inner-gaps by-column" *ngIf="!isDialog">
       <button mat-raised-button type="button" [planetSubmit]="resourceForm.valid" color="primary" (click)="onSubmit()"  i18n>Submit</button>
       <button mat-raised-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
     </div>

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -118,7 +118,8 @@ export class ResourcesAddComponent implements OnInit {
       sourcePlanet: this.stateService.configuration.code,
       resideOn: this.stateService.configuration.code,
       createdDate: this.couchService.datePlaceholder,
-      updatedDate: this.couchService.datePlaceholder
+      updatedDate: this.couchService.datePlaceholder,
+      private: this.isDialog
     });
   }
 

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -31,7 +31,6 @@ import { TagsService } from '../shared/forms/tags.service';
 export class ResourcesAddComponent implements OnInit {
   constants = constants;
   file: any;
-  existingResource: any = {};
   deleteAttachment = false;
   resourceForm: FormGroup;
   readonly dbName = 'resources'; // make database name a constant
@@ -42,6 +41,7 @@ export class ResourcesAddComponent implements OnInit {
   resourceFilename = '';
   languages = languages;
   tags = this.fb.control([]);
+  @Input() existingResource: any = {};
   @Input() isDialog = false;
   @Input() privateFor: any;
   @Output() afterSubmit = new EventEmitter<any>();
@@ -73,6 +73,7 @@ export class ResourcesAddComponent implements OnInit {
     });
     this.userDetail = this.userService.get();
     this.resourcesService.requestResourcesUpdate(false, false);
+    this.resourceForm.patchValue(this.existingResource.doc);
     if (!this.isDialog && this.route.snapshot.url[0].path === 'update') {
       this.resourcesService.resourcesListener(false).pipe(first())
         .subscribe((resources: any[]) => {
@@ -156,7 +157,8 @@ export class ResourcesAddComponent implements OnInit {
         const existingData = this.deleteAttachment ? { _id, _rev } : this.existingResource.doc;
         // Start with empty object so this.resourceForm.value does not change
         const newResource = Object.assign({}, existingData, this.resourceForm.value, resource);
-        const message = newResource.title + (this.pageType === 'Update' ?  ' Updated Successfully' : ' Added');
+        const message = newResource.title +
+          (this.pageType === 'Update' || this.existingResource.doc ?  ' Updated Successfully' : ' Added');
         this.updateResource(newResource, file).subscribe(([ resourceRes ]) => {
           if (this.isDialog) {
             this.afterSubmit.next(resourceRes);

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -79,6 +79,7 @@ export class ResourcesAddComponent implements OnInit {
           this.pageType = 'Update';
           const resource = resources.find(r => r._id === this.route.snapshot.paramMap.get('id'));
           this.existingResource = resource;
+          this.privateFor = resource.privateFor;
           // If the resource does not have an attachment, disable file downloadable toggle
           this.disableDownload = !resource.doc._attachments;
           this.disableDelete = !resource.doc._attachments;
@@ -97,9 +98,15 @@ export class ResourcesAddComponent implements OnInit {
         '',
         CustomValidators.required,
         // an arrow function is for lexically binding 'this' otherwise 'this' would be undefined
-        !this.isDialog && this.route.snapshot.url[0].path === 'update'
-          ? ac => this.validatorService.isNameAvailible$(this.dbName, 'title', ac, this.route.snapshot.params.id)
-          : ac => this.validatorService.isUnique$(this.dbName, 'title', ac)
+        ac => this.validatorService.isUnique$(
+          this.dbName, 'title', ac,
+          {
+            selectors: {
+              '_id': this.existingResource._id && { '$ne': this.existingResource._id },
+              'privateFor': { '$or': [ this.privateFor, { '$exists': false } ] }
+            }
+          }
+        )
       ],
       author: '',
       year: '',

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -43,6 +43,7 @@ export class ResourcesAddComponent implements OnInit {
   languages = languages;
   tags = this.fb.control([]);
   @Input() isDialog = false;
+  @Input() privateFor: any;
   @Output() afterSubmit = new EventEmitter<any>();
 
   constructor(
@@ -181,7 +182,9 @@ export class ResourcesAddComponent implements OnInit {
   }
 
   updateResource(resourceInfo, file) {
-    return this.couchService.updateDocument(this.dbName, { ...resourceInfo, updatedDate: this.couchService.datePlaceholder })
+    return this.couchService.updateDocument(
+      this.dbName, { ...resourceInfo, updatedDate: this.couchService.datePlaceholder, privateFor: this.privateFor }
+    )
     .pipe(switchMap((resourceRes) =>
       forkJoin([
         of(resourceRes),

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -112,7 +112,9 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
       map(([ resources, shelf ]) => this.setupList(resources, (shelf || this.userService.shelf).resourceIds)),
       switchMap((resources) => this.parent ? this.couchService.localComparison(this.dbName, resources) : of(resources))
     ).subscribe((resources) => {
-      this.resources.data = resources.filter((resource: any) => this.excludeIds.indexOf(resource._id) === -1);
+      this.resources.data = resources.filter(
+        (resource: any) => this.excludeIds.indexOf(resource._id) === -1 && resource.doc.private !== true
+      );
       this.emptyData = !this.resources.data.length;
       this.resources.paginator = this.paginator;
       this.dialogsLoadingService.stop();

--- a/src/app/resources/resources.module.ts
+++ b/src/app/resources/resources.module.ts
@@ -34,6 +34,6 @@ import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search
     ResourcesSearchComponent,
     ResourcesSearchListComponent
   ],
-  exports: [ ResourcesViewerComponent, ResourcesComponent ]
+  exports: [ ResourcesViewerComponent, ResourcesComponent, ResourcesAddComponent ]
 })
 export class ResourcesModule {}

--- a/src/app/shared/dialogs/dialogs-add-resources.component.html
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.html
@@ -1,0 +1,14 @@
+<ng-container [ngSwitch]="view">
+  <planet-resources *ngSwitchCase="'resources'" [isDialog]="true" [excludeIds]="data.excludeIds"></planet-resources>
+  <planet-resources-add *ngSwitchCase="'resourcesAdd'" [isDialog]="true" (afterSubmit)="addNewResource($event)"></planet-resources-add>
+</ng-container>
+<mat-dialog-actions>
+  <ng-container *ngIf="data.canAdd">
+    <button color="accent" mat-raised-button (click)="toggleNewOrExisting()" i18n>
+      {view, select, resources {Create New Resource} resourcesAdd {Select Existing Resource(s)}}
+    </button>
+    <span class="margin-lr-8" i18n>OR</span>
+  </ng-container>
+  <button color="primary" mat-raised-button (click)="ok()" i18n>OK</button>
+  <button color="warn" mat-raised-button mat-dialog-close i18n>Cancel</button>
+</mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-add-resources.component.html
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.html
@@ -1,9 +1,9 @@
 <ng-container [ngSwitch]="view">
   <planet-resources *ngSwitchCase="'resources'" [isDialog]="true" [excludeIds]="data.excludeIds"></planet-resources>
-  <planet-resources-add *ngSwitchCase="'resourcesAdd'" [isDialog]="true" [privateFor]="linkInfo" (afterSubmit)="addNewResource($event)"></planet-resources-add>
+  <planet-resources-add *ngSwitchCase="'resourcesAdd'" [isDialog]="true" [privateFor]="linkInfo" [existingResource]="existingResource" (afterSubmit)="addNewResource($event)"></planet-resources-add>
 </ng-container>
 <mat-dialog-actions>
-  <ng-container *ngIf="data.canAdd">
+  <ng-container *ngIf="data.canAdd && !updateResource">
     <button color="accent" mat-raised-button (click)="toggleNewOrExisting()" i18n>
       {view, select, resources {Create New Resource} resourcesAdd {Select Existing Resource(s)}}
     </button>

--- a/src/app/shared/dialogs/dialogs-add-resources.component.html
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.html
@@ -1,6 +1,6 @@
 <ng-container [ngSwitch]="view">
   <planet-resources *ngSwitchCase="'resources'" [isDialog]="true" [excludeIds]="data.excludeIds"></planet-resources>
-  <planet-resources-add *ngSwitchCase="'resourcesAdd'" [isDialog]="true" (afterSubmit)="addNewResource($event)"></planet-resources-add>
+  <planet-resources-add *ngSwitchCase="'resourcesAdd'" [isDialog]="true" [privateFor]="linkInfo" (afterSubmit)="addNewResource($event)"></planet-resources-add>
 </ng-container>
 <mat-dialog-actions>
   <ng-container *ngIf="data.canAdd">

--- a/src/app/shared/dialogs/dialogs-add-resources.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.ts
@@ -1,19 +1,16 @@
 import { Component, Inject, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { ResourcesComponent } from '../../resources/resources.component';
+import { ResourcesAddComponent } from '../../resources/resources-add.component';
 
 @Component({
-  template: `
-    <planet-resources [isDialog]="true" [excludeIds]="data.excludeIds"></planet-resources>
-    <mat-dialog-actions>
-      <button color="primary" mat-raised-button (click)="ok()" i18n>OK</button>
-      <button color="warn" mat-raised-button mat-dialog-close i18n>Cancel</button>
-    </mat-dialog-actions>
-  `
+  templateUrl: 'dialogs-add-resources.component.html'
 })
 export class DialogsAddResourcesComponent {
 
   @ViewChild(ResourcesComponent) resourcesComponent: ResourcesComponent;
+  @ViewChild(ResourcesAddComponent) resourcesAddComponent: ResourcesAddComponent;
+  view: 'resources' | 'resourcesAdd' = 'resources';
 
   constructor(
     public dialogRef: MatDialogRef<DialogsAddResourcesComponent>,
@@ -21,10 +18,33 @@ export class DialogsAddResourcesComponent {
   ) {}
 
   ok() {
+    switch (this.view) {
+      case 'resources':
+        this.addExistingResources();
+        break;
+      case 'resourcesAdd':
+        this.submitNewResource();
+        break;
+    }
+  }
+
+  addExistingResources() {
     const tableData = this.resourcesComponent.resources.data;
     const selection = this.resourcesComponent.selection.selected;
     const resources = tableData.filter((resource: any) => selection.indexOf(resource._id) > -1);
     this.data.okClick(resources);
+  }
+
+  submitNewResource() {
+    this.resourcesAddComponent.onSubmit();
+  }
+
+  addNewResource(resource) {
+    this.data.okClick([ { _id: resource.id } ]);
+  }
+
+  toggleNewOrExisting() {
+    this.view = this.view === 'resources' ? 'resourcesAdd' : 'resources';
   }
 
 }

--- a/src/app/shared/dialogs/dialogs-add-resources.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.ts
@@ -12,12 +12,19 @@ export class DialogsAddResourcesComponent {
   @ViewChild(ResourcesAddComponent) resourcesAddComponent: ResourcesAddComponent;
   view: 'resources' | 'resourcesAdd' = 'resources';
   linkInfo: any;
+  updateResource = false;
+  existingResource: any = {};
 
   constructor(
     public dialogRef: MatDialogRef<DialogsAddResourcesComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     this.linkInfo = this.data.db ? { [this.data.db]: this.data.linkId } : undefined;
+    if (this.data.resource) {
+      this.updateResource = true;
+      this.view = 'resourcesAdd';
+      this.existingResource = { doc: this.data.resource, _id: this.data.resource._id, _rev: this.data.resource._rev };
+    }
   }
 
   ok() {
@@ -43,7 +50,7 @@ export class DialogsAddResourcesComponent {
   }
 
   addNewResource(resource) {
-    this.data.okClick([ { _id: resource.id } ]);
+    this.data.okClick(this.existingResource.doc ? [] : [ { _id: resource.id } ]);
   }
 
   toggleNewOrExisting() {

--- a/src/app/shared/dialogs/dialogs-add-resources.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.ts
@@ -11,11 +11,14 @@ export class DialogsAddResourcesComponent {
   @ViewChild(ResourcesComponent) resourcesComponent: ResourcesComponent;
   @ViewChild(ResourcesAddComponent) resourcesAddComponent: ResourcesAddComponent;
   view: 'resources' | 'resourcesAdd' = 'resources';
+  linkInfo: any;
 
   constructor(
     public dialogRef: MatDialogRef<DialogsAddResourcesComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
-  ) {}
+  ) {
+    this.linkInfo = this.data.db ? { [this.data.db]: this.data.linkId } : undefined;
+  }
 
   ok() {
     switch (this.view) {

--- a/src/app/shared/dialogs/dialogs-add-resources.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.ts
@@ -50,7 +50,7 @@ export class DialogsAddResourcesComponent {
   }
 
   addNewResource(resource) {
-    this.data.okClick(this.existingResource.doc ? [] : [ { _id: resource.id } ]);
+    this.data.okClick(this.existingResource.doc ? [] : [ resource ]);
   }
 
   toggleNewOrExisting() {

--- a/src/app/shared/dialogs/dialogs-add-resources.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.component.ts
@@ -11,12 +11,12 @@ import { ResourcesComponent } from '../../resources/resources.component';
     </mat-dialog-actions>
   `
 })
-export class CoursesAddResourcesComponent {
+export class DialogsAddResourcesComponent {
 
   @ViewChild(ResourcesComponent) resourcesComponent: ResourcesComponent;
 
   constructor(
-    public dialogRef: MatDialogRef<CoursesAddResourcesComponent>,
+    public dialogRef: MatDialogRef<DialogsAddResourcesComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {}
 

--- a/src/app/shared/dialogs/dialogs-add-resources.module.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.module.ts
@@ -1,0 +1,24 @@
+import { MaterialModule  } from '../material.module';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResourcesModule } from '../../resources/resources.module';
+import { DialogsAddResourcesComponent } from './dialogs-add-resources.component';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MaterialModule,
+    ResourcesModule
+  ],
+  exports: [
+    DialogsAddResourcesComponent
+  ],
+  declarations: [
+    DialogsAddResourcesComponent
+  ],
+  entryComponents: [
+    DialogsAddResourcesComponent
+  ]
+})
+export class DialogsAddResourcesModule {}

--- a/src/app/shared/dialogs/dialogs-add-resources.module.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.module.ts
@@ -1,4 +1,4 @@
-import { MaterialModule  } from '../material.module';
+import { MaterialModule } from '../material.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ResourcesModule } from '../../resources/resources.module';

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -92,6 +92,9 @@
           <ul class="request-list">
             <li *ngFor="let resource of resources">
               <a [routerLink]="'/resources/view/' + resource.resource._id">{{resource.resource.title}}</a>
+              <button type="button" mat-icon-button (click)="removeResource(resource)" color="warn" class="mini-icon-button" matSuffix>
+                <mat-icon>remove_circle</mat-icon>
+              </button>
             </li>
           </ul>
         </ng-template>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -86,6 +86,15 @@
             <a [routerLink]="'/courses/view/' + course._id">{{course.courseTitle}}</a>
           </mat-card>
         </ng-template>
+        <p i18n><b>Resources: ({{resources?.length || 0}})</b></p>
+        <p *ngIf="resources?.length < 1; else resourceList" i18n>There are no resources associated with this team.</p>
+        <ng-template #resourceList>
+          <ul class="request-list">
+            <li *ngFor="let resource of resources">
+              <a [routerLink]="'/resources/view/' + resource.resource._id">{{resource.resource.title}}</a>
+            </li>
+          </ul>
+        </ng-template>
       </ng-container>
     </div>
   </div>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -16,6 +16,9 @@
           <button mat-raised-button color="accent" class="margin-lr-3" (click)="openCourseDialog()" i18n>
             Manage Courses
           </button>
+          <button mat-raised-button color="accent" class="margin-lr-3" (click)="openResourcesDialog()" i18n>
+            Manage Resources
+          </button>
           <button mat-raised-button color="accent" class="margin-lr-3" (click)="toggleMembership(team, true)" i18n>
             Leave
           </button>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -95,7 +95,7 @@
               <button type="button" mat-icon-button (click)="removeResource(resource)" color="warn" class="mini-icon-button" matSuffix>
                 <mat-icon>remove_circle</mat-icon>
               </button>
-              <button type="button" mat-icon-button (click)="editResource(resource.resource)" class="mini-icon-button" matSuffix>
+              <button type="button" mat-icon-button (click)="editResource(resource.resource)" class="mini-icon-button" *ngIf="resource.resource.private===true" matSuffix>
                 <mat-icon>edit</mat-icon>
               </button>
             </li>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -17,7 +17,7 @@
             Manage Courses
           </button>
           <button mat-raised-button color="accent" class="margin-lr-3" (click)="openResourcesDialog()" i18n>
-            Manage Resources
+            Add Resources
           </button>
           <button mat-raised-button color="accent" class="margin-lr-3" (click)="toggleMembership(team, true)" i18n>
             Leave

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -95,7 +95,7 @@
               <button type="button" mat-icon-button (click)="removeResource(resource)" color="warn" class="mini-icon-button" matSuffix>
                 <mat-icon>remove_circle</mat-icon>
               </button>
-              <button type="button" mat-icon-button (click)="editResource(resource.resource)" class="mini-icon-button" *ngIf="resource.resource.private===true" matSuffix>
+              <button type="button" mat-icon-button (click)="openResourcesDialog(resource.resource)" class="mini-icon-button" *ngIf="resource.resource.private===true" matSuffix>
                 <mat-icon>edit</mat-icon>
               </button>
             </li>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -95,6 +95,9 @@
               <button type="button" mat-icon-button (click)="removeResource(resource)" color="warn" class="mini-icon-button" matSuffix>
                 <mat-icon>remove_circle</mat-icon>
               </button>
+              <button type="button" mat-icon-button (click)="editResource(resource.resource)" class="mini-icon-button" matSuffix>
+                <mat-icon>edit</mat-icon>
+              </button>
             </li>
           </ul>
         </ng-template>

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -278,4 +278,10 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     });
   }
 
+  removeResource(resource) {
+    this.couchService.post('teams', { ...resource.linkDoc, _deleted: true })
+      .pipe(switchMap(() => this.getMembers()))
+      .subscribe(() => this.planetMessageService.showMessage(`${resource.resource.title} removed`));
+  }
+
 }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -274,22 +274,14 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
         okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team)
           .pipe(switchMap(() => this.getMembers())).subscribe(() => dialogRef.close()),
         excludeIds: this.resources.map(r => r.resource._id),
-        canAdd: true,
-        db: 'teams',
-        linkId: this.teamId,
-        resource
+        canAdd: true, db: 'teams', linkId: this.teamId, resource
       }
     });
   }
 
   removeResource(resource) {
-    this.couchService.post('teams', { ...resource.linkDoc, _deleted: true })
-      .pipe(switchMap(() => this.getMembers()))
+    this.couchService.post('teams', { ...resource.linkDoc, _deleted: true }).pipe(switchMap(() => this.getMembers()))
       .subscribe(() => this.planetMessageService.showMessage(`${resource.resource.title} removed`));
-  }
-
-  editResource(resource) {
-    this.openResourcesDialog(resource);
   }
 
 }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -273,7 +273,8 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
       data: {
         okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team)
           .pipe(switchMap(() => this.getMembers())).subscribe(() => dialogRef.close()),
-        excludeIds: this.resources.map(resource => resource.resource._id)
+        excludeIds: this.resources.map(resource => resource.resource._id),
+        canAdd: true
       }
     });
   }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -274,7 +274,9 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
         okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team)
           .pipe(switchMap(() => this.getMembers())).subscribe(() => dialogRef.close()),
         excludeIds: this.resources.map(resource => resource.resource._id),
-        canAdd: true
+        canAdd: true,
+        db: 'teams',
+        linkId: this.teamId
       }
     });
   }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -267,16 +267,17 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     this.leftTileContent = this.leftTileContent === 'news' ? 'description' : 'news';
   }
 
-  openResourcesDialog() {
+  openResourcesDialog(resource?) {
     const dialogRef = this.dialog.open(DialogsAddResourcesComponent, {
       width: '80vw',
       data: {
         okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team)
           .pipe(switchMap(() => this.getMembers())).subscribe(() => dialogRef.close()),
-        excludeIds: this.resources.map(resource => resource.resource._id),
+        excludeIds: this.resources.map(r => r.resource._id),
         canAdd: true,
         db: 'teams',
-        linkId: this.teamId
+        linkId: this.teamId,
+        resource
       }
     });
   }
@@ -285,6 +286,10 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     this.couchService.post('teams', { ...resource.linkDoc, _deleted: true })
       .pipe(switchMap(() => this.getMembers()))
       .subscribe(() => this.planetMessageService.showMessage(`${resource.resource.title} removed`));
+  }
+
+  editResource(resource) {
+    this.openResourcesDialog(resource);
   }
 
 }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -265,4 +265,14 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     this.leftTileContent = this.leftTileContent === 'news' ? 'description' : 'news';
   }
 
+  openResourcesDialog() {
+    const dialogRef = this.dialog.open(DialogsAddResourcesComponent, {
+      width: '80vw',
+      data: {
+        okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team).subscribe(() => dialogRef.close()),
+        excludeIds: []
+      }
+    });
+  }
+
 }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -16,6 +16,7 @@ import { NewsService } from '../news/news.service';
 import { findDocuments } from '../shared/mangoQueries';
 import { ReportsService } from '../manager-dashboard/reports/reports.service';
 import { StateService } from '../shared/state.service';
+import { DialogsAddResourcesComponent } from '../shared/dialogs/dialogs-add-resources.component';
 
 @Component({
   templateUrl: './teams-view.component.html',

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -272,7 +272,7 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
       width: '80vw',
       data: {
         okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team).subscribe(() => dialogRef.close()),
-        excludeIds: []
+        excludeIds: this.resources.map(resource => resource.resource._id)
       }
     });
   }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -35,6 +35,7 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
   dialogRef: MatDialogRef<DialogsListComponent>;
   user = this.userService.get();
   news: any[] = [];
+  resources: any[] = [];
   leftTileContent: 'description' | 'news';
   isRoot = true;
   visits: any = {};
@@ -85,15 +86,16 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     if (this.team === undefined) {
       return [];
     }
-    return this.teamsService.getTeamMembers(this.team, true).pipe(map((docs: any[]) => {
-      const docsWithName = docs.map(mem => ({ ...mem, name: mem.userId.split(':')[1] }));
+    return this.teamsService.getTeamMembers(this.team, true).pipe(switchMap((docs: any[]) => {
+      const docsWithName = docs.map(mem => ({ ...mem, name: mem.userId && mem.userId.split(':')[1] }));
       this.members = docsWithName.filter(mem => mem.docType === 'membership')
         .sort((a, b) => a.userId === this.team.createdBy ? -1 : 0);
       this.requests = docsWithName.filter(mem => mem.docType === 'request');
       this.leader = this.team.createdBy;
       this.disableAddingMembers = this.members.length >= this.team.limit;
       this.setStatus(this.team, this.userService.get());
-    }));
+      return this.teamsService.getTeamResources(docs.filter(doc => doc.docType === 'resourceLink'));
+    }), map(resources => this.resources = resources));
   }
 
   toggleAdd(data) {

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -271,7 +271,8 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     const dialogRef = this.dialog.open(DialogsAddResourcesComponent, {
       width: '80vw',
       data: {
-        okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team).subscribe(() => dialogRef.close()),
+        okClick: (resources: any[]) => this.teamsService.linkResourcesToTeam(resources, this.team)
+          .pipe(switchMap(() => this.getMembers())).subscribe(() => dialogRef.close()),
         excludeIds: this.resources.map(resource => resource.resource._id)
       }
     });

--- a/src/app/teams/teams.module.ts
+++ b/src/app/teams/teams.module.ts
@@ -6,6 +6,7 @@ import { TeamsComponent } from './teams.component';
 import { TeamsViewComponent } from './teams-view.component';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { NewsModule } from '../news/news.module';
+import { DialogsAddResourcesModule } from '../shared/dialogs/dialogs-add-resources.module';
 
 @NgModule({
   imports: [
@@ -13,7 +14,8 @@ import { NewsModule } from '../news/news.module';
     CommonModule,
     MaterialModule,
     PlanetDialogsModule,
-    NewsModule
+    NewsModule,
+    DialogsAddResourcesModule
   ],
   declarations: [
     TeamsComponent,

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -202,4 +202,12 @@ export class TeamsService {
     return this.couchService.updateDocument('team_activities', data);
   }
 
+  linkResourcesToTeam(resources, team) {
+    const { teamPlanetCode, teamType } = team;
+    const links = resources.map(
+      resource => ({ resourceId: resource._id, teamId: team._id, teamPlanetCode, teamType, docType: 'resourceLink' })
+    );
+    return this.couchService.bulkDocs('teams', links);
+  }
+
 }

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -130,8 +130,8 @@ export class TeamsService {
     };
   }
 
-  getTeamMembers(team, withRequests = false) {
-    const typeObj = withRequests ? {} : { docType: 'membership' };
+  getTeamMembers(team, withAllLinks = false) {
+    const typeObj = withAllLinks ? {} : { docType: 'membership' };
     return forkJoin([
       this.couchService.findAll(this.dbName, findDocuments({ teamId: team._id, teamPlanetCode: team.teamPlanetCode, ...typeObj })),
       this.couchService.findAll('shelf', findDocuments({ 'myTeamIds': { '$in': [ team._id ] } }, 0))
@@ -139,6 +139,15 @@ export class TeamsService {
       ...membershipDocs,
       ...shelves.map((shelf: any) => ({ ...shelf, fromShelf: true, docType: 'membership', userId: shelf._id, teamId: team._id }))
     ]));
+  }
+
+  getTeamResources(linkDocs: any[]) {
+    return this.stateService.getCouchState('resources', 'local').pipe(map((resources: any[]) =>
+      linkDocs.map(linkDoc => ({
+        linkDoc,
+        resource: resources.find(resource => resource._id === linkDoc.resourceId)
+      }))
+    ));
   }
 
   isTeamEmpty(team) {

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -214,7 +214,10 @@ export class TeamsService {
   linkResourcesToTeam(resources, team) {
     const { teamPlanetCode, teamType } = team;
     const links = resources.map(
-      resource => ({ resourceId: resource._id, teamId: team._id, teamPlanetCode, teamType, docType: 'resourceLink' })
+      resource => ({
+        resourceId: resource.doc._id, sourcePlanet: resource.doc.sourcePlanet,
+        teamId: team._id, teamPlanetCode, teamType, docType: 'resourceLink'
+      })
     );
     return this.couchService.bulkDocs('teams', links);
   }

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -219,7 +219,14 @@ export class TeamsService {
         teamId: team._id, teamPlanetCode, teamType, docType: 'resourceLink'
       })
     );
+    if (teamPlanetCode !== this.stateService.configuration.code) {
+      this.updateSendDocs(resources, teamPlanetCode);
+    }
     return this.couchService.bulkDocs('teams', links);
+  }
+
+  updateSendDocs(resources, sendTo) {
+    this.couchService.bulkDocs('send_items', resources.map(resource => ({ db: 'resources', sendTo, item: resource }))).subscribe();
   }
 
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -121,6 +121,21 @@ body {
     margin: 0 3px;
   }
 
+  .mini-icon-button {
+    height: 1.5em;
+    width: 1.5em;
+    vertical-align: baseline;
+    font: inherit;
+
+    .mat-icon {
+      font-size: inherit;
+      height: 1.125em;
+      line-height: 1.125;
+      width: 1em;
+      vertical-align: top;
+    }
+  }
+
   $list-title-height: 36px;
 
   .list-content-menu, .table-selection-top {


### PR DESCRIPTION
Allows a resource to be linked to a team from the library, or to create a new resource with the option (default) to make it only viewable by the team.

TODOs:

- A private team resource should be editable
- A private team resource should be deleted when removed (with a prompt notifying the user that the resource will be deleted)
- Private resources should be synced (for syncing teams), and maybe the public ones should be as well?  The public ones could cause conflicts, however.  Maybe there could be a button that the nation clicks to flag a public resource as ok to sync?  Or we only sync ones created on the community?