### PR TITLE
News: Add & sort by share time (fixes #5799)

### DIFF
--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -2,37 +2,38 @@
   <mat-card-header>
     <img mat-card-avatar [src]="item.avatar">
     <mat-card-title>
-      <a [routerLink]="['/users/profile', item.user.name, planetCode === item.user.planetCode ? {} : { planet: item.user.planetCode }]">
-        {{item.user.firstName ?
-          item.user.firstName + ((' ' + item.user.middleName) || '') + ' ' + item.user.lastName :
-          item.user.name}}
+      <a [routerLink]="['/users/profile', item.doc.user.name, planetCode === item.doc.user.planetCode ? {} : { planet: item.doc.user.planetCode }]">
+        {{item.doc.user.firstName ?
+          item.doc.user.firstName + ((' ' + item.doc.user.middleName) || '') + ' ' + item.doc.user.lastName :
+          item.doc.user.name}}
       </a>
     </mat-card-title>
     <mat-card-subtitle>
-      <p class="primary-text-color" *ngIf="item.createdOn !== planetCode"><ng-container i18n>Member of Planet</ng-container> {{item.createdOn}}</p>
-      <ng-container i18n>wrote on</ng-container> {{item.time | date: 'medium' }}
-      <ng-container *ngIf="item.updatedDate !== item.time && item.updatedDate"> | <ng-container i18n>edited on</ng-container> {{item.updatedDate | date: 'medium'}}</ng-container>
+      <p class="primary-text-color" *ngIf="item.doc.createdOn !== planetCode"><ng-container i18n>Member of Planet</ng-container> {{item.doc.createdOn}}</p>
+      <ng-container i18n>wrote on</ng-container> {{item.doc.time | date: 'medium' }}
+      <ng-container *ngIf="item.doc.updatedDate !== item.doc.time && item.doc.updatedDate"> | <ng-container i18n>edited on</ng-container> {{item.doc.updatedDate | date: 'medium'}}</ng-container>
+      <ng-container *ngIf="item.sharedDate"> | <ng-container i18n>shared on</ng-container> {{item.sharedDate | date: 'medium'}}</ng-container>
       <mat-chip-list>
-        <mat-chip color="primary" selected [disableRipple]="true" class="planet-chip-label" *ngFor="let label of item.labels"><planet-label [label]="label"></planet-label></mat-chip>
+        <mat-chip color="primary" selected [disableRipple]="true" class="planet-chip-label" *ngFor="let label of item.doc.labels"><planet-label [label]="label"></planet-label></mat-chip>
       </mat-chip-list>
     </mat-card-subtitle>
   </mat-card-header>
   <mat-card-content>
     <div [ngClass]="{'show-less': showLess}" #content>
-      <planet-markdown [content]="item.message"></planet-markdown>
+      <planet-markdown [content]="item.doc.message"></planet-markdown>
     </div>
     <span class="primary-text-color cursor-pointer" *ngIf="contentHeight > content.clientHeight || !showLess" (click)="showLess = !showLess" i18n>{{ showLess ? "Show More" : "Show Less" }}</span>
   </mat-card-content>
   <mat-card-actions class="display-flex">
     <button mat-button *ngIf="editable" type="button" (click)="addReply(item)" i18n>Reply</button>
-    <button mat-button type="button" *ngIf="replyObject[item._id]?.length > 0 && showRepliesButton" (click)="showReplies(item)">
-      <ng-container i18n>Show Replies</ng-container> ({{replyObject[item._id]?.length}})
+    <button mat-button type="button" *ngIf="replyObject[item.doc._id]?.length > 0 && showRepliesButton" (click)="showReplies(item)">
+      <ng-container i18n>Show Replies</ng-container> ({{replyObject[item.doc._id]?.length}})
     </button>
-    <ng-container *ngIf="item.user.name === currentUser.name">
+    <ng-container *ngIf="item.doc.user.name === currentUser.name">
       <button mat-icon-button type="button" (click)="editNews(item)" i18n><mat-icon>edit</mat-icon></button>
       <button mat-icon-button type="button" (click)="openDeleteDialog(item)" i18n><mat-icon>delete</mat-icon></button>
     </ng-container>
-    <button mat-button i18n *ngIf="item.user.name === currentUser.name && editable" [matMenuTriggerFor]="labelMenu">Add Label</button>
+    <button mat-button i18n *ngIf="item.doc.user.name === currentUser.name && editable" [matMenuTriggerFor]="labelMenu">Add Label</button>
     <mat-menu #labelMenu="matMenu">
       <button mat-menu-item *ngFor="let label of labels" (click)="labelClick(label)"><planet-label [label]="label"></planet-label></button>
     </mat-menu>

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -26,7 +26,7 @@
   </mat-card-content>
   <mat-card-actions class="display-flex">
     <button mat-button *ngIf="editable" type="button" (click)="addReply(item.doc)" i18n>Reply</button>
-    <button mat-button type="button" *ngIf="replyObject[item.doc._id]?.length > 0 && showRepliesButton" (click)="showReplies(item.doc)">
+    <button mat-button type="button" *ngIf="replyObject[item.doc._id]?.length > 0 && showRepliesButton" (click)="showReplies(item)">
       <ng-container i18n>Show Replies</ng-container> ({{replyObject[item.doc._id]?.length}})
     </button>
     <ng-container *ngIf="item.doc.user.name === currentUser.name">

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -25,19 +25,19 @@
     <span class="primary-text-color cursor-pointer" *ngIf="contentHeight > content.clientHeight || !showLess" (click)="showLess = !showLess" i18n>{{ showLess ? "Show More" : "Show Less" }}</span>
   </mat-card-content>
   <mat-card-actions class="display-flex">
-    <button mat-button *ngIf="editable" type="button" (click)="addReply(item)" i18n>Reply</button>
-    <button mat-button type="button" *ngIf="replyObject[item.doc._id]?.length > 0 && showRepliesButton" (click)="showReplies(item)">
+    <button mat-button *ngIf="editable" type="button" (click)="addReply(item.doc)" i18n>Reply</button>
+    <button mat-button type="button" *ngIf="replyObject[item.doc._id]?.length > 0 && showRepliesButton" (click)="showReplies(item.doc)">
       <ng-container i18n>Show Replies</ng-container> ({{replyObject[item.doc._id]?.length}})
     </button>
     <ng-container *ngIf="item.doc.user.name === currentUser.name">
-      <button mat-icon-button type="button" (click)="editNews(item)" i18n><mat-icon>edit</mat-icon></button>
-      <button mat-icon-button type="button" (click)="openDeleteDialog(item)" i18n><mat-icon>delete</mat-icon></button>
+      <button mat-icon-button type="button" (click)="editNews(item.doc)" i18n><mat-icon>edit</mat-icon></button>
+      <button mat-icon-button type="button" (click)="openDeleteDialog(item.doc)" i18n><mat-icon>delete</mat-icon></button>
     </ng-container>
     <button mat-button i18n *ngIf="item.doc.user.name === currentUser.name && editable" [matMenuTriggerFor]="labelMenu">Add Label</button>
     <mat-menu #labelMenu="matMenu">
       <button mat-menu-item *ngFor="let label of labels" (click)="labelClick(label)"><planet-label [label]="label"></planet-label></button>
     </mat-menu>
-    <button mat-button i18n *ngIf="showShare" (click)="shareStory(item)">Share with {
+    <button mat-button i18n *ngIf="showShare" (click)="shareStory(item.doc)">Share with {
       shareTarget, select, community {Community} nation {Nation} center {Earth}
     }</button>
   </mat-card-actions>

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -45,7 +45,7 @@ export class NewsListItemComponent implements OnInit, AfterViewChecked {
     this.targetLocalPlanet = this.shareTarget === this.stateService.configuration.planetType;
     this.showShare = this.shareTarget &&
       (!this.targetLocalPlanet ||
-      (this.item.viewIn || []).every(({ _id }) => _id !== `${configuration.code}@${configuration.parentCode}`));
+      (this.item.doc.viewIn || []).every(({ _id }) => _id !== `${configuration.code}@${configuration.parentCode}`));
   }
 
   ngAfterViewChecked() {
@@ -119,7 +119,7 @@ export class NewsListItemComponent implements OnInit, AfterViewChecked {
   }
 
   labelClick(label) {
-    this.addLabel.emit({ label, news: this.item });
+    this.addLabel.emit({ label, news: this.item.doc });
   }
 
 }

--- a/src/app/news/news-list.component.html
+++ b/src/app/news/news-list.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="replyViewing._id!=='root'">
   <div class="action-buttons">
     <button mat-stroked-button type="button" (click)="showReplies({_id:'root'})" i18n>Show main conversation</button>
-    <button mat-stroked-button type="button" *ngIf="replyViewing.replyTo && replyViewing.replyTo !== 'root'" (click)="showPreviousReplies()" i18n>Show previous replies</button>
+    <button mat-stroked-button type="button" *ngIf="replyViewing.doc.replyTo && replyViewing.doc.replyTo !== 'root'" (click)="showPreviousReplies()" i18n>Show previous replies</button>
   </div>
   <p i18n>Viewing replies for:</p>
   <planet-news-list-item class="main-message"

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -45,7 +45,7 @@ export class NewsListComponent implements OnChanges {
   ngOnChanges() {
     this.replyObject = {};
     this.items.forEach(item => {
-      this.replyObject[item.replyTo || 'root'] = [ ...(this.replyObject[item.replyTo || 'root'] || []), item ];
+      this.replyObject[item.doc.replyTo || 'root'] = [ ...(this.replyObject[item.doc.replyTo || 'root'] || []), item ];
     });
     this.displayedItems = this.replyObject[this.replyViewing._id];
   }
@@ -57,7 +57,7 @@ export class NewsListComponent implements OnChanges {
   }
 
   showPreviousReplies() {
-    this.showReplies(this.items.find(item => item._id === this.replyViewing.replyTo));
+    this.showReplies(this.items.find(item => item._id === this.replyViewing.doc.replyTo));
   }
 
   openUpdateDialog({ title, placeholder, initialValue = '', news = {} }) {

--- a/src/app/news/news.component.ts
+++ b/src/app/news/news.component.ts
@@ -36,7 +36,10 @@ export class NewsComponent implements OnInit, OnDestroy {
   }
 
   getMessages() {
-    this.newsService.requestNews({ createdOn: this.configuration.code, viewableBy: 'community' });
+    this.newsService.requestNews({
+      selectors: { createdOn: this.configuration.code, viewableBy: 'community' },
+      viewId: ''
+    });
   }
 
   postMessage() {

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -81,7 +81,9 @@ export class NewsService {
   }
 
   shareNews(news, planets?: any[]) {
-    const viewInObject = (planet) => ({ '_id': `${planet.code}@${planet.parentCode}`, section: 'community' });
+    const viewInObject = (planet) => (
+      { '_id': `${planet.code}@${planet.parentCode}`, section: 'community', sharedDate: this.couchService.datePlaceholder }
+    );
     // TODO: Filter newPlanets by ones currently existing in viewIn array
     const newPlanets = planets ? planets.map(planet => viewInObject(planet)) : [ viewInObject(this.stateService.configuration) ];
     return this.postNews(

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -16,7 +16,7 @@ export class NewsService {
   dbName = 'news';
   imgUrlPrefix = environment.couchAddress;
   newsUpdated$ = new Subject<any[]>();
-  currentSelector = {};
+  currentOptions: { selectors: any, viewId: string } = { selectors: {}, viewId: '' };
 
   constructor(
     private couchService: CouchService,
@@ -25,16 +25,15 @@ export class NewsService {
     private planetMessageService: PlanetMessageService
   ) {}
 
-  requestNews(selectors = this.currentSelector) {
-    this.currentSelector = selectors;
+  requestNews({ selectors, viewId } = this.currentOptions) {
+    this.currentOptions = { selectors, viewId };
     forkJoin([
       this.couchService.findAll(this.dbName, findDocuments(selectors, 0, [ { 'time': 'desc' } ])),
       this.couchService.findAll('attachments')
     ]).subscribe(([ newsItems, avatars ]) => {
-      this.newsUpdated$.next(newsItems.map((item: any) => {
-        const avatar = this.findAvatar(item.user, avatars);
-        return { ...item, avatar };
-      }));
+      this.newsUpdated$.next(newsItems.map((item: any) => (
+        { doc: item, sharedDate: this.findShareDate(item, viewId), avatar: this.findAvatar(item.user, avatars), _id: item._id }
+      )));
     });
   }
 
@@ -47,6 +46,10 @@ export class NewsService {
       user._attachments ?
       `${this.imgUrlPrefix}/_users/${user._id}/${extractFilename(user)}` :
       'assets/image.png';
+  }
+
+  findShareDate(item, viewId) {
+    return ((item.viewIn || []).find(view => view._id === viewId) || {}).sharedDate;
   }
 
   postNews(post, successMessage = 'Thank you for submitting your news', isMessageEdit = true) {

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -122,7 +122,10 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   initTeam(teamId: string) {
     this.newsService.requestNews({
-      '$or': [ { viewableBy: 'teams', viewableId: teamId }, { viewIn: { '$elemMatch': { '_id': teamId, section: 'teams' } } } ]
+      selectors: {
+        '$or': [ { viewableBy: 'teams', viewableId: teamId }, { viewIn: { '$elemMatch': { '_id': teamId, section: 'teams' } } } ]
+      },
+      viewId: teamId
     });
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(news => this.news = news);
     if (this.mode === 'services') {


### PR DESCRIPTION
Adds a "share time" which is set differently for the different communities the story was shared with.

Since this should only be present for community news, the sorting only runs for community news.

There's a larger change to the news components to keep the database document in a `doc` property with other calculated metadata like `avatar` and `sharedDate` separate.  This makes sure the news document is not affected after editing or adding a label.