### PR TITLE
chat: better order (fixes #7383)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.13.93",
+  "version": "0.13.97",
   "myplanet": {
-    "latest": "v0.12.09",
+    "latest": "v0.12.28",
     "min": "v0.11.60"
   },
   "scripts": {

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -30,7 +30,7 @@
     </div>
     <ng-container *ngIf="filteredConversations?.length; else noChats">
       <ul>
-        <li *ngFor="let conversation of filteredConversations.reverse(); let i = index" (click)="selectConversation(conversation)">
+        <li *ngFor="let conversation of filteredConversations; let i = index" (click)="selectConversation(conversation)">
           <ng-container *ngIf="isEditing; else notEditing">
             <ng-container *ngIf="selectedConversation?._id === conversation?._id; else conversationTitle">
               <form [formGroup]="titleForm[conversation?._id]" (ngSubmit)="submitTitle(conversation)">

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -102,7 +102,12 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   getChatHistory() {
     this.chatService.findConversations([], [ this.userService.get().name ]).subscribe(
       (conversations: any) => {
-        this.conversations = conversations.sort((a, b) => b.createdDate - a.createdDate);
+        this.conversations = conversations.sort((a, b) => {
+          const dateA = a.updatedDate || a.createdDate;
+          const dateB = b.updatedDate || b.createdDate;
+
+          return dateB - dateA;
+        });
         this.filteredConversations = [ ...conversations ];
         this.initializeFormGroups();
       },

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -101,8 +101,8 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   getChatHistory() {
     this.chatService.findConversations([], [ this.userService.get().name ]).subscribe(
-      (conversations) => {
-        this.conversations = conversations;
+      (conversations: any) => {
+        this.conversations = conversations.sort((a, b) => b.createdDate - a.createdDate);
         this.filteredConversations = [ ...conversations ];
         this.initializeFormGroups();
       },


### PR DESCRIPTION
Fixes #7383 

Chat list ordering based on the `createdDate` and `updatedDate` db fields.

The latest(either by creation time or update time) shows up first