### PR TITLE
chat: sharing improvements (fixes #7466)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.35",
+  "version": "0.14.36",
   "myplanet": {
-    "latest": "v0.15.39",
-    "min": "v0.14.39"
+    "latest": "v0.15.47",
+    "min": "v0.14.47"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -47,7 +47,7 @@
     </button>
     <span class="toolbar-fill"></span>
     <ng-container *ngIf="item.doc.user.name === currentUser.name">
-      <button mat-icon-button type="button" (click)="editNews(item.doc)" *ngIf="!item.doc.chat"><mat-icon>edit</mat-icon></button>
+      <button mat-icon-button type="button" (click)="editNews(item.doc)"><mat-icon>edit</mat-icon></button>
       <button mat-icon-button type="button" (click)="openDeleteDialog(item.doc)"><mat-icon>delete</mat-icon></button>
     </ng-container>
     <button mat-button i18n *ngIf="editable && !item.doc.chat" [matMenuTriggerFor]="labelMenu" [disabled]="labels.listed.length === 0">Add Label</button>

--- a/src/app/news/news-list-item.scss
+++ b/src/app/news/news-list-item.scss
@@ -46,3 +46,15 @@ mat-card-content {
   color: #ff0000;
   font-style: italic;
 }
+
+@media (max-width: $screen-md) {
+  .chat-container {
+    padding: 20px;
+  }
+}
+
+@media (max-width: $screen-sm) {
+  .chat-container {
+    padding: 10px;
+  }
+}

--- a/src/app/shared/dialogs/dialogs-chat-share.component.html
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.html
@@ -41,7 +41,7 @@
             </mat-step>
             <mat-step i18n-label label="Message" [stepControl]="teamForm">
               <mat-form-field class="full-width">
-                <textarea matInput i18n-placeholder placeholder="Message" formControlName="message" required></textarea>
+                <textarea matInput i18n-placeholder placeholder="Message" formControlName="message"></textarea>
                 <mat-error><planet-form-error-messages [control]="teamForm.controls.message"></planet-form-error-messages></mat-error>
               </mat-form-field>
               <button mat-raised-button color="primary" type="submit" mat-dialog-close i18n>

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -6,12 +6,10 @@ import { forkJoin } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
 
 
-import { CustomValidators } from '../../validators/custom-validators';
 import { CouchService } from '../../shared/couchdb.service';
 import { NewsService } from '../../news/news.service';
 import { TeamsService } from '../../teams/teams.service';
 import { UserService } from '../../shared/user.service';
-import { ValidatorService } from '../../validators/validator.service';
 
 @Component({
   templateUrl: './dialogs-chat-share.component.html',
@@ -46,7 +44,6 @@ export class DialogsChatShareComponent implements OnInit {
     private newsService: NewsService,
     private teamsService: TeamsService,
     private userService: UserService,
-    private validatorService: ValidatorService
   ) {
     this.conversation = data || this.conversation;
   }
@@ -56,16 +53,14 @@ export class DialogsChatShareComponent implements OnInit {
       message: [ '' ]
     });
     this.teamForm = this.formBuilder.group({
-      message: [ '', CustomValidators.required, ac => this.validatorService.isUnique$('teams', 'title', ac, {}) ],
-      route: [ '', CustomValidators.required ],
-      linkId: '',
-      teamType: ''
+      message: [ '' ],
+      linkId: [ '' ],
+      teamType: [ '' ]
     });
     this.getTeams();
   }
 
-  teamSelect({ mode, teamId, teamType }) {
-    this.teamForm.controls.route.setValue(this.teamsService.teamLinkRoute(mode, teamId));
+  teamSelect({ teamId, teamType }) {
     this.teamForm.controls.linkId.setValue(teamId);
     this.teamForm.controls.teamType.setValue(teamType);
     this.linkStepper.selected.completed = true;

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -50,12 +50,12 @@ export class DialogsChatShareComponent implements OnInit {
 
   ngOnInit() {
     this.communityForm = this.formBuilder.group({
-      message: [ '' ]
+      message: ''
     });
     this.teamForm = this.formBuilder.group({
-      message: [ '' ],
-      linkId: [ '' ],
-      teamType: [ '' ]
+      message: '',
+      linkId: '',
+      teamType: ''
     });
     this.getTeams();
   }


### PR DESCRIPTION
Minor Improvements to the chat sharing.

- Allow sharing with the team/enterprise without a message
- Allow the users to edit the message of the shared chat
- Mobile/Tablet responsiveness of the Shared chat

Tablet view:
![image](https://github.com/open-learning-exchange/planet/assets/48474421/512ef3ad-2a6c-4272-bff0-d619974befd9)

Mobile view:
![image](https://github.com/open-learning-exchange/planet/assets/48474421/d063fb3a-7631-43af-b298-449f71a11e54)
