### PR TITLE
Health: Fix old exam dialog open (fixes #5307)

### DIFF
--- a/src/app/health/health-event-dialog.component.ts
+++ b/src/app/health/health-event-dialog.component.ts
@@ -15,7 +15,7 @@ export class HealthEventDialogComponent {
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: any) {
     this.event = this.data.event || {};
-    this.conditions = Object.entries(this.event.conditions)
+    this.conditions = Object.entries(this.event.conditions || {})
       .filter(([ condition, active ]) => active).map(([ condition, active ]) => condition).join(', ');
     this.hasConditionAndTreatment = this.conditionAndTreatmentFields.some(field => this.event[field] !== '');
   }


### PR DESCRIPTION
#5307 

Not as bad of an error as I initially thought since this will only affect exams created before 0.9.31.