### PR TITLE
Change production English locale (fixes #2794)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - stage: docker-creation
       name: "English"
       script:
-        - bash ./.travis/deploy_single_language.sh 'eng' 'en'
+        - bash ./.travis/deploy_single_language.sh 'eng' 'en-GB'
     - stage: docker-creation
       if: tag = branch
       name: "Arabic"

--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -4,7 +4,7 @@ build_single(){
   LANG=$1
   LANG2=$2
   if [ -z "${LANG}" ]; then
-    npm run ng-high-memory -- build --prod --base-href /eng/ --output-path=dist/eng
+    npm run ng-high-memory -- build --prod --base-href /eng/ --output-path=dist/eng --aot --i18n-locale=en-GB
   else
     npm run ng-high-memory -- build --prod --base-href /$LANG/ --output-path=dist/$LANG --aot --i18n-file=src/i18n/messages.$LANG.xlf --i18n-locale=$LANG2 --i18n-format=xlf
   fi


### PR DESCRIPTION
Trying out `en-GB`, could use `en-EU` instead.

Change is so the app uses 24 hour time and euro style date formats.