### PR TITLE
markdown-textbox: set min-height to prevent text cutoff (fixes #7212)

### DIFF
--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -22,7 +22,7 @@
 planet-markdown-textbox {
   .CodeMirror, .CodeMirror-scroll {
     height: inherit;
-    min-height: inherit;
+    min-height: 15vh !important;
     max-height: 15vh;
   }
 


### PR DESCRIPTION
Set the min-height of the .CodeMirror-scroll class to prevent text from being cut-off and not being viewable in the planet-markdown-textbox

fixes #7212 