### PR TITLE
Resources & Courses: Track searches (fixes #5893)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
       script:
         - set -e
         - echo "Waiting for couchdb to finish initialization"; until [ $(docker ps -aq --filter "name=db-init" --filter "status=exited" | wc -c) -gt 0 ] || [ $WAIT_TIME -eq 600 ]; do echo "..."; sleep 5; WAIT_TIME=$(expr $WAIT_TIME + 5); done
-        - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 39 ]; then exit 1; fi
+        - i=$(curl -X GET http://127.0.0.1:5984/_all_dbs | jq length); if [ $i -ne 40 ]; then exit 1; fi
         - webdriver-manager update --versions.chrome=$(google-chrome --version | cut -d ' ' -f 3)
         - npm run e2e
     - stage: automated-test-and-compose-languages

--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -159,6 +159,7 @@ DBS=(
   "health"
   "messages"
   "course_activities"
+  "search_activities"
 )
 
 insert_dbs $DBS

--- a/src/app/shared/forms/search.service.ts
+++ b/src/app/shared/forms/search.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+import { debounceTime, switchMap, tap, distinctUntilChanged } from 'rxjs/operators';
+import { CouchService } from '../couchdb.service';
+import { deepEqual } from '../utils';
+import { StateService } from '../state.service';
+import { UserService } from '../user.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchService {
+
+  private searchChange: Subject<any>;
+  readonly dbName = 'search_activities';
+  private inProgress = false;
+
+  constructor(
+    private couchService: CouchService,
+    private userService: UserService,
+    private stateService: StateService
+  ) {
+    this.initObservable();
+  }
+
+  initObservable() {
+    this.searchChange = new Subject<any>();
+    this.searchChange.pipe(
+      tap(() => this.inProgress = true),
+      debounceTime(5000),
+      distinctUntilChanged((a, b) => deepEqual(a, b)),
+      switchMap(value => this.couchService.updateDocument(
+        this.dbName,
+        {
+          ...value,
+          time: this.couchService.datePlaceholder,
+          user: this.userService.get().name,
+          createdOn: this.stateService.configuration.code,
+          parentCode: this.stateService.configuration.parentCode
+        }
+      ))
+    ).subscribe(() => this.inProgress = false);
+  }
+
+  recordSearch(value, complete = false) {
+    if (!complete || this.inProgress) {
+      this.searchChange.next(value);
+    }
+    if (complete) {
+      this.searchChange.complete();
+      this.initObservable();
+    }
+  }
+
+}

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -95,7 +95,7 @@ export const deepEqual = (item1: any, item2: any) => {
     return item1.length === item2.length && item1.every(value1 => item2.find(value2 => deepEqual(value1, value2)) !== undefined);
   }
   if (item1 instanceof Object) {
-    return Object.entries(item1).every(([ key1, value1 ]) => deepEqual(value1, item2[key1]));
+    return Object.keys({ ...item1, ...item2 }).every((key) => deepEqual(item1[key], item2[key])) ;
   }
   return item1 === item2;
 };


### PR DESCRIPTION
Creating a `search_activities` database to keep this separate since this may become the largest database very quickly.

Includes data for the text searches, collections/tags, and the filter fields for Courses and Resources.

Changes are debounced for 5 seconds or until the user leaves the Courses or Resources pages.  If after the 5 seconds the search is the same as it was previously, nothing is written to the database.