### PR TITLE
surveys: smoother list (fixes #7621)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.14.93",
+  "version": "0.15.0",
   "myplanet": {
     "latest": "v0.20.47",
     "min": "v0.19.47"

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -41,7 +41,7 @@
       </ng-container>
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef mat-sort-header="name" i18n>Survey</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
+        <mat-cell *matCellDef="let element"><span>{{element.name}}</span></mat-cell>
       </ng-container>
       <ng-container matColumnDef="taken">
         <mat-header-cell *matHeaderCellDef mat-sort-header="taken" i18n>Number of Times Taken</mat-header-cell>

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -41,7 +41,7 @@
       </ng-container>
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef mat-sort-header="name" i18n>Survey</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
+        <mat-cell *matCellDef="let element"><span>{{element.name}}</span></mat-cell>
       </ng-container>
       <ng-container matColumnDef="taken">
         <mat-header-cell *matHeaderCellDef mat-sort-header="taken" i18n>Number of Times Taken</mat-header-cell>
@@ -69,12 +69,14 @@
             </button>
           </ng-container>
           <div i18n-matTooltip matTooltip="There is no data to export" [matTooltipDisabled]="!!element.taken">
-            <button mat-raised-button color="primary" [disabled]="!element.taken" [matMenuTriggerFor]="exportMenu"  i18n><mat-icon>move_to_inbox</mat-icon> Export Survey</button>
+            <button mat-raised-button color="primary" [disabled]="!element.taken" [matMenuTriggerFor]="exportMenu" i18n>
+              <mat-icon>move_to_inbox</mat-icon> Export Survey
+            </button>
             <mat-menu #exportMenu="matMenu">
               <button mat-menu-item (click)="exportCSV(element)" i18n>Excel (CSV)</button>
               <button mat-menu-item (click)="exportPdf(element)" i18n>Print (PDF)</button>
             </mat-menu>
-          </div>
+          </div>          
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -41,7 +41,7 @@
       </ng-container>
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef mat-sort-header="name" i18n>Survey</mat-header-cell>
-        <mat-cell *matCellDef="let element"><span>{{element.name}}</span></mat-cell>
+        <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="taken">
         <mat-header-cell *matHeaderCellDef mat-sort-header="taken" i18n>Number of Times Taken</mat-header-cell>
@@ -61,22 +61,22 @@
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
         <mat-cell *matCellDef="let element">
           <ng-container *ngIf="!element.parent === true">
-            <button mat-raised-button color="primary" (click)="routeToEditSurvey('update', element._id)" i18n><mat-icon>edit</mat-icon> Edit Survey</button>
-            <button mat-raised-button color="primary" [disabled]="!element.questions.length" (click)="openSendSurveyDialog(element)" i18n><mat-icon>send</mat-icon> Send Survey</button>
+            <button mat-raised-button color="primary" (click)="routeToEditSurvey('update', element._id)" i18n><mat-icon>edit</mat-icon> Edit</button>
+            <button mat-raised-button color="primary" [disabled]="!element.questions.length" (click)="openSendSurveyDialog(element)" i18n><mat-icon>send</mat-icon> Send</button>
             <button mat-raised-button color="primary" [disabled]="!element.questions.length" (click)="recordSurvey(element)"
               i18n-matTooltip matTooltip="Record survey information from a person who is not a member of {{configuration.name}}" i18n>
-              <mat-icon>fiber_manual_record</mat-icon> Record Survey
+              <mat-icon>fiber_manual_record</mat-icon> Record
             </button>
           </ng-container>
           <div i18n-matTooltip matTooltip="There is no data to export" [matTooltipDisabled]="!!element.taken">
             <button mat-raised-button color="primary" [disabled]="!element.taken" [matMenuTriggerFor]="exportMenu" i18n>
-              <mat-icon>move_to_inbox</mat-icon> Export Survey
+              <mat-icon>move_to_inbox</mat-icon> Export
             </button>
             <mat-menu #exportMenu="matMenu">
               <button mat-menu-item (click)="exportCSV(element)" i18n>Excel (CSV)</button>
               <button mat-menu-item (click)="exportPdf(element)" i18n>Print (PDF)</button>
             </mat-menu>
-          </div>          
+          </div>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -1,0 +1,123 @@
+@import "../variables.scss";
+
+
+.mat-column-select {
+  max-width: 44px;
+}
+
+.mat-column-taken {
+  max-width: 150px;
+}
+
+.mat-column-createdDate {
+  max-width: 150px;
+}
+
+.course-title {
+  max-width: 200px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 15px;
+  position: relative;
+}
+
+.mat-cell button, .mat-cell div button[mat-raised-button] {
+  width: 150px; 
+  text-align: center;
+  padding: 8px 12px;
+  white-space: nowrap; 
+  overflow: hidden; 
+  text-overflow: ellipsis; 
+}
+
+
+.mat-column-name span {
+  max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+/* Targeting tablet screens */
+@media (max-width: $screen-md) {
+  .container {
+    padding: 15px;
+  }
+
+  .card {
+    width: 100%;
+    margin: 0;
+  }
+
+  .mat-header-cell, .mat-cell {
+    max-width: 125px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mat-column-name {
+    max-width: 125px;
+  }
+
+  .list-item-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px;
+  }
+
+  .mat-cell button, .mat-cell div button[mat-raised-button] {
+    width: 100px;
+  }
+
+  .mat-cell div button[mat-raised-button][matMenuTriggerFor] {
+    width: 100px;
+  }
+}
+
+/* Targeting mobile screens */
+@media (max-width: $screen-sm) {
+  .container {
+    padding: 10px;
+  }
+
+  .card {
+    width: 100%;
+    margin: 0;
+  }
+
+  .mat-header-cell, .mat-cell {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mat-column-name {
+    max-width: 100px;
+  }
+
+  .mat-column-taken {
+    max-width: 50px; 
+    text-align: center; 
+  }
+
+  .mat-cell button, .mat-cell div button[mat-raised-button] {
+    width: 100%; 
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mat-cell div button[mat-raised-button][matMenuTriggerFor] {
+    width: 100%; 
+  }
+
+  .update-button-container {
+    justify-content: flex-start;
+  }
+}

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -8,22 +8,12 @@
   max-width: 150px;
 }
 
-.mat-column-name span {
-  max-width: 150px;
+.course-title, .mat-column-name span {
+  max-width: 250px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: block;
-}
-
-.course-title {
-  max-width: 200px;
-  display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  line-height: 15px;
-  position: relative;
 }
 
 .mat-cell button, .mat-cell div button[mat-raised-button] {

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -1,16 +1,19 @@
 @import "../variables.scss";
 
-
 .mat-column-select {
   max-width: 44px;
 }
 
-.mat-column-taken {
+.mat-column-taken, .mat-column-createdDate {
   max-width: 150px;
 }
 
-.mat-column-createdDate {
+.mat-column-name span {
   max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
 }
 
 .course-title {
@@ -24,100 +27,43 @@
 }
 
 .mat-cell button, .mat-cell div button[mat-raised-button] {
-  width: 150px; 
+  width: 150px;
   text-align: center;
   padding: 8px 12px;
-  white-space: nowrap; 
-  overflow: hidden; 
-  text-overflow: ellipsis; 
-}
-
-
-.mat-column-name span {
-  max-width: 150px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: block;
 }
 
 /* Targeting tablet screens */
 @media (max-width: $screen-md) {
-  .container {
-    padding: 15px;
-  }
-
-  .card {
-    width: 100%;
-    margin: 0;
-  }
-
-  .mat-header-cell, .mat-cell {
-    max-width: 125px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 
   .mat-column-name {
     max-width: 125px;
   }
 
-  .list-item-content {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 10px;
-  }
-
   .mat-cell button, .mat-cell div button[mat-raised-button] {
     width: 100px;
-  }
-
-  .mat-cell div button[mat-raised-button][matMenuTriggerFor] {
-    width: 100px;
+    text-align: center;
+    padding: 8px 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
 /* Targeting mobile screens */
 @media (max-width: $screen-sm) {
-  .container {
-    padding: 10px;
-  }
-
-  .card {
-    width: 100%;
-    margin: 0;
-  }
-
-  .mat-header-cell, .mat-cell {
-    max-width: 100px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 
   .mat-column-name {
-    max-width: 100px;
+    max-width: 80px;
   }
 
-  .mat-column-taken {
-    max-width: 50px; 
-    text-align: center; 
+  .mat-column-action {
+    max-width: 125px;
   }
 
   .mat-cell button, .mat-cell div button[mat-raised-button] {
-    width: 100%; 
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .mat-cell div button[mat-raised-button][matMenuTriggerFor] {
-    width: 100%; 
-  }
-
-  .update-button-container {
-    justify-content: flex-start;
+    width: 50px;
   }
 }

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -25,31 +25,8 @@ import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { DialogsAddTableComponent } from '../shared/dialogs/dialogs-add-table.component';
 
 @Component({
-  'templateUrl': './surveys.component.html',
-  styles: [ `
-    /* Column Widths */
-    .mat-column-select {
-      max-width: 44px;
-    }
-    .mat-column-taken {
-      max-width: 150px;
-    }
-    .mat-column-createdDate {
-      max-width: 150px;
-    }
-    .btn:disabled{
-      pointer-events: none;
-    }
-    .course-title {
-      max-width: 200px;
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      line-height: 15px;
-      position: relative;
-    }
-  ` ]
+  templateUrl: './surveys.component.html',
+  styleUrls: ['./surveys.component.scss']
 })
 export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   selection = new SelectionModel(true, []);


### PR DESCRIPTION
Made the Surveys page responsive and improved button alignment and text overflow. 

web:
![image](https://github.com/user-attachments/assets/c7b557c3-eca1-4911-b04f-6a8e1590baa3)

$screen-md:
![image](https://github.com/user-attachments/assets/3b1f6d8b-642f-4c9e-9102-f16b0fa7a4a2)

$screen-sm:
![image](https://github.com/user-attachments/assets/17216117-b6af-4d2c-baf0-547fb4bc3ff3)

Fixes #7621 