### PR TITLE
community: labeling for everbody (fixes #7343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.82",
+  "version": "0.14.6",
   "myplanet": {
-    "latest": "v0.11.56",
-    "min": "v0.11.31"
+    "latest": "v0.12.59",
+    "min": "v0.12.0"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -37,7 +37,7 @@
       <button mat-icon-button type="button" (click)="editNews(item.doc)"><mat-icon>edit</mat-icon></button>
       <button mat-icon-button type="button" (click)="openDeleteDialog(item.doc)"><mat-icon>delete</mat-icon></button>
     </ng-container>
-    <button mat-button i18n *ngIf="item.doc.user.name === currentUser.name && editable" [matMenuTriggerFor]="labelMenu" [disabled]="labels.listed.length === 0">Add Label</button>
+    <button mat-button i18n *ngIf="editable" [matMenuTriggerFor]="labelMenu" [disabled]="labels.listed.length === 0">Add Label</button>
     <mat-menu #labelMenu="matMenu">
       <button mat-menu-item *ngFor="let label of labels.listed" (click)="labelClick(label, 'add')"><planet-label [label]="label"></planet-label></button>
     </mat-menu>


### PR DESCRIPTION
Fixes #7343

Allow any user to add a label for a news item.
Affects the Community , Teams & Enterprises.