### PR TITLE
CommunityList: Show and hide hub correctly (fixes #6490 fixes #6495)

### DIFF
--- a/src/app/community/community-list.component.ts
+++ b/src/app/community/community-list.component.ts
@@ -31,13 +31,15 @@ export class CommunityListComponent implements OnInit {
         hubs
       );
       this.planets = {
-        hubs: allHubs.hubs.filter(hub => hub.children.length > 0).map(hub => {
-          const planet = children.find(child => child._id === hub.planetId);
-          if (!planet) {
-            return hub;
-          }
-          return { ...hub, children: [ { doc: planet }, ...hub.children ] };
-        }),
+        hubs: allHubs.hubs
+          .map(hub => {
+            const planet = children.find(child => child._id === hub.planetId);
+            if (!planet || this.excludeIds.indexOf(planetAndParentId(planet)) > -1) {
+              return hub;
+            }
+            return { ...hub, children: [ { doc: planet }, ...hub.children ] };
+          })
+          .filter(hub => hub.children.length > 0),
         sandboxPlanets: allHubs.sandboxPlanets
       };
     });


### PR DESCRIPTION
Since the two fixes overlap in code, combined #6490 and #6495.

When there are no other communities left in the share list, the hub community still shows up.

Conversely, if the post has already been shared with the hub community, the hub will no longer show up.