### PR TITLE
Markdown: Fix markdown image base url (fixes #5343)

### DIFF
--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -8,6 +8,6 @@ import { environment } from '../../environments/environment';
 export class PlanetMarkdownComponent {
 
   @Input() content: string;
-  couchAddress = environment.couchAddress;
+  couchAddress = `${environment.couchAddress}/`;
 
 }


### PR DESCRIPTION
The `hostedUrl` property for `td-markdown` requires a closing `/` otherwise it cuts off part of the url.