### PR TITLE
ResourcesAdd: Faster resources check unique (fixes #6353)

### DIFF
--- a/design/resources/resources-design.js
+++ b/design/resources/resources-design.js
@@ -7,6 +7,11 @@ module.exports = {
         }
       },
       "reduce": "_count"
+    },
+    "titles": {
+      "map": function (doc) {
+        emit(doc.title.toLowerCase().trim(), doc.privateFor);
+      }
     }
   }
 }

--- a/design/resources/resources-design.json
+++ b/design/resources/resources-design.json
@@ -1,1 +1,1 @@
-{"views":{"count_tags":{"map":"function (doc) {\n        for (var i = 0; i < doc.tags.length; i++) {\n          emit(doc.tags[i], 1);\n        }\n      }","reduce":"_count"}}}
+{"views":{"count_tags":{"map":"function (doc) {\n        for (var i = 0; i < doc.tags.length; i++) {\n          emit(doc.tags[i], 1);\n        }\n      }","reduce":"_count"},"titles":{"map":"function (doc) {\n        emit(doc.title.toLowerCase().trim(), doc.privateFor);\n      }"}}}

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -111,15 +111,7 @@ export class ResourcesAddComponent implements OnInit {
         '',
         CustomValidators.required,
         // an arrow function is for lexically binding 'this' otherwise 'this' would be undefined
-        ac => this.validatorService.isUnique$(
-          this.dbName, 'title', ac,
-          {
-            selectors: {
-              '_id': this.existingResource._id && { '$ne': this.existingResource._id },
-              'privateFor': { '$or': [ this.privateFor, { '$exists': false } ] }
-            }
-          }
-        )
+        ac => this.validatorService.checkUniqueResourceTitle$(ac, this.existingResource._id, this.privateFor)
       ],
       author: '',
       year: '',

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -94,7 +94,7 @@ export const deepEqual = (item1: any, item2: any) => {
   if (item1 instanceof Array) {
     return item1.length === item2.length && item1.every(value1 => item2.find(value2 => deepEqual(value1, value2)) !== undefined);
   }
-  if (item1 instanceof Object) {
+  if (item1 && item2 && item1 instanceof Object) {
     return Object.keys({ ...item1, ...item2 }).every((key) => deepEqual(item1[key], item2[key])) ;
   }
   return item1 === item2;


### PR DESCRIPTION
#6353 

Indexes won't work with regex, and I think because of the uppercase/lowercase issue we wouldn't be able to do an equality `_find`.  I went with the view approach, and this should be a lot faster/less intensive on the RasPi.