### PR TITLE
Health: Fix number validation (fixes #6263)

### DIFF
--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -17,6 +17,7 @@ import { PlanetTagInputDialogComponent, PlanetTagInputToggleIconComponent } from
 import { SharedComponentsModule } from '../shared-components.module';
 import { PlanetTimeMaskDirective } from './planet-time-mask.directive';
 import { PlanetSelectorComponent } from './planet-selector.component';
+import { PlanetNumberValidatorDirective } from './planet-number-validator.directive';
 
 @NgModule({
   imports: [
@@ -43,7 +44,8 @@ import { PlanetSelectorComponent } from './planet-selector.component';
     PlanetStepListNumberDirective,
     PlanetStepListItemComponent,
     PlanetMarkdownTextboxComponent,
-    PlanetTimeMaskDirective
+    PlanetTimeMaskDirective,
+    PlanetNumberValidatorDirective
   ],
   declarations: [
     FormErrorMessagesComponent,
@@ -62,7 +64,8 @@ import { PlanetSelectorComponent } from './planet-selector.component';
     PlanetStepListNumberDirective,
     PlanetStepListItemComponent,
     PlanetMarkdownTextboxComponent,
-    PlanetTimeMaskDirective
+    PlanetTimeMaskDirective,
+    PlanetNumberValidatorDirective
   ],
   entryComponents: [ PlanetTagInputDialogComponent ]
 })

--- a/src/app/shared/forms/planet-number-validator.directive.ts
+++ b/src/app/shared/forms/planet-number-validator.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, Host, ElementRef, AfterViewInit } from '@angular/core';
+import { FormControlName, FormControl, Validators } from '@angular/forms';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: 'input[type="number"]'
+})
+export class PlanetNumberValidatorDirective implements AfterViewInit {
+
+  constructor(@Host() private controlName: FormControlName, @Host() private elementRef: ElementRef) { }
+
+  ngAfterViewInit() {
+
+    const control: FormControl = this.controlName.control;
+    const numberValidator = () => !this.elementRef.nativeElement.validity.valid ? { 'invalidInt': true } : null;
+    const existingValidator = control.validator;
+
+    control.setValidators(existingValidator ? Validators.compose([ existingValidator, numberValidator ]) : numberValidator);
+    setTimeout(() => control.updateValueAndValidity(), 0);
+
+  }
+}


### PR DESCRIPTION
#6263 

In researching I found that you can also enter something just `+` in Chrome which should trigger a validation error without a number after.

Also found that this is a longstanding issue with Angular.  Added a little workaround that will automatically be in place for any `<input type="number">` fields.