### PR TITLE
Fix travis error

### DIFF
--- a/docker/planet/Dockerfile
+++ b/docker/planet/Dockerfile
@@ -23,14 +23,13 @@ RUN ./create_version_json.sh
 
 FROM nginx:1.16.0-alpine
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN rm -rf /usr/share/nginx/html/*
 RUN apk add --no-cache \
       fcgi=2.4.0-r8 \
     fcgiwrap=1.1.0-r3 \
     spawn-fcgi=1.6.4-r3 \
       ca-certificates=20190108-r0 \
-      nghttp2-libs=1.35.1-r0 \
+      nghttp2-libs=1.35.1-r1 \
       libssh2=1.8.2-r0 \
       libcurl=7.64.0-r2 \
     curl=7.64.0-r2 \


### PR DESCRIPTION
All of our builds are throwing an error in the `apk add` step of stage 1.1.  Changing the version of the package throwing the error fixes the error, at least.  Is there a different approach we should take to fixing this?

https://travis-ci.org/open-learning-exchange/planet/jobs/577669663#L400

![image](https://user-images.githubusercontent.com/9203229/63826034-16836f80-c92b-11e9-86ca-f9ff362ff926.png)
