### PR TITLE
[Fixes #4110] Library/Courses: manager action should be enabled only on select of entity

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -49,7 +49,7 @@
           <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
             <planet-tag-input [db]="dbName" [disabled]="selection?.selected?.length === 0" mode="add" labelType="change" [helperText]="false" [filteredData]="courses.data" [selectedIds]="selection.selected" (finalTags)="addTagsToSelected($event)"></planet-tag-input>
           </mat-form-field>
-          <button mat-button [matMenuTriggerFor]="managerMenu" *planetAuthorizedRoles>Manager Actions</button>
+          <button mat-button [matMenuTriggerFor]="managerMenu" *planetAuthorizedRoles [disabled]="!selection.selected.length">Manager Actions</button>
           <mat-menu #managerMenu="matMenu">
             <!-- TODO: Need to figure out how to resolve conflicts when sending course back to parent -->
             <button *ngIf="planetType !== 'center' && planetConfiguration.registrationRequest === 'accepted'" mat-menu-item (click)="shareLocal(selection.selected)" [disabled]="selectedLocal === 0">

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -46,7 +46,7 @@
           <mat-icon aria-hidden="true" class="margin-lr-3">clear</mat-icon><span i18n>Leave Selected</span>
           <span *ngIf="selectedAdded > 0"> ({{selectedAdded}})</span>
         </button>
-        <button mat-button [matMenuTriggerFor]="managerMenu" *planetAuthorizedRoles>Manager Actions</button>
+        <button mat-button [matMenuTriggerFor]="managerMenu" *planetAuthorizedRoles [disabled]="!selection.selected.length">Manager Actions</button>
         <mat-menu #managerMenu="matMenu">
           <button *ngIf="planetConfiguration.registrationRequest === 'accepted'" mat-menu-item [disabled]="!selectedSync?.length" (click)="shareResource('push', selectedSync)">
             <mat-icon aria-hidden="true" class="margin-lr-3">cloud_upload</mat-icon>


### PR DESCRIPTION
[Fixes #4110] Library/Courses: manager action should be enabled only on select of entity