### PR TITLE
Courses & Resources: Improve speed

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -73,7 +73,7 @@
   </mat-toolbar>
 
   <div class="view-container view-full-height view-table" *ngIf="!emptyData; else notFoundMessage">
-    <mat-table #table [dataSource]="courses" matSort [matSortDisableClear]="true">
+    <mat-table #table [dataSource]="courses" matSort [matSortDisableClear]="true" [trackBy]="trackById">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>
           <mat-checkbox (change)="$event ? masterToggle() : null"

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -12,7 +12,7 @@ import { switchMap, takeUntil, map } from 'rxjs/operators';
 import {
   filterDropdowns, filterSpecificFields, composeFilterFunctions, sortNumberOrString,
   dropdownsFill, createDeleteArray, filterSpecificFieldsByWord, filterTags, commonSortingDataAccessor,
-  selectedOutOfFilter, filterShelf
+  selectedOutOfFilter, filterShelf, trackById
 } from '../shared/table-helpers';
 import * as constants from './constants';
 import { debug } from '../debug-operator';
@@ -92,6 +92,7 @@ export class CoursesComponent implements OnInit, AfterViewInit, OnDestroy {
     filterSpecificFieldsByWord([ 'doc.courseTitle' ]),
     filterShelf(this.myCoursesFilter, 'admission')
   ]);
+  trackById = trackById;
 
   @ViewChild(PlanetTagInputComponent, { static: false })
   private tagInputComponent: PlanetTagInputComponent;

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -68,7 +68,7 @@
   </mat-toolbar>
 
   <div class="view-container view-full-height view-table" [ngClass]="{'view-with-search':showFilters==='on'}" *ngIf="!emptyData; else notFoundMessage">
-    <mat-table #table [dataSource]="resources" matSort [matSortDisableClear]="true">
+    <mat-table #table [dataSource]="resources" matSort [matSortDisableClear]="true" [trackBy]="trackById">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>
           <mat-checkbox (change)="$event ? masterToggle() : null"

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -10,7 +10,7 @@ import { PlanetMessageService } from '../shared/planet-message.service';
 import { UserService } from '../shared/user.service';
 import {
   filterSpecificFields, composeFilterFunctions, filterTags, filterAdvancedSearch, filterShelf,
-  createDeleteArray, filterSpecificFieldsByWord, commonSortingDataAccessor, selectedOutOfFilter
+  createDeleteArray, filterSpecificFieldsByWord, commonSortingDataAccessor, selectedOutOfFilter, trackById
 } from '../shared/table-helpers';
 import { ResourcesService } from './resources.service';
 import { environment } from '../../environments/environment';
@@ -80,6 +80,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
       filterShelf(this.myLibraryFilter, 'libraryInfo')
     ]
   );
+  trackById = trackById;
 
   @ViewChild(PlanetTagInputComponent, { static: false })
   private tagInputComponent: PlanetTagInputComponent;

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -143,3 +143,5 @@ export const commonSortingDataAccessor = (item: any, property: string) => {
       return item[property] ? sortNumberOrString(item, property) : sortNumberOrString(item.doc, property);
   }
 };
+
+export const trackById = (index, item) => item._id;


### PR DESCRIPTION
@dogi noted that in Courses there's a long wait before the list is usable.  I've noted that in resources as well.

Trying to add a `trackBy` function to the tables in case the issue is that the data source is being updated too much causing the entire table to rerender.