### PR TITLE
courses: improve resources list in view (fixes #7554)

### DIFF
--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -63,13 +63,6 @@
         i18n>
         View Resource Details
       </a>
-      <mat-form-field *ngIf="stepDetail.resources.length > 1">
-        <mat-select i18n-placeholder placeholder="List of Resources" [value]="resource" (selectionChange)="onResourceChange($event.value)">
-          <mat-option class="margin-lr-10" *ngFor="let resource of stepDetail.resources; index as i" [value]="resource">
-            {{ resource.title }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
       <span>{{stepNum}}/{{maxStep}}</span>
       <button mat-icon-button *ngIf="maxStep !== 1" [disabled]="stepNum === 1" (click)="changeStep(-1)"><mat-icon>navigate_before</mat-icon></button>
       <button mat-icon-button *ngIf="stepNum !== maxStep"  [disabled]="stepNum === maxStep || (!parent && stepDetail?.exam?.questions.length > 0 && !attempts)" (click)="changeStep(1)"><mat-icon>navigate_next</mat-icon></button>
@@ -85,13 +78,18 @@
     </ng-container>
     <ng-template #stepViewContent>
       <planet-markdown *ngIf="stepDetail?.description" class="description img-resize" [content]="stepDetail.description"></planet-markdown>
-      <planet-resources-viewer
-        [ngClass]="{'center-resource': resource?.mediaType !== 'pdf'}"
-        *ngIf="resource?._attachments"
-        [fetchRating]="false"
-        [resourceId]="resource._id"
-        (resourceUrl)="setResourceUrl($event)">
-      </planet-resources-viewer>
+      <div>
+        <mat-button-toggle-group class="full-width-toggle-group" *ngIf="stepDetail.resources.length > 1" [(ngModel)]="resource" (change)="onResourceChange($event.value)">
+          <mat-button-toggle *ngFor="let resource of stepDetail.resources; index as i" [value]="resource" class="full-width-toggle" i18n>{{resource.title}}</mat-button-toggle>
+        </mat-button-toggle-group>
+        <planet-resources-viewer
+          [ngClass]="{'center-resource': resource?.mediaType !== 'pdf'}"
+          *ngIf="resource?._attachments"
+          [fetchRating]="false"
+          [resourceId]="resource._id"
+          (resourceUrl)="setResourceUrl($event)">
+        </planet-resources-viewer>
+      </div>
     </ng-template>
   </div>
   <ng-template #emptyRecord>

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -80,7 +80,7 @@
       <planet-markdown *ngIf="stepDetail?.description" class="description img-resize" [content]="stepDetail.description"></planet-markdown>
       <div>
         <mat-button-toggle-group class="full-width-toggle-group" *ngIf="stepDetail.resources.length > 1" [(ngModel)]="resource" (change)="onResourceChange($event.value)">
-          <mat-button-toggle *ngFor="let resource of stepDetail.resources; index as i" [value]="resource" class="full-width-toggle" i18n>{{resource.title}}</mat-button-toggle>
+          <mat-button-toggle *ngFor="let resource of stepDetail.resources; index as i" [value]="resource" class="full-width-toggle" [matTooltip]="resource.title" i18n>{{resource.title}}</mat-button-toggle>
         </mat-button-toggle-group>
         <planet-resources-viewer
           [ngClass]="{'center-resource': resource?.mediaType !== 'pdf'}"

--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -40,4 +40,20 @@
     max-width: 100%;
   }
 
+  .full-width-toggle-group {
+    width: 100%;
+    display: flex;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  .full-width-toggle {
+    flex: 1;
+    text-align: center;
+    box-sizing: border-box;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
 }


### PR DESCRIPTION
Fixes #7554

Enhance the display of multiple resources in the course view screen to reduce clutter in the toolbar and optimize user experience.

Old View:
![image](https://github.com/user-attachments/assets/9d2f4e06-5be8-4839-a5e8-1b65d243017d)


Current View:
![image](https://github.com/user-attachments/assets/a5b2c3e3-01e9-470f-80ba-7d0957620024)

