### PR TITLE
Dashboard: Fix empty row error (connects #6178)

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -126,7 +126,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {
-    return this.couchService.bulkGet(db, shelf)
+    return this.couchService.bulkGet(db, shelf.filter(id => id))
       .pipe(
         catchError(() => {
           return of([]);


### PR DESCRIPTION
#6178 

This is the quick patch so the dashboard information appears.  Leave the issue open so we know to investigate why there are `null` values in the shelf database for some members.