### PR TITLE
Tasks: Click task to open details (fixes #6174)

### DIFF
--- a/src/app/tasks/tasks.component.html
+++ b/src/app/tasks/tasks.component.html
@@ -12,8 +12,8 @@
   </mat-button-toggle>
 </mat-button-toggle-group>
 <mat-action-list [disableRipple]="!editable">
-  <button mat-list-item *ngFor="let task of filteredTasks; trackBy: trackById" (click)="toggleTaskComplete(task)" [disabled]="!editable">
-    <mat-checkbox [checked]="task.completed" [disabled]="!editable"></mat-checkbox>
+  <button mat-list-item *ngFor="let task of filteredTasks; trackBy: trackById" (click)="openTaskDetail(task)" [disabled]="!editable">
+    <mat-checkbox [checked]="task.completed" [disabled]="!editable" (click)="toggleTaskComplete(task); $event.stopPropagation()"></mat-checkbox>
     <p matLine>{{task.title}}</p>
     <p matLine><ng-container i18n>Deadline:</ng-container> {{task.deadline | date}} {{task.deadline | date: 'shortTime'}}</p>
     <p matLine *ngIf="task.completed"><ng-container i18n>Completed:</ng-container> {{task.completedTime | date}} {{task.completedTime | date: 'shortTime'}}</p>

--- a/src/app/tasks/tasks.component.ts
+++ b/src/app/tasks/tasks.component.ts
@@ -11,6 +11,7 @@ import { MatDialog } from '@angular/material';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { DialogsAddMeetupsComponent } from '../shared/dialogs/dialogs-add-meetups.component';
 
 @Component({
   selector: 'planet-tasks',
@@ -156,6 +157,19 @@ export class TasksComponent implements OnInit {
     };
     return this.notificationsService.sendNotificationToUser(notificationDoc);
   }
+
+  openTaskDetail(task) {
+    this.dialog.open(DialogsAddMeetupsComponent, {
+      data: {
+        meetup: task,
+        view: 'view',
+        link: this.link,
+        sync: this.sync,
+        editable: false
+      }
+    });
+  }
+
 }
 
 @Pipe({


### PR DESCRIPTION
#6174

Went with a simple solution: clicking the list opens the dialog the same as the calendar, so you need to click exactly on the checkbox to complete the task.

I think we could add more to the dialog for completion, reassignment, and editing functionality but this is a good start.