### PR TITLE
CoursesAdd: Fix description requirement (connects #6833)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -78,7 +78,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
           this.dbName, 'courseTitle', ac, { selectors: { '_id': { '$ne': this.documentInfo._id || '' } } }
         )
       ],
-      description: [ '', CustomValidators.required ],
+      description: [ '', CustomValidators.requiredMarkdown ],
       languageOfInstruction: '',
       gradeLevel: this.gradeLevels[0],
       subjectLevel: this.subjectLevels[0],


### PR DESCRIPTION
#6833 

The error will no longer occur because blank markdown will now correctly block the form from being submitted, but I'm not sure if this fixes all cases where this error shows up hence the "connects" in the title.