### PR TITLE
chat: add fullscreen toggle (fixes #7227)

### DIFF
--- a/src/app/chat/chat.component.html
+++ b/src/app/chat/chat.component.html
@@ -2,9 +2,12 @@
   <button mat-icon-button (click)="goBack()"><mat-icon>arrow_back</mat-icon></button>
   <span i18n>Chat Prompts</span>
   <span class="toolbar-fill"></span>
+  <button mat-icon-button (click)="toggleFullScreen()">
+    <mat-icon>{{ isFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
+  </button>
 </mat-toolbar>
 
-<div class="space-container">
+<div class="space-container" [ngClass]="{'fullscreen': isFullscreen}">
   <div class="chat-container" #chat>
     <div *ngFor="let conversation of conversations">
       <div class="conversation">

--- a/src/app/chat/chat.component.scss
+++ b/src/app/chat/chat.component.scss
@@ -53,3 +53,25 @@ textarea:focus {
   border-color: #007bff;
   box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
 }
+
+.fullscreen {
+  .space-container {
+    height: 100vh;
+  }
+
+  .form-container {
+    display: none;
+  }
+
+  .chat-container {
+    flex-grow: 1;
+    overflow-y: auto;
+    margin: 0;
+  }
+
+  textarea {
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-shadow: none;
+  }
+}

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -13,6 +13,7 @@ import { ChatService } from '../shared/chat.service';
 })
 export class ChatComponent implements OnInit {
   spinnerOn = true;
+  isFullscreen = false;
   promptForm: FormGroup;
   messages: any[] = [];
   conversations: any[] = [];
@@ -83,17 +84,21 @@ export class ChatComponent implements OnInit {
     );
   }
 
-sanitizeText(text: string): string {
-  // Replace newline characters with <br> tags
-  const textWithLineBreaks = text.replace(/\n/g, '<br>');
+  sanitizeText(text: string): string {
+    // Replace newline characters with <br> tags
+    const textWithLineBreaks = text.replace(/\n/g, '<br>');
 
-  // Replace code block markers with <code> tags
-  const codeBlockStart = /```/g;
-  const codeBlockEnd = /```/g;
-  const textWithCodeBlocks = textWithLineBreaks
-    .replace(codeBlockStart, '<code>')
-    .replace(codeBlockEnd, '</code>');
+    // Replace code block markers with <code> tags
+    const codeBlockStart = /```/g;
+    const codeBlockEnd = /```/g;
+    const textWithCodeBlocks = textWithLineBreaks
+      .replace(codeBlockStart, '<code>')
+      .replace(codeBlockEnd, '</code>');
 
-  return textWithCodeBlocks;
-}
+    return textWithCodeBlocks;
+  }
+
+  toggleFullScreen() {
+    this.isFullscreen = !this.isFullscreen;
+  }
 }


### PR DESCRIPTION
Fixes #7227

Add a fullscreen toggle to the chat container to allow its expansion

https://www.loom.com/share/54332677f29941b8afbbdf7d5a49f6a1?sid=23b86c03-a6e8-46b2-8775-8c6f0143010b