### PR TITLE
Fix rounding and input validation (fixes #6337)

### DIFF
--- a/src/app/health/health-event.component.ts
+++ b/src/app/health/health-event.component.ts
@@ -103,7 +103,7 @@ export class HealthEventComponent {
       'weight': { min: 1, max: 150 },
       'bp': 'n/a'
     };
-    if (!value || !limits[field]) {
+    if (value === null || value === '' || !limits[field]) {
       return true;
     }
     if (field === 'bp') {

--- a/src/app/shared/forms/planet-round.directive.ts
+++ b/src/app/shared/forms/planet-round.directive.ts
@@ -13,7 +13,7 @@ export class PlanetRoundDirective {
   ) {}
 
   @HostListener('focusout') onFocusOut() {
-    if (typeof this.ngControl.value !== 'number') {
+    if (typeof this.ngControl.value !== 'number' || this.ngControl.value === 0 ) {
       return;
     }
     const precision = this.precision || 0;


### PR DESCRIPTION
Fixes #6337 

JavaScript wasn't recognizing zero as a number, so the `onFocusOut()` in **planet-round.directive** would fail at the first check. This was causing strange behavior where the zero would be converted into an empty string, but the input element would still have the `ng-valid` attribute, allowing the form to be submitted.

I updated the check in **planet-round.directive** to pass if the value entered is a zero in addition to checking the type. Now the minimum validator in **HealthEventComponent** will show the error `The number cannot be below zero` when zero is entered.