### PR TITLE
5095 issue fix

### DIFF
--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -41,6 +41,9 @@
   <div class="view-container view-full-height">
     <mat-tab-group [(selectedIndex)]="tabSelectedIndex">
       <mat-tab i18n-label label="Chat" *ngIf="team?.public === true || userStatus === 'member'">
+        <ng-template mat-tab-label>
+          <ng-container i18n><span [matBadge]="messageCounter" [matBadgeHidden]="messageCounter === 0" matBadgeOverlap="false">Chat</span></ng-container>
+        </ng-template>
         <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot && userStatus === 'member'" i18n>New message</button>
         <planet-news-list [items]="news" viewableBy="teams" [viewableId]="team?._id" [shareTarget]="configuration?.planetType" (viewChange)="toggleAdd($event)" editSuccessMessage="Message has been updated successfully" [editable]="userStatus === 'member'"></planet-news-list>
       </mat-tab>


### PR DESCRIPTION
Added logic in `getMember` for counting unread messages
Added function `updateMessagesList` to `put` id's of read messages to the database 
Added a function call `updateMessagesList` in `postMessage` 
Added logic in `getActiveTab` to set messages as read
With the last one have some problem:
+ I don't clearly understand how function wich call `getActiveTabe` works. Because of this, I changed the default value of `tabSelectIndex` from 0 to 1
+ And everything works, but I have a console error and don't clue how to fix it.

![another_console_error](https://user-images.githubusercontent.com/42728999/76462270-ae393e80-63e1-11ea-92c8-313dccd9d973.png)
