### PR TITLE
Community: Fix services links (fixes #5628)

### DIFF
--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -32,7 +32,7 @@
           } Description</button>
           <mat-nav-list>
             <mat-list-item *ngFor="let link of links">
-              <a [routerLink]="link.route" i18n>
+              <a matLine [routerLink]="link.route" i18n>
                 {{link.title}}
               </a>
               <button *ngIf="deleteMode" mat-icon-button color="warn" (click)="openDeleteLinkDialog(link)"><mat-icon>delete</mat-icon></button>


### PR DESCRIPTION
#5628 

Turns out the links were working, but only if you clicked on the text.  Now clicking anywhere along the row in the list will direct to the linked team or enterprise.