### PR TITLE
library: activate video filter (fixes #7195)(fixes #7196)

### DIFF
--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -7,7 +7,6 @@ import { UsersService } from '../users/users.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { StateService } from '../shared/state.service';
 import { TagsService } from '../shared/forms/tags.service';
-import { dedupeShelfReduce, arraySubField } from '../shared/utils';
 import { CouchService } from '../shared/couchdb.service';
 import { findDocuments } from '../shared/mangoQueries';
 

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -94,8 +94,6 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
   searchLists = [];
   selected: any = {};
 
-  constructor () {}
-
   ngOnInit() {
     this.reset({ startingSelection: this.startingSelection, isInit: true });
   }

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -87,7 +87,7 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
   categories = [
     { 'label': 'subject', 'options': constants.subjectList },
     { 'label': 'language', 'options': languages },
-    { 'label': 'mediaType', 'options': constants.media },
+    { 'label': 'medium', 'options': constants.media },
     { 'label': 'level', 'options': constants.levelList }
   ];
 


### PR DESCRIPTION
Fixes #7195 & #7196 

- Update the categories label from `mediaType` to `medium`. Medium is the correct field in use in couch.

![image](https://github.com/open-learning-exchange/planet/assets/48474421/03e24991-f927-4cf2-8a18-fa8032e03e14)


Other updates
- Remove empty constructor
- Removed unused imports in the `resources.service.ts`