### PR TITLE
courses: smoother chat view (fixes #7527)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.59",
+  "version": "0.14.60",
   "myplanet": {
-    "latest": "v0.17.37",
-    "min": "v0.16.37"
+    "latest": "v0.17.42",
+    "min": "v0.16.42"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -10,7 +10,7 @@
     </button>
     <span class="toolbar-fill"></span>
     <div>
-      <button mat-icon-button (click)="this.isGridView = !this.isGridView">
+      <button mat-icon-button *ngIf="resource?._attachments" (click)="this.isGridView = !this.isGridView">
         <mat-icon>{{isGridView ? 'view_list' : 'view_column'}}</mat-icon>
       </button>
       <span class="margin-lr-10" *ngIf="attempts && !parent" i18n>Past attempts: {{attempts}}</span>

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -10,7 +10,7 @@
     </button>
     <span class="toolbar-fill"></span>
     <div>
-      <button mat-icon-button *ngIf="resource?._attachments" (click)="this.isGridView = !this.isGridView">
+      <button mat-icon-button *ngIf="resource?._attachments && !showChat" (click)="this.isGridView = !this.isGridView">
         <mat-icon>{{isGridView ? 'view_list' : 'view_column'}}</mat-icon>
       </button>
       <span class="margin-lr-10" *ngIf="attempts && !parent" i18n>Past attempts: {{attempts}}</span>
@@ -76,16 +76,23 @@
       <button mat-raised-button *ngIf="stepNum === maxStep && maxStep !== 1" [disabled]="!parent && stepDetail?.exam?.questions.length > 0 && !attempts" (click)="backToCourseDetail()" i18n>Finish</button>
     </div>
   </mat-toolbar>
-  <div class="view-container view-full-height" [ngClass]="{'flex-view': !isGridView}" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">
+  <div class="view-container view-full-height" [ngClass]="{'grid-view': showChat, 'flex-view': !isGridView && !showChat}" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">
     <planet-chat-window *ngIf="stepDetail?.description && showChat" [context]="{type: 'coursestep', data: localizedStepInfo}"></planet-chat-window>
-    <planet-markdown *ngIf="stepDetail?.description" class="description img-resize" [content]="stepDetail.description"></planet-markdown>
-    <planet-resources-viewer
-      [ngClass]="{'center-resource': resource?.mediaType !== 'pdf'}"
-      *ngIf="resource?._attachments"
-      [fetchRating]="false"
-      [resourceId]="resource._id"
-      (resourceUrl)="setResourceUrl($event)">
-    </planet-resources-viewer>
+    <ng-container *ngIf="showChat; else stepViewContent">
+      <div class="flex-view">
+        <ng-container *ngTemplateOutlet="stepViewContent"></ng-container>
+      </div>
+    </ng-container>
+    <ng-template #stepViewContent>
+      <planet-markdown *ngIf="stepDetail?.description" class="description img-resize" [content]="stepDetail.description"></planet-markdown>
+      <planet-resources-viewer
+        [ngClass]="{'center-resource': resource?.mediaType !== 'pdf'}"
+        *ngIf="resource?._attachments"
+        [fetchRating]="false"
+        [resourceId]="resource._id"
+        (resourceUrl)="setResourceUrl($event)">
+      </planet-resources-viewer>
+    </ng-template>
   </div>
   <ng-template #emptyRecord>
     <div class="view-container view-full-height" i18n>No description provided.</div>

--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -25,6 +25,13 @@
     }
   }
 
+  .grid-view {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
+    grid-column-gap: 1rem;
+  }
+
   .center-resource {
     align-self: center;
   }


### PR DESCRIPTION
Fixes #7527 

- Adjust the grid view to only show 2 columns when the chat window is active. The resource-viewer & markdown appear in flex view  when the chat window is active
- Only show the flex/grid view toggle when the chat window is not active


![image](https://github.com/user-attachments/assets/a2b5c7ab-2eff-4ded-948d-ede644453618)
