### PR TITLE
Resources: Fix gradual load of library

### DIFF
--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -77,9 +77,7 @@ export class ResourcesService {
   }
 
   updateResources(resources) {
-    if (!this.isActiveResourceFetch) {
-      this.resourcesUpdated.next(resources);
-    }
+    this.resourcesUpdated.next(resources);
   }
 
   getRatings(resourceIds: string[], opts: any) {

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -51,7 +51,6 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
   // Use string rather than boolean for i18n select
   fullView = 'on';
   resourceId: string;
-  resourcesCount = 0;
 
   ngOnInit() {
     this.route.paramMap
@@ -66,7 +65,6 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
         this.resource = resources.find((r: any) => r._id === this.resourceId);
         if (this.resource === undefined) {
           if (this.resourcesService.isActiveResourceFetch) {
-            this.resourcesCount = resources.length;
             return;
           }
           this.planetMessageService.showAlert('Resource does not exist in Library');


### PR DESCRIPTION
#5294 caused a regression on the library loading.  Previously the loading spinner would stop after the first 1000 resources were loaded and the table would continue to update as more batches of 1000 resources were fetched from the database.  After that PR the loading spinner waits for all resources before closing.

There are two things to test here 
- On the Library page hit refresh to see if the resources again load in batches of 1000.
- On a page viewing a resource not in the first batch of 1000, refresh to make sure the resource loads.  #5294 fixed an issue where that resource would not load on refresh & the app would navigate to the resource list.