### PR TITLE
Fix request for planet report filter

### DIFF
--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -59,7 +59,7 @@ export class ReportsService {
       findDocuments({
         ...{ [field]: planetCode },
         ...this.timeFilter(dateField, tillDate),
-        ...(fromMyPlanet ? { androidId: { '$exists': fromMyPlanet } } : {})
+        ...(fromMyPlanet !== undefined ? { androidId: { '$exists': fromMyPlanet } } : {})
       }) :
       undefined;
   }


### PR DESCRIPTION
Fixes the request to ensure the selector contains `{ androidId: { '$exists': false } }` when **Planet** is selected in the reports