### PR TITLE
Collections: Fix adding a subcollection

### DIFF
--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -26,7 +26,7 @@
   </mat-expansion-panel>
   <mat-action-list *ngIf="selectMany">
     <ng-container *ngFor="let tag of tags">
-      <mat-list-item (click)="tag.subTags.length === 0 ? tagChange([ tag._id || tag.name ].concat(subTagIds(tag.subTags)), { deselectSubs: true }) : toggleSubcollection($event,tag._id)" class="cursor-pointer">
+      <mat-list-item (click)="tag.subTags.length === 0 ? tagChange(tag._id || tag.name) : toggleSubcollection($event,tag._id)" class="cursor-pointer">
         <p matLine>
           <planet-tag-input-toggle-icon *ngIf="tag.subTags.length > 0" [isOpen]="subcollectionIsOpen.get(tag._id)"></planet-tag-input-toggle-icon>
           <mat-checkbox *ngIf="tag.subTags.length === 0" (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)"></mat-checkbox>
@@ -38,7 +38,7 @@
         </p>
       </mat-list-item>
       <ng-container *ngIf="subcollectionIsOpen.get(tag._id)">
-        <mat-list-item *ngFor="let subTag of tag.subTags" (click)="tagChange([ subTag._id || subTag.name ])" class="cursor-pointer">
+        <mat-list-item *ngFor="let subTag of tag.subTags" (click)="tagChange(subTag._id || subTag.name, { parentTag: tag })" class="cursor-pointer">
           <mat-icon mat-list-icon>subdirectory_arrow_right</mat-icon>
           <p matLine>
             <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)"></mat-checkbox>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -71,7 +71,7 @@ export class PlanetTagInputDialogComponent {
     this.data.startingTags
       .filter((tag: any) => tag)
       .forEach(tag => {
-        this.tagChange([ tag.tagId || tag ], { tagOne: !this.selectMany });
+        this.tagChange(tag.tagId || tag, { tagOne: !this.selectMany });
         this.indeterminate.set(tag.tagId || tag, tag.indeterminate || false);
       });
     this.addTagForm = this.fb.group({
@@ -85,7 +85,7 @@ export class PlanetTagInputDialogComponent {
     this.tags = this.filterTags(this.filterValue);
     this.mode = this.data.mode;
     if (this.newTagId !== undefined && this.mode === 'add') {
-      this.tagChange([ this.newTagId ]);
+      this.tagChange(this.newTagId);
     }
     this.newTagId = undefined;
   }
@@ -96,17 +96,17 @@ export class PlanetTagInputDialogComponent {
     this.data.reset(this._selectMany);
   }
 
-  tagChange(tags, { tagOne = false, deselectSubs = false }: { tagOne?, deselectSubs? } = {}) {
-    const newState = !this.selected.get(tags[0]);
-    const setAllTags = newState !== deselectSubs;
-    tags.forEach((tag, index) => {
-      if (index === 0 || setAllTags) {
-        this.selected.set(tag, newState || this.indeterminate.get(tag));
-        this.indeterminate.set(tag, false);
-
-        this.data.tagUpdate(tag, this.selected.get(tag), tagOne);
-      }
-    });
+  tagChange(tagId, { tagOne = false, parentTag }: { tagOne?, parentTag? } = {}) {
+    const newState = !this.selected.get(tagId);
+    const updateTag = (id) => {
+      this.selected.set(id, newState || this.indeterminate.get(id));
+      this.indeterminate.set(id, false);
+      this.data.tagUpdate(id, this.selected.get(id), tagOne);
+    };
+    updateTag(tagId);
+    if (parentTag && (newState || parentTag.subTags.every(sub => !this.selected.get(sub._id)))) {
+      updateTag(parentTag._id);
+    }
   }
 
   subTagIds(subTags: any[]) {


### PR DESCRIPTION
When adding a subcollection to a resource or course the main/parent collection is also selected to make sure the subcollection shows up in the resources/courses view.