### PR TITLE
Community: Delete links for nation replication (fixes #5648)

### DIFF
--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -177,7 +177,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   }
 
   deleteLink(link) {
-    return this.couchService.delete(`teams/${link._id}?rev=${link._rev}`);
+    return this.couchService.updateDocument('teams', { ...link, _deleted: true });
   }
 
   openAddLinkDialog() {


### PR DESCRIPTION
#5648 

The selector for the replication of the `teams` documents means that doing a DELETE request to remove a link removes it from replication.

Doing a POST request with `_deleted: true` deletes the document but keeps the metadata so the replication will still work.