### PR TITLE
added media queries to login.scss (fixes #7061)

### DIFF
--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -19,8 +19,7 @@
     .myplanet-link {
       display: flex;
       align-items: center;
-      flex-direction: column;
-      margin-top: 15px; 
+    
 
       a {
         padding: 0 0.5rem;
@@ -76,6 +75,13 @@
   .ole-logo {
     width: 7rem;
     display: block;
+  }
+
+  @media screen and (max-width: 1080px){
+    .myplanet-link{
+      flex-direction: column;
+      margin-top: 15px; 
+    }
   }
 
 }

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -77,7 +77,7 @@
     display: block;
   }
 
-  @media screen and (max-width: 1080px){
+  @media screen and (max-width: 810px){
     .myplanet-link{
       flex-direction: column;
       margin-top: 15px; 

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -19,6 +19,8 @@
     .myplanet-link {
       display: flex;
       align-items: center;
+      flex-direction: column;
+      margin-top: 15px; 
 
       a {
         padding: 0 0.5rem;

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -85,3 +85,11 @@
   }
 
 }
+@media screen and (max-width: 375px){
+  .login-container{
+    padding: 0 !important;
+  }
+  .login-card{
+    height: 100vh !important;
+  }
+}


### PR DESCRIPTION
<!-- This is a new issue template for open-learning-exchange.github.io.
Please ensure you have searched open and closed issues for duplicate.
You may preview your issue before submission.
Please write N/A in the sections that aren't applicable to your particular issue.
Thank you for contributing! -->

### Problem
#7061
no break line for "on android, try myPlanet"
login-container does not fit to size of the wrapper when mobile


### Steps to reproduce the problem
<!-- Write N/A if not applicable -->
N/A refer to #7061

### Screenshots
<!-- drag and drop images below. Write N/A if not applicable -->
<img width="1097" alt="Screen Shot 2022-03-21 at 7 52 29 AM" src="https://user-images.githubusercontent.com/94139372/159256562-cc0a801c-796d-417e-bcdd-54525e2990bc.png">


### Proposed solution
<!-- Write N/A if not applicable -->

added media queries to add flex properties to myplanet div with "on android" and myplanet link for tablet
removed padding on wrapper and changed height of login container for mobile
