### PR TITLE
resources: improve resources form layout (fixes #7270)

### DIFF
--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -3,7 +3,7 @@
 :host {
   .view-container {
     display: grid;
-    grid-template-columns: min-content auto;
+    grid-template-columns: 1.5fr 1fr;
     grid-template-rows: auto 42px;
     grid-column-gap: 0.25rem;
     > * {
@@ -17,6 +17,14 @@
 
   .actions-container {
     align-self: center;
+  }
+
+  .form-container {
+    width: auto;
+  }
+
+  .form-spacing {
+    width: auto;
   }
 
   @media (max-width: $screen-md) {

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -5,7 +5,7 @@
 <div [ngClass]="{'space-container':!isDialog}">
   <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add new {Add new} Update {Update}} Resource</mat-toolbar>
   <div class="view-container view-full-height">
-    <div class="form-container">
+    <div>
       <form class="form-spacing" [formGroup]="resourceForm" novalidate>
         <mat-form-field>
           <input matInput i18n-placeholder placeholder="Title" formControlName="title" required>

--- a/src/app/resources/resources-add.scss
+++ b/src/app/resources/resources-add.scss
@@ -13,6 +13,11 @@
     align-self: center;
   }
 
+  .form-spacing {
+    width: auto;
+    justify-content: center;
+  }
+
   @media (max-width: $screen-sm) {
     .form-container {
       width: auto;


### PR DESCRIPTION
- Resources: Make the resources form to take up full layout width
- Courses: Resize the propotions of the main form container & steps/add step form container

## **Resources old layout:** 
![image](https://github.com/open-learning-exchange/planet/assets/48474421/217d997f-fd6e-44b5-9461-2a9db12ef4c3)

## **Resources new layout**
![image](https://github.com/open-learning-exchange/planet/assets/48474421/e4512bb8-0d48-4221-8299-912fad664443)

##  **Courses old layout:**
![image](https://github.com/open-learning-exchange/planet/assets/48474421/4eec75e7-df2d-48f7-9a4d-f18ee24596e8)
![image](https://github.com/open-learning-exchange/planet/assets/48474421/872ce31e-d3b6-4f72-92ee-ffec2e896981)


## **Courses new layout:**
![image](https://github.com/open-learning-exchange/planet/assets/48474421/bf0622ff-c2ac-483b-846d-acdc97ae8521)
![image](https://github.com/open-learning-exchange/planet/assets/48474421/6897ca45-6af0-4d1e-a056-eaf7401365a7)
