### PR TITLE
Community: Only show specific planet news (fixes #5645)

### DIFF
--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -58,14 +58,16 @@ export class CommunityComponent implements OnInit, OnDestroy {
     this.route.paramMap.pipe(
       switchMap((params: ParamMap) => {
         this.planetCode = params.get('code');
-        this.getCommunityData(this.planetCode);
-        this.getLinks(this.planetCode);
         if (this.planetCode) {
           return this.couchService.findAll('communityregistrationrequests', { selector: { code: this.planetCode } });
         }
         return of([ this.stateService.configuration ]);
       })
-    ).subscribe(configurations => this.configuration = configurations[0]);
+    ).subscribe(configurations => {
+      this.configuration = configurations[0];
+      this.getCommunityData(this.planetCode);
+      this.getLinks(this.planetCode);
+    });
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(news => this.news = news);
     this.usersService.usersListener(true).pipe(takeUntil(this.onDestroy$)).subscribe(users => {
       if (!this.planetCode) {

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -89,11 +89,11 @@ export class CommunityComponent implements OnInit, OnDestroy {
 
   getCommunityData(planetCode?: string) {
     if (planetCode) {
-      this.newsService.requestNews({ createdOn: planetCode, viewableBy: 'community' });
+      this.newsService.requestNews({ messagePlanetCode: planetCode, viewableBy: 'community' });
       this.stateService.requestData('child_users', 'local');
       return;
     }
-    this.newsService.requestNews({ createdOn: this.configuration.code, viewableBy: 'community' });
+    this.newsService.requestNews({ messagePlanetCode: this.configuration.code, viewableBy: 'community' });
     this.usersService.requestUsers();
   }
 

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -58,10 +58,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
     this.route.paramMap.pipe(
       switchMap((params: ParamMap) => {
         this.planetCode = params.get('code');
-        if (this.planetCode) {
-          return this.couchService.findAll('communityregistrationrequests', { selector: { code: this.planetCode } });
-        }
-        return of([ this.stateService.configuration ]);
+        return this.planetCode ?
+          this.couchService.findAll('communityregistrationrequests', { selector: { code: this.planetCode } }) :
+          of([ this.stateService.configuration ]);
       })
     ).subscribe(configurations => {
       this.configuration = configurations[0];


### PR DESCRIPTION
#5645 

The **CommunityComponent** was fetching its news before the configuration was set.  That means if `planetCode` was not set, it would show all news on the page instead of the ones based on the current planet configuration.