### PR TITLE
HealthEvent: Allow adding an event before profile (fixes #5013)

### DIFF
--- a/src/app/health/health-event.component.ts
+++ b/src/app/health/health-event.component.ts
@@ -41,7 +41,7 @@ export class HealthEventComponent implements OnInit {
   }
 
   onSubmit() {
-    this.healthService.addEvent({ ...this.healthForm.value, date: Date.now() }).subscribe(() => {
+    this.healthService.addEvent(this.route.snapshot.params.id, { ...this.healthForm.value, date: Date.now() }).subscribe(() => {
       this.goBack();
     });
   }

--- a/src/app/health/health.component.html
+++ b/src/app/health/health.component.html
@@ -6,7 +6,7 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1">
     <a mat-raised-button color="accent" class="margin-lr-3" i18n [routerLink]="['update']">Update Details</a>
-    <a mat-raised-button color="accent" class="margin-lr-3" i18n [routerLink]="['event']">Add Examination</a>
+    <a mat-raised-button color="accent" class="margin-lr-3" i18n [routerLink]="['event', { id: userDetail._id }]">Add Examination</a>
   </mat-toolbar>
   <div class="view-container view-full-height">
     <div class="profile-container">

--- a/src/app/health/health.service.ts
+++ b/src/app/health/health.service.ts
@@ -32,8 +32,8 @@ export class HealthService {
       .pipe(tap((response) => this.healthData = response));
   }
 
-  addEvent(event: any) {
-    return this.postHealthData({ events: [ ...(this.healthData.events || []), event ] });
+  addEvent(_id: string, event: any) {
+    return this.postHealthData({ _id, events: [ ...(this.healthData.events || []), event ] });
   }
 
   postHealthData(data) {


### PR DESCRIPTION
#5013

Fixed by adding an `id` parameter to the HealthEvent route which is used when the event/exam is submitted.