### PR TITLE
courses: improve responsive mobile layout (fixes #7312)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.70",
+  "version": "0.13.71",
   "myplanet": {
-    "latest": "v0.11.37",
-    "min": "v0.11.12"
+    "latest": "v0.11.39",
+    "min": "v0.11.14"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -154,14 +154,23 @@
       </ng-container>
       <ng-container matColumnDef="courseTitle">
         <mat-header-cell *matHeaderCellDef mat-sort-header="courseTitle" i18n> Title </mat-header-cell>
-        <mat-cell  *matCellDef="let element" class="list-content-menu" [ngClass]="{'list-content-menu-auto': element.doc.courseTitle.length > 50 }">
+        <mat-cell *matCellDef="let element" class="list-content-menu" [ngClass]="{'list-content-menu-auto': element.doc.courseTitle.length > 50 }">
           <h3 class="header">
-            <a *ngIf="!isDialog && !isForm; else newTabLink" [routerLink]="['view', element._id]">{{ element.doc.courseTitle.length > 180 ? element.doc.courseTitle.slice(0, 180) + '...' : element.doc.courseTitle }}</a>
-            <ng-template #newTabLink><a class="cursor-pointer" (click)="openCourseViewDialog(element._id)">{{ element.doc.courseTitle.length > 180 ? element.doc.courseTitle.slice(0, 180) + '...' : element.doc.courseTitle }}</a></ng-template>
-            <span *ngIf="!parent && !isDialog" [ngClass]="{ 'cursor-pointer': !isForm }">
-              <mat-icon class="margin-lr-3" i18n-matTooltip matTooltip="In myCourses" [inline]="true" *ngIf="element.admission" (click)="courseToggle(element._id, 'resign')">bookmark</mat-icon>
-              <mat-icon class="margin-lr-3" i18n-matTooltip matTooltip="Not in myCourses" [inline]="true" *ngIf="!element.admission && element.doc.steps.length" (click)="courseToggle(element._id, 'admission')">bookmark_border</mat-icon>
-            </span>
+            <ng-container *ngIf="deviceType === deviceTypes.MOBILE">
+              <mat-checkbox (change)="$event ? selection.toggle(element._id) : null"
+                [checked]="selection.isSelected(element._id)">
+              </mat-checkbox>
+              <span class="margin-lr-5"></span>
+            </ng-container>
+            <ng-container *ngTemplateOutlet="headerText"></ng-container>
+            <ng-template #headerText>
+              <a *ngIf="!isDialog && !isForm; else newTabLink" [routerLink]="['view', element._id]">{{ element.doc.courseTitle.length > 180 ? element.doc.courseTitle.slice(0, 180) + '...' : element.doc.courseTitle }}</a>
+              <ng-template #newTabLink><a class="cursor-pointer" (click)="openCourseViewDialog(element._id)">{{ element.doc.courseTitle.length > 180 ? element.doc.courseTitle.slice(0, 180) + '...' : element.doc.courseTitle }}</a></ng-template>
+              <span *ngIf="!parent && !isDialog" [ngClass]="{ 'cursor-pointer': !isForm }">
+                <mat-icon class="margin-lr-3" i18n-matTooltip matTooltip="In myCourses" [inline]="true" *ngIf="element.admission" (click)="courseToggle(element._id, 'resign')">bookmark</mat-icon>
+                <mat-icon class="margin-lr-3" i18n-matTooltip matTooltip="Not in myCourses" [inline]="true" *ngIf="!element.admission && element.doc.steps.length" (click)="courseToggle(element._id, 'admission')">bookmark_border</mat-icon>
+              </span>
+            </ng-template>
           </h3>
           <div class="course-progress" *ngIf="element.admission && element.doc.steps.length && !parent && !isDialog && !isForm">
             <span i18n>myProgress:</span>

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -82,7 +82,7 @@
   }
 
   .table-selection-top {
-    align-self: center;
+    display: none;
   }
 
   .rating-cell {

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -122,12 +122,21 @@
         <mat-header-cell *matHeaderCellDef mat-sort-header="title" i18n>Title</mat-header-cell>
         <mat-cell *matCellDef="let element" class="list-content-menu" [ngClass]="{'list-content-menu-auto': element.doc.title.length > 50 }">
           <h3 class="header">
-            <a *ngIf="!isDialog; else dialog" [routerLink]="['view', element._id]">{{ element.doc.title.length > 200 ? element.doc.title.slice(0, 200) + '...' : element.doc.title }}</a>
-            <ng-template #dialog><a [routerLink]="['resources/view', element._id]" target="_blank">{{ element.doc.title.length > 180 ? element.doc.title.slice(0, 180) + '...' : element.doc.title }}</a></ng-template>
-            <ng-container *ngIf="!parent && !isDialog && myView !== 'myPersonals'">
-              <mat-icon class="margin-lr-3 cursor-pointer" i18n-matTooltip matTooltip="In myLibrary" [inline]="true" *ngIf="element.libraryInfo" (click)="libraryToggle([ element._id ], 'remove')">bookmark</mat-icon>
-              <mat-icon class="margin-lr-3 cursor-pointer" i18n-matTooltip matTooltip="Not in myLibrary" [inline]="true" *ngIf="!element.libraryInfo" (click)="libraryToggle([ element._id ], 'add')">bookmark_border</mat-icon>
+            <ng-container *ngIf="deviceType === deviceTypes.MOBILE">
+              <mat-checkbox (change)="$event ? selection.toggle(element._id) : null"
+                [checked]="selection.isSelected(element._id)">
+              </mat-checkbox>
+              <span class="margin-lr-5"></span>
             </ng-container>
+            <ng-container *ngTemplateOutlet="headerText"></ng-container>
+            <ng-template #headerText>
+              <a *ngIf="!isDialog; else dialog" [routerLink]="['view', element._id]">{{ element.doc.title.length > 200 ? element.doc.title.slice(0, 200) + '...' : element.doc.title }}</a>
+              <ng-template #dialog><a [routerLink]="['resources/view', element._id]" target="_blank">{{ element.doc.title.length > 180 ? element.doc.title.slice(0, 180) + '...' : element.doc.title }}</a></ng-template>
+              <ng-container *ngIf="!parent && !isDialog && myView !== 'myPersonals'">
+                <mat-icon class="margin-lr-3 cursor-pointer" i18n-matTooltip matTooltip="In myLibrary" [inline]="true" *ngIf="element.libraryInfo" (click)="libraryToggle([ element._id ], 'remove')">bookmark</mat-icon>
+                <mat-icon class="margin-lr-3 cursor-pointer" i18n-matTooltip matTooltip="Not in myLibrary" [inline]="true" *ngIf="!element.libraryInfo" (click)="libraryToggle([ element._id ], 'add')">bookmark_border</mat-icon>
+              </ng-container>
+            </ng-template>
           </h3>
           <mat-chip-list #tagsList class="tags-list">
             <ng-container *ngFor="let tag of element.tags">

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -75,7 +75,7 @@ $label-height: 1rem;
     }
 
     .table-selection-top {
-      align-self: center;
+      display: none;
     }
   }
 


### PR DESCRIPTION
Fixes #7312

Reposition the checkbox cell for mobile devices in the courses and the resources.

![image](https://github.com/open-learning-exchange/planet/assets/48474421/9d384f4f-eca4-412b-8728-8d505d8ebfdc)
