### PR TITLE
teams: smoother courses view (fixes #7513)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.51",
+  "version": "0.14.54",
   "myplanet": {
-    "latest": "v0.16.70",
-    "min": "v0.15.78"
+    "latest": "v0.17.18",
+    "min": "v0.16.18"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -121,15 +121,15 @@
               <mat-card *ngFor="let resource of resources" (click)="resource.resource._attachments ? openResource(resource.resource._id) : false" i18n-matTooltip matTooltip="There is no content for this resource" [matTooltipDisabled]="resource.resource._attachments" [ngClass]="{'cursor-pointer': resource.resource._attachments}">
                 <div class="mat-subheading-2">
                   <span *ngIf="resource.resource!==undefined">
-                    <b>{{resource.resource.title}}</b>
+                    <b>{{resource.resource.title?.length > 75 ? resource.resource.title.slice(0,75) + '...' : resource.resource.title}}</b>
                   </span>
                   <span *ngIf="resource.resource===undefined" i18n-matTooltip
                     matTooltip="Resource unavailable. Contact your administrator to add resource to this Planet.">
-                    {{resource.linkDoc.title}}
+                    {{resource.linkDoc.title?.length > 75 ? resource.linkDoc.title.slice(0,75) + '...' : resource.linkDoc.title}}
                   </span>
                 </div>
                 <mat-card-content>
-                  <planet-markdown [content]="resource.resource.description || ''"></planet-markdown>
+                  <planet-markdown [content]="(resource.resource.description | slice:0:120) + (resource.resource.description.length > 120 ? '...' : '')"></planet-markdown>
                 </mat-card-content>
                 <button class="top-right-icon" *ngIf="userStatus === 'member'" mat-icon-button [matMenuTriggerFor]="resourceMenu" (click)="$event.stopPropagation()">
                   <mat-icon>more_vert</mat-icon>
@@ -156,9 +156,11 @@
           <ng-template #courseList>
             <div class="card-grid">
               <mat-card *ngFor="let course of team?.courses" (click)="openCourseView(course._id)" class="cursor-pointer">
-                <div class="mat-subheading-2"><b>{{course.courseTitle}}</b></div>
+                <div class="mat-subheading-2">
+                  <b>{{course.courseTitle?.length > 75 ? course.courseTitle.slice(0,75) + '...' : course.courseTitle }}</b>
+                </div>
                 <mat-card-content>
-                  <planet-markdown [content]="course.description || ''"></planet-markdown>
+                  <planet-markdown [content]="(course.description | slice:0:120) + (course.description.length > 120 ? '...' : '')"></planet-markdown>
                 </mat-card-content>
                 <button class="top-right-icon" *ngIf="userStatus === 'member'" mat-icon-button [matMenuTriggerFor]="courseMenu" (click)="$event.stopPropagation()">
                   <mat-icon>more_vert</mat-icon>


### PR DESCRIPTION
Fixes #7513

- Slice course/resource titles and desciptions to avoid text-overflow.


![image](https://github.com/user-attachments/assets/30f652db-d4cc-4f32-8a01-ace314d74ccb)
