### PR TITLE
courses: progress menu item admin only (fixes #7253)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.36",
+  "version": "0.13.38",
   "myplanet": {
-    "latest": "v0.10.32",
-    "min": "v0.10.10"
+    "latest": "v0.10.41",
+    "min": "v0.10.20"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -207,7 +207,7 @@
               <mat-icon>visibility</mat-icon>
               <span i18n>View Course</span>
             </a>
-            <a mat-menu-item [routerLink]="['/courses/progress', element._id]">
+            <a *ngIf="user.isUserAdmin" mat-menu-item [routerLink]="['/courses/progress', element._id]">
               <mat-icon>equalizer</mat-icon>
               <span i18n>Progress</span>
             </a>


### PR DESCRIPTION
Fixes #7253 

Restrict the courses progress menu item to be visiblle to admin users only