### PR TITLE
chat: smoother provider management (fixes #7558)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.69",
+  "version": "0.14.72",
   "myplanet": {
     "latest": "v0.18.99",
     "min": "v0.17.99"

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { catchError } from 'rxjs/operators';
-import { of } from 'rxjs';
 
 import { ChatService } from '../shared/chat.service';
 import { AIServices, ProviderName } from './chat.model';
@@ -23,24 +21,20 @@ export class ChatComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.chatService.fetchAIProviders().pipe(
-      catchError(err => {
-        console.error(err);
-        return of({ openai: false, perplexity: false, gemini: false });
-      })
-    ).subscribe((services: AIServices) => {
-      for (const [ key, value ] of Object.entries(services)) {
-        if (value === true) {
+    this.chatService.listAIProviders().subscribe((services: AIServices | null) => {
+      if (services) {
+        for (const [ key, value ] of Object.entries(services)) {
+          if (value === true) {
             this.aiServices.push({
-               name: key as ProviderName,
-               value: key as ProviderName
+              name: key as ProviderName,
+              value: key as ProviderName
             });
+          }
         }
+        this.activeService = this.aiServices[0].value;
+        this.displayToggle = this.aiServices.length > 0;
+        this.chatService.toggleAIServiceSignal(this.activeService);
       }
-
-      this.activeService = this.aiServices[0].value;
-      this.displayToggle = this.aiServices.length > 0;
-      this.chatService.toggleAIServiceSignal(this.activeService);
     });
   }
 


### PR DESCRIPTION
Fixes #7558

Implement state management for providers to avoid calls to the `checkproviders` endpoint on every chat component init, Instead have it once on app init