### PR TITLE
collections: only managers can create or manage collections (fixes #7419)

### DIFF
--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -6,7 +6,7 @@
   <mat-form-field class="full-width">
     <input matInput i18n-placeholder placeholder="Filter by Collection Name" [ngModel]="filterValue" (ngModelChange)="updateFilter($event)">
   </mat-form-field>
-  <mat-expansion-panel *planetAuthorizedRoles>
+  <mat-expansion-panel *planetAuthorizedRoles="'manager'">
     <mat-expansion-panel-header>
       <mat-panel-title i18n>Create New Collection</mat-panel-title>
     </mat-expansion-panel-header>


### PR DESCRIPTION
Fixes #7419 

Allow only planet authorized managers to create and manage the collections.
Learners allowed to filter through and select the collection

![image](https://github.com/open-learning-exchange/planet/assets/48474421/18cb80ef-9981-4703-99a3-929b5c298281)
