### PR TITLE
Surveys: Fix submissions in survey list (fixes #5590)

### DIFF
--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -128,7 +128,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
       if (parentSurvey) {
         parentSurvey.taken = parentSurvey.taken + (submission.status !== 'pending' ? 1 : 0);
       }
-      if (parentSurvey || submission.parent.sourcePlanet === this.stateService.configuration.code) {
+      if (parentSurvey || submission.parent.sourcePlanet === this.stateService.configuration.code || !submission.parent.sourcePlanet) {
         return parentSurveys;
       }
       return [ ...parentSurveys, { ...submission.parent, taken: submission.status !== 'pending' ? 1 : 0, parent: true } ];


### PR DESCRIPTION
#5590 

I realized the issue is that we did not have a `sourcePlanet` field in the exams database so older surveys were being duplicated or added to the list even if they were not from the nation/parent planet.

Since the main survey in the field we are working with has that field (and future surveys will have it, too), I think we can safely ignore those submissions for the purpose of exporting nation survey data from the list.