### PR TITLE
re-ordering courses tool bar buttons fixes ( #4649 )

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -37,9 +37,9 @@
         </button>
       </ng-container>
       <ng-container *ngIf="!parent">
-          <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
-            <planet-tag-input [db]="dbName" [disabled]="selection?.selected?.length === 0" mode="add" labelType="change" [helperText]="false" [filteredData]="courses.data" [selectedIds]="selection.selected" (finalTags)="addTagsToSelected($event)"></planet-tag-input>
-          </mat-form-field>
+        <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
+          <planet-tag-input [db]="dbName" [disabled]="selection?.selected?.length === 0" mode="add" labelType="change" [helperText]="false" [filteredData]="courses.data" [selectedIds]="selection.selected" (finalTags)="addTagsToSelected($event)"></planet-tag-input>
+        </mat-form-field>
         <button mat-button [disabled]="selectedNotEnrolled === 0" (click)="enrollLeaveToggle(selection.selected, 'add')">
           <mat-icon aria-hidden="true" class="margin-lr-3">library_add</mat-icon><span i18n>Join Selected</span>
           <span *ngIf="selectedNotEnrolled > 0"> ({{selectedNotEnrolled}})</span>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -37,18 +37,18 @@
         </button>
       </ng-container>
       <ng-container *ngIf="!parent">
+          <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
+            <planet-tag-input [db]="dbName" [disabled]="selection?.selected?.length === 0" mode="add" labelType="change" [helperText]="false" [filteredData]="courses.data" [selectedIds]="selection.selected" (finalTags)="addTagsToSelected($event)"></planet-tag-input>
+          </mat-form-field>
         <button mat-button [disabled]="selectedNotEnrolled === 0" (click)="enrollLeaveToggle(selection.selected, 'add')">
           <mat-icon aria-hidden="true" class="margin-lr-3">library_add</mat-icon><span i18n>Join Selected</span>
           <span *ngIf="selectedNotEnrolled > 0"> ({{selectedNotEnrolled}})</span>
         </button>
-        <button mat-button [disabled]="selectedEnrolled === 0" (click)="enrollLeaveToggle(selection.selected, 'remove')">
-          <mat-icon aria-hidden="true" class="margin-lr-3">clear</mat-icon><span i18n>Leave Selected</span>
-          <span *ngIf="selectedEnrolled > 0"> ({{selectedEnrolled}})</span>
-        </button>
         <ng-container *ngIf="user.isUserAdmin">
-          <mat-form-field class="font-size-1 margin-lr-3 mat-form-field-type-no-underline mat-form-field-dynamic-width">
-            <planet-tag-input [db]="dbName" [disabled]="selection?.selected?.length === 0" mode="add" labelType="change" [helperText]="false" [filteredData]="courses.data" [selectedIds]="selection.selected" (finalTags)="addTagsToSelected($event)"></planet-tag-input>
-          </mat-form-field>
+          <button mat-button [disabled]="selectedEnrolled === 0" (click)="enrollLeaveToggle(selection.selected, 'remove')">
+            <mat-icon aria-hidden="true" class="margin-lr-3">clear</mat-icon><span i18n>Leave Selected</span>
+            <span *ngIf="selectedEnrolled > 0"> ({{selectedEnrolled}})</span>
+          </button> 
           <button mat-button [matMenuTriggerFor]="managerMenu" *planetAuthorizedRoles [disabled]="!selection.selected.length">Manager Actions</button>
           <mat-menu #managerMenu="matMenu">
             <!-- TODO: Need to figure out how to resolve conflicts when sending course back to parent -->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53117273/63893999-29d91e00-c9b1-11e9-813b-26dfad242a86.png)

![image](https://user-images.githubusercontent.com/53117273/63893896-eda5bd80-c9b0-11e9-8fe2-6e5d72e5e289.png)

note this is the updated courses tool-bar, which is now symmetrical to the resource tool-bar. ^^^