### PR TITLE
Couch peruser: Fix invalid database name (fixes #5122)

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -36,11 +36,12 @@ insert_dbs() {
 
 set_couch_per_user() {
   CONFIGURATION=$(curl "$COUCHURL/configurations/_all_docs?include_docs=true" $PROXYHEADER)
-  CODE=$(echo $CONFIGURATION | jq -r '.["rows"][0]["doc"]["code"] // empty')
+  CODE=$(echo $CONFIGURATION | jq -rj '.["rows"][0]["doc"]["code"] // empty')
+  HEXCODE=$(echo $CODE | tr -d \\n | xxd -p)
   BETAMODE=$(echo $CONFIGURATION | jq -r '.["rows"][0]["doc"]["betaEnabled"] // empty')
   if [ ! -z "$CODE" ] && [ "$BETAMODE" != "off" ];
   then
-    upsert_doc _node/nonode@nohost/_config couch_peruser/database_prefix '"userdb-'$CODE'-"'
+    upsert_doc _node/nonode@nohost/_config couch_peruser/database_prefix '"userdb-'$HEXCODE'-"'
     upsert_doc _node/nonode@nohost/_config couch_peruser/delete_dbs '"true"'
     upsert_doc _node/nonode@nohost/_config couch_peruser/enable '"true"'
   fi

--- a/src/app/configuration/configuration.service.ts
+++ b/src/app/configuration/configuration.service.ts
@@ -6,7 +6,7 @@ import { switchMap, mergeMap, takeWhile } from 'rxjs/operators';
 import { forkJoin, of } from 'rxjs';
 import { findDocuments } from '../shared/mangoQueries';
 import { SyncService } from '../shared/sync.service';
-import { dedupeShelfReduce } from '../shared/utils';
+import { dedupeShelfReduce, stringToHex } from '../shared/utils';
 
 @Injectable({
   providedIn: 'root'
@@ -172,7 +172,7 @@ export class ConfigurationService {
   setCouchPerUser({ doc: configuration }) {
     return configuration.betaEnabled !== 'off' ?
       forkJoin([
-        this.couchService.put('_node/nonode@nohost/_config/couch_peruser/database_prefix', `userdb-${configuration.code}-`),
+        this.couchService.put('_node/nonode@nohost/_config/couch_peruser/database_prefix', `userdb-${stringToHex(configuration.code)}-`),
         this.couchService.put('_node/nonode@nohost/_config/couch_peruser/delete_dbs', 'true'),
         this.couchService.put('_node/nonode@nohost/_config/couch_peruser/enable', 'true')
       ]) :

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -64,3 +64,7 @@ export const urlToParamObject = (url: string) => url.split(';').reduce((params, 
 }, {});
 
 export const toProperCase = (string: string) => `${string.slice(0, 1).toUpperCase()}${string.slice(1)}`;
+
+export const stringToHex = (string: string) => string.split('').map(char => char.charCodeAt(0).toString(16)).join('');
+
+export const hexToString = (string: string) => string.match(/.{1,2}/g).map(hex => String.fromCharCode(parseInt(hex, 16))).join('');


### PR DESCRIPTION
#5122 

Change to convert the `planetCode` into a hex string as well.  This ensures the database prefix is limited to valid characters for CouchDB databases.