### PR TITLE
TeamsView: Task tab loads after notification (fixes #4864)

### DIFF
--- a/src/app/tasks/tasks.component.ts
+++ b/src/app/tasks/tasks.component.ts
@@ -96,6 +96,7 @@ export class TasksComponent implements OnInit {
       user: assignee.userId,
       'message': 'You were assigned a new task',
       link,
+      linkParams: { task: true },
       'type': 'newTask',
       'priority': 1,
       'status': 'unread',

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -31,7 +31,7 @@
     </div>
   </mat-toolbar>
   <div class="view-container view-full-height">
-    <mat-tab-group>
+    <mat-tab-group [(selectedIndex)]="tabSelectedIndex">
       <mat-tab i18n-label label="Messages" *ngIf="userStatus === 'member'">
         <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot" i18n>New message</button>
         <planet-news-list [items]="news" viewableBy="teams" [viewableId]="team?._id" (viewChange)="toggleAdd($event)" editSuccessMessage="Message has been updated successfully"></planet-news-list>
@@ -97,7 +97,7 @@
           </ng-template>
           <planet-calendar *ngIf="calendarTab.isActive" [link]="{ teams: teamId }"></planet-calendar>
         </mat-tab>
-        <mat-tab>
+        <mat-tab #taskTab>
           <ng-template mat-tab-label>
             <ng-container i18n>Tasks</ng-container>
           </ng-template>


### PR DESCRIPTION
#4864

After clicking a notification for being assigned a task, the tab selected switches to Tasks.

The switch is a little wonky (it stops at Calendar first for me), but as long as it gets to Tasks for you then let's merge.