### PR TITLE
Setup: Remove activity_logs from script

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -157,7 +157,6 @@ upsert_doc notifications _index '{"index":{"fields":[{"time":"desc"}]},"name":"t
 upsert_doc ratings _index '{"index":{"fields":[{"item":"desc"}]},"name":"parent-index"}' POST
 upsert_doc feedback _index '{"index":{"fields":[{"openTime":"desc"}]},"name":"time-index"}' POST
 upsert_doc communityregistrationrequests _index '{"index":{"fields":[{"createdDate":"desc"}]},"name":"time-index"}' POST
-upsert_doc activity_logs _index '{"index":{"fields":[{"createdTime":"desc"}]},"name":"time-index"}' POST
 upsert_doc resources _index '{"index":{"fields":[{"title":"asc"}]},"name":"time-index"}' POST
 upsert_doc news _index '{"index":{"fields":[{"time":"desc"}]},"name":"time-index"}' POST
 upsert_doc tags _index '{"index":{"fields":[{"name":"asc"}]},"name":"name-index"}' POST

--- a/design/security-update/security-update.json
+++ b/design/security-update/security-update.json
@@ -195,19 +195,6 @@
     }
   },
   {
-    "dbName": "activity_logs",
-    "json": {
-      "admins": {
-        "names": [],
-        "roles": []
-      },
-      "members": {
-        "names": [],
-        "roles": []
-      }
-    }
-  },
-  {
   "dbName": "courses_progress",
     "json": {
       "admins": {


### PR DESCRIPTION
I just noticed that in the setup script we attempt to add an index & security for an `activity_logs` database that we never create.  Removing those lines since they are unnecessary.