### PR TITLE
teams: improve stability (fixes #7339)

### DIFF
--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -102,6 +102,9 @@
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
       <mat-row (click)="teamClick(row.doc._id, row.doc.teamType)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
     </mat-table>
+    <div *ngIf="userNotInShelf" i18n style="text-align: center;">
+      You do not have access to some Teams/Enterprises functions, contact your administrator
+    </div>
     <mat-paginator #paginator
       [pageSize]="50"
       [pageSizeOptions]="[5, 10, 20, 50, 100, 200]">

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -7,8 +7,8 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
-import { switchMap, map, finalize } from 'rxjs/operators';
-import { forkJoin, of } from 'rxjs';
+import { switchMap, map, finalize, catchError } from 'rxjs/operators';
+import { forkJoin, throwError } from 'rxjs';
 import {
   filterSpecificFieldsByWord, composeFilterFunctions, filterSpecificFields, deepSortingDataAccessor
 } from '../shared/table-helpers';
@@ -61,6 +61,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   filter: string;
   deviceType: DeviceType;
   isMobile: boolean;
+  userNotInShelf = false;
 
   constructor(
     private userService: UserService,
@@ -123,7 +124,18 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       }
       this.emptyData = !this.teams.data.length;
       this.dialogsLoadingService.stop();
-    }, (error) => console.log(error));
+    }, (error) => {
+      if (this.userNotInShelf) {
+        this.displayedColumns = [ 'doc.name', 'visitLog.lastVisit', 'visitLog.visitCount', 'doc.teamType' ]
+        this.couchService.findAll(this.dbName, { 'selector': { 'status': 'active' } }).subscribe((teams) => {
+          this.teams.data = this.teamList(teams.filter((team: any) => {
+            return (team.type === this.mode || (team.type === undefined && this.mode === 'team')) && this.excludeIds.indexOf(team._id) === -1;
+          }));
+        })
+      }
+      this.dialogsLoadingService.stop();
+      console.log(error)
+    });
   }
 
   getMembershipStatus() {
@@ -134,7 +146,13 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       map(([ membershipDocs, shelf ]) => this.userMembership = [
         ...membershipDocs,
         ...(shelf.myTeamIds || []).map(id => ({ teamId: id, fromShelf: true, docType: 'membership', userId: this.user._id }))
-      ])
+      ]),
+      catchError(error => {
+        if(error.status === 404) {
+          this.userNotInShelf = true;
+        }
+        return throwError(error)
+      })
     );
   }
 

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -126,15 +126,16 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       this.dialogsLoadingService.stop();
     }, (error) => {
       if (this.userNotInShelf) {
-        this.displayedColumns = [ 'doc.name', 'visitLog.lastVisit', 'visitLog.visitCount', 'doc.teamType' ]
+        this.displayedColumns = [ 'doc.name', 'visitLog.lastVisit', 'visitLog.visitCount', 'doc.teamType' ];
         this.couchService.findAll(this.dbName, { 'selector': { 'status': 'active' } }).subscribe((teams) => {
           this.teams.data = this.teamList(teams.filter((team: any) => {
-            return (team.type === this.mode || (team.type === undefined && this.mode === 'team')) && this.excludeIds.indexOf(team._id) === -1;
+            return (team.type === this.mode || (team.type === undefined && this.mode === 'team'))
+            && this.excludeIds.indexOf(team._id) === -1;
           }));
-        })
+        });
       }
       this.dialogsLoadingService.stop();
-      console.log(error)
+      console.log(error);
     });
   }
 
@@ -148,10 +149,10 @@ export class TeamsComponent implements OnInit, AfterViewInit {
         ...(shelf.myTeamIds || []).map(id => ({ teamId: id, fromShelf: true, docType: 'membership', userId: this.user._id }))
       ]),
       catchError(error => {
-        if(error.status === 404) {
+        if (error.status === 404) {
           this.userNotInShelf = true;
         }
-        return throwError(error)
+        return throwError(error);
       })
     );
   }


### PR DESCRIPTION
Fixes #7339 

Improve the teams/enterprises stability when a user is not added to the `shelf` database on creation(currently only happens via myPlanet cc: @Okuro3499)

Shows the teams/enterpises(without action buttons) and a message to contact support.


![image](https://github.com/open-learning-exchange/planet/assets/48474421/881ba45a-e25f-44a9-8300-dbf7b0012690)



