### PR TITLE
Surveys: Can't export some surveys attached to course(fixes #5775)

### DIFF
--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -258,7 +258,7 @@ export class SubmissionsService {
   }
 
   getSubmissionsExport(exam, type: 'exam' | 'survey') {
-    const query = findDocuments({ parentId: exam._id, type, status: 'complete' });
+    const query = findDocuments({ 'parent._id': exam._id, type, status: 'complete' });
     return forkJoin([ this.getSubmissions(query), this.couchService.currentTime(), of(exam.questions.map(question => question.body)) ]);
   }
 


### PR DESCRIPTION
Thanks @paulbert for your review,  as I was looking through this issue. I found out all the new courses that we create recently attached to surveys are not having problem. I have newly created community so I was unable to replicate in my development environment. I work with with these specific case in planed.dev and planet.somalia which were not being exported.

1. In planet.dev. there is survey ‘DEMO-Courses with surveys’ which when we export gives console error answers[index] is undefined. 
2. In planet.somalia also there is a survey ‘Your Reading Pledge’  whose submissoin.length was 0. Which was also not being exported.
