### PR TITLE
Travis memory fix (fixes #4804)

### DIFF
--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -22,6 +22,7 @@ prepare_ci(){
   COMMIT=${TRAVIS_COMMIT::8}
   REMOTE_MASTER_HASH=$(git ls-remote https://github.com/open-learning-exchange/planet.git | grep refs/heads/master | cut -f 1)
   LOCAL_HASH=$(git log -n 1 --pretty=format:"%H")
+  export NODE_OPTIONS=--max_old_space_size=4096
 }
 
 push_a_docker(){

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -2,18 +2,18 @@
 
 build_multi(){
   {
-    "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng
-    "$(npm bin)"/ng build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-    "$(npm bin)"/ng build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
+    "$(npm bin)"/ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
+    "$(npm bin)"/ng-high-memory build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
+    "$(npm bin)"/ng-high-memory build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
   } &
   {
-    "$(npm bin)"/ng build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
-    "$(npm bin)"/ng build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
-    "$(npm bin)"/ng build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
+    "$(npm bin)"/ng-high-memory build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
+    "$(npm bin)"/ng-high-memory build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
+    "$(npm bin)"/ng-high-memory build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
   } &
   wait
 }
 
 build_single(){
-  "$(npm bin)"/ng build --prod --base-href /eng/ --output-path=dist/eng
+  "$(npm bin)"/ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
 }

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -2,18 +2,18 @@
 
 build_multi(){
   {
-    ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
-    ng-high-memory build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-    ng-high-memory build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
+    npm run ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
+    npm run ng-high-memory build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
+    npm run ng-high-memory build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
   } &
   {
-    ng-high-memory build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
-    ng-high-memory build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
-    ng-high-memory build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
+    npm run ng-high-memory build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
+    npm run ng-high-memory build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
+    npm run ng-high-memory build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
   } &
   wait
 }
 
 build_single(){
-  ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
+  npm run ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
 }

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -2,18 +2,18 @@
 
 build_multi(){
   {
-    npm run ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
-    npm run ng-high-memory build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-    npm run ng-high-memory build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
+    npm run ng-high-memory -- build --prod --base-href /eng/ --output-path=dist/eng
+    npm run ng-high-memory -- build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
+    npm run ng-high-memory -- build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
   } &
   {
-    npm run ng-high-memory build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
-    npm run ng-high-memory build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
-    npm run ng-high-memory build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
+    npm run ng-high-memory -- build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
+    npm run ng-high-memory -- build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
+    npm run ng-high-memory -- build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
   } &
   wait
 }
 
 build_single(){
-  npm run ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
+  npm run ng-high-memory -- build --prod --base-href /eng/ --output-path=dist/eng
 }

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -2,18 +2,18 @@
 
 build_multi(){
   {
-    "$(npm bin)"/ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
-    "$(npm bin)"/ng-high-memory build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
-    "$(npm bin)"/ng-high-memory build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
+    ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
+    ng-high-memory build --prod --base-href /ara/ --output-path=dist/ara --aot --i18n-file=src/i18n/messages.ara.xlf --i18n-locale=ar --i18n-format=xlf
+    ng-high-memory build --prod --base-href /spa/ --output-path=dist/spa --aot --i18n-file=src/i18n/messages.spa.xlf --i18n-locale=es --i18n-format=xlf
   } &
   {
-    "$(npm bin)"/ng-high-memory build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
-    "$(npm bin)"/ng-high-memory build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
-    "$(npm bin)"/ng-high-memory build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
+    ng-high-memory build --prod --base-href /fra/ --output-path=dist/fra --aot --i18n-file=src/i18n/messages.fra.xlf --i18n-locale=fr --i18n-format=xlf
+    ng-high-memory build --prod --base-href /nep/ --output-path=dist/nep --aot --i18n-file=src/i18n/messages.nep.xlf --i18n-locale=ne --i18n-format=xlf
+    ng-high-memory build --prod --base-href /som/ --output-path=dist/som --aot --i18n-file=src/i18n/messages.som.xlf --i18n-locale=so --i18n-format=xlf
   } &
   wait
 }
 
 build_single(){
-  "$(npm bin)"/ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
+  ng-high-memory build --prod --base-href /eng/ --output-path=dist/eng
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "LNG=${LNG:-en};ng serve --aot --i18n-file=src/i18n/messages.$LNG.xlf --locale=$LNG --i18n-format=xlf",
     "v-serve": "vagrant ssh dev -- -t 'cd /vagrant;ng serve'",
-    "build": "LNG=${LNG:-en};ng-high-memory build --prod --i18n-file=src/i18n/messages.$LNG.xlf --locale=$LNG --i18n-format=xlf",
+    "build": "LNG=${LNG:-en};npm run ng-high-memory -- build --prod --i18n-file=src/i18n/messages.$LNG.xlf --i18n-locale=$LNG --i18n-format=xlf",
     "v-build": "vagrant ssh dev -- -t 'cd /vagrant;ng build --prod'",
     "test": "ng test",
     "v-test": "vagrant ssh dev -- -t 'cd /vagrant;ng test'",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "license": "AGPL-3.0",
   "scripts": {
     "ng": "ng",
+    "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "LNG=${LNG:-en};ng serve --aot --i18n-file=src/i18n/messages.$LNG.xlf --locale=$LNG --i18n-format=xlf",
     "v-serve": "vagrant ssh dev -- -t 'cd /vagrant;ng serve'",
-    "build": "LNG=${LNG:-en};ng build --prod --i18n-file=src/i18n/messages.$LNG.xlf --locale=$LNG --i18n-format=xlf",
+    "build": "LNG=${LNG:-en};ng-high-memory build --prod --i18n-file=src/i18n/messages.$LNG.xlf --locale=$LNG --i18n-format=xlf",
     "v-build": "vagrant ssh dev -- -t 'cd /vagrant;ng build --prod'",
     "test": "ng test",
     "v-test": "vagrant ssh dev -- -t 'cd /vagrant;ng test'",


### PR DESCRIPTION
Based on a couple of solutions found:

https://travis-ci.community/t/how-to-fix-the-following-build-error-in-travis-ci-fatal-error-call-and-retry-last-allocation-failed-javascript-heap-out-of-memory/4428
https://github.com/angular/angular-cli/issues/5618#issuecomment-450151214

In Travis we set an environment variable that increases the memory limit for Node.  I also added the npm command suggested by the Angular CLI dev so we can run the build locally without memory issues.