### PR TITLE
calendar: selectable meetup dates (fixes #7364)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.90",
+  "version": "0.13.91",
   "myplanet": {
-    "latest": "v0.11.88",
-    "min": "v0.11.63"
+    "latest": "v0.11.95",
+    "min": "v0.11.70"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -55,9 +55,7 @@ export class MeetupsAddComponent implements OnInit {
     private fb: FormBuilder,
     private userService: UserService,
     private stateService: StateService
-  ) {
-    this.createForm();
-  }
+  ) { }
 
   ngOnInit() {
     if (this.meetup._id) {
@@ -69,6 +67,7 @@ export class MeetupsAddComponent implements OnInit {
         error => console.log(error)
       );
     }
+    this.createForm();
   }
 
   setMeetupData(meetup: any) {
@@ -86,8 +85,8 @@ export class MeetupsAddComponent implements OnInit {
     this.meetupForm = this.fb.group({
       title: [ '', CustomValidators.required ],
       description: [ '', CustomValidators.required ],
-      startDate: '',
-      endDate: [ '', CustomValidators.endDateValidator() ],
+      startDate: this.meetup?.startDate ? this.meetup.startDate : '',
+      endDate: [ this.meetup?.endDate ? this.meetup.endDate : '', CustomValidators.endDateValidator() ],
       recurring: 'none',
       day: this.fb.array([]),
       startTime: [ '', CustomValidators.timeValidator() ],

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -175,13 +175,16 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     if (event?.start) {
       meetup = {
         startDate: event?.start,
-        endDate: event?.end
+        endDate: this.adjustEndDate(event?.end)
       };
     }
-
     this.dialog.open(DialogsAddMeetupsComponent, {
       data: { meetup: meetup, link: this.link, sync: this.sync, onMeetupsChange: this.onMeetupsChange.bind(this), editable: this.editable }
     });
+  }
+
+  adjustEndDate(endDate: Date): Date {
+    return new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate() - 1, 23, 59, 59, 999);
   }
 
   onMeetupsChange() {

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -57,6 +57,8 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     customButtons: this.buttons,
     firstDay: 6,
     dayMaxEventRows: 2,
+    selectable: true,
+    select: this.openAddEventDialog.bind(this),
     eventClick: this.eventClick.bind(this)
   };
 
@@ -168,9 +170,17 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     return events;
   }
 
-  openAddEventDialog() {
+  openAddEventDialog(event) {
+    let meetup;
+    if (event?.start) {
+      meetup = {
+        startDate: event?.start,
+        endDate: event?.end
+      };
+    }
+
     this.dialog.open(DialogsAddMeetupsComponent, {
-      data: { link: this.link, sync: this.sync, onMeetupsChange: this.onMeetupsChange.bind(this), editable: this.editable }
+      data: { meetup: meetup, link: this.link, sync: this.sync, onMeetupsChange: this.onMeetupsChange.bind(this), editable: this.editable }
     });
   }
 


### PR DESCRIPTION
Fixes #7364 

Make the dates selectable to set events with date info preloaded.

![image](https://github.com/open-learning-exchange/planet/assets/48474421/6b0ed038-c7b0-42f3-8d50-e0df145a0143)
