### PR TITLE
Remove landing page video and link it from external source

### DIFF
--- a/src/app/landing/landing-hero/landing-hero.component.ts
+++ b/src/app/landing/landing-hero/landing-hero.component.ts
@@ -1,14 +1,23 @@
 import { Component, Output, EventEmitter } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogsVideoComponent } from '../../shared/dialogs/dialogs-video.component';
 
+import { environment } from '../../../environments/environment';
 @Component({
   selector: 'planet-landing-hero',
   templateUrl: 'landing-hero.component.html',
   styleUrls: [ 'landing-hero.scss' ]
 })
 export class LandingHeroComponent {
-  @Output() playVideoEvent = new EventEmitter<boolean>();
+  constructor(
+    private dialog: MatDialog
+  ) {}
 
   playVideo() {
-    this.playVideoEvent.emit(true);
+    this.dialog.open(DialogsVideoComponent, {
+      data: {
+        videoUrl: environment.uPlanetVideo
+      }
+    });
   }
 }

--- a/src/app/shared/dialogs/dialogs-video.component.ts
+++ b/src/app/shared/dialogs/dialogs-video.component.ts
@@ -1,0 +1,27 @@
+import { Component, Inject } from "@angular/core";
+import { MAT_DIALOG_DATA } from "@angular/material/dialog";
+import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
+
+@Component({
+  template: `
+    <iframe
+      width="560"
+      height="315"
+      [src]="videoUrl"
+      frameborder="0"
+      allowfullscreen
+    ></iframe>
+  `,
+})
+export class DialogsVideoComponent {
+  videoUrl: SafeResourceUrl;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private sanitizer: DomSanitizer
+  ) {
+    this.videoUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
+      data.videoUrl
+    );
+  }
+}

--- a/src/app/shared/dialogs/dialogs-video.component.ts
+++ b/src/app/shared/dialogs/dialogs-video.component.ts
@@ -1,6 +1,6 @@
-import { Component, Inject } from "@angular/core";
-import { MAT_DIALOG_DATA } from "@angular/material/dialog";
-import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   template: `

--- a/src/app/shared/dialogs/planet-dialogs.module.ts
+++ b/src/app/shared/dialogs/planet-dialogs.module.ts
@@ -17,8 +17,8 @@ import { SyncDirective } from '../../manager-dashboard/sync.directive';
 import { MeetupsModule } from '../../meetups/meetups.module';
 import { DialogsAddMeetupsComponent } from './dialogs-add-meetups.component';
 import { DialogsImagesComponent } from './dialogs-images.component';
+import { DialogsVideoComponent } from './dialogs-video.component';
 import { DialogsRatingsComponent, DialogsRatingsDirective } from './dialogs-ratings.component';
-
 
 @NgModule({
   imports: [
@@ -37,6 +37,7 @@ import { DialogsRatingsComponent, DialogsRatingsDirective } from './dialogs-rati
     DialogsListComponent,
     DialogsLoadingComponent,
     DialogsImagesComponent,
+    DialogsVideoComponent,
     DialogsRatingsComponent,
     DialogsRatingsDirective,
     ChangePasswordDirective,
@@ -50,6 +51,7 @@ import { DialogsRatingsComponent, DialogsRatingsDirective } from './dialogs-rati
     DialogsListComponent,
     DialogsLoadingComponent,
     DialogsImagesComponent,
+    DialogsVideoComponent,
     DialogsRatingsComponent,
     DialogsRatingsDirective,
     ChangePasswordDirective,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -11,5 +11,6 @@ export const environment = {
   uPlanetCode: 'guatemala',
   uParentCode: 'guatemala@earth',
   upgradeAddress: window.location.origin + '/upgrade',
-  syncAddress: 'planet-sync-address'
+  syncAddress: 'planet-sync-address',
+  uPlanetVideo: 'https://res.cloudinary.com/dezt8mocb/video/upload/v1688415252/Landing/video/landing_o5zpgv.mp4'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,5 +14,6 @@ export const environment = {
   uPlanetCode: 'guatemala',
   uParentCode: 'guatemala@earth',
   upgradeAddress: window.location.origin + '/upgrade',
-  syncAddress: window.location.protocol + '//localhost:5984'
+  syncAddress: window.location.protocol + '//localhost:5984',
+  uPlanetVideo: 'https://res.cloudinary.com/dezt8mocb/video/upload/v1688415252/Landing/video/landing_o5zpgv.mp4'
 };


### PR DESCRIPTION
Target: To reduce the container build size

- Remove the uPlanet Landing video
- Link it from external source(cloudinary - could also be youtube as well)
- Create video dialog component and use it landing component
