### PR TITLE
added media queries for login.scss (fixes #7061)

### DIFF
--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -75,41 +75,41 @@
     display: block;
   }
 
-  @media screen and (max-width: 810px) {
+@media only screen and (max-device-width: 810px) {
     .myplanet-link {
       flex-direction: column;
       margin-top: 15px;
     }
   }
 }
-@media screen and (max-width: 375px) {
+@media only screen and (max-device-width: 375px) and (orientation: 'portrait'){
   .login-container {
-    padding: 0 !important;
+    padding: 0vh;
   }
   .login-card {
-    height: 100vh !important;
+    height: 100vh;
   }
 }
 
-@media screen, (max-height: 375px) and (orientation: 'landscape'){
+@media only screen and (device-height: 375px) and (orientation: 'landscape'){
   .login-container{
-    overflow: auto !important;
-    padding: 0 !important;
+    overflow: auto ;
+    padding: 0 ;
   }
   .login-card {
-    height: 100vh !important;
-    grid-template-columns: 1fr 1fr !important;
-    grid-template-rows: 1fr !important;
+    height: 100vh ;
+    grid-template-columns: 1fr 1fr ;
+    grid-template-rows: 1fr ;
   }
   .login-left-tile-container {
-    display: inline !important;
+    display: inline ;
   }
   .ole-logo {
-    display: inline !important;
-    width: 5rem !important;
+    display: inline ;
+    width: 5rem ;
   }
 
   .myplanet-link{
-    display: inline !important;
+    display: inline ;
   }
 }

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -19,8 +19,7 @@
     .myplanet-link {
       display: flex;
       align-items: center;
-      flex-direction: column;
-      margin-top: 15px; 
+    
 
       a {
         padding: 0 0.5rem;
@@ -76,6 +75,13 @@
   .ole-logo {
     width: 7rem;
     display: block;
+  }
+
+  @media screen and (max-width: 1080px){
+    .myplanet-link{
+      flex-direction: column;
+      margin-top: 15px; 
+    }
   }
 
 }

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -77,7 +77,7 @@
     display: block;
   }
 
-  @media screen and (max-width: 1080px){
+  @media screen and (max-width: 810px){
     .myplanet-link{
       flex-direction: column;
       margin-top: 15px; 

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -19,6 +19,8 @@
     .myplanet-link {
       display: flex;
       align-items: center;
+      flex-direction: column;
+      margin-top: 15px; 
 
       a {
         padding: 0 0.5rem;

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -85,3 +85,11 @@
   }
 
 }
+@media screen and (max-width: 375px){
+  .login-container{
+    padding: 0 !important;
+  }
+  .login-card{
+    height: 100vh !important;
+  }
+}

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -81,35 +81,36 @@
       margin-top: 15px;
     }
   }
-}
-@media only screen and (max-device-width: 375px) and (orientation: 'portrait'){
-  .login-container {
-    padding: 0vh;
+  @media only screen and (max-device-width: 375px) and (orientation: 'portrait'){
+    .login-container {
+      padding: 0vh;
+    }
+    .login-card {
+      height: 100vh;
+    }
   }
-  .login-card {
-    height: 100vh;
+  
+  @media only screen and (device-height: 375px) and (orientation: 'landscape'){
+    .login-container{
+      overflow: auto ;
+      padding: 0 ;
+    }
+    .login-card {
+      height: 100vh ;
+      grid-template-columns: 1fr 1fr ;
+      grid-template-rows: 1fr ;
+    }
+    .login-left-tile-container {
+      display: inline ;
+    }
+    .ole-logo {
+      display: inline ;
+      width: 5rem ;
+    }
+  
+    .myplanet-link{
+      display: inline ;
+    }
   }
 }
 
-@media only screen and (device-height: 375px) and (orientation: 'landscape'){
-  .login-container{
-    overflow: auto ;
-    padding: 0 ;
-  }
-  .login-card {
-    height: 100vh ;
-    grid-template-columns: 1fr 1fr ;
-    grid-template-rows: 1fr ;
-  }
-  .login-left-tile-container {
-    display: inline ;
-  }
-  .ole-logo {
-    display: inline ;
-    width: 5rem ;
-  }
-
-  .myplanet-link{
-    display: inline ;
-  }
-}

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -90,3 +90,26 @@
     height: 100vh !important;
   }
 }
+
+@media screen, (max-height: 375px) and (orientation: 'landscape'){
+  .login-container{
+    overflow: auto !important;
+    padding: 0 !important;
+  }
+  .login-card {
+    height: 100vh !important;
+    grid-template-columns: 1fr 1fr !important;
+    grid-template-rows: 1fr !important;
+  }
+  .login-left-tile-container {
+    display: inline !important;
+  }
+  .ole-logo {
+    display: inline !important;
+    width: 5rem !important;
+  }
+
+  .myplanet-link{
+    display: inline !important;
+  }
+}

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -1,9 +1,8 @@
-@import '../variables.scss';
-@import '../../planet-mat-theme.scss';
-@import '../mixins.scss';
+@import "../variables.scss";
+@import "../../planet-mat-theme.scss";
+@import "../mixins.scss";
 
 :host {
-
   @include left-right-grid-areas;
 
   text-align: center;
@@ -19,20 +18,17 @@
     .myplanet-link {
       display: flex;
       align-items: center;
-    
 
       a {
         padding: 0 0.5rem;
       }
-
     }
-
   }
 
   .login-left-tile::before {
     content: "";
     height: 80vh;
-    background: linear-gradient(to right, $grey, #FFFFFF);
+    background: linear-gradient(to right, $grey, #ffffff);
     width: 30px;
     position: absolute;
     left: 100%;
@@ -48,14 +44,15 @@
 
   .login-card {
     padding: 0;
-    height:80vh;
+    height: 80vh;
     display: grid;
     grid-template-areas: "lt rt";
     grid-template-columns: 1fr 2fr;
     grid-auto-rows: 1fr;
   }
 
-  .login-form, .login-left-tile-container {
+  .login-form,
+  .login-left-tile-container {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -63,7 +60,8 @@
   }
 
   .login-form {
-    a, button[mat-raised-button] {
+    a,
+    button[mat-raised-button] {
       margin-bottom: 1rem;
     }
 
@@ -77,19 +75,18 @@
     display: block;
   }
 
-  @media screen and (max-width: 810px){
-    .myplanet-link{
+  @media screen and (max-width: 810px) {
+    .myplanet-link {
       flex-direction: column;
-      margin-top: 15px; 
+      margin-top: 15px;
     }
   }
-
 }
-@media screen and (max-width: 375px){
-  .login-container{
+@media screen and (max-width: 375px) {
+  .login-container {
     padding: 0 !important;
   }
-  .login-card{
+  .login-card {
     height: 100vh !important;
   }
 }


### PR DESCRIPTION
<!-- This is a new issue template for open-learning-exchange.github.io.
Please ensure you have searched open and closed issues for duplicate.
You may preview your issue before submission.
Please write N/A in the sections that aren't applicable to your particular issue.
Thank you for contributing! -->

### Problem
#7061
no break line for "on android, try myPlanet"
login-container does not fit to size of the wrapper when mobile


### Steps to reproduce the problem
<!-- Write N/A if not applicable -->
N/A refer to #7061

### Screenshots
<!-- drag and drop images below. Write N/A if not applicable -->
<img width="1097" alt="Screen Shot 2022-03-21 at 7 52 29 AM" src="https://user-images.githubusercontent.com/94139372/159256562-cc0a801c-796d-417e-bcdd-54525e2990bc.png">


### Proposed solution
<!-- Write N/A if not applicable -->

added media queries to add flex properties to myplanet div with "on android" and myplanet link for tablet
removed padding on wrapper and changed height of login container for mobile
