### PR TITLE
step-view: smoother view (fixes #7661)

### DIFF
--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -57,4 +57,12 @@
     max-width: 100%;
   }
 
+  .ellipsis-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+    display: block;
+  }
+
 }

--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -54,6 +54,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 100%;
   }
 
 }


### PR DESCRIPTION
fixes #7661

@Mutugiii The original code already had ellipsis if the title was too long, I just added a max-width to make sure there is no overflow of the title, also I couldn't get an image for this pull request since I don't have any resources within my courses on Planet