### PR TITLE
[#3718] Course update reload

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -92,6 +92,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    const continued = this.route.snapshot.params.continue === 'true' && Object.keys(this.coursesService.course).length;
     forkJoin([
       this.pouchService.getDocEditing(this.dbName, this.courseId),
       this.couchService.get('courses/' + this.courseId).pipe(catchError((err) => of(err.error))),
@@ -103,11 +104,11 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       }
       const doc = draft === undefined ? saved : draft;
       this.setInitialTags(tags, this.documentInfo, draft);
-      if (this.route.snapshot.params.continue !== 'true') {
+      if (!continued) {
         this.setFormAndSteps({ form: doc, steps: doc.steps, tags: doc.tags, initialTags: this.coursesService.course.initialTags });
       }
     });
-    if (this.route.snapshot.params.continue === 'true') {
+    if (continued) {
       this.documentInfo = { '_rev': this.coursesService.course._rev, '_id': this.coursesService.course._id };
       this.setFormAndSteps(this.coursesService.course);
       this.submitAddedExam();


### PR DESCRIPTION
@paulbert tried to check different approach. It was updating courseservice with initaltags and resetting course, so not sure why it was done so. But after looking for some options I came to update course if courseservice was not intially set which happens when you are not coming back from course view or edit such as reload.

Could you test with some more cases to make sure it works with all.