### PR TITLE
chat: only spin on valid submission (fixes #7235)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.31",
+  "version": "0.13.32",
   "myplanet": {
-    "latest": "v0.10.0",
+    "latest": "v0.10.5",
     "min": "v0.10.0"
   },
   "scripts": {

--- a/src/app/chat/chat.component.html
+++ b/src/app/chat/chat.component.html
@@ -18,10 +18,10 @@
     <form [formGroup]="promptForm" class="form-spacing" (ngSubmit)="onSubmit()">
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <mat-label>Send a Message</mat-label>
-        <textarea class="full-width" rows="5" required matInput i18n-placeholder placeholder="Send a message" [formControl]="promptForm.controls.prompt"></textarea>
+        <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
         <mat-error><planet-form-error-messages [control]="promptForm.controls.prompt"></planet-form-error-messages></mat-error>
       </mat-form-field>
-      <button type="submit" mat-raised-button [planetSubmit]="spinnerOn" color="primary" i18n>
+      <button mat-raised-button [planetSubmit]="promptForm.valid && spinnerOn" color="primary" i18n>
        Chat
        <mat-icon>send</mat-icon>
      </button>

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { CustomValidators } from '../validators/custom-validators';
 import { showFormErrors } from '../shared/table-helpers';
 import { ChatService } from '../shared/chat.service';
 
@@ -40,7 +39,7 @@ export class ChatComponent implements OnInit {
 
   createForm() {
     this.promptForm = this.formBuilder.group({
-      prompt: [ '', CustomValidators.required ],
+      prompt: [ '', Validators.required ],
     });
   }
 
@@ -49,12 +48,11 @@ export class ChatComponent implements OnInit {
   }
 
   onSubmit() {
-    if (!this.promptForm.valid) {
+    if (this.promptForm.valid) {
+      this.submitPrompt();
+    } else {
       showFormErrors(this.promptForm.controls);
-      return;
     }
-
-    this.submitPrompt();
   }
 
   submitPrompt() {
@@ -74,12 +72,13 @@ export class ChatComponent implements OnInit {
       },
       (error: any) => {
         this.spinnerOn = false;
-        this.changeDetectorRef.detectChanges();
         this.conversations.push({
           query: content,
           response: 'Error: ' + error.message,
           error: true,
         });
+        this.changeDetectorRef.detectChanges();
+        this.scrollToBottom();
         this.spinnerOn = true;
       }
     );


### PR DESCRIPTION
Fixes #7235 

Prevent the spinner from loading when the chat form is invalid

Other updates
- Changed the Validators class in use
- Refactor the onSumbit function
- Add scrolling effect on error detection