### PR TITLE
courses: markdown block images (fixes #7272)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.48",
+  "version": "0.13.51",
   "myplanet": {
-    "latest": "v0.10.72",
-    "min": "v0.10.47"
+    "latest": "v0.10.87",
+    "min": "v0.10.62"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -70,7 +70,7 @@
     </div>
   </mat-toolbar>
   <div class="view-container view-full-height" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">
-    <planet-markdown *ngIf="stepDetail?.description" class="description img-wrap" [content]="stepDetail.description"></planet-markdown>
+    <planet-markdown *ngIf="stepDetail?.description" class="description img-resize" [content]="stepDetail.description"></planet-markdown>
     <planet-resources-viewer
       *ngIf="resource?._attachments"
       [fetchRating]="false"

--- a/src/app/courses/view-courses/courses-view-detail.component.html
+++ b/src/app/courses/view-courses/courses-view-detail.component.html
@@ -5,4 +5,4 @@
 <p *ngIf="courseDetail?.creatorDoc"><b i18n>Creator:</b> {{courseDetail?.creatorDoc?.fullName}} </p>
 <p *ngIf="courseDetail?.sourcePlanet !== planetConfiguration.code && courseDetail?.sourcePlanet"><b i18n>Source:</b> {{courseDetail?.sourcePlanet}}</p>
 <p><b i18n>Description:</b></p>
-<planet-markdown [content]="courseDetail?.description" [imageSource]="imageSource" class="img-wrap"></planet-markdown>
+<planet-markdown [content]="courseDetail?.description" [imageSource]="imageSource" class="img-resize"></planet-markdown>

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -48,7 +48,7 @@
               <planet-course-icon *ngIf="step.progress && step.progress.passed" [icon]="'done'"></planet-course-icon>
               <planet-course-icon *ngIf="step.progress && !step.progress.passed" [icon]="'rotate_right'"></planet-course-icon>
             </mat-expansion-panel-header>
-            <planet-markdown [imageSource]="parent ? 'parent' : 'local'" [content]="step.description" class="img-wrap"></planet-markdown>
+            <planet-markdown [imageSource]="parent ? 'parent' : 'local'" [content]="step.description" class="img-resize"></planet-markdown>
             <div *ngIf="step.description.length === 0 && (step.exam === undefined || step?.exam?.questions.length === 0) && step?.resources?.length === 0 && step?.survey?.questions.length === 0; else contentMessage" i18n>
               There is no content for this step.
             </div>

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -1,12 +1,21 @@
 planet-markdown.img-wrap td-markdown.td-markdown {
-
   & > div {
     overflow: auto;
   }
 
   img {
     max-width: 50%;
+    float: left;
     margin-right: 0.5rem;
   }
+}
 
+planet-markdown.img-resize td-markdown.td-markdown {
+  & > div {
+    overflow: auto;
+  }
+
+  img {
+    max-width: 50%;
+  }
 }

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -7,6 +7,7 @@ planet-markdown.img-wrap td-markdown.td-markdown {
     max-width: 50%;
     float: left;
     margin-right: 0.5rem;
+    padding: 0.25rem;
   }
 }
 

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -6,7 +6,6 @@ planet-markdown.img-wrap td-markdown.td-markdown {
 
   img {
     max-width: 50%;
-    float: left;
     margin-right: 0.5rem;
   }
 


### PR DESCRIPTION
Fixes #7272 

Building on #6150 

- Create a new css class that only resizes the images -> This will have them using the default **block display**.
- Apply this new css class to specific areas: **Courses view**, **view-detail** and **step-view**
- Maintain the text wrap around images for the Courses & Resources pages(Table)
- Add padding to separate Images that are in text wraps

![image](https://github.com/open-learning-exchange/planet/assets/48474421/fc6f46ee-2419-40be-be79-a69bf98bf004)
