### PR TITLE
Health: Fix database setup without beta (fixes #6710)

### DIFF
--- a/couchdb-setup.sh
+++ b/couchdb-setup.sh
@@ -38,13 +38,9 @@ set_couch_per_user() {
   CONFIGURATION=$(curl "$COUCHURL/configurations/_all_docs?include_docs=true" $PROXYHEADER)
   CODE=$(echo $CONFIGURATION | jq -rj '.["rows"][0]["doc"]["code"] // empty')
   HEXCODE=$(echo $CODE | tr -d \\n | hexdump -v -e '/1 "%02x"')
-  BETAMODE=$(echo $CONFIGURATION | jq -r '.["rows"][0]["doc"]["betaEnabled"] // empty')
-  if [ ! -z "$CODE" ] && [ "$BETAMODE" != "off" ];
-  then
-    upsert_doc _node/nonode@nohost/_config couch_peruser/database_prefix '"userdb-'$HEXCODE'-"'
-    upsert_doc _node/nonode@nohost/_config couch_peruser/delete_dbs '"true"'
-    upsert_doc _node/nonode@nohost/_config couch_peruser/enable '"true"'
-  fi
+  upsert_doc _node/nonode@nohost/_config couch_peruser/database_prefix '"userdb-'$HEXCODE'-"'
+  upsert_doc _node/nonode@nohost/_config couch_peruser/delete_dbs '"true"'
+  upsert_doc _node/nonode@nohost/_config couch_peruser/enable '"true"'
 }
 
 # Options are -u for username -w for passWord and -p for port number

--- a/src/app/configuration/configuration.service.ts
+++ b/src/app/configuration/configuration.service.ts
@@ -168,13 +168,11 @@ export class ConfigurationService {
   }
 
   setCouchPerUser({ doc: configuration }) {
-    return configuration.betaEnabled !== 'off' ?
-      forkJoin([
-        this.couchService.put('_node/nonode@nohost/_config/couch_peruser/database_prefix', `userdb-${stringToHex(configuration.code)}-`),
-        this.couchService.put('_node/nonode@nohost/_config/couch_peruser/delete_dbs', 'true'),
-        this.couchService.put('_node/nonode@nohost/_config/couch_peruser/enable', 'true')
-      ]) :
-      of({});
+    return forkJoin([
+      this.couchService.put('_node/nonode@nohost/_config/couch_peruser/database_prefix', `userdb-${stringToHex(configuration.code)}-`),
+      this.couchService.put('_node/nonode@nohost/_config/couch_peruser/delete_dbs', 'true'),
+      this.couchService.put('_node/nonode@nohost/_config/couch_peruser/enable', 'true')
+    ]);
   }
 
 }


### PR DESCRIPTION
#6710 

Once a Planet has been setup with Health it has the database correctly configured.  This fixes the setup for new Planets or ones that have not been setup with Health yet.