### PR TITLE
CoursesStepView: Fix empty exam blocking progress

### DIFF
--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -58,7 +58,7 @@
       </mat-form-field>
       <span i18n>{{stepNum}}/{{maxStep}}</span>
       <button mat-icon-button [disabled]="stepNum === 1" (click)="changeStep(-1)"><mat-icon>navigate_before</mat-icon></button>
-      <button mat-icon-button [disabled]="stepNum === maxStep || (!parent && stepDetail?.exam?.questions.length && !attempts)" (click)="changeStep(1)"><mat-icon>navigate_next</mat-icon></button>
+      <button mat-icon-button [disabled]="stepNum === maxStep || (!parent && stepDetail?.exam?.questions.length > 0 && !attempts)" (click)="changeStep(1)"><mat-icon>navigate_next</mat-icon></button>
     </div>
   </mat-toolbar>
   <div class="view-container view-full-height" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">


### PR DESCRIPTION
Seems like the conditional needs to be `true` or `false` because the `*ngIf` in the line returns `0` but still shows when there are no questions on the exam.