### PR TITLE
Increase Travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
         - travis_retry npm install -g karma
       script:
         - set -e
-        - echo  "Waiting for couchdb to start"; WAIT_TIME=0; until curl http://127.0.0.1:5984/_all_dbs || [ $WAIT_TIME -eq 180 ]; do echo "..."; sleep 5; WAIT_TIME=$(expr $WAIT_TIME + 5); done
+        - echo  "Waiting for couchdb to start"; WAIT_TIME=0; until curl http://127.0.0.1:5984/_all_dbs || [ $WAIT_TIME -eq 600 ]; do echo "..."; sleep 5; WAIT_TIME=$(expr $WAIT_TIME + 5); done
         - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 34 ]; then exit 1; fi
         - ng e2e
     - stage: docker-release


### PR DESCRIPTION
The "Automated-test" phase continues to fail regularly, now when waiting for CouchDB to start.  Increasing the timeout hoping that it will no longer fail as often.