### PR TITLE
courses: smoother details loading (fixes #6744)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.13",
+  "version": "0.15.22",
   "myplanet": {
     "latest": "v0.20.66",
     "min": "v0.19.66"

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -123,7 +123,8 @@
             </mat-action-row>
           </mat-expansion-panel>
         </ng-container>
-        <span *ngIf="courseDetail.steps.length===0" i18n>There is no content for this course</span>
+        <span *ngIf="isLoading" i18n>Loading course details...</span>
+        <span *ngIf="courseDetail.steps.length===0 && !isLoading" i18n>There is no content for this course</span>
       </div>
     </div>
   </div>

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -49,11 +49,11 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.isLoading = true
+    this.isLoading = true;
     this.coursesService.courseUpdated$.pipe(
       switchMap(({ course, progress = [ { stepNum: 0 } ] }: { course: any, progress: any }) => {
         this.courseDetail = course;
-        this.isLoading = false
+        this.isLoading = false;
         this.coursesService.courseActivity('visit', course);
         this.courseDetail.steps = this.courseDetail.steps.map((step, index) => ({
           ...step,

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -24,6 +24,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   currentView: string;
   courseId: string;
   canManage: boolean;
+  isLoading: boolean
   currentUser = this.userService.get();
   planetConfiguration = this.stateService.configuration;
   examText: 'retake' | 'take' = 'take';
@@ -48,9 +49,11 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.isLoading = true
     this.coursesService.courseUpdated$.pipe(
       switchMap(({ course, progress = [ { stepNum: 0 } ] }: { course: any, progress: any }) => {
         this.courseDetail = course;
+        this.isLoading = false
         this.coursesService.courseActivity('visit', course);
         this.courseDetail.steps = this.courseDetail.steps.map((step, index) => ({
           ...step,

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -24,7 +24,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   currentView: string;
   courseId: string;
   canManage: boolean;
-  isLoading: boolean
+  isLoading: boolean;
   currentUser = this.userService.get();
   planetConfiguration = this.stateService.configuration;
   examText: 'retake' | 'take' = 'take';


### PR DESCRIPTION
Fixes #6744 

Here is a video starting at 0:08, since its very hard to see, you should pause at 0:09
https://www.loom.com/share/90d8709658a342d2ad0c01a0493d6f4a?t=9&sid=fd1fcc4e-304d-4456-9bfa-9c71f4a21934

Here's a screenshot also:
<img width="563" alt="Screenshot 2024-10-30 at 1 16 45 PM" src="https://github.com/user-attachments/assets/9466c921-4d2c-4ebf-a74a-0ac332cd6ee0">

**Now it will only display `No Content on Courses` when it finsihed loading the courses**
![image](https://github.com/user-attachments/assets/fecbaa85-2206-424d-b642-bf671363cbdc)
