### PR TITLE
Community: Fix missing links & finances (fixes #5678)

### DIFF
--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -167,18 +167,13 @@ export class TeamsService {
       this.usersService.usersListener(true).pipe(take(1)),
       this.couchService.findAll('attachments')
     ]).pipe(map(([ membershipDocs, shelves, users, attachments ]: any[]) => [
-      ...[ ...(team.type === 'services' ? this.servicesMembers(team, users) : []), ...membershipDocs ].map(doc => ({
+      ...membershipDocs.map(doc => ({
         ...doc,
         userDoc: users.find(user => user._id === doc.userId && user.doc.planetCode === doc.userPlanetCode),
         attachmentDoc: attachments.find(attachment => attachment._id === `${doc.userId}@${doc.userPlanetCode}`)
       })),
       ...shelves.map((shelf: any) => ({ ...shelf, fromShelf: true, docType: 'membership', userId: shelf._id, teamId: team._id }))
     ]));
-  }
-
-  servicesMembers(team, users) {
-    return users.filter(user => user.name !== 'satellite' && (user.roles.length > 0 || user.isUserAdmin === true))
-      .map(user => this.membershipProps(team, { userId: user._id, userPlanetCode: team.teamPlanetCode }, 'membership'));
   }
 
   getTeamResources(linkDocs: any[]) {


### PR DESCRIPTION
#5678 

Removed a section that was causing the error but no longer used.

That piece of code was from when the Community section was the same as an Enterprise, but with all members of the Community in the Members tab.  Now we only show the leaders & use different functions to do that.