### PR TITLE
User image replication

### DIFF
--- a/src/app/manager-dashboard/sync.directive.ts
+++ b/src/app/manager-dashboard/sync.directive.ts
@@ -91,14 +91,16 @@ export class SyncDirective {
       { db: 'achievements', selector: { sendToNation: true, createdOn: this.planetConfiguration.code } },
       { db: 'apk_logs' },
       { db: 'myplanet_activities' },
-      { db: 'notifications', selector: { userPlanetCode: this.planetConfiguration.parentCode } }
+      { db: 'notifications', selector: { userPlanetCode: this.planetConfiguration.parentCode } },
+      { db: 'attachments', selector: { planetCode: this.planetConfiguration.code } }
     ];
   }
 
   pullList() {
     return [
       { db: 'feedback', selector: { source: this.planetConfiguration.code } },
-      { db: 'notifications', selector: { userPlanetCode: this.planetConfiguration.code } }
+      { db: 'notifications', selector: { userPlanetCode: this.planetConfiguration.code } },
+      { db: 'attachments', selector: { planetCode: this.planetConfiguration.parentCode } }
     ];
   }
 

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -234,10 +234,10 @@ export class UserService {
       switchMap((attachmentDocs: any[]) => {
         const obs = users.reduce((obsArr, user) => {
           const key = user._attachments && Object.keys(user._attachments)[0];
-          const attachmentDoc = attachmentDocs.find(attachmentDoc => attachmentDoc.userId === user._id);
+          const attachmentDoc = attachmentDocs.find(aDoc => aDoc.userId === user._id);
           const aDocDigest = attachmentDoc && attachmentDoc._attachments[key] && attachmentDoc._attachments[key].digest;
           if ((attachmentDoc === undefined && addNew) || (key && user._attachments[key].digest !== aDocDigest)) {
-            return [ ...obsArr, this.getProfileImage(user, attachmentDoc) ]
+            return [ ...obsArr, this.getProfileImage(user, attachmentDoc) ];
           }
           return obsArr;
         }, []);
@@ -250,7 +250,7 @@ export class UserService {
 
   private getProfileImage(user, attachmentDoc = {}) {
     return this.couchService.get(`${this.usersDb}/${user._id}?attachments=true`, { headers: { 'Accept': 'application/json' } }).pipe(
-      map(user => ({ ...user, attachmentDoc }))
+      map(u => ({ ...u, attachmentDoc }))
     );
   }
 

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -258,7 +258,8 @@ export class UserService {
     return this.couchService.bulkDocs('attachments', userDocs.map(userDoc => ({
       _id: `${userDoc._id}@${userDoc.planetCode}`,
       userId: userDoc._id,
-      userPlanetCode: userDoc.planetCode,
+      planetCode: userDoc.planetCode,
+      parentCode: userDoc.parentCode,
       _rev: userDoc.attachmentDoc._rev,
       _attachments: userDoc._attachments
     })));

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -53,6 +53,7 @@
           <div class="card-grid">
             <mat-card *ngFor="let member of members">
               <mat-card-header>
+                <img mat-card-avatar [src]="member.avatar">
                 <a mat-card-title [routerLink]="['/users/profile', member.name, planetCode === member.userPlanetCode ? {} : { planet: member.userPlanetCode }]">
                   {{ member.userDoc?.firstName || member.name }}
                 </a>
@@ -81,6 +82,7 @@
             <div class="card-grid">
               <mat-card *ngFor="let request of requests">
                 <mat-card-header>
+                  <img mat-card-avatar [src]="request.avatar">
                   <a mat-card-title [routerLink]="['/users/profile', request.name, planetCode === request.userPlanetCode ? {} : { planet: request.userPlanetCode }]">{{request.userDoc?.firstName || request.name}}</a>
                 </mat-card-header>
                 <mat-card-actions>

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -198,7 +198,7 @@ export class TeamsViewComponent implements OnInit, OnDestroy {
     switch (type) {
       case 'request':
         return ({
-          obs: this.teamsService.requestToJoinTeam(this.team, this.user._id),
+          obs: this.teamsService.requestToJoinTeam(this.team, this.user),
           message: 'Request to join team sent'
         });
       case 'removed':

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -71,7 +71,9 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       this.getMembershipStatus()
     ]).subscribe(([ teams, requests ]) => {
       this.teams.data = this.teamList(teams);
-      if (this.teams.data.some(team => team.userStatus === 'member' || team.userStatus === 'requesting')) {
+      if (this.teams.data.some(
+        ({ doc, userStatus }) => doc.teamType === 'sync' && (userStatus === 'member' || userStatus === 'requesting')
+      )) {
         this.userService.addImageForReplication(true).subscribe(() => {});
       }
       this.emptyData = !this.teams.data.length;

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -31,7 +31,7 @@ import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.compone
 })
 export class TeamsComponent implements OnInit, AfterViewInit {
 
-  teams = new MatTableDataSource();
+  teams = new MatTableDataSource<any>();
   @ViewChild(MatSort, { static: false }) sort: MatSort;
   @ViewChild(MatPaginator, { static: false }) paginator: MatPaginator;
   userMembership: any[] = [];
@@ -71,6 +71,9 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       this.getMembershipStatus()
     ]).subscribe(([ teams, requests ]) => {
       this.teams.data = this.teamList(teams);
+      if (this.teams.data.some(team => team.userStatus === 'member' || team.userStatus === 'requesting')) {
+        this.userService.addImageForReplication(true).subscribe(() => {});
+      }
       this.emptyData = !this.teams.data.length;
       this.dialogsLoadingService.stop();
     }, (error) => console.log(error));
@@ -176,7 +179,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   }
 
   requestToJoin(team) {
-    this.teamsService.requestToJoinTeam(team, this.userService.get()._id).pipe(
+    this.teamsService.requestToJoinTeam(team, this.userService.get()).pipe(
       switchMap(() => this.teamsService.getTeamMembers(team)),
       switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team, url: this.router.url + '/view/' + team._id })),
       switchMap(() => this.getMembershipStatus())

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -81,9 +81,11 @@ export class TeamsService {
     }));
   }
 
-  requestToJoinTeam(team, userId) {
+  requestToJoinTeam(team, user) {
     const userPlanetCode = this.stateService.configuration.code;
-    return this.couchService.post(this.dbName, this.membershipProps(team, { userId, userPlanetCode }, 'request'));
+    return this.couchService.post(this.dbName, this.membershipProps(team, { userId: user._id, userPlanetCode }, 'request')).pipe(
+      switchMap(() => this.userService.addImageForReplication(true, user))
+    );
   }
 
   removeFromRequests(team, memberInfo) {

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -145,9 +145,14 @@ export class TeamsService {
     return forkJoin([
       this.couchService.findAll(this.dbName, findDocuments({ teamId: team._id, teamPlanetCode: team.teamPlanetCode, ...typeObj })),
       this.couchService.findAll('shelf', findDocuments({ 'myTeamIds': { '$in': [ team._id ] } }, 0)),
-      this.couchService.findAll('_users')
-    ]).pipe(map(([ membershipDocs, shelves, users ]: any[]) => [
-      ...membershipDocs.map(doc => ({ ...doc, userDoc: users.find(user => user._id === doc.userId) })),
+      this.couchService.findAll('_users'),
+      this.couchService.findAll('attachments')
+    ]).pipe(map(([ membershipDocs, shelves, users, attachments ]: any[]) => [
+      ...membershipDocs.map(doc => ({
+        ...doc,
+        userDoc: users.find(user => user._id === doc.userId),
+        attachmentDoc: attachments.find(attachment => attachment._id === `${doc.userId}@${doc.userPlanetCode}`)
+      })),
       ...shelves.map((shelf: any) => ({ ...shelf, fromShelf: true, docType: 'membership', userId: shelf._id, teamId: team._id }))
     ]));
   }

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -84,7 +84,7 @@ export class TeamsService {
   requestToJoinTeam(team, user) {
     const userPlanetCode = this.stateService.configuration.code;
     return this.couchService.post(this.dbName, this.membershipProps(team, { userId: user._id, userPlanetCode }, 'request')).pipe(
-      switchMap(() => this.userService.addImageForReplication(true, user))
+      switchMap(() => this.userService.addImageForReplication(true, [ user ]))
     );
   }
 

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -84,7 +84,7 @@ export class TeamsService {
   requestToJoinTeam(team, user) {
     const userPlanetCode = this.stateService.configuration.code;
     return this.couchService.post(this.dbName, this.membershipProps(team, { userId: user._id, userPlanetCode }, 'request')).pipe(
-      switchMap(() => this.userService.addImageForReplication(true, [ user ]))
+      switchMap(() => team.teamType === 'sync' ? this.userService.addImageForReplication(true, [ user ]) : of({}))
     );
   }
 


### PR DESCRIPTION
The goal of this is to show member images in teams for local and connected teams.

Images will be added to the `attachments` database when the member is requesting membership or a member of a connected team.  That database will sync back and forth between community & nation so images will be available.

Added images to the **Members** and **Requests** tabs.  That could have been a different PR, but otherwise there would not have been any changes in the UI.

This does not handle cleaning out images when the member is no longer associated with a connected team.  If that is a problem, we can devise another solution for that.