### PR TITLE
chat: node 18 on alpine 3.16 (fixes #7426)

### DIFF
--- a/docker/chatapi/amd64-Dockerfile
+++ b/docker/chatapi/amd64-Dockerfile
@@ -1,4 +1,4 @@
-FROM treehouses/node
+FROM treehouses/node:3.16
 
 RUN apk update
 

--- a/docker/chatapi/arm-Dockerfile
+++ b/docker/chatapi/arm-Dockerfile
@@ -6,7 +6,7 @@ RUN bash ./crosscompile_chatapi.sh armv7 install
 
 #####
 
-FROM treehouses/node-tags:arm
+FROM treehouses/node-tags:arm-3.16
 
 RUN apk update
 

--- a/docker/chatapi/arm64-Dockerfile
+++ b/docker/chatapi/arm64-Dockerfile
@@ -6,7 +6,7 @@ RUN bash ./crosscompile_chatapi.sh armv8 install
 
 #####
 
-FROM treehouses/node-tags:arm64
+FROM treehouses/node-tags:arm64-3.16
 
 RUN apk update
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.18",
+  "version": "0.14.21",
   "myplanet": {
-    "latest": "v0.14.21",
+    "latest": "v0.14.49",
     "min": "v0.13.69"
   },
   "scripts": {

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -13,7 +13,6 @@
       <mat-label i18n>Chat</mat-label>
       <div class="textarea-container">
         <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
-        <mat-error><planet-form-error-messages [control]="promptForm.controls.prompt"></planet-form-error-messages></mat-error>
         <button mat-icon-button [planetSubmit]="promptForm.valid && spinnerOn" [disabled]="!promptForm.valid" color="primary"><mat-icon>send</mat-icon></button>
       </div>
     </mat-form-field>


### PR DESCRIPTION
Fixes #7426 

Update the the node versions to 18 

Enables running of Gemini, Perplexity and streaming functionality for openai