### PR TITLE
Fix badge not showing for submissions (fixes #4175)

### DIFF
--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -16,7 +16,7 @@
             [routerLink]="item.link"
             cdkDrag
           >
-            <span [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false">{{item.title}}</span>
+            <span [matBadge]="item.badge" [matBadgeHidden]="item.badge===0">{{item.title}}</span>
             <button mat-icon-button class="delete-item" (click)="removeFromShelf($event, item)" *ngIf="cardTitle!=='myLife'">
               <mat-icon>clear</mat-icon>
             </button>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -143,6 +143,7 @@ export class DashboardComponent implements OnInit {
   getExams() {
     this.getSubmissions('exam', 'requires grading').subscribe((exams) => {
       this.examsCount = exams.length;
+      this.myLifeItems = this.myLifeItems.map(item => item.title === 'Submissions' ? { ...item, badge: this.examsCount } : item);
     });
   }
 


### PR DESCRIPTION
I changed the badges to overlap with the text since for submissions the badge overflowed beyond the box otherwise.

Ultimately I think we should have icons and the badges with numbers can be on the icon, but for now this adds the badge back into view, at least.