### PR TITLE
CoursesStepView: Fix never ending _find requests (fixes #5824)

### DIFF
--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -144,7 +144,7 @@ export class CoursesService {
     };
     this.findOneCourseProgress(courseId, userId).pipe(switchMap((progress: any[] = []) => {
       const currentProgress: any[] = progress.length > 0 ? progress.filter((p: any) => p.stepNum === stepNum) : [];
-      if (currentProgress.length > 0 && currentProgress.every(current => current.passed === newProgress.passed)) {
+      if (currentProgress.length === 1 && currentProgress.every(current => current.passed === newProgress.passed)) {
         return of({});
       }
       return this.couchService.bulkDocs(this.progressDb, this.newProgressDocs(currentProgress, newProgress));


### PR DESCRIPTION
Ensures that any extra documents in the `courses_progress` database are deleted, even if they all have the correct value for `passed`.