### PR TITLE
Fix underline (fixes #6500)

### DIFF
--- a/src/app/manager-dashboard/reports/reports-detail.scss
+++ b/src/app/manager-dashboard/reports/reports-detail.scss
@@ -7,6 +7,10 @@ mat-toolbar mat-form-field {
   }
 }
 
+.diagnosis-trend {
+  line-height: 3.7em
+}
+
 .manager-reports-detail {
   mat-grid-tile.label figure {
     justify-content: start;

--- a/src/app/manager-dashboard/reports/reports-health.component.html
+++ b/src/app/manager-dashboard/reports/reports-health.component.html
@@ -12,8 +12,8 @@
     </span>
   </div>
   <h1 class="mat-title" i18n>Diagnosis Trend</h1>
-  <div>
-    <span i18n class="diagnosis-trend">Select diagnosis to view trend:</span>
+  <div class="trend-filters">
+    <span i18n>Select diagnosis to view trend:</span>
     <mat-form-field>
       <mat-select mat-select [value]="initialSelectedCondition" (selectionChange)="onSelectedConditionChange($event.value)">
        <mat-option *ngFor="let condition of conditions" value={{condition}}>{{condition}}</mat-option>

--- a/src/app/manager-dashboard/reports/reports-health.component.html
+++ b/src/app/manager-dashboard/reports/reports-health.component.html
@@ -13,10 +13,12 @@
   </div>
   <h1 class="mat-title" i18n>Diagnosis Trend</h1>
   <div>
-    <span i18n>Select diagnosis to view trend:</span>
-    <mat-select [value]="initialSelectedCondition" (selectionChange)="onSelectedConditionChange($event.value)">
-      <mat-option *ngFor="let condition of conditions" value={{condition}}>{{condition}}</mat-option>
-    </mat-select>
+    <span i18n class="diagnosis-trend">Select diagnosis to view trend:</span>
+    <mat-form-field>
+      <mat-select mat-select [value]="initialSelectedCondition" (selectionChange)="onSelectedConditionChange($event.value)">
+       <mat-option *ngFor="let condition of conditions" value={{condition}}>{{condition}}</mat-option>
+      </mat-select>
+    </mat-form-field>
   </div>
   <div class="chart-container">
     <canvas id="diagnosesTrend" #diagnosesChart></canvas>

--- a/src/app/manager-dashboard/reports/reports-health.component.ts
+++ b/src/app/manager-dashboard/reports/reports-health.component.ts
@@ -21,6 +21,12 @@ import { conditions } from '../../health/health.constants';
     .chart-container {
       height: 30vh;
     }
+    .trend-filters {
+      margin: -1rem 0;
+    }
+    .trend-filters > span {
+      align-self: center;
+    }
   ` ]
 })
 export class ReportsHealthComponent implements OnChanges {


### PR DESCRIPTION
Fixes #6500 

The reason the `mat-select` didn't have an underline was because it wasn't wrapped in a`mat-form-field`, so I added that. However, that brought a lot of spacing that I was unable to figure out how to disable/reduce. So I tried to vertically center the span in relation to its parent div to align with the `mat-select` field. 

## Old
![Annotation 2020-06-09 165159](https://user-images.githubusercontent.com/54686871/84204891-879baa00-aa9b-11ea-9377-7811e661c1eb.png)

## New
![Annotation 2020-06-09 165215](https://user-images.githubusercontent.com/54686871/84204905-8d918b00-aa9b-11ea-9c4f-3413ed589e3d.png)



