### PR TITLE
Surveys: Fix slow loading (fixes #5606)

### DIFF
--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -83,7 +83,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit() {
     this.surveys.filterPredicate = filterSpecificFields([ 'name' ]);
     this.surveys.sortingDataAccessor = sortNumberOrString;
-    const receiveData = (dbName: string, type: string) => this.couchService.findAll(dbName, { 'selector': { 'type': type } });
+    const receiveData = (dbName: string, type: string) => this.couchService.findAll(dbName, findDocuments({ 'type': type }));
     forkJoin([
       receiveData('exams', 'surveys'),
       receiveData('submissions', 'survey'),


### PR DESCRIPTION
#5606 

A little more about that issue: it's most noticeable on Somalia where there are many submissions.  Fetching 25 at a time meant there were a lot of requests to the database which made loading the survey list very slow.