### PR TITLE
Health: If many keys use first created (fixes #5305)

### DIFF
--- a/src/app/health/health.service.ts
+++ b/src/app/health/health.service.ts
@@ -24,9 +24,9 @@ export class HealthService {
   getUserKey(userDb: string, createIfNone = false) {
     return this.couchService.findAll(userDb).pipe(
       switchMap((docs: any[]) => {
-        const max = docs.reduce((minDoc, doc) => doc.createdOn < minDoc.createdOn ? doc : minDoc, { createdOn: Infinity });
-        return max.key && max.iv ?
-          of({ doc: max }) :
+        const first = docs.reduce((minDoc, doc) => doc.createdOn < minDoc.createdOn ? doc : minDoc, { createdOn: Infinity });
+        return first.key && first.iv ?
+          of({ doc: first }) :
           createIfNone ?
           this.createUserKey(userDb) :
           of({ doc: {} });

--- a/src/app/health/health.service.ts
+++ b/src/app/health/health.service.ts
@@ -24,7 +24,7 @@ export class HealthService {
   getUserKey(userDb: string, createIfNone = false) {
     return this.couchService.findAll(userDb).pipe(
       switchMap((docs: any[]) => {
-        const max = docs.reduce((maxDoc, doc) => doc.createdOn > maxDoc.createdOn ? doc : maxDoc, { createdOn: -Infinity });
+        const max = docs.reduce((minDoc, doc) => doc.createdOn < minDoc.createdOn ? doc : minDoc, { createdOn: Infinity });
         return max.key && max.iv ?
           of({ doc: max }) :
           createIfNone ?


### PR DESCRIPTION
Making a change to the strategy if multiple keys were created for a user by mistake.

If they already have a health document, it was created with the first key.  This way we hopefully avoid them not being able to access their data because the system is using the wrong key.