### PR TITLE
Vagrantfile: Update dev CouchDB to 2.3.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,7 +87,7 @@ Vagrant.configure(2) do |config|
         -v /srv/planet/conf:/opt/couchdb/etc/local.d \
         -v /srv/planet/data:/opt/couchdb/data \
         -v /srv/planet/log:/opt/couchdb/var/log/ \
-        treehouses/couchdb:2.3.0
+        treehouses/couchdb:2.3.1-stretch
 
       # Add CORS to CouchDB so app has access to databases
       #git clone https://github.com/pouchdb/add-cors-to-couchdb.git
@@ -101,7 +101,7 @@ Vagrant.configure(2) do |config|
 
       curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/log/file -d '"/opt/couchdb/var/log/couch.log"'
       curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/log/writer -d '"file"'
-      curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/chttpd/authentication_handlers -d '"{chttpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}"'
+      curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/chttpd/authentication_handlers -d '"{chttpd_auth, cookie_authentication_handler}, {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}"'
 
       docker restart planet
 


### PR DESCRIPTION
In addition switches the proxy authentication setting from a deprecated value to the most up to date one.