### PR TITLE
chat: improve form control (fixes #7405)

### DIFF
--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -13,6 +13,7 @@
       <mat-label i18n>Chat</mat-label>
       <div class="textarea-container">
         <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
+        <mat-error><planet-form-error-messages [control]="promptForm.controls.prompt"></planet-form-error-messages></mat-error>
         <button mat-icon-button [planetSubmit]="promptForm.valid && spinnerOn" [disabled]="!promptForm.valid" color="primary"><mat-icon>send</mat-icon></button>
       </div>
     </mat-form-field>

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -103,9 +103,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
 
   postSubmit() {
     this.changeDetectorRef.detectChanges();
-    this.spinnerOn = true;
+    this.spinnerOn = false;
     this.scrollToBottom();
-    this.promptForm.controls['prompt'].setValue('');
+    this.promptForm.reset();
   }
 
   onSubmit() {
@@ -133,7 +133,6 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
         this.chatService.sendNewChatAddedSignal();
       },
       (error: any) => {
-        this.spinnerOn = false;
         this.conversations.push({ query: content, response: 'Error: ' + error.message, error: true });
         this.postSubmit();
       }


### PR DESCRIPTION
Fixes #7405

- Form control error message
- Reset the form instead of clearing the form field(clear triggers the mat-error)
- Spinner is consistent


![image](https://github.com/open-learning-exchange/planet/assets/48474421/c5a0675c-0c82-4045-8b9c-fda221e291d0)
