### PR TITLE
courses: improve filter stability (fixes #7261)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.41",
+  "version": "0.13.55",
   "myplanet": {
-    "latest": "v0.10.47",
-    "min": "v0.10.25"
+    "latest": "v0.10.98",
+    "min": "v0.10.73"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -13,8 +13,8 @@ import { UserService } from '../shared/user.service';
 import { Subject, of } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import {
-  filterDropdowns, filterSpecificFields, composeFilterFunctions, createDeleteArray, filterSpecificFieldsByWord, filterTags, commonSortingDataAccessor,
-  selectedOutOfFilter, filterShelf, trackById, filterIds
+  filterDropdowns, filterSpecificFields, composeFilterFunctions, createDeleteArray, filterSpecificFieldsByWord, filterTags,
+  commonSortingDataAccessor, selectedOutOfFilter, filterShelf, trackById, filterIds
 } from '../shared/table-helpers';
 import * as constants from './constants';
 import { debug } from '../debug-operator';

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -10,11 +10,10 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { Router, ActivatedRoute, } from '@angular/router';
 import { FormBuilder, FormGroup, FormControl, } from '@angular/forms';
 import { UserService } from '../shared/user.service';
-import { Subject, of, forkJoin } from 'rxjs';
-import { switchMap, takeUntil, map } from 'rxjs/operators';
+import { Subject, of } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs/operators';
 import {
-  filterDropdowns, filterSpecificFields, composeFilterFunctions, sortNumberOrString,
-  dropdownsFill, createDeleteArray, filterSpecificFieldsByWord, filterTags, commonSortingDataAccessor,
+  filterDropdowns, filterSpecificFields, composeFilterFunctions, createDeleteArray, filterSpecificFieldsByWord, filterTags, commonSortingDataAccessor,
   selectedOutOfFilter, filterShelf, trackById, filterIds
 } from '../shared/table-helpers';
 import * as constants from './constants';

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -7,7 +7,7 @@ const dropdownString = (fieldValue: any, value: string) => {
   }
 
   if (fieldValue instanceof Array) {
-    return fieldValue.indexOf(value) === -1
+    return fieldValue.indexOf(value) === -1;
   }
 
   // Ensure both value and fieldValue are strings before calling toLowerCase

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -5,7 +5,15 @@ const dropdownString = (fieldValue: any, value: string) => {
     // If there is no value to filter, include item.  If the data field is undefined, exclude item.
     return value !== undefined;
   }
-  return fieldValue instanceof Array ? fieldValue.indexOf(value) === -1 : value.toLowerCase() !== fieldValue.toLowerCase();
+
+  if (fieldValue instanceof Array) {
+    return fieldValue.indexOf(value) === -1
+  }
+
+  // Ensure both value and fieldValue are strings before calling toLowerCase
+  if (typeof value === 'string' && typeof fieldValue === 'string') {
+    return value.toLowerCase() !== fieldValue.toLowerCase();
+  }
 };
 
 const dropdownArray = (fieldValue: any, values: string[]) => {


### PR DESCRIPTION
Fixes #7261 

Courses: Resolve the filter bug that occurs when the **grade level** or **subject level** are not defined during course creation.
- Check if the value is a string before calling _toLowerCase_ which was throwing an error
- Remove unused imports in the `courses.component.ts`
