### PR TITLE
courses: responsive filter toggle (fixes #7310)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.69",
+  "version": "0.13.70",
   "myplanet": {
-    "latest": "v0.11.35",
-    "min": "v0.11.10"
+    "latest": "v0.11.37",
+    "min": "v0.11.12"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -18,20 +18,24 @@
       <mat-form-field class="font-size-1 margin-lr-4 mat-form-field-type-no-underline mat-form-field-dynamic-width collections-search">
         <planet-tag-input [formControl]="tagFilter" [db]="dbName" [parent]="parent" [filteredData]="courses.filteredData" [helperText]="false" [largeFont]="true" [selectMany]="false" mode="filter" [updateRouteParam]="!isDialog"></planet-tag-input>
       </mat-form-field>
+      <span class="toolbar-fill"></span>
+      <button mat-icon-button *ngIf="deviceType !== deviceTypes.DESKTOP" (click)="toggleFilters()" ><mat-icon>filter_list</mat-icon></button>
     </mat-toolbar-row>
-    <ng-container *ngIf="deviceType === deviceTypes.MOBILE">
-      <mat-toolbar-row>
-        <ng-container *ngTemplateOutlet="gradeLevelSelect"></ng-container>
-        <ng-container *ngTemplateOutlet="subjectLevelSelect"></ng-container>
-      </mat-toolbar-row>
-      <mat-toolbar-row>
-        <ng-container *ngTemplateOutlet="titleClearButtonLevelSelect"></ng-container>
-      </mat-toolbar-row>
-    </ng-container>
-    <ng-container *ngIf="deviceType === deviceTypes.TABLET">
-      <mat-toolbar-row>
-        <ng-container *ngTemplateOutlet="filterOptions"></ng-container>
-      </mat-toolbar-row>
+    <ng-container *ngIf="showFiltersRow">
+      <ng-container *ngIf="deviceType === deviceTypes.MOBILE">
+        <mat-toolbar-row>
+          <ng-container *ngTemplateOutlet="gradeLevelSelect"></ng-container>
+          <ng-container *ngTemplateOutlet="subjectLevelSelect"></ng-container>
+        </mat-toolbar-row>
+        <mat-toolbar-row>
+          <ng-container *ngTemplateOutlet="titleClearButtonLevelSelect"></ng-container>
+        </mat-toolbar-row>
+      </ng-container>
+      <ng-container *ngIf="deviceType === deviceTypes.TABLET">
+        <mat-toolbar-row>
+          <ng-container *ngTemplateOutlet="filterOptions"></ng-container>
+        </mat-toolbar-row>
+      </ng-container>
     </ng-container>
   </ng-template>
 </mat-toolbar>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -96,7 +96,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   trackById = trackById;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
-  showFiltersRow: boolean = false;
+  showFiltersRow = false;
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -96,6 +96,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   trackById = trackById;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
+  showFiltersRow: boolean = false;
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;
@@ -447,6 +448,10 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     if (tag.trim()) {
       this.tagInputComponent.writeValue([ tag ]);
     }
+  }
+
+  toggleFilters() {
+    this.showFiltersRow = !this.showFiltersRow;
   }
 
 }

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -10,8 +10,10 @@
   <ng-template #mobileView>
     <mat-toolbar-row>
       <ng-container *ngTemplateOutlet="collectionRow"></ng-container>
+      <span class="toolbar-fill"></span>
+      <button mat-icon-button (click)="toggleFiltersRow()" ><mat-icon>filter_list</mat-icon></button>
     </mat-toolbar-row>
-    <mat-toolbar-row>
+    <mat-toolbar-row *ngIf="showFiltersRow">
       <ng-container *ngTemplateOutlet="filterRow"></ng-container>
     </mat-toolbar-row>
   </ng-template>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -91,6 +91,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
   isTablet: boolean;
+  showFiltersRow: boolean = false;
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;
@@ -386,6 +387,10 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   hasAttachment(id: string) {
     return this.resources.data.find((resource: any) => resource._id === id && resource.doc._attachments);
+  }
+
+  toggleFiltersRow() {
+    this.showFiltersRow = !this.showFiltersRow;
   }
 
 }

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -91,7 +91,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
   isTablet: boolean;
-  showFiltersRow: boolean = false;
+  showFiltersRow = false;
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;


### PR DESCRIPTION
Fixes #7310 

For mobile or tablets add a responsive toggle to show or hide the filter rows - allows us to capture more screen real estate.

![image](https://github.com/open-learning-exchange/planet/assets/48474421/5ea390ff-e888-4d84-b52a-a74a7e367fce)


![image](https://github.com/open-learning-exchange/planet/assets/48474421/59c156c2-6216-4b6c-a480-6920a5481444)
