### PR TITLE
resources: fullscreen for pdfs (fixes #7531)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.60",
+  "version": "0.14.61",
   "myplanet": {
-    "latest": "v0.17.42",
-    "min": "v0.16.42"
+    "latest": "v0.17.70",
+    "min": "v0.16.70"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/resources/view-resources/resources-viewer.component.html
+++ b/src/app/resources/view-resources/resources-viewer.component.html
@@ -6,8 +6,15 @@
   <audio controls [src]="resourceSrc" *ngSwitchCase="'audio'" i18n>
     Browser not supported
   </audio>
-  <iframe [src]="pdfSrc" *ngSwitchCase="'pdf'" width="100%" height="100%" allowfullscreen mozallowfullscreen webkitallowfullscreen
-    oallowfullscreen msallowfullscreen ></iframe>
+  <div *ngSwitchCase="'pdf'" style="position: relative;">
+    <div class="pdf-toolbar">
+      <button mat-icon-button style="color: white" (click)="openFullscreen()">
+        <mat-icon>fullscreen</mat-icon>
+      </button>
+    </div>
+    <iframe #pdfViewer [src]="pdfSrc" width="100%" height="100%" allowfullscreen mozallowfullscreen webkitallowfullscreen
+      oallowfullscreen msallowfullscreen></iframe>
+  </div>
   <div *ngSwitchCase="'other'"><a mat-raised-button color="primary" i18n href={{resourceSrc}}>Download/Open</a></div>
   <iframe *ngSwitchCase="'HTML'" [src]="pdfSrc"></iframe>
 </div>

--- a/src/app/resources/view-resources/resources-viewer.component.ts
+++ b/src/app/resources/view-resources/resources-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, EventEmitter, Output } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, EventEmitter, Output, ViewChild, ElementRef } from '@angular/core';
 
 import { DomSanitizer } from '@angular/platform-browser';
 import { environment } from '../../../environments/environment';
@@ -29,6 +29,7 @@ export class ResourcesViewerComponent implements OnChanges, OnDestroy {
   parent = this.route.snapshot.data.parent;
   pdfSrc: any;
   private onDestroy$ = new Subject<void>();
+  @ViewChild('pdfViewer') pdfViewer: ElementRef;
 
   constructor(
     private sanitizer: DomSanitizer,
@@ -101,6 +102,19 @@ export class ResourcesViewerComponent implements OnChanges, OnDestroy {
     }
     // Emit resource src so parent component can use for links
     this.resourceUrl.emit(this.resourceSrc);
+  }
+
+  openFullscreen() {
+    const elem = this.pdfViewer.nativeElement;
+    if (elem.requestFullscreen) {
+      elem.requestFullscreen();
+    } else if (elem.mozRequestFullScreen) { /* Firefox */
+      elem.mozRequestFullScreen();
+    } else if (elem.webkitRequestFullscreen) { /* Chrome, Safari & Opera */
+      elem.webkitRequestFullscreen();
+    } else if (elem.msRequestFullscreen) { /* IE/Edge */
+      elem.msRequestFullscreen();
+    }
   }
 
 }

--- a/src/app/resources/view-resources/resources-viewer.scss
+++ b/src/app/resources/view-resources/resources-viewer.scss
@@ -31,6 +31,13 @@ $full-height: calc(#{$view-container-height} - 2rem);
 
   }
 
+  .pdf-toolbar {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+
 }
 
 .image-fit {


### PR DESCRIPTION
Fixes #7531 

Update the resources-viewer to support full-screen mode when working with pdfs

![image](https://github.com/user-attachments/assets/cab72546-ca80-4f9c-b8b2-a4dacde28250)

![image](https://github.com/user-attachments/assets/fb8c193e-f3ad-4b77-bb4b-b30f82e16251)
