### PR TITLE
Surveys: Only show parent not any other planet (fixes #5590)

### DIFF
--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -130,11 +130,10 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
       const parentSurvey = parentSurveys.find(nSurvey => nSurvey._id === submission.parent._id);
       if (parentSurvey) {
         parentSurvey.taken = parentSurvey.taken + (submission.status !== 'pending' ? 1 : 0);
+      } else if (submission.parent.sourcePlanet === this.stateService.configuration.parentCode) {
+        return [ ...parentSurveys, { ...submission.parent, taken: submission.status !== 'pending' ? 1 : 0, parent: true } ];
       }
-      if (parentSurvey || submission.parent.sourcePlanet === this.stateService.configuration.code || !submission.parent.sourcePlanet) {
-        return parentSurveys;
-      }
-      return [ ...parentSurveys, { ...submission.parent, taken: submission.status !== 'pending' ? 1 : 0, parent: true } ];
+      return parentSurveys;
     }, []);
   }
 


### PR DESCRIPTION
#5590

Another pass at this because on planet.dev.ole.org there were still many surveys on the list from communities that should not appear there.

Explicitly only shows surveys created on the parent planet.  Note this means that surveys passed between nations, like the challenge survey copied from somalia to dev, will no longer show up in communities unless the `sourcePlanet` property is changed to match the planet it was moved to.