### PR TITLE
manager: smoother courses progress export (fixes #7601)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.89",
+  "version": "0.14.90",
   "myplanet": {
-    "latest": "v0.20.13",
-    "min": "v0.19.13"
+    "latest": "v0.20.22",
+    "min": "v0.19.22"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -218,7 +218,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     this.activityService.courseProgressReport().subscribe(({ enrollments, completions, steps, courses }) => {
       this.progress.enrollments.data = enrollments;
       this.progress.completions.data = completions;
-      this.progress.steps.data = steps.map(step => ({ ...step, user: step.userId.replace('org.couchdb.user:', '') }));
+      this.progress.steps.data = steps.map(({ userId, ...step }) => ({ ...step, user: userId.replace('org.couchdb.user:', '') }));
       this.setStepCompletion();
       this.courseActivities.total.data = this.courseActivities.total.data.map(courseActivity => {
         const course = courses.find(c => c._id === courseActivity.courseId) || { steps: 0, exams: 0 };


### PR DESCRIPTION
Fixes #7601

We have both user and userId column when exporting `courses progress`