### PR TITLE
teams: better members view (fixes #7334)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.80",
+  "version": "0.13.81",
   "myplanet": {
-    "latest": "v0.11.53",
-    "min": "v0.11.28"
+    "latest": "v0.11.55",
+    "min": "v0.11.30"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -38,7 +38,7 @@ planet-calendar {
 .card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  grid-template-rows: repeat(auto-fill, 125px);
+  grid-auto-rows: 125px;
   margin: 0 0.5rem;
   .top-right-icon {
     position: absolute;

--- a/src/app/teams/teams-view.scss
+++ b/src/app/teams/teams-view.scss
@@ -6,9 +6,9 @@
   .card-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    grid-template-rows: repeat(auto-fill, 180px);
+    grid-auto-rows: 180px;
     &.member-cards {
-      grid-template-rows: repeat(auto-fill, 280px);
+      grid-auto-rows: 280px;
       mat-card-content {
         max-height: 149px;
       }


### PR DESCRIPTION
Fixes #7334 

In the Community Leaders & Team Members tabs
Fix the inconsistent height issue of the cards showing the members

Community Leaders
![image](https://github.com/open-learning-exchange/planet/assets/48474421/ac9ee992-f019-4ad6-8e85-2215ccd68369)


Teams Members
![image](https://github.com/open-learning-exchange/planet/assets/48474421/996502fa-147a-4daa-b7a8-6d2f1462ff12)
