### PR TITLE
enterprises: add finances export (fixes #7411)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.9",
+  "version": "0.14.14",
   "myplanet": {
-    "latest": "v0.12.78",
-    "min": "v0.12.0"
+    "latest": "v0.13.89",
+    "min": "v0.13.0"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -11,6 +11,9 @@
     <mat-datepicker #dateFilterEnd></mat-datepicker>
   </mat-form-field>
   <button mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
+  <button class="margin-lr-10" color="accent" mat-raised-button i18n (click)="exportTableData()">
+    Export Transactions
+  </button>
 </div>
 <mat-card class="margin-lr" *ngIf="showBalanceWarning">
   <mat-icon color="accent">warning</mat-icon><span i18n>The current balance is negative!</span>

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -188,7 +188,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   }
 
   exportTableData() {
-    let updatedData = [...this.table.filteredData]
+    let updatedData = [ ...this.table.filteredData ];
     updatedData.shift();
 
     updatedData = updatedData.map(row => ({

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -12,6 +12,7 @@ import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { millisecondsToDay } from '../meetups/constants';
 import { StateService } from '../shared/state.service';
+import { CsvService } from '../shared/csv.service';
 
 @Component({
   selector: 'planet-teams-view-finances',
@@ -36,13 +37,14 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   curCode = this.stateService.configuration.currency || {};
 
   constructor(
-    private teamsService: TeamsService,
+    private csvService: CsvService,
     private couchService: CouchService,
-    private planetMessageService: PlanetMessageService,
+    private dialog: MatDialog,
     private dialogsFormService: DialogsFormService,
     private dialogsLoadingService: DialogsLoadingService,
-    private dialog: MatDialog,
-    private stateService: StateService
+    private planetMessageService: PlanetMessageService,
+    private stateService: StateService,
+    private teamsService: TeamsService
   ) {
     this.couchService.currentTime().subscribe((date) => this.dateNow = date);
   }
@@ -184,6 +186,24 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
     this.endDate = undefined;
     this.table.filter = '';
     this.emptyTable = this.table.data.length <= 1;
+  }
+
+  exportTableData() {
+    let updatedData = [...this.table.filteredData]
+    updatedData.shift();
+
+    updatedData = updatedData.map(row => ({
+      date: row.date,
+      description: row.description,
+      credit: row.credit,
+      debit: row.debit,
+      balance: row.balance
+    }));
+
+    this.csvService.exportCSV({
+      data: updatedData,
+      title: $localize`Finances Transactions for ${this.team.name} Enterprise`
+    });
   }
 
 }

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnChanges, EventEmitter, Output, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
-import { Validators } from '@angular/forms';
 import { map } from 'rxjs/operators';
 import { TeamsService } from './teams.service';
 import { CouchService } from '../shared/couchdb.service';


### PR DESCRIPTION
Fixes #7411 

Add an `export transactions` button in the teams and community finances

![image](https://github.com/open-learning-exchange/planet/assets/48474421/ac6d4ba0-bc4e-4c08-b566-9c7bffcddb8c)


![image](https://github.com/open-learning-exchange/planet/assets/48474421/4a94623e-2862-4759-bf7c-2659a2da6fb8)
