### PR TITLE
manager: smoother reports navigation (fixes #7620)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.93",
+  "version": "0.14.98",
   "myplanet": {
-    "latest": "v0.20.47",
-    "min": "v0.19.47"
+    "latest": "v0.20.55",
+    "min": "v0.19.55"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/manager-dashboard/reports/reports.component.html
+++ b/src/app/manager-dashboard/reports/reports.component.html
@@ -7,10 +7,10 @@
 </mat-toolbar>
 <div class="space-container">
   <mat-toolbar>
-    <mat-toolbar-row class="primary-color font-size-1">
+    <mat-toolbar-row class="primary-color font-size-1 toolbar-responsive">
       <span i18n>Summary of Connected Planets</span>
       <span class="toolbar-fill"></span>
-      <a mat-raised-button color="accent" class="margin-lr-10" [routerLink]="['detail']" i18n>Report Detail</a>
+      <a mat-raised-button color="accent" class="margin-lr-10 small-button" [routerLink]="['detail']" i18n>Report Detail</a>
     </mat-toolbar-row>
   </mat-toolbar>
   <div class="view-container view-full-height">

--- a/src/app/manager-dashboard/reports/reports.component.html
+++ b/src/app/manager-dashboard/reports/reports.component.html
@@ -10,7 +10,7 @@
     <mat-toolbar-row class="primary-color font-size-1 toolbar-responsive">
       <span i18n>Summary of Connected Planets</span>
       <span class="toolbar-fill"></span>
-      <a mat-raised-button color="accent" class="margin-lr-10 small-button" [routerLink]="['detail']" i18n>Report Detail</a>
+      <a mat-raised-button color="accent" class="margin-lr-10" [routerLink]="['detail']" i18n>Report Detail</a>
     </mat-toolbar-row>
   </mat-toolbar>
   <div class="view-container view-full-height">

--- a/src/app/manager-dashboard/reports/reports.component.ts
+++ b/src/app/manager-dashboard/reports/reports.component.ts
@@ -15,7 +15,8 @@ import { takeUntil, switchMap } from 'rxjs/operators';
     mat-panel-title {
       align-items: center;
     }
-  ` ]
+  ` ],
+  styleUrls: ['./reports.components.scss']
 })
 export class ReportsComponent implements OnInit, OnDestroy {
 

--- a/src/app/manager-dashboard/reports/reports.components.scss
+++ b/src/app/manager-dashboard/reports/reports.components.scss
@@ -1,0 +1,15 @@
+@import '../../variables';
+
+@media (max-width: $screen-sm) {
+  .toolbar-responsive {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    height: auto;
+  }
+
+	.margin-lr-10 {
+		margin: 10px 0
+	}
+}


### PR DESCRIPTION
Fixes #7620

For Small Screen ($screen-sm)
![image](https://github.com/user-attachments/assets/9e824092-aeab-4793-a207-c44a44dc6ecb)

For Tablet ($screen-md)
![image](https://github.com/user-attachments/assets/54f0da53-64ad-4d15-8f4d-eb0128465427)

For Desktop
![image](https://github.com/user-attachments/assets/acbe751e-a8b4-4362-b9a9-b489f21f989f)



P.S, I didn't change out anything for Tablet ($screen-md) and Desktop since the button didnt overflow for the secondary toolbar. However, I did found out that the ipad mini (which I found as a tablet) still falls under small screen sizes, so it follows the small screen layout