### PR TITLE
Couch per user

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -35,8 +35,10 @@ insert_dbs() {
 }
 
 set_couch_per_user() {
-  CODE=$(curl "$COUCHURL/configurations/_all_docs?include_docs=true" $PROXYHEADER | jq -r '.["rows"][0]["doc"]["code"] // empty')
-  if [ ! -z "$CODE" ]
+  CONFIGURATION=$(curl "$COUCHURL/configurations/_all_docs?include_docs=true" $PROXYHEADER)
+  CODE=$(echo $CONFIGURATION | jq -r '.["rows"][0]["doc"]["code"] // empty')
+  BETAMODE=$(echo $CONFIGURATION | jq -r '.["rows"][0]["doc"]["betaEnabled"] // empty')
+  if [ ! -z "$CODE" ] && [ "$BETAMODE" != "off" ];
   then
     upsert_doc _node/nonode@nohost/_config couch_peruser/database_prefix '"userdb-'$CODE'-"'
     upsert_doc _node/nonode@nohost/_config couch_peruser/delete_dbs '"true"'


### PR DESCRIPTION
Sets the CouchDB into couch per user mode with the "databases" named like
```
userdb-<configurationcode>-<hexofusername>
```

Creates the setting in two places
1. When the configuration is initially created
2. In `couchdb-setup.sh` if the Planet configuration has been set.  This is used to upgrade current deployments and fix in case the CouchDB setting is changed.