### PR TITLE
dashboard rating mobile screen (fixes #7074)

### DIFF
--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -33,9 +33,6 @@ $top-row-height: calc(#{$dashboard-tile-width} + 0.5rem);
     grid-column-gap: 1rem;
     padding: 0.5rem;
     margin: 0 2px;
-    @media (max-width: $screen-md) and (min-width: 648) {
-      grid-template-rows: [row2-start] 1.5rem;
-    }
     img {
       grid-area: img;
       width: calc(#{$dashboard-tile-width} - 0.5rem);

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -29,13 +29,13 @@ $top-row-height: calc(#{$dashboard-tile-width} + 0.5rem);
       "img info . date"
       "img info badge badge";
     grid-template-columns: calc(#{$dashboard-tile-width} - 0.5rem) max-content auto 1fr;
-    // grid-template-rows: 1.5rem calc(#{$top-row-height} - 2.5rem);
+    grid-template-rows: auto calc(#{$top-row-height} - 2.5rem);
     grid-column-gap: 1rem;
     padding: 0.5rem;
     margin: 0 2px;
-    // @media (max-width: $screen-md) and (min-width: 648) {
-    //   grid-template-rows: [row2-start] 1.5rem;
-    // }
+    @media (max-width: $screen-md) and (min-width: 648) {
+      grid-template-rows: [row2-start] 1.5rem;
+    }
     img {
       grid-area: img;
       width: calc(#{$dashboard-tile-width} - 0.5rem);

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -34,7 +34,7 @@ $top-row-height: calc(#{$dashboard-tile-width} + 0.5rem);
     padding: 0.5rem;
     margin: 0 2px;
     // @media (max-width: $screen-md) and (min-width: 648) {
-    //   grid-template-rows: [row2-start] 1.5rem
+    //   grid-template-rows: [row2-start] 1.5rem;
     // }
     img {
       grid-area: img;

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -29,10 +29,13 @@ $top-row-height: calc(#{$dashboard-tile-width} + 0.5rem);
       "img info . date"
       "img info badge badge";
     grid-template-columns: calc(#{$dashboard-tile-width} - 0.5rem) max-content auto 1fr;
-    grid-template-rows: 1.5rem calc(#{$top-row-height} - 2.5rem);
+    // grid-template-rows: 1.5rem calc(#{$top-row-height} - 2.5rem);
     grid-column-gap: 1rem;
     padding: 0.5rem;
     margin: 0 2px;
+    // @media (max-width: $screen-md) and (min-width: 648) {
+    //   grid-template-rows: [row2-start] 1.5rem
+    // }
     img {
       grid-area: img;
       width: calc(#{$dashboard-tile-width} - 0.5rem);

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -67,7 +67,7 @@ export class PlanetCalendarComponent implements OnInit {
         }
       } :
       {};
-    this.calendarOptions.customButtons = this.buttons
+    this.calendarOptions.customButtons = this.buttons;
   }
 
   getMeetups() {

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -67,7 +67,7 @@ export class PlanetCalendarComponent implements OnInit {
         }
       } :
       {};
-    this.calendarOptions.customButtons = this.buttons;
+    this.calendarOptions.customButtons = this.buttons
   }
 
   getMeetups() {


### PR DESCRIPTION
Fixes #7074 

#### Description
For mobile devices rating star was unresponsive and stayed on the side instead of moving down as the date moved for smaller screens
Issue is with grid template rows specifying the rating star row position

Idea was to make the rating star closer to the date on larger screens as was initially set, hence the commented out media query


#### Result

![ole_7074_pr](https://user-images.githubusercontent.com/48474421/162831850-1a51afd4-ad4d-4a64-886a-74b801940d11.png)
