### PR TITLE
Vagrant: Fix member creation error in development (fixes #2470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ sudo npm install --unsafe-perm
 
 The trailing `/*` will remove all files & sub-directories of node_modules.  You won't be able to remove node_modules because of the link between the vagrant VM and your host.
 
+### Cannot create new members in development environment
+
+Sometimes our custom setup for the `_users` database is overwritten by the default.  If that is the case, run the following command to run our database setup script again:
+
+```
+./v-couchdb-setup.sh -u <your admin username> -w <your admin password>
+```
+
 ### Cannot GET /
 
 There are two things you can try for this.  First involves the node-sass module which can be problematic.  You will need to rebuild it from the VM:

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ sudo npm install --unsafe-perm
 
 The trailing `/*` will remove all files & sub-directories of node_modules.  You won't be able to remove node_modules because of the link between the vagrant VM and your host.
 
-### Cannot create new members in development environment
+### Cannot create new members in development environment or database missing
 
-Sometimes our custom setup for the `_users` database is overwritten by the default.  If that is the case, run the following command to run our database setup script again:
+Sometimes our custom setup for the `_users` database is overwritten by the default or new databases were added in other commits that have not been created in your local environment.  If you are seeing errors with lack of authorization or missing databases, you can run the following command to run our database setup script again:
 
 ```
 ./v-couchdb-setup.sh -u <your admin username> -w <your admin password>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,6 +101,9 @@ Vagrant.configure(2) do |config|
 
       curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/log/file -d '"/opt/couchdb/var/log/couch.log"'
       curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/log/writer -d '"file"'
+      curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/chttpd/authentication_handlers -d '"{chttpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}"'
+
+      docker restart planet
 
       # node_modules folder breaks when setting up in Windows, so use binding to fix
       #echo "Preparing local node_modules folder…"
@@ -124,7 +127,7 @@ Vagrant.configure(2) do |config|
         docker start planet
         while ! curl -X GET http://127.0.0.1:5984/_all_dbs ; do sleep 1; done
         cd /vagrant
-        . couchdb-setup.sh -p 5984
+        . couchdb-setup.sh -p 5984 -x
       fi
       mount --bind /vagrant_node_modules /vagrant/node_modules
       # Starts the app in a screen (virtual terminal)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,7 +120,12 @@ Vagrant.configure(2) do |config|
 
     # Run binding on each startup make sure the mount is available on VM restart
     dev.vm.provision "shell", run: "always", inline: <<-SHELL
-      docker start planet
+      if [ ! $(docker inspect -f '{{.State.Running}}' planet) ]; then
+        docker start planet
+        while ! curl -X GET http://127.0.0.1:5984/_all_dbs ; do sleep 1; done
+        cd /vagrant
+        . couchdb-setup.sh -p 5984
+      fi
       mount --bind /vagrant_node_modules /vagrant/node_modules
       # Starts the app in a screen (virtual terminal)
       sudo -u vagrant screen -dmS build bash -c 'cd /vagrant; ng serve'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,7 +120,7 @@ Vagrant.configure(2) do |config|
 
     # Run binding on each startup make sure the mount is available on VM restart
     dev.vm.provision "shell", run: "always", inline: <<-SHELL
-      if [ ! $(docker inspect -f '{{.State.Running}}' planet) ]; then
+      if [ $(docker inspect -f '{{.State.Running}}' planet) = "false" ]; then
         docker start planet
         while ! curl -X GET http://127.0.0.1:5984/_all_dbs ; do sleep 1; done
         cd /vagrant

--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -50,7 +50,7 @@ ISINSTALL=${INSTALLFLAG:-0}
 
 if [ -z "$HOST" ]
 then
-  HOST=localhost
+  HOST=127.0.0.1
 fi
 
 # Default port for CouchDB accessed from host machine is 2200

--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -7,14 +7,14 @@ upsert_doc() {
   DOC_LOC=$3
   # Default method is PUT, fourth argument overrides
   METHOD=${4:-"PUT"}
-  DOC=$(curl $COUCHURL/$DB/$DOC_NAME)
+  DOC=$(curl $COUCHURL/$DB/$DOC_NAME $PROXYHEADER)
   # If DOC includes a rev then it exists so we need to update
   # Otherwise we simply insert
   if [[ $DOC == *rev* ]]; then
     DOC_REV=$(echo $DOC | jq -r '. | ._rev')
-    curl -H 'Content-Type: application/json' -X $METHOD $COUCHURL/$DB/$DOC_NAME?rev=$DOC_REV -d $DOC_LOC
+    curl -H 'Content-Type: application/json' -X $METHOD $COUCHURL/$DB/$DOC_NAME?rev=$DOC_REV -d $DOC_LOC $PROXYHEADER
   else
-    curl -H 'Content-Type: application/json' -X $METHOD $COUCHURL/$DB/$DOC_NAME -d $DOC_LOC
+    curl -H 'Content-Type: application/json' -X $METHOD $COUCHURL/$DB/$DOC_NAME -d $DOC_LOC $PROXYHEADER
   fi
 }
 
@@ -22,17 +22,27 @@ upsert_doc() {
 insert_docs() {
   DB=$1
   DOC_LOC=$2
-  curl -H 'Content-Type: application/json' -X POST $COUCHURL/$DB/_bulk_docs  -d @$DOC_LOC
+  curl -H 'Content-Type: application/json' -X POST $COUCHURL/$DB/_bulk_docs -d @$DOC_LOC $PROXYHEADER
+}
+
+# Function to add databases
+insert_dbs() {
+  DBS=$1
+  for DB in "${DBS[@]}"
+  do
+    curl -X PUT $COUCHURL/$DB $PROXYHEADER
+  done
 }
 
 # Options are -u for username -w for passWord and -p for port number
-while getopts "u:w:p:h:i" option; do
+while getopts "u:w:p:h:i:x" option; do
   case $option in
     u) COUCHUSER=${OPTARG};;
     w) COUCHPASSWORD=${OPTARG};;
     p) PORT=${OPTARG};;
     h) HOST=${OPTARG};;
     i) INSTALLFLAG=1;;
+    x) PROXYHEADER="-H X-Auth-CouchDB-Roles:_admin -H X-Auth-CouchDB-UserName:username"
   esac
 done
 
@@ -40,7 +50,7 @@ ISINSTALL=${INSTALLFLAG:-0}
 
 if [ -z "$HOST" ]
 then
-  HOST=127.0.0.1
+  HOST=localhost
 fi
 
 # Default port for CouchDB accessed from host machine is 2200
@@ -66,8 +76,8 @@ insert_attachments() {
     FILE_NAME=$(echo $i | jq -r '.file_name')
     FILE_LOCATION=$(echo $i | jq -r '.file_location')
     FILE_TYPE=$(echo $i | jq -r '.file_type')
-    REV=$(curl $COUCHURL/$DB/$ID | jq -r '._rev')
-    curl -X PUT $COUCHURL/$DB/$ID/$FILE_NAME?rev=$REV --data-binary @$FILE_LOCATION -H Content-Type:$FILE_TYPE
+    REV=$(curl $COUCHURL/$DB/$ID | jq -r '._rev' $PROXYHEADER)
+    curl -X PUT $COUCHURL/$DB/$ID/$FILE_NAME?rev=$REV --data-binary @$FILE_LOCATION -H Content-Type:$FILE_TYPE $PROXYHEADER
   done
 }
 
@@ -93,44 +103,47 @@ add_security_admin_roles() {
   echo $NEW_DOCS | jq -c '.'
 }
 
-# Add CouchDB standard databases
-curl -X PUT $COUCHURL/_users
-curl -X PUT $COUCHURL/_replicator
-curl -X PUT $COUCHURL/_global_changes
 
-# Add planet app databases
-curl -X PUT $COUCHURL/meetups
-curl -X PUT $COUCHURL/resources
-curl -X PUT $COUCHURL/courses
-curl -X PUT $COUCHURL/exams
-curl -X PUT $COUCHURL/nations
-curl -X PUT $COUCHURL/communityregistrationrequests
-curl -X PUT $COUCHURL/feedback
-curl -X PUT $COUCHURL/resource_activities
-curl -X PUT $COUCHURL/configurations
-curl -X PUT $COUCHURL/login_activities
-curl -X PUT $COUCHURL/notifications
-curl -X PUT $COUCHURL/ratings
-curl -X PUT $COUCHURL/shelf
-curl -X PUT $COUCHURL/submissions
-curl -X PUT $COUCHURL/courses_progress
-curl -X PUT $COUCHURL/attachments
-curl -X PUT $COUCHURL/send_items
-curl -X PUT $COUCHURL/teams
-curl -X PUT $COUCHURL/tablet_users
-curl -X PUT $COUCHURL/child_users
-curl -X PUT $COUCHURL/replicator_users
-curl -X PUT $COUCHURL/admin_activities
-curl -X PUT $COUCHURL/child_statistics
-curl -X PUT $COUCHURL/tags
-curl -X PUT $COUCHURL/apk_logs
-curl -X PUT $COUCHURL/hubs
-curl -X PUT $COUCHURL/achievements
-curl -X PUT $COUCHURL/myplanet_activities
-curl -X PUT $COUCHURL/news
-curl -X PUT $COUCHURL/parent_users
-curl -X PUT $COUCHURL/team_activities
+DBS=(
+  # CouchDB standard databases
+  "_users"
+  "_replicator"
+  "_global_changes"
+  # Planet app databases
+  "meetups"
+  "resources"
+  "courses"
+  "exams"
+  "nations"
+  "communityregistrationrequests"
+  "feedback"
+  "resource_activities"
+  "configurations"
+  "login_activities"
+  "notifications"
+  "ratings"
+  "shelf"
+  "submissions"
+  "courses_progress"
+  "attachments"
+  "send_items"
+  "teams"
+  "tablet_users"
+  "child_users"
+  "replicator_users"
+  "admin_activities"
+  "child_statistics"
+  "tags"
+  "apk_logs"
+  "hubs"
+  "achievements"
+  "myplanet_activities"
+  "news"
+  "parent_users"
+  "team_activities"
+)
 
+insert_dbs $DBS
 # Create design documents
 node ./design/create-design-docs.js
 # Add or update design docs

--- a/v-couchdb-setup.sh
+++ b/v-couchdb-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Options are -u for username -w for passWord and -p for port number
+while getopts "u:w:p:h:i" option; do
+  case $option in
+    u) COUCHUSER=${OPTARG};;
+    w) COUCHPASSWORD=${OPTARG};;
+    p) PORT=${OPTARG};;
+  esac
+done
+PORT=${PORT:-5984}
+vagrant ssh dev -- -t "cd /vagrant;./couchdb-setup.sh -p $PORT -u $COUCHUSER -w $COUCHPASSWORD"


### PR DESCRIPTION
Updates the Vagrantfile and setup script to

1. Only run the `docker start` in the "always" script if it is not already running
2. In addition run the CouchDB setup script after the container starts with proxy _admin authentication

@dogi I think we can add the new configuration setting to our template instead of here, correct?

In addition in case this problem comes up again added a small script `v-couchdb-setup.sh` to simplify the fix and referenced this in the **Troubleshooting** section of the README