### PR TITLE
community: calendar cleanup (fixes #7326)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.78",
+  "version": "0.13.79",
   "myplanet": {
-    "latest": "v0.11.51",
-    "min": "v0.11.26"
+    "latest": "v0.11.52",
+    "min": "v0.11.27"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -17,17 +17,6 @@
   }
 }
 
-.fc .fc-toolbar {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.fc .fc-toolbar-title {
-  font-size: 1.25em !important;
-  margin: 1rem !important;
-}
-
 .community-news {
   grid-area: news;
   overflow-y: auto;
@@ -55,19 +44,5 @@ planet-calendar {
     position: absolute;
     top: -0.25rem;
     right: -0.25rem;
-  }
-}
-
-.fc-h-event .fc-event-title {
-  text-overflow: ellipsis;
-}
-
-@media only screen and (min-width: #{$screen-md}) {
-  .fc .fc-more-popover .fc-popover-body {
-    min-width: unset !important;
-
-    .fc-event-title-container {
-      max-width: 100px;
-    }
   }
 }

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, Component, Inject, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, Inject, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { CalendarOptions } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -7,7 +7,6 @@ import interactionPlugin from '@fullcalendar/interaction';
 import allLocales from '@fullcalendar/core/locales-all';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogsAddMeetupsComponent } from './dialogs/dialogs-add-meetups.component';
-// import { LandingEventDetailComponent } from "../landing/landing-home/landing-event/landing-eventdetail/landing-eventdetail.component";
 import { days, millisecondsToDay } from '../meetups/constants';
 import { CouchService } from './couchdb.service';
 import { findDocuments } from './mangoQueries';
@@ -83,10 +82,6 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     this.calendarOptions.customButtons = this.buttons;
     this.calendarOptions.events = [ ...this.events, ...this._events ];
   }
-
-  // ngAfterViewChecked(): void {
-  //   this.calendarOptions.events = [...this.events, ...this._events];
-  // }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.resizeCalendar && changes.resizeCalendar.currentValue) {
@@ -195,13 +190,5 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
       }
     });
   }
-
-  // uplanetEventClick({ event }) {
-  //   this.dialog.open(LandingEventDetailComponent, {
-  //     data: event.extendedProps.meetup,
-  //     width: '40vw',
-  //     maxHeight: '90vh'
-  //   });
-  // }
 
 }

--- a/src/styles/calendar.scss
+++ b/src/styles/calendar.scss
@@ -3,37 +3,32 @@
 @import '../app/variables';
 
 full-calendar {
-  .fc-day-grid-event > .fc-content {
+  .fc-h-event .fc-event-title {
     text-overflow: ellipsis;
   }
+  .fc-toolbar-title {
+    font-size: 1.25em !important;
+    margin: 1rem !important;
+  }
+  .fc-toolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
   .fc-button-primary {
-    background-color: $primary;
-    border: none;
-    font-size: 14px;
-    font-weight: 500;
-    line-height: 36px;
-    padding: 0 16px;
     position: relative;
-
-    &:disabled {
-      background-color: $disabled-button;
-      color: $disabled-button-text;
-    }
-
-    &:not(:disabled).fc-button-active, &:not(:disabled).fc-button-active:hover {
-      background-color: $primary-dark;
-    }
 
     &:not(:disabled):hover {
       background-color: $primary;
-      &::before {
-        height: 100%;
-        width: 100%;
-        content: "";
-        background-color: rgba(0, 0, 0, 0.04);
-        position: absolute;
-        top: 0;
-        left: 0;
+    }
+  }
+
+  @media only screen and (min-width: #{$screen-md}) {
+    .fc-more-popover .fc-popover-body {
+      min-width: unset !important;
+
+      .fc-event-title-container {
+        max-width: 100px;
       }
     }
   }


### PR DESCRIPTION
Fixes #7326 

- Remove unused imports and comments
- Clean up the `calendar.scss` styles
- Move calendar related styles from the `community.scss` to the `calendar.scss`
