### PR TITLE
Tasks: Past date allowed in edit (fixes #6224)

### DIFF
--- a/src/app/tasks/tasks.service.ts
+++ b/src/app/tasks/tasks.service.ts
@@ -72,7 +72,10 @@ export class TasksService {
       ],
       formGroup: {
         title: [ task.title || '', CustomValidators.required ],
-        deadline: [
+        deadline: task.title ? [
+          deadline,
+          CustomValidators.dateValidRequired
+        ] : [
           deadline,
           CustomValidators.dateValidRequired,
           (ac) => this.validatorService.notDateInPast$(ac)


### PR DESCRIPTION
issue: #6224 
When editing tasks any past date can be added.
Thanks for your review in advance. 