### PR TITLE
CoursesProgress: Fix spinner stuck (fixes #5724)

### DIFF
--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -175,7 +175,7 @@ export class SubmissionsService {
   }
 
   filterSubmissions(submissions, parentId) {
-    return submissions.filter(s => s.parentId.indexOf(parentId) > -1).reduce((subs, submission) => {
+    return submissions.filter(s => s.type !== 'photo' && s.parentId.indexOf(parentId) > -1).reduce((subs, submission) => {
       const userSubmissionIndex = subs.findIndex((s) => s.user._id === submission.user._id && s.parentId === submission.parentId);
       if (userSubmissionIndex !== -1) {
         const oldSubmission = subs[userSubmissionIndex];


### PR DESCRIPTION
The page with all learner progress for a course (from the `Progress` choice in the three dot menu for a course) was not loading in my production environment.

I realized myPlanet had put photos in the `submissions` database with a different format than the other documents.  I know myPlanet no longer does that, but there may be similar documents in the field.  Rather than try to remove those, we can ignore them where they would throw errors.