### PR TITLE
courses: better handling long titles (fixes #7259)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.50",
+  "version": "0.13.54",
   "myplanet": {
-    "latest": "v0.10.82",
-    "min": "v0.10.57"
+    "latest": "v0.10.94",
+    "min": "v0.10.69"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -150,7 +150,7 @@
       </ng-container>
       <ng-container matColumnDef="courseTitle">
         <mat-header-cell *matHeaderCellDef mat-sort-header="courseTitle" i18n> Title </mat-header-cell>
-        <mat-cell  *matCellDef="let element" class="list-content-menu">
+        <mat-cell  *matCellDef="let element" class="list-content-menu" [ngClass]="{'list-content-menu-auto': element.doc.courseTitle.length > 50 }">
           <h3 class="header">
             <a *ngIf="!isDialog && !isForm; else newTabLink" [routerLink]="['view', element._id]">{{element.doc.courseTitle}}</a>
             <ng-template #newTabLink><a class="cursor-pointer" (click)="openCourseViewDialog(element._id)">{{element.doc.courseTitle}}</a></ng-template>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -152,8 +152,8 @@
         <mat-header-cell *matHeaderCellDef mat-sort-header="courseTitle" i18n> Title </mat-header-cell>
         <mat-cell  *matCellDef="let element" class="list-content-menu" [ngClass]="{'list-content-menu-auto': element.doc.courseTitle.length > 50 }">
           <h3 class="header">
-            <a *ngIf="!isDialog && !isForm; else newTabLink" [routerLink]="['view', element._id]">{{element.doc.courseTitle}}</a>
-            <ng-template #newTabLink><a class="cursor-pointer" (click)="openCourseViewDialog(element._id)">{{element.doc.courseTitle}}</a></ng-template>
+            <a *ngIf="!isDialog && !isForm; else newTabLink" [routerLink]="['view', element._id]">{{ element.doc.courseTitle.length > 180 ? element.doc.courseTitle.slice(0, 180) + '...' : element.doc.courseTitle }}</a>
+            <ng-template #newTabLink><a class="cursor-pointer" (click)="openCourseViewDialog(element._id)">{{ element.doc.courseTitle.length > 180 ? element.doc.courseTitle.slice(0, 180) + '...' : element.doc.courseTitle }}</a></ng-template>
             <span *ngIf="!parent && !isDialog" [ngClass]="{ 'cursor-pointer': !isForm }">
               <mat-icon class="margin-lr-3" i18n-matTooltip matTooltip="In myCourses" [inline]="true" *ngIf="element.admission" (click)="courseToggle(element._id, 'resign')">bookmark</mat-icon>
               <mat-icon class="margin-lr-3" i18n-matTooltip matTooltip="Not in myCourses" [inline]="true" *ngIf="!element.admission && element.doc.steps.length" (click)="courseToggle(element._id, 'admission')">bookmark_border</mat-icon>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -118,10 +118,10 @@
       </ng-container>
       <ng-container matColumnDef="title">
         <mat-header-cell *matHeaderCellDef mat-sort-header="title" i18n>Title</mat-header-cell>
-        <mat-cell *matCellDef="let element" class="list-content-menu">
+        <mat-cell *matCellDef="let element" class="list-content-menu" [ngClass]="{'list-content-menu-auto': element.doc.title.length > 50 }">
           <h3 class="header">
-            <a *ngIf="!isDialog; else dialog" [routerLink]="['view', element._id]">{{element.doc.title}}</a>
-            <ng-template #dialog><a [routerLink]="['resources/view', element._id]" target="_blank">{{element.doc.title}}</a></ng-template>
+            <a *ngIf="!isDialog; else dialog" [routerLink]="['view', element._id]">{{ element.doc.title.length > 200 ? element.doc.title.slice(0, 200) + '...' : element.doc.title }}</a>
+            <ng-template #dialog><a [routerLink]="['resources/view', element._id]" target="_blank">{{ element.doc.title.length > 180 ? element.doc.title.slice(0, 180) + '...' : element.doc.title }}</a></ng-template>
             <ng-container *ngIf="!parent && !isDialog && myView !== 'myPersonals'">
               <mat-icon class="margin-lr-3 cursor-pointer" i18n-matTooltip matTooltip="In myLibrary" [inline]="true" *ngIf="element.libraryInfo" (click)="libraryToggle([ element._id ], 'remove')">bookmark</mat-icon>
               <mat-icon class="margin-lr-3 cursor-pointer" i18n-matTooltip matTooltip="Not in myLibrary" [inline]="true" *ngIf="!element.libraryInfo" (click)="libraryToggle([ element._id ], 'add')">bookmark_border</mat-icon>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -191,6 +191,10 @@ body {
 
   }
 
+  .list-content-menu-auto {
+    grid-template-rows: auto 1fr min-content;
+  }
+
   // the colored stars are placed on top of the uncolored ones
   // the width is set dynamically with JS
   $stars-margin: 1px;


### PR DESCRIPTION
Fixes #7259

Courses & Resources: Handle the title overlap in 2 ways
- Set the grid row height of the title row to auto when the title exceeds 50 chars
- Cut off the title when it exceeds 180 char(courses) & 200 chars(resources)

**Before**
![image](https://github.com/open-learning-exchange/planet/assets/48474421/eb5b02a2-c7e9-48aa-8bab-28c562fca64a)


**After**
![image](https://github.com/open-learning-exchange/planet/assets/48474421/6af980f7-cf1f-4066-bfc5-2f97e34c40b6)
