### PR TITLE
Sync: Clear passwords from replicator_users (fixes #5895)

### DIFF
--- a/src/app/manager-dashboard/sync.directive.ts
+++ b/src/app/manager-dashboard/sync.directive.ts
@@ -110,12 +110,13 @@ export class SyncDirective {
   }
 
   updateReplicatorUsers() {
+    const userProperties = this.userService.userProperties.filter(prop => prop !== 'requestId');
     return forkJoin([
       this.couchService.findAll('_users', findDocuments(
         { 'isUserAdmin': { '$exists': true }, 'requestId': { '$exists': false } },
-        this.userService.userProperties.filter(prop => prop !== 'requestId')
+        userProperties
       )),
-      this.couchService.findAll('replicator_users', { 'selector': {} })
+      this.couchService.findAll('replicator_users', findDocuments({}, [ ...userProperties, 'couchId', 'planetCode' ]))
     ]).pipe(
       switchMap(([ users, repUsers ]) => {
         const newRepUsers = this.createReplicatorUserDoc(users, repUsers);


### PR DESCRIPTION
#5895 

If a document has fields that should not exist in `replicator_users`, they will be removed after syncing.