### PR TITLE
Teams: Set leader in membership doc (fixes #4214)

### DIFF
--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -83,10 +83,10 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     }
     return this.teamsService.getTeamMembers(this.team, true).pipe(map((docs: any[]) => {
       const docsWithName = docs.map(mem => ({ ...mem, name: mem.userId.split(':')[1] }));
-      this.members = docsWithName.filter(mem => mem.docType === 'membership')
-        .sort((a, b) => a.userId === this.team.createdBy ? -1 : 0);
-      this.requests = docsWithName.filter(mem => mem.docType === 'request');
       this.leader = (docsWithName.find(mem => mem.isLeader) || {}).userId || this.team.createdBy;
+      this.members = docsWithName.filter(mem => mem.docType === 'membership')
+        .sort((a, b) => a.userId === this.leader ? -1 : 0);
+      this.requests = docsWithName.filter(mem => mem.docType === 'request');
       this.disableAddingMembers = this.members.length >= this.team.limit;
       this.setStatus(this.team, this.userService.get());
     }));

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -86,7 +86,7 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
       this.members = docsWithName.filter(mem => mem.docType === 'membership')
         .sort((a, b) => a.userId === this.team.createdBy ? -1 : 0);
       this.requests = docsWithName.filter(mem => mem.docType === 'request');
-      this.leader = this.team.createdBy;
+      this.leader = (docsWithName.find(mem => mem.isLeader) || {}).userId || this.team.createdBy;
       this.disableAddingMembers = this.members.length >= this.team.limit;
       this.setStatus(this.team, this.userService.get());
     }));

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -52,7 +52,7 @@ export class TeamsService {
           empty()
         ),
         switchMap((response) => !team._id ?
-          this.toggleTeamMembership(response, false, { userId, userPlanetCode: configuration.code }) :
+          this.toggleTeamMembership(response, false, { userId, userPlanetCode: configuration.code, isLeader: true }) :
           of(response)
         )
       );
@@ -118,10 +118,10 @@ export class TeamsService {
   }
 
   membershipProps(team, memberInfo, docType) {
-    const { userId, userPlanetCode } = memberInfo;
+    const { userId, userPlanetCode, isLeader } = memberInfo;
     const { _id: teamId, teamPlanetCode, teamType } = team;
     return {
-      teamId, userId, teamPlanetCode, teamType, userPlanetCode, docType
+      teamId, userId, teamPlanetCode, teamType, userPlanetCode, docType, isLeader
     };
   }
 


### PR DESCRIPTION
Adjusts how the team leader is set to prepare for allowing leadership to be passed to different member than team creator