### PR TITLE
enterprises: better finances currency handling (fixes #7336)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.81",
+  "version": "0.13.82",
   "myplanet": {
-    "latest": "v0.11.55",
-    "min": "v0.11.30"
+    "latest": "v0.11.56",
+    "min": "v0.11.31"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/teams/teams-reports-detail.component.ts
+++ b/src/app/teams/teams-reports-detail.component.ts
@@ -26,7 +26,7 @@ export class TeamsReportsDetailComponent implements OnChanges {
   income: number;
   net: number;
   endingBalance: number;
-  curCode = this.stateService.configuration.currency || undefined;
+  curCode = this.stateService.configuration.currency || '';
 
   constructor(
     private stateService: StateService

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -33,7 +33,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   endDate: Date;
   emptyTable = true;
   showBalanceWarning = false;
-  curCode = this.stateService.configuration.currency || undefined;
+  curCode = this.stateService.configuration.currency || '';
 
   constructor(
     private teamsService: TeamsService,


### PR DESCRIPTION
Fixes #7336 

When the currency is not in the configurations db, null is not displayed, it displays $.