### PR TITLE
chat: clear textarea on submit (fixes #7234)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.32",
+  "version": "0.13.34",
   "myplanet": {
-    "latest": "v0.10.5",
+    "latest": "v0.10.10",
     "min": "v0.10.0"
   },
   "scripts": {

--- a/src/app/chat/chat.component.html
+++ b/src/app/chat/chat.component.html
@@ -17,7 +17,7 @@
   <div class="form-container">
     <form [formGroup]="promptForm" class="form-spacing" (ngSubmit)="onSubmit()">
       <mat-form-field class="full-width mat-form-field-type-no-underline">
-        <mat-label>Send a Message</mat-label>
+        <mat-label>Chat</mat-label>
         <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
         <mat-error><planet-form-error-messages [control]="promptForm.controls.prompt"></planet-form-error-messages></mat-error>
       </mat-form-field>

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -50,6 +50,7 @@ export class ChatComponent implements OnInit {
   onSubmit() {
     if (this.promptForm.valid) {
       this.submitPrompt();
+      this.promptForm.controls['prompt'].setValue(' ');
     } else {
       showFormErrors(this.promptForm.controls);
     }


### PR DESCRIPTION
Fixes #7234 

- Clear the chat text area on chat submission
- Rename message label to avoid duplication with the textaeea placeholder