### PR TITLE
Capitalize today button (fixes #6345)

### DIFF
--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -18,6 +18,7 @@ import { addDateAndTime, styleVariables } from './utils';
       [plugins]="calendarPlugins"
       [firstDay]="6"
       [header]="header"
+      [buttonText]="buttonText"
       [customButtons]="buttons"
       (eventClick)="eventClick($event)">
     </full-calendar>
@@ -34,6 +35,9 @@ export class PlanetCalendarComponent implements OnInit {
     left: 'title',
     center: '',
     right: 'addEventButton today prev,next'
+  };
+  buttonText = {
+    today: 'Today'
   };
   buttons = {};
   eventTimeFormat = {


### PR DESCRIPTION
Fixes #6345 

[Full Calendar Docs](https://fullcalendar.io/docs/buttonText) provides a way to change the text in any of the default buttons.