### PR TITLE
7104 calendar render issue

### DIFF
--- a/src/app/manager-dashboard/certifications/certifications-add.component.ts
+++ b/src/app/manager-dashboard/certifications/certifications-add.component.ts
@@ -80,7 +80,11 @@ export class CertificationsAddComponent implements OnInit, AfterViewChecked {
       ...this.certificateInfo, ...this.certificateForm.value, courseIds: this.courseIds
     }).subscribe((res) => {
       this.certificateInfo = { _id: res.id, _rev: res.rev };
-      this.planetMessageService.showMessage(this.pageType === 'Add' ? $localize`New certification added` : $localize`Certification updated`);
+      this.planetMessageService.showMessage(
+        this.pageType === 'Add' ?
+        $localize`New certification added` :
+        $localize`Certification updated`
+      );
       if (reroute) {
         this.goBack();
       }

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -113,7 +113,7 @@ export class NewsListItemComponent implements OnChanges, AfterViewChecked {
   }
 
   formLabel(news) {
-    return news.viewableBy === 'teams' ?  $localize`Message` :  $localize`Story`;
+    return news.viewableBy === 'teams' ? $localize`Message` : $localize`Story`;
   }
 
   showReplies(news) {

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -43,6 +43,7 @@ export class PlanetCalendarComponent implements OnInit {
 
   calendarOptions: CalendarOptions = {
     initialView: 'dayGridMonth',
+    contentHeight: 'auto',
     events: this.events,
     headerToolbar: this.header,
     customButtons: this.buttons,

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -68,7 +68,7 @@ export class PlanetCalendarComponent implements OnInit {
         }
       } :
       {};
-    this.calendarOptions.customButtons = this.buttons
+    this.calendarOptions.customButtons = this.buttons;
   }
 
   getMeetups() {


### PR DESCRIPTION
Fixes #7104 

Update the calendarOptions by setting the contentHeight to auto to allow the full rendering of the calendar in the Teams and Enterprise tabs.