### PR TITLE
courses: reactive table resizing (fixes #7260)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.40",
+  "version": "0.13.41",
   "myplanet": {
-    "latest": "v0.10.45",
-    "min": "v0.10.23"
+    "latest": "v0.10.47",
+    "min": "v0.10.25"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -245,7 +245,7 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header"  mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
+          <planet-rating class="rating-item" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -240,9 +240,9 @@
         <mat-cell *matCellDef="let element">{{element.doc.createdDate | date}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="rating">
-        <mat-header-cell *matHeaderCellDef mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef class="rating-header"  mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element">
-          <planet-rating [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
+          <planet-rating class="rating-item" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -35,34 +35,7 @@ import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 @Component({
   selector: 'planet-courses',
   templateUrl: './courses.component.html',
-  styles: [ `
-    /* Column Widths */
-    .mat-column-select {
-      max-width: 44px;
-    }
-    .mat-column-info {
-      max-width: 200px;
-    }
-    .mat-column-createdDate {
-      max-width: 95px;
-    }
-    .mat-column-rating {
-      max-width: 225px;
-    }
-    .column {
-      display: flex;
-      flex-direction: column;
-    }
-    .column > * {
-      line-height: normal;
-    }
-    .course-progress {
-      margin-top: 0.5rem;
-    }
-    .ellipsis-menu {
-      text-align: center;
-    }
-  ` ]
+  styleUrls: [ './courses.scss' ]
 })
 
 export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDestroy {

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -1,0 +1,53 @@
+@import '../variables';
+
+/* Column Widths */
+.mat-column-select {
+  max-width: 44px;
+}
+
+.mat-column-info {
+  max-width: 200px;
+}
+
+.mat-column-createdDate {
+  max-width: 95px;
+}
+
+.mat-column-rating {
+  max-width: 225px;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
+.column > * {
+  line-height: normal;
+}
+
+.course-progress {
+  margin-top: 0.5rem;
+}
+
+.ellipsis-menu {
+  text-align: center;
+}
+
+@media(max-width: $screen-md) {
+  .mat-column-info {
+    max-width: 120px;
+  }
+
+  .mat-column-createdDate {
+    max-width: 70px;
+  }
+
+  .mat-column-rating {
+    max-width: 115px;
+  }
+
+  .rating-header {
+    justify-content: center;
+  }
+}

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -38,9 +38,31 @@
   display: none;
 }
 
+@media(max-width: $screen-md) {
+  .mat-column-info {
+    max-width: 120px;
+  }
+
+  .mat-column-createdDate {
+    max-width: 70px;
+  }
+
+  .mat-column-rating {
+    max-width: 115px;
+  }
+
+  .rating-header {
+    justify-content: center;
+  }
+}
+
 @media(max-width: $screen-sm) {
   .created-label {
     display: inline-block;
+  }
+
+  .mat-column-info {
+    max-width: fit-content;
   }
 
   .mat-column-createdDate {
@@ -65,22 +87,3 @@
     align-self: flex-end;
   }
 }
-
-@media(max-width: $screen-md) {
-  .mat-column-info {
-    max-width: 120px;
-  }
-
-  .mat-column-createdDate {
-    max-width: 70px;
-  }
-
-  .mat-column-rating {
-    max-width: 115px;
-  }
-
-  .rating-header {
-    justify-content: center;
-  }
-}
-

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -187,9 +187,9 @@
         <mat-cell *matCellDef="let element">{{element.doc.createdDate | date}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="rating">
-        <mat-header-cell *matHeaderCellDef mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef class="rating-header" mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element">
-          <planet-rating [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog"></planet-rating>
+          <planet-rating class="rating-item" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns" class="hide"></mat-header-row>

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -49,7 +49,6 @@ $label-height: 1rem;
   text-align: center;
 }
 
-
 @media(max-width: $screen-md) {
   .resources-list {
     .mat-column-createdDate {

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -48,3 +48,20 @@ $label-height: 1rem;
 .ellipsis-menu {
   text-align: center;
 }
+
+
+@media(max-width: $screen-md) {
+  .resources-list {
+    .mat-column-createdDate {
+      max-width: 100px;
+    }
+
+    .mat-column-rating {
+      max-width: 115px;
+    }
+  }
+
+  .rating-header {
+    justify-content: center;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -284,8 +284,7 @@ body {
 
   @media (max-width: $screen-md) {
     .rating-item .list-item-rating {
-      display: grid !important;
-      margin: 5px 0;
+      display: grid;
       grid-template-areas:
         'ratio'
         'total'

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -282,6 +282,32 @@ body {
 
   }
 
+  @media (max-width: $screen-md) {
+    .rating-item .list-item-rating {
+      display: grid !important;
+      margin: 5px 0;
+      grid-template-areas:
+        'ratio'
+        'total'
+        'rating'
+        'your'
+        'your-label';
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr;
+
+      .stats-ratio {
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr;
+      }
+
+      .avg-rating {
+        .rating-number {
+          font-size: 1.5rem;
+        }
+      }
+    }
+  }
+
   // create an empty bar with only the border and add another bar inside it with dynamic width calculated with JS
   .rating-bar {
     display: block;


### PR DESCRIPTION
Courses & Resources
Resizing the tables and the table item sizes for $screen-md sizes and below

Resizing the non-title fields:
![image](https://github.com/open-learning-exchange/planet/assets/48474421/e564e1fb-4b59-4691-b217-b58d3fe09384)
