### PR TITLE
chat: sharing (fixes #7455)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "license": "AGPL-3.0",
   "version": "0.14.34",
   "myplanet": {
-    "latest": "v0.15.36",
-    "min": "v0.14.36"
+    "latest": "v0.15.39",
+    "min": "v0.14.39"
   },
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.29",
+  "version": "0.14.34",
   "myplanet": {
-    "latest": "v0.15.10",
-    "min": "v0.14.10"
+    "latest": "v0.15.36",
+    "min": "v0.14.36"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -30,11 +30,11 @@
     </div>
     <ng-container *ngIf="filteredConversations?.length; else noChats">
       <ul>
-        <li *ngFor="let conversation of filteredConversations; let i = index" (click)="selectConversation(conversation, i)">
+        <li *ngFor="let conversation of filteredConversations; let i = index" (click)="selectConversation(conversation, i)" style="width: 230px;">
           <ng-container *ngIf="isEditing; else notEditing">
             <ng-container *ngIf="selectedConversation?._id === conversation?._id; else conversationTitle">
               <form [formGroup]="titleForm[conversation?._id]" (ngSubmit)="submitTitle(conversation)">
-                <mat-form-field class="mat-form-field-type-no-underline">
+                <mat-form-field class="mat-form-field" style="width: 50%;">
                   <input matInput [formControl]="titleForm[conversation?._id].controls.title" required>
                   <mat-error>
                     <planet-form-error-messages [formControl]="titleForm[conversation?._id].controls.title"></planet-form-error-messages>
@@ -47,9 +47,10 @@
           </ng-container>
           <ng-template #notEditing>
             <ng-container *ngTemplateOutlet="conversationTitle"></ng-container>
-            <mat-icon *ngIf="selectedConversation?._id === conversation?._id" class="sidebar-icon" (click)="toggleEditTitle()" style="font-size:larger;">
-              edit
-            </mat-icon>
+            <button mat-icon-button class="sidebar-icon" *ngIf="selectedConversation?._id === conversation?._id" (click)="toggleEditTitle()">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button class="sidebar-icon" *ngIf="selectedConversation?._id === conversation?._id" (click)="openShareDialog()"><mat-icon>share</mat-icon></button>
           </ng-template>
           <ng-template #conversationTitle>
             {{ conversation?.title?.slice(0, 25) || conversation.conversations[0].query.slice(0, 25) }}

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -50,7 +50,9 @@
             <button mat-icon-button class="sidebar-icon" *ngIf="selectedConversation?._id === conversation?._id" (click)="toggleEditTitle()">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button class="sidebar-icon" *ngIf="selectedConversation?._id === conversation?._id" (click)="openShareDialog()"><mat-icon>share</mat-icon></button>
+            <button mat-icon-button class="sidebar-icon" *ngIf="selectedConversation?._id === conversation?._id" (click)="openShareDialog(conversation)">
+              <mat-icon>share</mat-icon>
+            </button>
           </ng-template>
           <ng-template #conversationTitle>
             {{ conversation?.title?.slice(0, 25) || conversation.conversations[0].query.slice(0, 25) }}

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -205,6 +205,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   openShareDialog(conversation) {
     this.dialog.open(DialogsChatShareComponent, {
       width: '50vw',
+      maxHeight: '90vh',
       data: {
         news: conversation,
       }

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -204,6 +204,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   openShareDialog(conversation) {
     this.dialog.open(DialogsChatShareComponent, {
+      width: '30vw',
       data: {
         news: conversation,
       }

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -204,7 +204,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   openShareDialog(conversation) {
     this.dialog.open(DialogsChatShareComponent, {
-      width: '30vw',
+      width: '50vw',
       data: {
         news: conversation,
       }

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -1,12 +1,15 @@
 import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+
 
 import { Conversation } from '../chat.model';
 import { ChatService } from '../../shared/chat.service';
 import { CouchService } from '../../shared/couchdb.service';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
+import { DialogsChatShareComponent } from '../../shared/dialogs/dialogs-chat-share.component';
 import { SearchService } from '../../shared/forms/search.service';
 import { showFormErrors } from '../../shared/table-helpers';
 import { UserService } from '../../shared/user.service';
@@ -42,6 +45,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
     private chatService: ChatService,
     private couchService: CouchService,
     private deviceInfoService: DeviceInfoService,
+    private dialog: MatDialog,
     private formBuilder: FormBuilder,
     private searchService: SearchService,
     private userService: UserService
@@ -197,4 +201,13 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
       return this.filterByTitle(conversation);
     });
   }
+
+  openShareDialog(conversation) {
+    this.dialog.open(DialogsChatShareComponent, {
+      data: {
+        news: conversation,
+      }
+    });
+  }
+
 }

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -1,9 +1,7 @@
 <div class="chat-container" #chat>
   <div *ngFor="let conversation of conversations">
-    <div class="conversation">
-      <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
-      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" class="conversation-err" [planetChatOutput]="conversation.response"></p>
-    </div>
+    <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
+    <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" class="conversation-err" [planetChatOutput]="conversation.response"></p>
   </div>
 </div>
 

--- a/src/app/chat/chat.module.ts
+++ b/src/app/chat/chat.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '../shared/material.module';
 import { PlanetFormsModule } from '../shared/forms/planet-forms.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
+import { DialogsChatShareModule } from '../shared/dialogs/dialogs-chat-share.module';
 
 import { ChatComponent } from './chat.component';
 import { ChatSidebarComponent } from './chat-sidebar/chat-sidebar.component';
@@ -17,7 +18,8 @@ import { ChatWindowComponent } from './chat-window/chat-window.component';
     MaterialModule,
     PlanetFormsModule,
     ReactiveFormsModule,
-    SharedComponentsModule
+    SharedComponentsModule,
+    DialogsChatShareModule,
   ],
   declarations: [
     ChatComponent,

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -16,7 +16,10 @@
       <mat-chip-list>
         <mat-chip color="primary" selected class="planet-chip-label chip-no-style" *ngFor="let label of item.doc.labels">
           <planet-label i18n-label [label]="label"></planet-label>
-          <mat-icon *ngIf="item.doc.user.name === currentUser.name && editable" matChipRemove (click)="labelClick(label, 'remove')">clear</mat-icon>
+          <mat-icon *ngIf="item.doc.user.name === currentUser.name && editable && !item.doc.chat" matChipRemove (click)="labelClick(label, 'remove')">clear</mat-icon>
+        </mat-chip>
+        <mat-chip class="planet-chip-label chip-no-style chat-chip" *ngIf="item.doc.chat">
+          <planet-label i18n-label [label]="'shared chat'"></planet-label>
         </mat-chip>
       </mat-chip-list>
     </mat-card-subtitle>
@@ -26,6 +29,16 @@
       <planet-markdown class="img-wrap" [content]="item.doc.message"></planet-markdown>
     </div>
     <span class="primary-text-color cursor-pointer" *ngIf="(showExpand || !showLess) && !item.latestMessage" (click)="showLess = !showLess" i18n>{{ showLess ? 'Show More' : 'Show Less' }}</span>
+    <ng-container *ngIf="item.doc.chat">
+      <div class="chat-container">
+        <div *ngFor="let conversation of item.doc.news.conversations">
+          <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
+          <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" [planetChatOutput]="conversation.response"></p>
+        </div>
+      </div>
+    </ng-container>
+    <ng-template #mdRender>
+    </ng-template>
   </mat-card-content>
   <mat-card-actions class="display-flex">
     <button mat-button *ngIf="editable || item.public === true" type="button" (click)="addReply(item.doc)" i18n>Reply</button>
@@ -34,10 +47,10 @@
     </button>
     <span class="toolbar-fill"></span>
     <ng-container *ngIf="item.doc.user.name === currentUser.name">
-      <button mat-icon-button type="button" (click)="editNews(item.doc)"><mat-icon>edit</mat-icon></button>
+      <button mat-icon-button type="button" (click)="editNews(item.doc)" *ngIf="!item.doc.chat"><mat-icon>edit</mat-icon></button>
       <button mat-icon-button type="button" (click)="openDeleteDialog(item.doc)"><mat-icon>delete</mat-icon></button>
     </ng-container>
-    <button mat-button i18n *ngIf="editable" [matMenuTriggerFor]="labelMenu" [disabled]="labels.listed.length === 0">Add Label</button>
+    <button mat-button i18n *ngIf="editable && !item.doc.chat" [matMenuTriggerFor]="labelMenu" [disabled]="labels.listed.length === 0">Add Label</button>
     <mat-menu #labelMenu="matMenu">
       <button mat-menu-item *ngFor="let label of labels.listed" (click)="labelClick(label, 'add')"><planet-label [label]="label"></planet-label></button>
     </mat-menu>

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -41,7 +41,7 @@
     <mat-menu #labelMenu="matMenu">
       <button mat-menu-item *ngFor="let label of labels.listed" (click)="labelClick(label, 'add')"><planet-label [label]="label"></planet-label></button>
     </mat-menu>
-    <button mat-button i18n *ngIf="showShare" (click)="shareStory(item.doc)" i8n>Share with {
+    <button mat-button *ngIf="showShare" (click)="shareStory(item.doc)" i18n>Share with {
       shareTarget, select, community {Community} nation {Nation} center {Earth}
     }</button>
   </mat-card-actions>

--- a/src/app/news/news-list-item.scss
+++ b/src/app/news/news-list-item.scss
@@ -18,3 +18,31 @@ mat-card {
 mat-card-content {
   margin-bottom: 0;
 }
+
+.chat-chip {
+  color: white;
+  background-color: #2c3e50;
+}
+
+.chat-container {
+  border: dashed 1px #2c3e50;
+  border-radius: 5px;
+  padding: 40px;
+}
+
+.conversation-query {
+  text-align: left;
+  padding: 8px;
+  border-radius: 5px;
+  background-color: #{$primary};
+  color: white;
+}
+
+.conversation-response {
+  margin: 8px 16px;
+}
+
+.conversation-error {
+  color: #ff0000;
+  font-style: italic;
+}

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -56,7 +56,7 @@ export class NewsService {
 
   postNews(post, successMessage = $localize`Thank you for submitting your news`, isMessageEdit = true) {
     const { configuration } = this.stateService;
-    const message = post.chat ? '</br>' : (typeof post.message === 'string' ? post.message : post.message.text);
+    const message = typeof post.message === 'string' ? post.message : post.message.text;
     const images = post.chat ? [] : this.createImagesArray(post, message);
     const newPost = {
       docType: 'message',

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -57,7 +57,7 @@ export class NewsService {
   postNews(post, successMessage = $localize`Thank you for submitting your news`, isMessageEdit = true) {
     const { configuration } = this.stateService;
     const message = typeof post.message === 'string' ? post.message : post.message.text;
-    const images = post.chat ? [] : this.createImagesArray(post, message);
+    const images = this.createImagesArray(post, message);
     const newPost = {
       docType: 'message',
       time: this.couchService.datePlaceholder,
@@ -90,7 +90,7 @@ export class NewsService {
     return this.couchService.bulkDocs(this.dbName, replies.map(reply => ({ ...reply.doc, replyTo: newReplyToId })));
   }
 
-  shareNews(news, planets?: any[]) {
+  shareNews(news, planets?: any[], successMessage = $localize`News has been successfully shared`) {
     const viewInObject = (planet) => (
       { '_id': `${planet.code}@${planet.parentCode}`, section: 'community', sharedDate: this.couchService.datePlaceholder }
     );
@@ -108,7 +108,7 @@ export class NewsService {
           ...newPlanets
         ]
       },
-      $localize`News has been successfully shared`,
+      successMessage,
       false
     );
   }

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -55,9 +55,9 @@ export class NewsService {
   }
 
   postNews(post, successMessage = $localize`Thank you for submitting your news`, isMessageEdit = true) {
-    const configuration = this.stateService.configuration;
-    const message = typeof post.message === 'string' ? post.message : post.message.text;
-    const images = this.createImagesArray(post, message);
+    const { configuration } = this.stateService;
+    const message = post.chat ? '</br>' : (typeof post.message === 'string' ? post.message : post.message.text);
+    const images = post.chat ? [] : this.createImagesArray(post, message);
     const newPost = {
       docType: 'message',
       time: this.couchService.datePlaceholder,

--- a/src/app/shared/dialogs/dialogs-chat-share.component.html
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.html
@@ -1,13 +1,8 @@
-<!-- <h1 mat-dialog-title i18n>Share this conversation</h1> -->
 <mat-dialog-content>
   <h3 i18n>- Share with Community:</h3>
   <div class="share-box">
-    <button mat-icon-button (click)="showForm = !showForm">
-      <mat-icon>{{
-        showForm ? "keyboard_arrow_up" : "keyboard_arrow_down"
-      }}</mat-icon>
-    </button>
-    <i i18n>add note</i>
+    <i i18n style="margin-right: 1rem;">add note</i>
+    <mat-checkbox [checked]="showForm" (change)="showForm = !showForm"></mat-checkbox>
     <form [formGroup]="communityForm" (ngSubmit)="shareWithCommunity()">
       <mat-form-field *ngIf="showForm" class="full-width">
         <textarea

--- a/src/app/shared/dialogs/dialogs-chat-share.component.html
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.html
@@ -1,49 +1,59 @@
 <mat-dialog-content>
-  <h3 i18n>- Share with Community:</h3>
-  <div class="share-box">
-    <i i18n style="margin-right: 1rem;">add note</i>
-    <mat-checkbox [checked]="showForm" (change)="showForm = !showForm"></mat-checkbox>
-    <form [formGroup]="communityForm" (ngSubmit)="shareWithCommunity()">
-      <mat-form-field *ngIf="showForm" class="full-width">
-        <textarea
-          matInput
-          placeholder="Optional message"
-          formControlName="message"
-          i18n-placeholder
-        ></textarea>
-      </mat-form-field>
-      <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>
-        Share
-      </button>
-    </form>
-  </div>
-  <hr>
-  <h3 i18n>- Share with Team/Enterprise:</h3>
-  <div class="share-box">
-    <mat-form-field class="full-width">
-      <mat-label i18n>Team or Entreprise</mat-label>
-      <mat-select [(ngModel)]="selectedLink">
-        <mat-option *ngFor="let link of links" [value]="link">{{link.title}}</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <form [formGroup]="teamForm" (ngSubmit)="shareWithTeam()" *ngIf="selectedLink?.db === 'teams'">
-      <mat-horizontal-stepper #linkStepper linear (selectionChange)="linkStepperChange($event)">
-        <mat-step i18n-label completed="false" label="Select">
-          <planet-teams [mode]="selectedLink?.selector?.type" [isDialog]="true" (rowClick)="teamSelect($event)"></planet-teams>
-        </mat-step>
-        <mat-step i18n-label label="Message" [stepControl]="teamForm">
-          <mat-form-field class="full-width">
-            <textarea matInput i18n-placeholder placeholder="Message" formControlName="message" required></textarea>
-            <mat-error><planet-form-error-messages [control]="teamForm.controls.message"></planet-form-error-messages></mat-error>
+  <mat-accordion [multi]="false">
+    <mat-expansion-panel>
+      <mat-expansion-panel-header>
+        <mat-panel-title> Share with Community </mat-panel-title>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <i i18n style="margin-right: 1rem;">add note</i>
+        <mat-checkbox [checked]="showForm" (change)="showForm = !showForm"></mat-checkbox><br>
+        <form [formGroup]="communityForm" (ngSubmit)="shareWithCommunity()">
+          <mat-form-field *ngIf="showForm" class="full-width">
+            <textarea
+              matInput
+              placeholder="Optional message"
+              formControlName="message"
+              i18n-placeholder
+            ></textarea>
           </mat-form-field>
           <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>
             Share
           </button>
-        </mat-step>
-      </mat-horizontal-stepper>
-    </form>
-  </div>
+        </form>
+      </ng-template>
+    </mat-expansion-panel>
+    <br>
+    <mat-expansion-panel>
+      <mat-expansion-panel-header>
+        <mat-panel-title>Share with Team/Enterprise</mat-panel-title>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <mat-form-field class="full-width">
+          <mat-label i18n>Team or Entreprise</mat-label>
+          <mat-select [(ngModel)]="selectedLink">
+            <mat-option *ngFor="let link of links" [value]="link">{{link.title}}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <form [formGroup]="teamForm" (ngSubmit)="shareWithTeam()" *ngIf="selectedLink?.db === 'teams'">
+          <mat-horizontal-stepper #linkStepper linear (selectionChange)="linkStepperChange($event)">
+            <mat-step i18n-label completed="false" label="Select">
+              <planet-teams [mode]="selectedLink?.selector?.type" [isDialog]="true" (rowClick)="teamSelect($event)"></planet-teams>
+            </mat-step>
+            <mat-step i18n-label label="Message" [stepControl]="teamForm">
+              <mat-form-field class="full-width">
+                <textarea matInput i18n-placeholder placeholder="Optional Message" formControlName="message"></textarea>
+                <mat-error><planet-form-error-messages [control]="teamForm.controls.message"></planet-form-error-messages></mat-error>
+              </mat-form-field>
+              <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>
+                Share
+              </button>
+            </mat-step>
+          </mat-horizontal-stepper>
+        </form>
+      </ng-template>
+    </mat-expansion-panel>
+  </mat-accordion>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button color="primary" mat-raised-button mat-dialog-close i18n>OK</button>
+  <button mat-raised-button mat-dialog-close i18n>Close</button>
 </mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-chat-share.component.html
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.html
@@ -1,0 +1,54 @@
+<!-- <h1 mat-dialog-title i18n>Share this conversation</h1> -->
+<mat-dialog-content>
+  <h3 i18n>- Share with Community:</h3>
+  <div class="share-box">
+    <button mat-icon-button (click)="showForm = !showForm">
+      <mat-icon>{{
+        showForm ? "keyboard_arrow_up" : "keyboard_arrow_down"
+      }}</mat-icon>
+    </button>
+    <i i18n>add note</i>
+    <form [formGroup]="communityForm" (ngSubmit)="shareWithCommunity()">
+      <mat-form-field *ngIf="showForm" class="full-width">
+        <textarea
+          matInput
+          placeholder="Optional message"
+          formControlName="message"
+          i18n-placeholder
+        ></textarea>
+      </mat-form-field>
+      <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>
+        Share
+      </button>
+    </form>
+  </div>
+  <hr>
+  <h3 i18n>- Share with Team/Enterprise:</h3>
+  <div class="share-box">
+    <mat-form-field class="full-width">
+      <mat-label i18n>Team or Entreprise</mat-label>
+      <mat-select [(ngModel)]="selectedLink">
+        <mat-option *ngFor="let link of links" [value]="link">{{link.title}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <form [formGroup]="teamForm" (ngSubmit)="shareWithTeam()" *ngIf="selectedLink?.db === 'teams'">
+      <mat-horizontal-stepper #linkStepper linear (selectionChange)="linkStepperChange($event)">
+        <mat-step i18n-label completed="false" label="Select">
+          <planet-teams [mode]="selectedLink?.selector?.type" [isDialog]="true" (rowClick)="teamSelect($event)"></planet-teams>
+        </mat-step>
+        <mat-step i18n-label label="Message" [stepControl]="teamForm">
+          <mat-form-field class="full-width">
+            <textarea matInput i18n-placeholder placeholder="Message" formControlName="message" required></textarea>
+            <mat-error><planet-form-error-messages [control]="teamForm.controls.message"></planet-form-error-messages></mat-error>
+          </mat-form-field>
+          <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>
+            Share
+          </button>
+        </mat-step>
+      </mat-horizontal-stepper>
+    </form>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button color="primary" mat-raised-button mat-dialog-close i18n>OK</button>
+</mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-chat-share.component.html
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.html
@@ -11,10 +11,9 @@
           <mat-form-field *ngIf="showForm" class="full-width">
             <textarea
               matInput
-              placeholder="Message"
+              placeholder="Optional message"
               formControlName="message"
               i18n-placeholder
-              required
             ></textarea>
           </mat-form-field>
           <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>

--- a/src/app/shared/dialogs/dialogs-chat-share.component.html
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.html
@@ -11,9 +11,10 @@
           <mat-form-field *ngIf="showForm" class="full-width">
             <textarea
               matInput
-              placeholder="Optional message"
+              placeholder="Message"
               formControlName="message"
               i18n-placeholder
+              required
             ></textarea>
           </mat-form-field>
           <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>
@@ -37,11 +38,11 @@
         <form [formGroup]="teamForm" (ngSubmit)="shareWithTeam()" *ngIf="selectedLink?.db === 'teams'">
           <mat-horizontal-stepper #linkStepper linear (selectionChange)="linkStepperChange($event)">
             <mat-step i18n-label completed="false" label="Select">
-              <planet-teams [mode]="selectedLink?.selector?.type" [isDialog]="true" (rowClick)="teamSelect($event)"></planet-teams>
+              <planet-teams [mode]="selectedLink?.selector?.type" [isDialog]="true" [excludeIds]="excludeIds" (rowClick)="teamSelect($event)"></planet-teams>
             </mat-step>
             <mat-step i18n-label label="Message" [stepControl]="teamForm">
               <mat-form-field class="full-width">
-                <textarea matInput i18n-placeholder placeholder="Optional Message" formControlName="message"></textarea>
+                <textarea matInput i18n-placeholder placeholder="Message" formControlName="message" required></textarea>
                 <mat-error><planet-form-error-messages [control]="teamForm.controls.message"></planet-form-error-messages></mat-error>
               </mat-form-field>
               <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ViewChild } from '@angular/core';
+import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatStepper } from '@angular/material/stepper';
@@ -14,9 +14,9 @@ import { TeamsService } from '../../teams/teams.service';
     .share-box {
       margin-left: 1.5rem;
     }
-  `]
+  ` ]
 })
-export class DialogsChatShareComponent {
+export class DialogsChatShareComponent implements OnInit {
   conversation: any;
   showForm: boolean;
   teamForm: FormGroup;
@@ -42,7 +42,7 @@ export class DialogsChatShareComponent {
 
   ngOnInit() {
     this.communityForm = this.formBuilder.group({
-      message: ['']
+      message: [ '' ]
     });
     this.teamForm = this.formBuilder.group({
       message: [ '', CustomValidators.required, ac => this.validatorService.isUnique$('teams', 'title', ac, {}) ],

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -1,55 +1,85 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatStepper } from '@angular/material/stepper';
 
+import { CustomValidators } from '../../validators/custom-validators';
+import { ValidatorService } from '../../validators/validator.service';
 import { NewsService } from '../../news/news.service';
+import { TeamsService } from '../../teams/teams.service';
 
 @Component({
-  template: `
-  <h2 mat-dialog-title i18n>Share this conversation</h2>
-  <mat-dialog-content>
-    <h4 i18n>- Share with Community: </h4>
-    <div style="margin-left: 1.5rem">
-      <button mat-icon-button (click)="showForm = !showForm">
-        <mat-icon>{{showForm ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}</mat-icon>
-      </button>
-      <i i18n>add message</i>
-      <form [formGroup]="shareChatForm" (ngSubmit)="shareWithCommunity()">
-        <mat-form-field *ngIf="showForm" style="margin-right: 2rem;">
-          <textarea matInput placeholder="Optional message" formControlName="message" i18n-placeholder></textarea>
-        </mat-form-field>
-        <button mat-raised-button color="primary" type="submit" i18n>Share</button>
-      </form>
-    </div>
-  </mat-dialog-content>
-  <mat-dialog-actions>
-    <button color="primary" mat-raised-button mat-dialog-close i18n>OK</button>
-  </mat-dialog-actions>
-  `
+  templateUrl: './dialogs-chat-share.component.html',
+  styles: [ `
+    .share-box {
+      margin-left: 1.5rem;
+    }
+  `]
 })
 export class DialogsChatShareComponent {
   conversation: any;
   showForm: boolean;
-  shareChatForm: FormGroup;
+  teamForm: FormGroup;
+  communityForm: FormGroup;
+
+  @ViewChild('linkStepper') linkStepper: MatStepper;
+  selectedLink: { db, title, selector? };
+  links: { db, title, selector? }[] = [
+    { db: 'teams', title: $localize`Teams`, selector: { type: 'team' } },
+    { db: 'teams', title: $localize`Enterprises`, selector: { type: 'enterprise' } }
+  ];
 
   constructor(
     public dialogRef: MatDialogRef<DialogsChatShareComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any,
     private formBuilder: FormBuilder,
-    private newsService: NewsService
+    private newsService: NewsService,
+    private teamsService: TeamsService,
+    private validatorService: ValidatorService
   ) {
     this.conversation = data || this.conversation;
   }
 
   ngOnInit() {
-    this.shareChatForm = this.formBuilder.group({
+    this.communityForm = this.formBuilder.group({
       message: ['']
+    });
+    this.teamForm = this.formBuilder.group({
+      message: [ '', CustomValidators.required, ac => this.validatorService.isUnique$('teams', 'title', ac, {}) ],
+      route: [ '', CustomValidators.required ],
+      linkId: '',
+      teamType: ''
     });
   }
 
+  teamSelect({ mode, teamId, teamType }) {
+    this.teamForm.controls.route.setValue(this.teamsService.teamLinkRoute(mode, teamId));
+    this.teamForm.controls.linkId.setValue(teamId);
+    this.teamForm.controls.teamType.setValue(teamType);
+    this.linkStepper.selected.completed = true;
+    this.linkStepper.next();
+  }
+
+  linkStepperChange({ selectedIndex }) {
+    if (selectedIndex === 0 && this.teamForm.pristine !== true) {
+      this.teamForm.reset();
+    }
+  }
+
+  shareWithTeam() {
+    if (this.teamForm.valid) {
+      const team = this.teamForm.value;
+
+      this.conversation.message = team.message ? team.message : '</br>';
+      this.conversation.team = team;
+    }
+    this.conversation.chat = true;
+    console.log(this.conversation);
+  }
+
   shareWithCommunity() {
-    if (this.shareChatForm.valid) {
-      const message = this.shareChatForm.get('message').value;
+    if (this.communityForm.valid) {
+      const message = this.communityForm.get('message').value;
       this.conversation.message = message ? message : '</br>';
     }
     this.conversation.chat = true;

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -11,8 +11,8 @@ import { TeamsService } from '../../teams/teams.service';
 @Component({
   templateUrl: './dialogs-chat-share.component.html',
   styles: [ `
-    .share-box {
-      margin-left: 1.5rem;
+    .mat-expansion-panel {
+      box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.1);
     }
   ` ]
 })

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -1,0 +1,38 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+// import { DialogsLoadingService } from './dialogs-loading.service';
+
+import { NewsService } from '../../news/news.service';
+
+@Component({
+  template: `
+  <h3 mat-dialog-title i18n>Share this conversation</h3>
+  <mat-dialog-content>
+    <span i18n>Share with Community  </span>
+    <button mat-raised-button (click)="shareWithCommunity()" i18n>
+      Share
+    </button>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button color="primary" mat-raised-button mat-dialog-close i18n>OK</button>
+  </mat-dialog-actions>
+  `
+})
+export class DialogsChatShareComponent {
+  conversation: any;
+
+  constructor(
+    public dialogRef: MatDialogRef<DialogsChatShareComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    // private dialogsLoadingService: DialogsLoadingService
+    private newsService: NewsService
+  ) {
+    this.conversation = data || this.conversation;
+  }
+
+  shareWithCommunity() {
+    this.conversation.chat = true;
+    this.newsService.shareNews(this.conversation).subscribe(() => {});
+  }
+
+}

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -1,17 +1,26 @@
 import { Component, Inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-// import { DialogsLoadingService } from './dialogs-loading.service';
 
 import { NewsService } from '../../news/news.service';
 
 @Component({
   template: `
-  <h3 mat-dialog-title i18n>Share this conversation</h3>
+  <h2 mat-dialog-title i18n>Share this conversation</h2>
   <mat-dialog-content>
-    <span i18n>Share with Community  </span>
-    <button mat-raised-button (click)="shareWithCommunity()" i18n>
-      Share
-    </button>
+    <h4 i18n>- Share with Community: </h4>
+    <div style="margin-left: 1.5rem">
+      <button mat-icon-button (click)="showForm = !showForm">
+        <mat-icon>{{showForm ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}</mat-icon>
+      </button>
+      <i i18n>add message</i>
+      <form [formGroup]="shareChatForm" (ngSubmit)="shareWithCommunity()">
+        <mat-form-field *ngIf="showForm" style="margin-right: 2rem;">
+          <textarea matInput placeholder="Optional message" formControlName="message" i18n-placeholder></textarea>
+        </mat-form-field>
+        <button mat-raised-button color="primary" type="submit" i18n>Share</button>
+      </form>
+    </div>
   </mat-dialog-content>
   <mat-dialog-actions>
     <button color="primary" mat-raised-button mat-dialog-close i18n>OK</button>
@@ -20,17 +29,29 @@ import { NewsService } from '../../news/news.service';
 })
 export class DialogsChatShareComponent {
   conversation: any;
+  showForm: boolean;
+  shareChatForm: FormGroup;
 
   constructor(
     public dialogRef: MatDialogRef<DialogsChatShareComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any,
-    // private dialogsLoadingService: DialogsLoadingService
+    private formBuilder: FormBuilder,
     private newsService: NewsService
   ) {
     this.conversation = data || this.conversation;
   }
 
+  ngOnInit() {
+    this.shareChatForm = this.formBuilder.group({
+      message: ['']
+    });
+  }
+
   shareWithCommunity() {
+    if (this.shareChatForm.valid) {
+      const message = this.shareChatForm.get('message').value;
+      this.conversation.message = message ? message : '</br>';
+    }
     this.conversation.chat = true;
     this.newsService.shareNews(this.conversation).subscribe(() => {});
   }

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { forkJoin } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
@@ -53,7 +53,7 @@ export class DialogsChatShareComponent implements OnInit {
 
   ngOnInit() {
     this.communityForm = this.formBuilder.group({
-      message: [ '', Validators.required ]
+      message: [ '' ]
     });
     this.teamForm = this.formBuilder.group({
       message: [ '', CustomValidators.required, ac => this.validatorService.isUnique$('teams', 'title', ac, {}) ],
@@ -104,9 +104,9 @@ export class DialogsChatShareComponent implements OnInit {
     this.excludeIds = [ ...this.excludeIds, ...difference.map(team => team._id) ];
   }
 
-  sendNotifications(type, members) {
+  sendNotifications(type, members, teamType) {
     return this.teamsService.sendNotifications(type, members, {
-      url: 'teams/view/' + this.teamInfo._id, team: { ...this.teamInfo }
+      url: `${teamType}/view/${this.teamInfo._id}`, team: { ...this.teamInfo }
     });
   }
 
@@ -126,15 +126,13 @@ export class DialogsChatShareComponent implements OnInit {
     ).subscribe((membersData) => {
       this.conversation.chat = true;
 
-      console.log(membersData);
-
       this.newsService.postNews({
         viewIn: [ { '_id': linkId, section: 'teams', public: false } ],
         messageType: teamType,
         messagePlanetCode: this.teamInfo.planetCode,
         ...this.conversation
       }, $localize`Chat has been shared to ${this.teamInfo.type} ${this.teamInfo.name}`).pipe(
-        switchMap(() => this.sendNotifications('message', membersData)),
+        switchMap(() => this.sendNotifications('message', membersData, teamType)),
       ).subscribe();
     });
   }

--- a/src/app/shared/dialogs/dialogs-chat-share.module.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.module.ts
@@ -1,0 +1,21 @@
+import { MaterialModule } from '../material.module';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MeetupsModule } from '../../meetups/meetups.module';
+import { DialogsChatShareComponent } from './dialogs-chat-share.component';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MaterialModule,
+    MeetupsModule
+  ],
+  exports: [
+    DialogsChatShareComponent
+  ],
+  declarations: [
+    DialogsChatShareComponent
+  ]
+})
+export class DialogsChatShareModule {}

--- a/src/app/shared/dialogs/dialogs-chat-share.module.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PlanetFormsModule } from '../forms/planet-forms.module';
 
 import { MeetupsModule } from '../../meetups/meetups.module';
+import { TeamsModule } from '../../teams/teams.module';
 import { DialogsChatShareComponent } from './dialogs-chat-share.component';
 
 
@@ -16,6 +17,7 @@ import { DialogsChatShareComponent } from './dialogs-chat-share.component';
     MaterialModule,
     MeetupsModule,
     PlanetFormsModule,
+    TeamsModule,
     ReactiveFormsModule
   ],
   exports: [

--- a/src/app/shared/dialogs/dialogs-chat-share.module.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.module.ts
@@ -1,13 +1,13 @@
-import { MaterialModule } from '../material.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { MaterialModule } from '../material.module';
+import { TeamsModule } from '../../teams/teams.module';
+import { MeetupsModule } from '../../meetups/meetups.module';
 import { PlanetFormsModule } from '../forms/planet-forms.module';
 
-import { MeetupsModule } from '../../meetups/meetups.module';
-import { TeamsModule } from '../../teams/teams.module';
 import { DialogsChatShareComponent } from './dialogs-chat-share.component';
-
 
 
 @NgModule({
@@ -17,8 +17,8 @@ import { DialogsChatShareComponent } from './dialogs-chat-share.component';
     MaterialModule,
     MeetupsModule,
     PlanetFormsModule,
-    TeamsModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    TeamsModule
   ],
   exports: [
     DialogsChatShareComponent

--- a/src/app/shared/dialogs/dialogs-chat-share.module.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.module.ts
@@ -1,15 +1,22 @@
 import { MaterialModule } from '../material.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { PlanetFormsModule } from '../forms/planet-forms.module';
+
 import { MeetupsModule } from '../../meetups/meetups.module';
 import { DialogsChatShareComponent } from './dialogs-chat-share.component';
+
 
 
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     MaterialModule,
-    MeetupsModule
+    MeetupsModule,
+    PlanetFormsModule,
+    ReactiveFormsModule
   ],
   exports: [
     DialogsChatShareComponent

--- a/src/app/shared/label.component.ts
+++ b/src/app/shared/label.component.ts
@@ -14,6 +14,7 @@ import { Component, Input } from '@angular/core';
       help {Help Wanted}
       offer {Offer}
       advice {Request for Advice}
+      shared chat {Shared Chat}
       Cancer {Cancer}
       Cardiovascular disorders {Cardiovascular disorders}
       Cirrhosis of the liver {Cirrhosis of the liver}


### PR DESCRIPTION
Fixes #7455 

Enable chat sharing with communities and teams.
- Custom label for shared chats.
- Send a message with the chat.