### PR TITLE
Tables: Fix case if filter field is blank string

### DIFF
--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -44,7 +44,7 @@ export const filterSpecificFieldsByWord = (filterFields: string[]): any => {
 // keys or undefined.
 function getProperty(data: any, fields: string) {
   const propertyArray = fields.split('.');
-  return propertyArray.reduce((obj, prop) => (obj && obj[prop]) ? obj[prop] : undefined, data);
+  return propertyArray.reduce((obj, prop) => (obj && obj[prop] !== undefined) ? obj[prop] : undefined, data);
 }
 
 export const filterDropdowns = (filterObj: any) => {


### PR DESCRIPTION
Found an error with table filters if one of the filtered field values is an empty string (or 0 in theory).  This error would break the table completely and it was not shown at all.