### PR TITLE
chat: smoother redirection (fixes #7472)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.38",
+  "version": "0.14.39",
   "myplanet": {
-    "latest": "v0.15.54",
-    "min": "v0.14.54"
+    "latest": "v0.15.60",
+    "min": "v0.14.60"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -74,7 +74,7 @@ import { CouchService } from '../shared/couchdb.service';
 
   // Function to close ws connection
   closeWebSocket(): void {
-    if (this.socket.readyState === WebSocket.OPEN) {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
       this.socket.close();
     }
   }


### PR DESCRIPTION
Fixes #7472 

Fixes the blank page that happens on redirecting from the chat

To replicate: streaming is set to off on the manager dashboard
Caused by websocket trying to be closed when it is not defined