### PR TITLE
Community: Show editing for local admins (fixes #5661)

### DIFF
--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -27,7 +27,7 @@
         </mat-tab>
         <mat-tab i18n-label label="Services">
           <planet-markdown [content]="team.description || ''"></planet-markdown>
-          <ng-container *ngIf="planetCode === user.code">
+          <ng-container *ngIf="!planetCode">
             <button *planetAuthorizedRoles (click)="openDescriptionDialog()" mat-stroked-button i18n>Edit {
               configuration.planetType, select, community {Community} nation {Nation} center {Earth}
             } Description</button>
@@ -40,7 +40,7 @@
               <button *ngIf="deleteMode" mat-icon-button color="warn" (click)="openDeleteLinkDialog(link)"><mat-icon>delete</mat-icon></button>
             </mat-list-item>
           </mat-nav-list>
-          <ng-container *ngIf="planetCode === user.code">
+          <ng-container *ngIf="!planetCode">
             <div *planetAuthorizedRoles class="action-buttons">
               <button (click)="openAddLinkDialog()" mat-stroked-button i18n>Add Link</button>
               <button (click)="toggleDeleteMode()" mat-stroked-button>
@@ -54,7 +54,7 @@
           <planet-community-list></planet-community-list>
         </mat-tab>
         <mat-tab i18n-label label="Finances">
-          <planet-teams-view-finances [finances]="finances" [team]="team" (financesChanged)="getLinks()" [editable]="isCommunityLeader && planetCode === user.code"></planet-teams-view-finances>
+          <planet-teams-view-finances [finances]="finances" [team]="team" (financesChanged)="getLinks()" [editable]="isCommunityLeader && !planetCode"></planet-teams-view-finances>
         </mat-tab>
       </mat-tab-group>
     </div>


### PR DESCRIPTION
#5661 

Fixed the condition for showing the editing buttons for Services and Finances.  They were not showing up because the `planetCode` is based on the route parameters, and for `/` that is `null`.