### PR TITLE
News: Relative links for images (fixes #5328)

### DIFF
--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -15,7 +15,7 @@
   </mat-card-header>
   <mat-card-content>
     <div [ngClass]="{'show-less': showLess}" #content>
-      <td-markdown [content]="item.message"></td-markdown>
+      <planet-markdown [content]="item.message"></planet-markdown>
     </div>
     <span class="primary-text-color cursor-pointer" *ngIf="contentHeight > content.clientHeight || !showLess" (click)="showLess = !showLess" i18n>{{ showLess ? "Show More" : "Show Less" }}</span>
   </mat-card-content>

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -25,7 +25,7 @@ export class NewsListItemComponent implements AfterViewChecked {
   ) {}
 
   ngAfterViewChecked() {
-    const offsetHeight = this.content && this.content.nativeElement.children[0].children[0].offsetHeight;
+    const offsetHeight = this.content && this.content.nativeElement.children[0].children[0].children[0].offsetHeight;
     if (offsetHeight && offsetHeight !== this.contentHeight) {
       this.contentHeight = offsetHeight;
       this.cdRef.detectChanges();

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -160,7 +160,7 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
       }
     }).afterClosed().subscribe(image => {
       if (image) {
-        this.editor.options.insertTexts.image = [ `![](${environment.couchAddress}/resources/${image._id}/${image.filename}` , ')' ];
+        this.editor.options.insertTexts.image = [ `![](resources/${image._id}/${image.filename}` , ')' ];
         this.editor._simpleMDE.drawImage();
       }
     });

--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'planet-markdown',
+  template: '<td-markdown [content]="content" [hostedUrl]="couchAddress"></td-markdown>'
+})
+export class PlanetMarkdownComponent {
+
+  @Input() content: string;
+  couchAddress = environment.couchAddress;
+
+}

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CovalentMarkdownModule } from '@covalent/markdown';
 import { PlanetLocalStatusComponent } from './planet-local-status.component';
 import { MaterialModule } from './material.module';
 import { SubmitDirective } from './submit.directive';
@@ -11,10 +12,11 @@ import { PlanetBetaDirective } from './beta.directive';
 import { FilteredAmountComponent } from './planet-filtered-amount.component';
 import { TasksComponent, FilterAssigneePipe } from '../tasks/tasks.component';
 import { PlanetRoleComponent } from './planet-role.component';
+import { PlanetMarkdownComponent } from './planet-markdown.component';
 
 @NgModule({
   imports: [
-    CommonModule, MaterialModule
+    CommonModule, MaterialModule, CovalentMarkdownModule
   ],
   exports: [
     PlanetLocalStatusComponent,
@@ -27,7 +29,8 @@ import { PlanetRoleComponent } from './planet-role.component';
     FilteredAmountComponent,
     TasksComponent,
     FilterAssigneePipe,
-    PlanetRoleComponent
+    PlanetRoleComponent,
+    PlanetMarkdownComponent
   ],
   declarations: [
     PlanetLocalStatusComponent,
@@ -40,7 +43,8 @@ import { PlanetRoleComponent } from './planet-role.component';
     FilteredAmountComponent,
     TasksComponent,
     FilterAssigneePipe,
-    PlanetRoleComponent
+    PlanetRoleComponent,
+    PlanetMarkdownComponent
   ]
 })
 export class SharedComponentsModule {}


### PR DESCRIPTION
@lmmrssa I know the suggestion was to use `/db/`, but looking into the documentation for the markdown parser we are using, the `[hostedUrl]` property is required for relative links anyway so I just set that to `environment.couchAddress`.