### PR TITLE
Sync: Fix conflict error (fixes #4740)

### DIFF
--- a/src/app/manager-dashboard/sync.directive.ts
+++ b/src/app/manager-dashboard/sync.directive.ts
@@ -39,8 +39,8 @@ export class SyncDirective {
   }
 
   syncPlanet() {
+    const defaultList = this.replicatorList((type) => (val) => this.syncService.replicatorId(val, type));
     const deleteArray = (replicators) => replicators.filter(rep => {
-      const defaultList = this.replicatorList((type) => (val) => val.db + '_' + type);
       return rep._replication_state === 'completed' || defaultList.indexOf(rep._id) > -1;
     }).map(rep => {
       return { ...rep, _deleted: true };

--- a/src/app/shared/sync.service.ts
+++ b/src/app/shared/sync.service.ts
@@ -51,7 +51,7 @@ export class SyncService {
     }
     return {
       // Name the id always after the local database
-      '_id': (type === 'push' ? dbSource : dbTarget).replace('_', '') + '_' + type + (replicator.date ? '_' + Date.now() : ''),
+      '_id': this.replicatorId(replicator, type),
       'source': this.dbObj(dbSource, credentials, type === 'pull' && type !== 'internal'),
       'target': this.dbObj(dbTarget, credentials, type !== 'pull' && type !== 'internal'),
       'selector': replicator.selector,
@@ -59,6 +59,10 @@ export class SyncService {
       'owner': credentials.name,
       'continuous': replicator.continuous
     };
+  }
+
+  replicatorId({ db, dbSource, dbTarget, date }: { db?, dbSource?, dbTarget?, date? }, type: 'push' | 'pull' | 'internal') {
+    return ((type === 'push' ? dbSource : dbTarget) || db).replace('_', '') + '_' + type + (date ? '_' + Date.now() : '');
   }
 
   private itemSelector(items) {


### PR DESCRIPTION
The replicator ids were changed in #4265 to remove the underscores from the database name, but the ids set to be deleted before a sync starts were not also changed to reflect this change.

Not sure if that change is necessary, but I kept it.  I made a shared function for creating the id for the replicator so the deletion & creation functions use the same one.