### PR TITLE
HealthList: Only load health data on current page (fixes #5285)

### DIFF
--- a/src/app/health/health-list.component.html
+++ b/src/app/health/health-list.component.html
@@ -11,7 +11,7 @@
 
 <div class="space-container">
   <ng-container *ngIf="!emptyData; else notFoundMessage">
-    <planet-users-table #table [users]="users" [search]="searchValue" [filter]="{}" [(tableState)]="tableState" [displayedColumns]="displayedColumns" containerClass="view-container view-full-height no-toolbar view-table"></planet-users-table>
+    <planet-users-table #table [users]="users" [search]="searchValue" [filter]="{}" [(tableState)]="tableState" [displayedColumns]="displayedColumns" containerClass="view-container view-full-height no-toolbar view-table" (tableDataChange)="tableDataChange($event)"></planet-users-table>
   </ng-container>
   <ng-template #notFoundMessage>
     <div class="view-container">No User Found</div>

--- a/src/app/health/health-list.component.ts
+++ b/src/app/health/health-list.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subject, forkJoin, merge, concat } from 'rxjs';
+import { Subject, concat } from 'rxjs';
 import { UsersService } from '../users/users.service';
-import { takeUntil, switchMap } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { TableState } from '../users/users-table.component';
 import { HealthService } from './health.service';
 
@@ -61,16 +61,6 @@ export class HealthListComponent implements OnInit, OnDestroy {
         } :
         user
       );
-      //   {
-      //   if (user.health || newData.findIndex(newUser => newUser._id === user._id) === -1) {
-      //     return user;
-      //   }
-      //   const userHealth = healthData.find(data => data._id === user._id) || { _id: user._id, events: [] };
-      //   return {
-      //     ...user,
-      //     health: { ...userHealth, lastVisit: userHealth.events.reduce((max, { date }) => date > max ? date : max, null) }
-      //   };
-      // });
     });
   }
 

--- a/src/app/health/health.service.ts
+++ b/src/app/health/health.service.ts
@@ -63,7 +63,7 @@ export class HealthService {
 
   private getHealthDoc(userId, { key, iv }) {
     return this.couchService.post(`health/_design/health/_show/decrypt/${userId}`, { key, iv }).pipe(
-      catchError(() => of({ profile: {}, events: [] }))
+      catchError(() => of({ _id: userId, profile: {}, events: [] }))
     );
   }
 

--- a/src/app/users/users-table.component.html
+++ b/src/app/users/users-table.component.html
@@ -49,7 +49,10 @@
           <p><b i18n>Type:</b> {{element.health?.profile.emergencyContactType}}</p>
           <p>{{element.health?.profile.emergencyContact}}</p>
         </div>
-        <ng-template #noneBlock><span i18n>None</span></ng-template>
+        <ng-template #noneBlock>
+          <span *ngIf="element.health" i18n>None</span>
+          <mat-progress-bar mode="buffer" *ngIf="!element.health"></mat-progress-bar>
+        </ng-template>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="birthDate">
@@ -58,7 +61,11 @@
     </ng-container>
     <ng-container matColumnDef="lastVisit">
       <mat-header-cell *matHeaderCellDef mat-sort-header i18n>Last Examination</mat-header-cell>
-      <mat-cell *matCellDef="let element">{{(element.health?.lastVisit | date: 'mediumDate') || 'Never'}}</mat-cell>
+      <mat-cell *matCellDef="let element">
+        {{(element.health?.lastVisit | date: 'mediumDate')}}
+        <span *ngIf="element.health && !element.health?.lastVisit" i18n>Never</span>
+        <mat-progress-bar mode="buffer" *ngIf="!element.health"></mat-progress-bar>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="roles">
       <mat-header-cell *matHeaderCellDef i18n>Roles</mat-header-cell>

--- a/src/app/users/users-table.component.html
+++ b/src/app/users/users-table.component.html
@@ -45,9 +45,9 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header i18n>Emergency Contact</mat-header-cell>
       <mat-cell *matCellDef="let element">
         <div *ngIf="element.health?.profile?.emergencyContact; else noneBlock">
-          <p><b i18n>Name:</b> {{element.health.profile.emergencyContactName}}</p>
-          <p><b i18n>Type:</b> {{element.health.profile.emergencyContactType}}</p>
-          <p>{{element.health.profile.emergencyContact}}</p>
+          <p><b i18n>Name:</b> {{element.health?.profile.emergencyContactName}}</p>
+          <p><b i18n>Type:</b> {{element.health?.profile.emergencyContactType}}</p>
+          <p>{{element.health?.profile.emergencyContact}}</p>
         </div>
         <ng-template #noneBlock><span i18n>None</span></ng-template>
       </mat-cell>
@@ -58,7 +58,7 @@
     </ng-container>
     <ng-container matColumnDef="lastVisit">
       <mat-header-cell *matHeaderCellDef mat-sort-header i18n>Last Examination</mat-header-cell>
-      <mat-cell *matCellDef="let element">{{(element.health.lastVisit | date: 'mediumDate') || 'Never'}}</mat-cell>
+      <mat-cell *matCellDef="let element">{{(element.health?.lastVisit | date: 'mediumDate') || 'Never'}}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="roles">
       <mat-header-cell *matHeaderCellDef i18n>Roles</mat-header-cell>

--- a/src/app/users/users-table.component.ts
+++ b/src/app/users/users-table.component.ts
@@ -72,6 +72,7 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
     this._tableState = newState;
   }
   @Output() tableStateChange = new EventEmitter<TableState>();
+  @Output() tableDataChange = new EventEmitter<any[]>();
   @ViewChild(MatSort, { static: false }) sort: MatSort;
   @ViewChild(MatPaginator, { static: false }) paginator: MatPaginator;
   usersTable = new MatTableDataSource();
@@ -112,6 +113,11 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
       filterFieldExists([ 'doc.requestId' ], this.filterType === 'associated'),
       filterSpecificFieldsByWord([ 'fullName' ])
     ])(data, filter);
+    this.usersTable.connect().subscribe(data => {
+      if (this.usersTable.paginator) {
+        this.tableDataChange.emit(data);
+      }
+    });
   }
 
   ngOnChanges() {

--- a/src/app/users/users-table.component.ts
+++ b/src/app/users/users-table.component.ts
@@ -31,7 +31,7 @@ export class TableState {
     .mat-column-profile {
       max-width: 100px;
     }
-    .mat-column-birthDate, .mat-column-lastVisit {
+    .mat-column-birthDate, .mat-column-lastVisit, mat-progress-bar {
       max-width: 225px;
     }
     mat-cell p {


### PR DESCRIPTION
Since the health list loads each individual's health record with a separate request to the database, we limit the requests to only the members on the current page of the table.