### PR TITLE
TeamsView: Public news messages (fixes #5923)

### DIFF
--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -12,7 +12,7 @@
               <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="showNewsButton" i18n>New Story</button>
             </ng-container>
           </h3>
-          <planet-news-list [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)"></planet-news-list>
+          <planet-news-list [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId"></planet-news-list>
         </mat-tab>
         <mat-tab i18n-label label="Community Leaders">
           <div class="card-grid">

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -70,7 +70,8 @@ export class NewsListItemComponent implements OnChanges, AfterViewChecked {
       news: {
         replyTo: news._id,
         messagePlanetCode: news.messagePlanetCode,
-        messageType: news.messageType
+        messageType: news.messageType,
+        viewIn: news.viewIn
       }
     });
     this.sendNewsNotifications(news);

--- a/src/app/news/news-list.component.html
+++ b/src/app/news/news-list.component.html
@@ -19,7 +19,7 @@
 <planet-news-list-item *ngFor="let item of displayedItems; trackBy: trackById"
   [item]="item"
   [replyObject]="replyObject"
-  [editable]="editable"
+  [editable]="editable || item.public === true"
   [shareTarget]="shareTarget"
   (changeReplyViewing)="showReplies($event)"
   (updateNews)="openUpdateDialog($event)"

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -63,7 +63,9 @@ export class NewsListComponent implements OnChanges {
     this.showReplies(this.items.find(item => item._id === this.replyViewing.doc.replyTo));
   }
 
-  openUpdateDialog({ title, placeholder, initialValue = '', news = {} }) {
+  openUpdateDialog(
+    { title, placeholder, initialValue = '', news = {} }: { title: string, placeholder: string, initialValue?: string, news?: any }
+  ) {
     const fields = [ {
       'type': 'markdown',
       'name': 'message',
@@ -75,7 +77,7 @@ export class NewsListComponent implements OnChanges {
     this.dialogsFormService.openDialogsForm(title, fields, formGroup, {
       onSubmit: (newNews: any) => {
         if (newNews) {
-          this.postNews(news, newNews);
+          this.postNews({ ...news, viewIn: news.viewIn.filter(view => view._id === this.viewableId) }, newNews);
         }
       },
       autoFocus: true
@@ -84,7 +86,7 @@ export class NewsListComponent implements OnChanges {
 
   postNews(oldNews, newNews) {
     this.newsService.postNews(
-      { ...oldNews, ...newNews, viewableBy: this.viewableBy, viewableId: this.viewableId },
+      { ...oldNews, ...newNews },
       oldNews._id ? this.editSuccessMessage : 'Reply has been posted successfully.'
     ).subscribe(() => {
       this.dialogsFormService.closeDialogsForm();

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -71,7 +71,7 @@ export class NewsListComponent implements OnChanges {
       'name': 'message',
       placeholder,
       'required': true,
-      imageGroup: this.viewableId ? { [this.viewableBy]: this.viewableId } : this.viewableBy
+      imageGroup: this.viewableBy !== 'community' ? { [this.viewableBy]: this.viewableId } : this.viewableBy
     } ];
     const formGroup = { message: [ initialValue, CustomValidators.required ] };
     this.dialogsFormService.openDialogsForm(title, fields, formGroup, {

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -40,8 +40,8 @@
   </mat-toolbar>
   <div class="view-container view-full-height">
     <mat-tab-group [(selectedIndex)]="tabSelectedIndex">
-      <mat-tab i18n-label label="Chat" *ngIf="team?.public === true || userStatus === 'member'">
-        <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot && userStatus === 'member'" i18n>New message</button>
+      <mat-tab i18n-label label="Chat">
+        <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot" i18n>New message</button>
         <planet-news-list [items]="news" viewableBy="teams" [viewableId]="team?._id" [shareTarget]="configuration?.planetType" (viewChange)="toggleAdd($event)" editSuccessMessage="Message has been updated successfully" [editable]="userStatus === 'member'"></planet-news-list>
       </mat-tab>
       <mat-tab>

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -122,13 +122,10 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   initTeam(teamId: string) {
-    this.newsService.requestNews({
-      selectors: {
-        '$or': [ { viewableBy: 'teams', viewableId: teamId }, { viewIn: { '$elemMatch': { '_id': teamId, section: 'teams' } } } ]
-      },
-      viewId: teamId
-    });
-    this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(news => this.news = news);
+    this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$))
+      .subscribe(news => this.news = news.map(news => ({
+        ...news, public: ((news.doc.viewIn || []).find(view => view._id === teamId) || {}).public
+      })));
     if (this.mode === 'services') {
       this.initServices(teamId);
       return;
@@ -151,6 +148,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
         this.visits[visit.user] = { count: visit.count, recentTime: visit.max && visit.max.time };
       });
       this.setStatus(teamId, this.userService.get());
+      this.requestTeamNews(teamId);
     });
   }
 
@@ -164,6 +162,23 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     ).subscribe(() => {
       this.leader = '';
       this.userStatus = 'member';
+    });
+  }
+
+  requestTeamNews(teamId) {
+    const showAll = this.userStatus === 'member' || this.team.public === true;
+    this.newsService.requestNews({
+      selectors: {
+        '$or': [
+          ...(showAll ? [ { viewableBy: 'teams', viewableId: teamId } ] : []),
+          {
+            viewIn: { '$elemMatch': {
+              '_id': teamId, section: 'teams', ...(showAll ? {} : { public: true })
+            } }
+          }
+        ],
+      },
+      viewId: teamId
     });
   }
 
@@ -451,7 +466,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   postMessage(message) {
     this.newsService.postNews({
-      viewIn: [ { '_id': this.teamId, section: 'teams' } ],
+      viewIn: [ { '_id': this.teamId, section: 'teams', public: this.userStatus !== 'member' } ],
       messageType: this.team.teamType,
       messagePlanetCode: this.team.teamPlanetCode,
       ...message

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -123,8 +123,8 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   initTeam(teamId: string) {
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$))
-      .subscribe(news => this.news = news.map(news => ({
-        ...news, public: ((news.doc.viewIn || []).find(view => view._id === teamId) || {}).public
+      .subscribe(news => this.news = news.map(post => ({
+        ...post, public: ((post.doc.viewIn || []).find(view => view._id === teamId) || {}).public
       })));
     if (this.mode === 'services') {
       this.initServices(teamId);


### PR DESCRIPTION
Allows people outside of the team or enterprise to post messages.  These messages can be viewed by anyone else in the community, also.

Replies for that message can also be viewed by anyone in the community.