### PR TITLE
TeamsMember: Show leader from other planets (connects #6061)

### DIFF
--- a/src/app/teams/teams-member.component.html
+++ b/src/app/teams/teams-member.component.html
@@ -6,7 +6,7 @@
   <mat-card-subtitle>
     <p class="primary-text-color" *ngIf="member?.userPlanetCode !== planetCode"><ng-container i18n>Member of Planet</ng-container> {{member?.userPlanetCode}}</p>
     <span i18n *ngIf="member?.userId === user._id && member?.userPlanetCode === planetCode">(You)</span>{{' '}}
-    <span i18n *ngIf="member?.userId === teamLeader && member?.userPlanetCode === planetCode">(Team Leader)</span>{{' '}}<span *ngIf="visits">({{ visits?.count || 0 }} <ng-container i18n>visits</ng-container>)</span>
+    <span i18n *ngIf="member?.userId === teamLeader">(Team Leader)</span>{{' '}}<span *ngIf="visits">({{ visits?.count || 0 }} <ng-container i18n>visits</ng-container>)</span>
     <p *ngIf="visits && (userStatus === 'member' || user.isUserAdmin)"><ng-container i18n>Last visit:</ng-container> {{ visits?.recentTime | date }}</p>
     <p class="primary-text-color" *ngIf="member?.doc?.leadershipTitle">{{member?.doc?.leadershipTitle}}</p>
     <p class="primary-text-color" *ngIf="member?.role">{{member?.role}}</p>


### PR DESCRIPTION
This is a small quick fix for #6061 

As noted in the issue, the full fix will require handling the case where there are two members with the same username (one from nation one from community)