### PR TITLE
courses: better step changes (fixes #7372)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.92",
+  "version": "0.13.96",
   "myplanet": {
-    "latest": "v0.11.97",
-    "min": "v0.11.72"
+    "latest": "v0.12.24",
+    "min": "v0.11.60"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -65,9 +65,9 @@
         </mat-select>
       </mat-form-field>
       <span>{{stepNum}}/{{maxStep}}</span>
-      <button mat-icon-button [disabled]="stepNum === 1" (click)="changeStep(-1)"><mat-icon>navigate_before</mat-icon></button>
+      <button mat-icon-button *ngIf="maxStep !== 1" [disabled]="stepNum === 1" (click)="changeStep(-1)"><mat-icon>navigate_before</mat-icon></button>
       <button mat-icon-button *ngIf="stepNum !== maxStep"  [disabled]="stepNum === maxStep || (!parent && stepDetail?.exam?.questions.length > 0 && !attempts)" (click)="changeStep(1)"><mat-icon>navigate_next</mat-icon></button>
-      <button *ngIf="stepNum === maxStep" mat-raised-button color="basic" (click)="backToCourseDetail()">Finish</button>
+      <button mat-raised-button *ngIf="stepNum === maxStep && maxStep !== 1" [disabled]="!parent && stepDetail?.exam?.questions.length > 0 && !attempts" (click)="backToCourseDetail()">Finish</button>
     </div>
   </mat-toolbar>
   <div class="view-container view-full-height" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">


### PR DESCRIPTION
Fixes #7372

- Hide the step changes if course has only one step
- Disable the `Finish` button if test has not been completed