### PR TITLE
images: restrict whitespaces in filenames (fixes #7341)

### DIFF
--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -106,14 +106,16 @@ export class ResourcesService {
     }));
   }
 
-  updateResource(resourceInfo, file, { newTags, existingTags } = { newTags: [], existingTags: [] }) {
+  updateResource(resourceInfo, file, { newTags, existingTags } = { newTags: [], existingTags: [] }, sanitizedFileName = undefined) {
+    console.log(sanitizedFileName);
+
     return this.couchService.updateDocument(this.dbName, { createdDate: this.couchService.datePlaceholder, ...resourceInfo }, ).pipe(
       switchMap((resourceRes) =>
         forkJoin([
           of(resourceRes),
           file ?
             this.couchService.putAttachment(
-              this.dbName + '/' + resourceRes.id + '/' + file.name + '?rev=' + resourceRes.rev, file,
+              this.dbName + '/' + resourceRes.id + '/' + (sanitizedFileName ? sanitizedFileName : file.name) + '?rev=' + resourceRes.rev, file,
               { headers: { 'Content-Type': file.type } }
             ) :
             of({}),

--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -106,17 +106,15 @@ export class ResourcesService {
     }));
   }
 
-  updateResource(resourceInfo, file, { newTags, existingTags } = { newTags: [], existingTags: [] }, sanitizedFileName = undefined) {
-    console.log(sanitizedFileName);
-
+  updateResource(resourceInfo, file, { newTags, existingTags } = { newTags: [], existingTags: [] }, sanitizedFileName = null) {
     return this.couchService.updateDocument(this.dbName, { createdDate: this.couchService.datePlaceholder, ...resourceInfo }, ).pipe(
       switchMap((resourceRes) =>
         forkJoin([
           of(resourceRes),
           file ?
             this.couchService.putAttachment(
-              this.dbName + '/' + resourceRes.id + '/' + (sanitizedFileName ? sanitizedFileName : file.name) + '?rev=' + resourceRes.rev, file,
-              { headers: { 'Content-Type': file.type } }
+              this.dbName + '/' + resourceRes.id + '/' + (sanitizedFileName ? sanitizedFileName : file.name) + '?rev=' + resourceRes.rev,
+              file, { headers: { 'Content-Type': file.type } }
             ) :
             of({}),
           this.couchService.bulkDocs('tags', this.tagsService.tagBulkDocs(resourceRes.id, this.dbName, newTags, existingTags))

--- a/src/app/shared/dialogs/dialogs-images.component.ts
+++ b/src/app/shared/dialogs/dialogs-images.component.ts
@@ -48,7 +48,9 @@ export class DialogsImagesComponent implements OnInit {
 
   uploadImage(event) {
     const file = event.target.files[0];
-    const imageExists = this.images.some(img => file.name === img.filename);
+
+    const sanitizedFileName =  file.name.trim().replace(/\s+/g, '_');
+    const imageExists = this.images.some(img => sanitizedFileName === img.filename);
     if (imageExists) {
       this.planetMessageService.showAlert('An image with that filename exists. Please rename or select another image.');
       return;
@@ -60,8 +62,8 @@ export class DialogsImagesComponent implements OnInit {
       return;
     }
     const newResource = {
-      title: file.name,
-      filename: file.name,
+      title: sanitizedFileName,
+      filename: sanitizedFileName,
       private: true,
       privateFor: this.data.imageGroup,
       sourcePlanet: planet,
@@ -69,7 +71,7 @@ export class DialogsImagesComponent implements OnInit {
       addedBy: this.userService.get().name,
       mediaType
     };
-    this.resourcesService.updateResource(newResource, file).subscribe(([ resourceResponse ]) => {
+    this.resourcesService.updateResource(newResource, file, undefined, sanitizedFileName).subscribe(([ resourceResponse ]) => {
       this.selectImage({ ...newResource, _id: resourceResponse.id });
     });
   }

--- a/src/app/shared/dialogs/dialogs-images.component.ts
+++ b/src/app/shared/dialogs/dialogs-images.component.ts
@@ -49,7 +49,7 @@ export class DialogsImagesComponent implements OnInit {
   uploadImage(event) {
     const file = event.target.files[0];
 
-    const sanitizedFileName =  file.name.trim().replace(/\s+/g, '_');
+    const sanitizedFileName = file.name.trim().replace(/\s+/g, '_');
     const imageExists = this.images.some(img => sanitizedFileName === img.filename);
     if (imageExists) {
       this.planetMessageService.showAlert('An image with that filename exists. Please rename or select another image.');


### PR DESCRIPTION
Fixes #7341 

Restricting spaces in image filenames to allow for their use in the myPlanet markdown.

Related to #2731 on [myPlanet](https://github.com/open-learning-exchange/myplanet/pull/2731)