### PR TITLE
Dashboard: Fix missing resource (fixes #6149)

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -114,9 +114,12 @@ export class CouchService {
 
   bulkGet(db: string, ids: string[], opts?: any) {
     const docs = ids.map(id => ({ id }));
+    const revNum = doc => +(doc._rev.split('-')[0]);
     return this.post(db + '/_bulk_get', { docs }, opts).pipe(
       map((response: any) => response.results
-        .map((result: any) => result.docs[0].ok)
+        .map((result: any) => {
+          return result.docs.reduce((maxDoc, { ok: doc }) => revNum(maxDoc) > revNum(doc) ? maxDoc : doc, { _rev: '0-0' });
+        })
         .filter((doc: any) => doc !== undefined && doc._deleted !== true)
       )
     );


### PR DESCRIPTION
#6149 

A specific resource was missing from the dashboard on Somalia (Mr. Smith Goes to Washington) because the `_bulk_get` request was returning two revisions, one of which was `_deleted`.

It's possible there are other cases where this would happen and in those cases the docs may not be sorted by revision, so we check all of them and pick the latest.