### PR TITLE
login activities: consistent export (fixes #7331)

### DIFF
--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -382,7 +382,11 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       case 'logins':
         this.csvService.exportCSV({
           data: filterByMember(filterByDate(this.loginActivities.data, 'loginTime', dateRange), members)
-            .map(activity => ({ ...activity, androidId: activity.androidId || '' })),
+          .map(activity => ({...activity,
+            androidId: activity.androidId || '',
+            deviceName: activity.deviceName || '',
+            customDeviceName: activity.customDeviceName || ''
+           })),
           title: $localize`Member Visits`
         });
         break;


### PR DESCRIPTION
Fixes #7331 

Consistent format while exporting login_activities i.e deviceName and customDeviceName are included having no undefined value.

All login activities
![image](https://github.com/open-learning-exchange/planet/assets/48474421/fcf33350-6703-4d4a-be01-8be6208dd003)

Pirate patrons
![image](https://github.com/open-learning-exchange/planet/assets/48474421/0ea2210d-d11c-4c7f-9aaf-230afed831e4)
