### PR TITLE
chat: last is first with auto refresh (fixes #7297)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.62",
+  "version": "0.13.63",
   "myplanet": {
-    "latest": "v0.11.16",
-    "min": "v0.10.91"
+    "latest": "v0.11.18",
+    "min": "v0.10.93"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -19,7 +19,7 @@
     </ng-container>
 
     <ng-template #noChats>
-      <span i18n>No chats available.</span>
+      <span i18n>No previous conversations.</span>
     </ng-template>
   </mat-drawer>
 

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -1,6 +1,6 @@
 <mat-drawer-container class="sidebar-drawer" autosize>
   <mat-drawer #drawer mode="side">
-    <div class="header">
+    <div class="header" i18n>
       <button type="button" mat-stroked-button color="primary" class="start-button" mat-button (click)="newChat()">
         <mat-icon>add</mat-icon>
         Start New Chat
@@ -9,12 +9,18 @@
         <i class="material-icons">chevron_left</i>
       </button>
     </div>
-    <h2>Conversations</h2>
-    <ul>
-      <li *ngFor="let conversation of conversations.reverse(); let i = index" (click)="selectConversation(conversation)">
-        {{ conversation.conversations[0].query.slice(0, 25) }}
-      </li>
-    </ul>
+    <h2 i18n>Conversations</h2>
+    <ng-container *ngIf="conversations.length; else noChats">
+      <ul>
+        <li *ngFor="let conversation of conversations.reverse(); let i = index" (click)="selectConversation(conversation)">
+          {{ conversation.conversations[0].query.slice(0, 25) }}
+        </li>
+      </ul>
+    </ng-container>
+
+    <ng-template #noChats>
+      <span i18n>No chats available.</span>
+    </ng-template>
   </mat-drawer>
 
   <div class="window-box">

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -11,7 +11,7 @@
     </div>
     <h2>Conversations</h2>
     <ul>
-      <li *ngFor="let conversation of conversations; let i = index" (click)="selectConversation(conversation)">
+      <li *ngFor="let conversation of conversations.reverse(); let i = index" (click)="selectConversation(conversation)">
         {{ conversation.conversations[0].query.slice(0, 25) }}
       </li>
     </ul>

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -14,7 +14,7 @@ export class ChatSidebarComponent implements OnInit {
   ngOnInit() {
     this.getChatHistory();
 
-    // Listen for any new chats
+    // Listen for any new chats and update
     this.chatService.newChatAdded$.subscribe(() => {
       this.getChatHistory();
     });

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -34,7 +34,6 @@ export class ChatSidebarComponent implements OnInit {
   }
 
   selectConversation(conversation) {
-    // this.getChatHistory();
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,
       '_rev': conversation?._rev

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -13,10 +13,15 @@ export class ChatSidebarComponent implements OnInit {
 
   ngOnInit() {
     this.getChatHistory();
+
+    // Listen for any new chats
+    this.chatService.newChatAdded$.subscribe(() => {
+      this.getChatHistory();
+    });
   }
 
   newChat() {
-    this.chatService.sendNewChatSignal();
+    this.chatService.sendNewChatSelectedSignal();
   }
 
   getChatHistory() {
@@ -29,7 +34,7 @@ export class ChatSidebarComponent implements OnInit {
   }
 
   selectConversation(conversation) {
-    this.getChatHistory();
+    // this.getChatHistory();
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,
       '_rev': conversation?._rev

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -10,7 +10,7 @@
 <div class="form-container">
   <form [formGroup]="promptForm" class="form-spacing" (ngSubmit)="onSubmit()">
     <mat-form-field class="full-width mat-form-field-type-no-underline">
-      <mat-label>Chat</mat-label>
+      <mat-label i18n>Chat</mat-label>
       <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
       <mat-error><planet-form-error-messages [control]="promptForm.controls.prompt"></planet-form-error-messages></mat-error>
     </mat-form-field>

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -112,6 +112,7 @@ export class ChatWindowComponent implements OnInit {
           '_rev': completion.couchDBResponse?.rev
         };
         this.postSubmit();
+        this.chatService.sendNewChatAddedSignal();
       },
       (error: any) => {
         this.spinnerOn = false;

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -12,9 +12,11 @@ import { CouchService } from '../shared/couchdb.service';
   private baseUrl = environment.chatAddress;
   private dbName = 'chat_history';
   private newChatSelected = new Subject<void>();
+  private newChatAdded = new Subject<void>();
   private selectedConversationIdSubject = new BehaviorSubject<object | null>(null);
 
   newChatSelected$ = this.newChatSelected.asObservable();
+  newChatAdded$ = this.newChatAdded.asObservable();
   selectedConversationId$: Observable<object | null> = this.selectedConversationIdSubject.asObservable();
 
 
@@ -34,8 +36,12 @@ import { CouchService } from '../shared/couchdb.service';
     return this.couchService.findAll(this.dbName, findDocuments({ '_id': inSelector(ids) }), opts);
   }
 
-  sendNewChatSignal() {
+  sendNewChatSelectedSignal() {
     this.newChatSelected.next();
+  }
+
+  sendNewChatAddedSignal() {
+    this.newChatAdded.next();
   }
 
   setSelectedConversationId(conversationId: object) {

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -11,12 +11,12 @@ import { CouchService } from '../shared/couchdb.service';
 }) export class ChatService {
   private baseUrl = environment.chatAddress;
   private dbName = 'chat_history';
-  private newChatSelected = new Subject<void>();
   private newChatAdded = new Subject<void>();
+  private newChatSelected = new Subject<void>();
   private selectedConversationIdSubject = new BehaviorSubject<object | null>(null);
 
-  newChatSelected$ = this.newChatSelected.asObservable();
   newChatAdded$ = this.newChatAdded.asObservable();
+  newChatSelected$ = this.newChatSelected.asObservable();
   selectedConversationId$: Observable<object | null> = this.selectedConversationIdSubject.asObservable();
 
 
@@ -36,12 +36,12 @@ import { CouchService } from '../shared/couchdb.service';
     return this.couchService.findAll(this.dbName, findDocuments({ '_id': inSelector(ids) }), opts);
   }
 
-  sendNewChatSelectedSignal() {
-    this.newChatSelected.next();
-  }
-
   sendNewChatAddedSignal() {
     this.newChatAdded.next();
+  }
+
+  sendNewChatSelectedSignal() {
+    this.newChatSelected.next();
   }
 
   setSelectedConversationId(conversationId: object) {


### PR DESCRIPTION
Fixes #7297 

- Ensures that the latest conversations are added to the top
- Auto updates the chat history list when a new chat is added
- Adds a message if there are no chats in the history.
- Add internationalization to chat(and related) components

![image](https://github.com/open-learning-exchange/planet/assets/48474421/a84e94d3-cf6f-4d36-a02c-94a4122955bd)
