### PR TITLE
Remove edit from Manager (fixes #6638)

### DIFF
--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -48,7 +48,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
         }));
         this.progress = progress;
         this.isUserEnrolled = this.checkMyCourses(course._id);
-        this.canManage = this.currentUser.isUserAdmin ||
+        this.canManage = (this.currentUser.isUserAdmin && !this.parent) ||
           this.courseDetail.creator !== undefined &&
           (this.currentUser.name === this.courseDetail.creator.slice(0, this.courseDetail.creator.indexOf('@')));
         return this.stateService.getCouchState('exams', 'local');

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -72,7 +72,7 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
         }
         this.dialogsLoadingService.stop();
         this.isUserEnrolled = this.userService.shelf.resourceIds.includes(this.resource._id);
-        this.canManage = this.currentUser.isUserAdmin ||
+        this.canManage = (this.currentUser.isUserAdmin && !this.parent) ||
           (this.currentUser.name === this.resource.doc.addedBy && this.resource.doc.sourcePlanet === this.planetConfiguration.code);
       });
   }


### PR DESCRIPTION
Fixes #6638 

Remove the edit option when a user tries to view **Resources** and **Courses** from the **Manager** page.