### PR TITLE
TeamsView: Fix breaking removal error (fixes #5709 fixes #5711)

### DIFF
--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -327,7 +327,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   private changeObject(type, memberDoc?) {
-    const memberName = memberDoc && (memberDoc.userDoc.fullName || memberDoc.name);
+    const memberName = memberDoc && memberDoc.userDoc && (memberDoc.userDoc.fullName || memberDoc.name);
     switch (type) {
       case 'request':
         return ({


### PR DESCRIPTION
#5709 #5711 

That section of code is called when initializing a dialog in **TeamsViewComponent** even when it is not used, so we needed to account for `memberDoc.userDoc` being undefined.