### PR TITLE
chat: improve submission validation (fixes #7302)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.63",
+  "version": "0.13.65",
   "myplanet": {
-    "latest": "v0.11.18",
-    "min": "v0.10.93"
+    "latest": "v0.11.27",
+    "min": "v0.11.2"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -10,7 +10,7 @@
       </button>
     </div>
     <h2 i18n>Conversations</h2>
-    <ng-container *ngIf="conversations.length; else noChats">
+    <ng-container *ngIf="conversations?.length; else noChats">
       <ul>
         <li *ngFor="let conversation of conversations.reverse(); let i = index" (click)="selectConversation(conversation)">
           {{ conversation.conversations[0].query.slice(0, 25) }}

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -12,9 +12,8 @@
     <mat-form-field class="full-width mat-form-field-type-no-underline">
       <mat-label i18n>Chat</mat-label>
       <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
-      <mat-error><planet-form-error-messages [control]="promptForm.controls.prompt"></planet-form-error-messages></mat-error>
     </mat-form-field>
-    <button mat-raised-button [planetSubmit]="promptForm.valid && spinnerOn" color="primary" i18n>
+    <button mat-raised-button [planetSubmit]="promptForm.valid && spinnerOn" [disabled]="!promptForm.valid" color="primary" i18n>
       Chat
       <mat-icon>send</mat-icon>
     </button>

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup } from '@angular/forms';
 
+import { CustomValidators } from '../../validators/custom-validators';
 import { ChatService } from '../../shared/chat.service';
 import { CouchService } from '../../shared/couchdb.service';
 import { UserService } from '../../shared/user.service';
@@ -50,7 +51,7 @@ export class ChatWindowComponent implements OnInit {
 
   createForm() {
     this.promptForm = this.formBuilder.group({
-      prompt: [ '', Validators.required ],
+      prompt: [ '', CustomValidators.required ],
     });
   }
 
@@ -91,6 +92,7 @@ export class ChatWindowComponent implements OnInit {
   }
 
   onSubmit() {
+    console.log(this.promptForm);
     if (this.promptForm.valid) {
       this.submitPrompt();
     } else {

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -92,7 +92,6 @@ export class ChatWindowComponent implements OnInit {
   }
 
   onSubmit() {
-    console.log(this.promptForm);
     if (this.promptForm.valid) {
       this.submitPrompt();
     } else {


### PR DESCRIPTION
Fixes #7302

Improve the chat form submission validation
- Prevent submission of only blank spaces
- Remove the mat-error message and disable the button in its place
- Handle the conversations length issue being thrown