### PR TITLE
courses: better table sizes (fixes #7279)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.50",
+  "version": "0.13.52",
   "myplanet": {
-    "latest": "v0.10.82",
-    "min": "v0.10.57"
+    "latest": "v0.10.89",
+    "min": "v0.10.64"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -245,7 +245,7 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header"  mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating class="rating-item" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
+          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -7,14 +7,16 @@
 
 .mat-column-info {
   max-width: 200px;
+  align-self: start;
 }
 
 .mat-column-createdDate {
-  max-width: 95px;
+  max-width: 100px;
+  align-self: start;
 }
 
 .mat-column-rating {
-  max-width: 225px;
+  max-width: 115px;
 }
 
 .column {
@@ -38,6 +40,10 @@
   display: none;
 }
 
+.rating-header {
+  justify-content: center;
+}
+
 @media(max-width: $screen-md) {
   .mat-column-info {
     max-width: 120px;
@@ -45,14 +51,6 @@
 
   .mat-column-createdDate {
     max-width: 70px;
-  }
-
-  .mat-column-rating {
-    max-width: 115px;
-  }
-
-  .rating-header {
-    justify-content: center;
   }
 }
 

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -192,7 +192,7 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header" mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating class="rating-item" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog"></planet-rating>
+          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns" class="hide"></mat-header-row>

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -12,7 +12,7 @@ $label-height: 1rem;
     max-width: 125px;
   }
   .mat-column-rating {
-    max-width: 225px;
+    max-width: 115px;
   }
   .mat-column-createdDate {
     max-width: 125px;
@@ -48,19 +48,19 @@ $label-height: 1rem;
   text-align: center;
 }
 
+.created-label {
+  display: none;
+}
+
+.rating-header {
+  justify-content: center;
+}
+
 @media(max-width: $screen-md) {
   .resources-list {
     .mat-column-createdDate {
       max-width: 100px;
     }
-
-    .mat-column-rating {
-      max-width: 115px;
-    }
-  }
-
-  .rating-header {
-    justify-content: center;
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -282,9 +282,7 @@ body {
 
   }
 
-  @media (max-width: $screen-md) {
-    .rating-item .list-item-rating {
-      display: grid;
+  .compress-rating .list-item-rating {
       grid-template-areas:
         'ratio'
         'total'
@@ -294,17 +292,11 @@ body {
       grid-template-columns: 1fr;
       grid-template-rows: 1fr;
 
-      .stats-ratio {
-        grid-template-columns: 1fr;
-        grid-template-rows: 1fr;
-      }
-
       .avg-rating {
         .rating-number {
           font-size: 1.5rem;
         }
       }
-    }
   }
 
   // create an empty bar with only the border and add another bar inside it with dynamic width calculated with JS


### PR DESCRIPTION
- Rework the table column sizes: Make the rating grid smaller in the courses & resources pages

Courses page
![image](https://github.com/open-learning-exchange/planet/assets/48474421/c165fbd8-d50f-4a67-ab3e-19c4fc548593)


Resources page
![image](https://github.com/open-learning-exchange/planet/assets/48474421/4593a989-279b-4a92-a2b7-ae8250944f82)
