### PR TITLE
calendar: showing maximum 2 events a day (fixes #7308)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.68",
+  "version": "0.13.69",
   "myplanet": {
-    "latest": "v0.11.32",
-    "min": "v0.11.7"
+    "latest": "v0.11.35",
+    "min": "v0.11.10"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -67,13 +67,13 @@ planet-calendar {
   }
 }
 
+.fc-h-event .fc-event-title {
+  text-overflow: ellipsis;
+}
+
 @media only screen and (min-width: #{$screen-md}) {
   .fc-event-title-container {
     max-width: 100px;
-  }
-
-  .fc-h-event .fc-event-title {
-    text-overflow: ellipsis;
   }
 
   .fc .fc-more-popover .fc-popover-body {

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -66,3 +66,17 @@ planet-calendar {
     right: -0.25rem;
   }
 }
+
+@media only screen and (min-width: #{$screen-md}) {
+  .fc-event-title-container {
+    max-width: 100px;
+  }
+
+  .fc-h-event .fc-event-title {
+    text-overflow: ellipsis;
+  }
+
+  .fc .fc-more-popover .fc-popover-body {
+    min-width: unset !important;
+  }
+}

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -72,11 +72,11 @@ planet-calendar {
 }
 
 @media only screen and (min-width: #{$screen-md}) {
-  .fc-event-title-container {
-    max-width: 100px;
-  }
-
   .fc .fc-more-popover .fc-popover-body {
     min-width: unset !important;
+
+    .fc-event-title-container {
+      max-width: 100px;
+    }
   }
 }

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -57,6 +57,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     events: this.events,
     customButtons: this.buttons,
     firstDay: 6,
+    dayMaxEventRows: 2,
     eventClick: this.eventClick.bind(this)
   };
 


### PR DESCRIPTION
Fixes #7308

- Improve how multiple events in a single day are displayed using a popover.
- Improve the handling of the titles length 

![image](https://github.com/open-learning-exchange/planet/assets/48474421/11c338eb-9971-4c69-8024-01a3b58baa15)
