### PR TITLE
community: smoother reports export (fixes #7670)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.4",
+  "version": "0.15.14",
   "myplanet": {
-    "latest": "v0.20.61",
-    "min": "v0.19.61"
+    "latest": "v0.20.69",
+    "min": "v0.19.69"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -1,6 +1,8 @@
 <div class="action-buttons" *ngIf="editable">
   <button mat-raised-button color="primary" i18n (click)="openAddReportDialog()">Add Report</button>
-  <button mat-raised-button color="primary" i18n (click)="exportReports()">Export as CSV</button>
+  <button mat-raised-button color="accent" i18n *ngIf="reports && reports.length > 0" (click)="exportAsCSV()">
+    Export as CSV
+  </button>
 </div>
 <div *ngIf="!reports || reports?.length == 0">
   <p i18n>No reports available at the moment.</p>
@@ -10,15 +12,18 @@
     <mat-card>
       <mat-card-header>
         <mat-card-title i18n>Financial Report</mat-card-title>
-        <mat-card-subtitle>{{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date : 'mediumDate' : '+0000' }}</mat-card-subtitle>
+        <mat-card-subtitle>{{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date :
+          'mediumDate' : '+0000' }}</mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
         <planet-teams-reports-detail [report]="report"></planet-teams-reports-detail>
       </mat-card-content>
       <mat-card-footer class="action-buttons margin-lr-10">
         <ng-container *ngIf="editable">
-          <button mat-icon-button (click)="$event.stopPropagation(); openDeleteReportDialog(report)"><mat-icon>delete</mat-icon></button>
-          <button mat-icon-button (click)="$event.stopPropagation(); openAddReportDialog(report)"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button
+            (click)="$event.stopPropagation(); openDeleteReportDialog(report)"><mat-icon>delete</mat-icon></button>
+          <button mat-icon-button
+            (click)="$event.stopPropagation(); openAddReportDialog(report)"><mat-icon>edit</mat-icon></button>
         </ng-container>
         <button mat-button i18n>View Report</button>
       </mat-card-footer>

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -1,10 +1,10 @@
 <div class="action-buttons" *ngIf="editable">
   <button mat-raised-button color="primary" i18n (click)="openAddReportDialog()">Add Report</button>
-  <button mat-raised-button color="accent" i18n *ngIf="reports && reports.length > 0" (click)="exportAsCSV()">
+  <button mat-raised-button color="accent" i18n *ngIf="reports && reports.length > 0" (click)="exportReports()">
     Export as CSV
   </button>
 </div>
-<div *ngIf="!reports || reports?.length == 0">
+<div *ngIf="reports?.length == 0">
   <p i18n>No reports available at the moment.</p>
 </div>
 <mat-grid-list [cols]="columns" gutterSize="0.5rem" rowHeight="22rem" id="report-grid">
@@ -12,18 +12,15 @@
     <mat-card>
       <mat-card-header>
         <mat-card-title i18n>Financial Report</mat-card-title>
-        <mat-card-subtitle>{{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date :
-          'mediumDate' : '+0000' }}</mat-card-subtitle>
+        <mat-card-subtitle>{{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date : 'mediumDate' : '+0000' }}</mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
         <planet-teams-reports-detail [report]="report"></planet-teams-reports-detail>
       </mat-card-content>
       <mat-card-footer class="action-buttons margin-lr-10">
         <ng-container *ngIf="editable">
-          <button mat-icon-button
-            (click)="$event.stopPropagation(); openDeleteReportDialog(report)"><mat-icon>delete</mat-icon></button>
-          <button mat-icon-button
-            (click)="$event.stopPropagation(); openAddReportDialog(report)"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button (click)="$event.stopPropagation(); openDeleteReportDialog(report)"><mat-icon>delete</mat-icon></button>
+          <button mat-icon-button (click)="$event.stopPropagation(); openAddReportDialog(report)"><mat-icon>edit</mat-icon></button>
         </ng-container>
         <button mat-button i18n>View Report</button>
       </mat-card-footer>

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -4,7 +4,7 @@
     Export as CSV
   </button>
 </div>
-<div *ngIf="reports?.length == 0">
+<div *ngIf="!reports || reports?.length == 0">
   <p i18n>No reports available at the moment.</p>
 </div>
 <mat-grid-list [cols]="columns" gutterSize="0.5rem" rowHeight="22rem" id="report-grid">


### PR DESCRIPTION
<img width="289" alt="reportsissuesolved" src="https://github.com/user-attachments/assets/ac7a0bb5-4791-401f-888e-935f39b051a3">

export to csv button only appears if there are reports available now