### PR TITLE
TeamsReports: Set date as entered (fixes #6953)

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -189,7 +189,8 @@ export class CouchService {
   }
 
   dateConversion(date: number | Date) {
-    return new Date(date).setUTCHours(0, 0, 0, 0);
+    const oldDate = new Date(date);
+    return Date.UTC(oldDate.getFullYear(), oldDate.getMonth(), oldDate.getDate());
   }
 
 }


### PR DESCRIPTION
#6953 