### PR TITLE
Refactor: Remove unnecessary file (fixes #4753)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -13,7 +13,7 @@ import { CoursesService } from '../courses.service';
 import { UserService } from '../../shared/user.service';
 import { StateService } from '../../shared/state.service';
 import { PlanetStepListService } from '../../shared/forms/planet-step-list.component';
-import { PouchService } from '../../shared/database';
+import { PouchService } from '../../shared/database/pouch.service';
 import { debug } from '../../debug-operator';
 import { TagsService } from '../../shared/forms/tags.service';
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -8,7 +8,7 @@ import { Subject, interval, of } from 'rxjs';
 import { switchMap, takeUntil, tap, catchError } from 'rxjs/operators';
 import { debug } from '../debug-operator';
 import { findDocuments } from '../shared/mangoQueries';
-import { PouchAuthService } from '../shared/database';
+import { PouchAuthService } from '../shared/database/pouch-auth.service';
 import { StateService } from '../shared/state.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { NotificationsService } from '../notifications/notifications.service';

--- a/src/app/login/login-form.component.ts
+++ b/src/app/login/login-form.component.ts
@@ -10,7 +10,8 @@ import { PlanetMessageService } from '../shared/planet-message.service';
 import { environment } from '../../environments/environment';
 import { ValidatorService } from '../validators/validator.service';
 import { SyncService } from '../shared/sync.service';
-import { PouchAuthService, PouchService } from '../shared/database';
+import { PouchAuthService } from '../shared/database/pouch-auth.service';
+import { PouchService } from '../shared/database/pouch.service';
 import { StateService } from '../shared/state.service';
 
 const registerForm = {

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -3,7 +3,7 @@ import { UserService } from './user.service';
 import { Observable, of, forkJoin } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
 import { Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { PouchAuthService } from './database';
+import { PouchAuthService } from './database/pouch-auth.service';
 import { StateService } from './state.service';
 
 @Injectable({

--- a/src/app/shared/database/index.ts
+++ b/src/app/shared/database/index.ts
@@ -1,6 +1,0 @@
-import { PouchService } from './pouch.service';
-import { PouchAuthService } from './pouch-auth.service';
-
-export { PouchService } from './pouch.service';
-export { PouchAuthService } from './pouch-auth.service';
-export const SHARED_SERVICES = [ PouchService, PouchAuthService ];


### PR DESCRIPTION
Last part missed in #4778.  There was a file that was only used to consolidate imports for two other files.   Required a few other changes to import statements to remove fully.