### PR TITLE
chat: advanced search (fixes #7319)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.88",
+  "version": "0.13.89",
   "myplanet": {
-    "latest": "v0.11.75",
-    "min": "v0.11.50"
+    "latest": "v0.11.81",
+    "min": "v0.11.56"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -10,16 +10,22 @@
       <mat-form-field class="font-size-1 margin-lr-3">
         <input matInput i18n-placeholder placeholder="Search" [(ngModel)]="titleSearch" (input)="onSearchChange()">
       </mat-form-field>
-      <button mat-icon-button color="primary" (click)="resetFilter()" [disabled]="!titleSearch"><mat-icon>delete</mat-icon></button><br>
+      <button mat-icon-button color="primary" (click)="resetFilter()" [disabled]="!titleSearch && !searchType"><mat-icon>delete</mat-icon></button><br>
       <div>
-        <span style="font-size: small; font-style: italic;" i18n>Full Text Search </span>
+        <span style="font-size: small; font-style: italic;" i18n>Full Conversation Search </span>
         <mat-checkbox [checked]="fullTextSearch" (change)="toggleSearchType()"></mat-checkbox>
-        <button mat-icon-button (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
+        <button style="text-align: end;" mat-icon-button (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
           <mat-icon>help_outline</mat-icon>
         </button>
         <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="overlayOpen">
-          <span class="overlay-text">In addition to the title, search through the entire conversation</span>
+          <span class="overlay-text" i18n>search through the entire conversation, not just the title</span>
         </ng-template>
+        <div>
+          <mat-button-toggle-group *ngIf="fullTextSearch" [(ngModel)]="searchType" (change)="filterConversations()">
+            <mat-button-toggle value="questions" i18n>Questions</mat-button-toggle>
+            <mat-button-toggle value="responses" i18n>Responses</mat-button-toggle>
+          </mat-button-toggle-group>
+        </div>
       </div>
     </div>
     <ng-container *ngIf="filteredConversations?.length; else noChats">

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -10,7 +10,7 @@
       <mat-form-field class="font-size-1 margin-lr-3">
         <input matInput i18n-placeholder placeholder="Search" [(ngModel)]="titleSearch" (input)="onSearchChange()">
       </mat-form-field>
-      <button mat-icon-button color="primary" (click)="resetFilter()"><mat-icon>delete</mat-icon></button><br>
+      <button mat-icon-button color="primary" (click)="resetFilter()" [disabled]="!titleSearch"><mat-icon>delete</mat-icon></button><br>
       <span style="font-size: small; font-style: italic;" i18n>Full Text Search </span>
       <mat-checkbox [checked]="fullTextSearch" (change)="toggleSearchType()"></mat-checkbox>
     </div>

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -11,8 +11,16 @@
         <input matInput i18n-placeholder placeholder="Search" [(ngModel)]="titleSearch" (input)="onSearchChange()">
       </mat-form-field>
       <button mat-icon-button color="primary" (click)="resetFilter()" [disabled]="!titleSearch"><mat-icon>delete</mat-icon></button><br>
-      <span style="font-size: small; font-style: italic;" i18n>Full Text Search </span>
-      <mat-checkbox [checked]="fullTextSearch" (change)="toggleSearchType()"></mat-checkbox>
+      <div>
+        <span style="font-size: small; font-style: italic;" i18n>Full Text Search </span>
+        <mat-checkbox [checked]="fullTextSearch" (change)="toggleSearchType()"></mat-checkbox>
+        <button mat-icon-button (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
+          <mat-icon>help_outline</mat-icon>
+        </button>
+        <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="overlayOpen">
+          <span class="overlay-text">In addition to the title, search through the entire conversation</span>
+        </ng-template>
+      </div>
     </div>
     <ng-container *ngIf="filteredConversations?.length; else noChats">
       <ul>

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -22,6 +22,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   selectedConversation: any;
   isEditing: boolean;
   fullTextSearch = false;
+  overlayOpen = false;
   titleForm: { [key: string]: FormGroup } = {};
   private _titleSearch = '';
   get titleSearch(): string { return this._titleSearch.trim(); }
@@ -64,6 +65,10 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   toggleEditTitle() {
     this.isEditing = !this.isEditing;
+  }
+
+  toggleOverlay() {
+    this.overlayOpen = !this.overlayOpen;
   }
 
   updateConversation(conversation, title) {

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -149,7 +149,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
         const conversationMatches = conversation.conversations.some(chat => {
           const queryMatch = chat.query?.toLowerCase().includes(this.titleSearch.toLowerCase());
           const responseMatch = chat.response?.toLowerCase().includes(this.titleSearch.toLowerCase());
-
           if (this.searchType === 'questions') {
             return queryMatch;
           } else if (this.searchType === 'responses') {

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -150,9 +150,9 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
           const queryMatch = chat.query?.toLowerCase().includes(this.titleSearch.toLowerCase());
           const responseMatch = chat.response?.toLowerCase().includes(this.titleSearch.toLowerCase());
 
-          if (this.searchType === "questions") {
+          if (this.searchType === 'questions') {
             return queryMatch;
-          } else if (this.searchType === "responses") {
+          } else if (this.searchType === 'responses') {
             return responseMatch;
           } else {
             return queryMatch || responseMatch;

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -22,6 +22,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   selectedConversation: any;
   isEditing: boolean;
   fullTextSearch = false;
+  searchType: 'questions' | 'responses';
   overlayOpen = false;
   titleForm: { [key: string]: FormGroup } = {};
   private _titleSearch = '';
@@ -123,6 +124,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   resetFilter() {
     this.titleSearch = '';
+    this.searchType = null;
   }
 
   recordSearch(complete = false) {
@@ -147,7 +149,14 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
         const conversationMatches = conversation.conversations.some(chat => {
           const queryMatch = chat.query?.toLowerCase().includes(this.titleSearch.toLowerCase());
           const responseMatch = chat.response?.toLowerCase().includes(this.titleSearch.toLowerCase());
-          return queryMatch || responseMatch;
+
+          if (this.searchType === "questions") {
+            return queryMatch;
+          } else if (this.searchType === "responses") {
+            return responseMatch;
+          } else {
+            return queryMatch || responseMatch;
+          }
         });
         return conversationMatches;
       }

--- a/src/app/chat/chat-sidebar/chat-sidebar.scss
+++ b/src/app/chat/chat-sidebar/chat-sidebar.scss
@@ -62,6 +62,16 @@ li:hover {
   align-self: flex-end;
 }
 
+.overlay-text {
+  width: 100px;
+  border: solid 1px #ccc;
+  border-radius: 5px;
+  background: #fff;
+  text-align: center;
+  padding: 10px;
+  margin: 0;
+}
+
 @media only screen and (max-width: $screen-md) {
   .expand-button {
     top: 10px;

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -1,4 +1,3 @@
-
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { OverlayModule } from '@angular/cdk/overlay';

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -1,6 +1,10 @@
-import { NgModule } from '@angular/core';
+
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { RouterModule } from '@angular/router';
 import { CovalentMarkdownModule } from '@covalent/markdown';
+
 import { PlanetLocalStatusComponent } from './planet-local-status.component';
 import { MaterialModule } from './material.module';
 import { SubmitDirective } from './submit.directive';
@@ -15,7 +19,6 @@ import { TasksComponent, FilterAssigneePipe, AssigneeNamePipe } from '../tasks/t
 import { PlanetRoleComponent } from './planet-role.component';
 import { PlanetMarkdownComponent } from './planet-markdown.component';
 import { CommunityListComponent } from '../community/community-list.component';
-import { RouterModule } from '@angular/router';
 import { LabelComponent } from './label.component';
 import { MyPlanetTableComponent } from '../manager-dashboard/reports/myplanet-table.component';
 import { TimePipe } from '../manager-dashboard/reports/time.pipe';
@@ -49,7 +52,8 @@ import { ChatOutputDirective } from './chat-output.directive';
     MyPlanetTableComponent,
     AvatarComponent,
     RestrictDiacriticsDirective,
-    ChatOutputDirective
+    ChatOutputDirective,
+    OverlayModule,
   ],
   declarations: [
     PlanetLocalStatusComponent,


### PR DESCRIPTION
Fixes #7319 

Advanced `Full Conversation Search` options i.e to search through the questions only or the responses only.

![image](https://github.com/open-learning-exchange/planet/assets/48474421/c5ebd13f-68bf-4cdd-95e8-e7c64fac2612)
