### PR TITLE
Ratings: Decrease time to fetch course ratings

### DIFF
--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -113,7 +113,7 @@ export class CoursesService {
     obs.push(this.ratingService.getRatings({ itemIds: [ courseId ], type: 'course' }, opts));
     forkJoin(obs).subscribe(([ progress, course, ratings ]: [ any[], any, any ]) => {
       this.progress = progress;
-      this.updateCourse({ progress: progress, course: this.createCourseList([ course ], ratings.docs)[0] });
+      this.updateCourse({ progress: progress, course: this.createCourseList([ course ], ratings)[0] });
     });
   }
 

--- a/src/app/shared/forms/rating.service.ts
+++ b/src/app/shared/forms/rating.service.ts
@@ -38,16 +38,12 @@ export class RatingService {
   getRatings({ itemIds, type }: {itemIds: string[], type: string}, opts: any) {
     const itemSelector = itemIds.length > 0 ?
       { '$in': itemIds } : { '$gt': null };
-    return this.couchService.post(this.dbName + '/_find', findDocuments({
+    return this.couchService.findAll(this.dbName, findDocuments({
       // Selector
       type,
       // Must have sorted property in selector to sort correctly
       'item': itemSelector
-    }, 0, [ { 'item': 'desc' } ], 1000), opts).pipe(catchError(err => {
-      // If there's an error, return a fake couchDB empty response
-      // so resources can be displayed.
-      return of({ docs: [] });
-    }));
+    }, 0, [ { 'item': 'desc' } ]), opts);
   }
 
   createItemList(itemsRes, ratings) {

--- a/src/app/shared/mangoQueries.ts
+++ b/src/app/shared/mangoQueries.ts
@@ -16,7 +16,7 @@ export function findAllDocuments(selector, query) {
 }
 
 // Creates more general find query that can search with multiple selectors & fields
-export function findDocuments(selectors, fields: any = 0, sort: any = 0, limit = 0, skip = 0) {
+export function findDocuments(selectors, fields: any = 0, sort: any = 0, limit = 1000, skip = 0) {
   const queries = { 'selector': selectors, 'skip': skip };
   if (fields) { queries['fields'] = fields; }
   if (limit) { queries['limit'] = limit; }


### PR DESCRIPTION
Noticed on planet somalia that courses was taking some time to load.  This should improve that by ensuring `_find` requests use `limit: 1000`.  This may improve speed in other areas since other requests were also using the default 25 instead of 1000.