### PR TITLE
landing: calendar toolbar alignment (fixes #7447)

### DIFF
--- a/src/app/landing/landing-home/landing-home.scss
+++ b/src/app/landing/landing-home/landing-home.scss
@@ -63,6 +63,9 @@
     background-color: rgb(244, 244, 244, 0.5);
     min-height: 330px;
   }
+  & .fc .fc-toolbar {
+    flex-direction: row;
+  }
   & .fc .fc-toolbar-title {
     @media (max-width: 400px) {
       font-size: 0.7rem;


### PR DESCRIPTION
Fixes #7447

Row alignment for the calendar toolbar in the landing page

![image](https://github.com/open-learning-exchange/planet/assets/48474421/996f55c4-47f9-485b-90a4-07284dee55e7)
