### PR TITLE
community: smoother voices (fixes #7691) (fixes #7682)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.17",
+  "version": "0.15.24",
   "myplanet": {
     "latest": "v0.20.69",
     "min": "v0.19.69"

--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -8,9 +8,17 @@
               <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="showNewsButton" i18n>New Voice</button>
             </ng-container>
           </h3>
-          <span *ngIf="isLoading" i18n>Loading voices...</span>
-          <span *ngIf="!isLoading && news?.length === 0" i18n>No Voices available.</span>
-          <planet-news-list *ngIf="!isLoading && news?.length > 0" [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId"></planet-news-list>
+          <ng-container *ngIf="isLoading; else loaded">
+            <span i18n>Loading voices...</span>
+          </ng-container>
+          <ng-template #loaded>
+            <ng-container *ngIf="news?.length > 0; else noVoices">
+              <planet-news-list [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId"></planet-news-list>
+            </ng-container>
+          </ng-template>
+          <ng-template #noVoices>
+            <p i18n>No Voices available.</p>
+          </ng-template>
         </mat-tab>
         <mat-tab i18n-label label="Community Leaders">
           <div class="card-grid">

--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -8,12 +8,9 @@
               <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="showNewsButton" i18n>New Voice</button>
             </ng-container>
           </h3>
-          <ng-container *ngIf="news?.length > 0; else noVoices">
-            <planet-news-list [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId"></planet-news-list>
-          </ng-container>
-          <ng-template #noVoices>
-            <p i18n>No Voices available.</p>
-          </ng-template>
+          <span *ngIf="isLoading" i18n>Loading voices...</span>
+          <span *ngIf="!isLoading && news?.length === 0" i18n>No Voices available.</span>
+          <planet-news-list *ngIf="!isLoading && news?.length > 0" [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId"></planet-news-list>
         </mat-tab>
         <mat-tab i18n-label label="Community Leaders">
           <div class="card-grid">
@@ -29,23 +26,19 @@
         </mat-tab>
         <mat-tab i18n-label label="Services">
           <planet-markdown *ngIf="team.description" [content]="team.description || ''"></planet-markdown>
-          <p *ngIf="!team.description" i18n>No description available.</p>
+          <span *ngIf="!team.description" i18n><p>No description available.</p></span>
           <ng-container *ngIf="!planetCode">
             <button *planetAuthorizedRoles="''" (click)="openDescriptionDialog()" mat-stroked-button i18n>
               { servicesDescriptionLabel, select, Edit {Edit} Add {Add}} { configuration.planetType, select, community {Community} nation {Nation} center {Earth}} Description
             </button>
           </ng-container>
-          <ng-container *ngIf="links?.length > 0; else noLinks">
+            <span *ngIf="links?.length === 0" i18n><p>No links available.</p></span>
             <mat-nav-list>
               <mat-list-item *ngFor="let link of links" [routerLink]="(link.teamType === 'sync' || !planetCode) ? link.route : []" i18n-matTooltip [matTooltip]="(link.teamType === 'sync' || !planetCode) ? '' : link.title + ' is only available on ' + configuration.name" [disableRipple]="link.teamType === 'local' && planetCode">
                 <span matLine>{{link.title}}</span>
                 <button *ngIf="deleteMode" mat-icon-button color="warn" (click)="openDeleteLinkDialog(link); $event.stopPropagation()"><mat-icon>delete</mat-icon></button>
               </mat-list-item>
             </mat-nav-list>
-          </ng-container>
-          <ng-template #noLinks>
-            <p i18n>No links available.</p>
-          </ng-template>
           <ng-container *ngIf="!planetCode">
             <div *planetAuthorizedRoles="''" class="action-buttons">
               <button (click)="openAddLinkDialog()" mat-stroked-button i18n>Add Link</button>

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -72,20 +72,17 @@ export class CommunityComponent implements OnInit, OnDestroy {
     this.isLoading = true;
     this.getCommunityData();
 
-    // Fetch and sort news
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(news => {
       this.news = news.sort((a, b) => newsSortValue(b) - newsSortValue(a));
       this.isLoading = false;
     });
 
-    // Listen for user updates
     this.usersService.usersListener(true).pipe(takeUntil(this.onDestroy$)).subscribe(users => {
       if (!this.planetCode) {
         this.setCouncillors(users);
       }
     });
 
-    // Handle child user state updates for specific planet code
     this.stateService.couchStateListener('child_users').pipe(takeUntil(this.onDestroy$)).subscribe(childUsers => {
       if (this.planetCode && childUsers) {
         const users = childUsers.newData

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -71,23 +71,18 @@ export class CommunityComponent implements OnInit, OnDestroy {
     const newsSortValue = (item: any) => item.sharedDate || item.doc.time;
     this.isLoading = true;
     this.getCommunityData();
-
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(news => {
       this.news = news.sort((a, b) => newsSortValue(b) - newsSortValue(a));
       this.isLoading = false;
     });
-
     this.usersService.usersListener(true).pipe(takeUntil(this.onDestroy$)).subscribe(users => {
       if (!this.planetCode) {
         this.setCouncillors(users);
       }
     });
-
     this.stateService.couchStateListener('child_users').pipe(takeUntil(this.onDestroy$)).subscribe(childUsers => {
       if (this.planetCode && childUsers) {
-        const users = childUsers.newData
-          .filter(user => user.planetCode === this.planetCode)
-          .map(user => ({ ...user, doc: user }));
+        const users = childUsers.newData.filter(user => user.planetCode === this.planetCode).map(user => ({ ...user, doc: user }));
         this.setCouncillors(users);
       }
     });

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -48,6 +48,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   resizeCalendar: any = false;
   deviceType: DeviceType;
   deviceTypes = DeviceType;
+  isLoading: boolean;
 
   constructor(
     private dialog: MatDialog,
@@ -68,18 +69,28 @@ export class CommunityComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     const newsSortValue = (item: any) => item.sharedDate || item.doc.time;
+    this.isLoading = true;
     this.getCommunityData();
+
+    // Fetch and sort news
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(news => {
       this.news = news.sort((a, b) => newsSortValue(b) - newsSortValue(a));
+      this.isLoading = false;
     });
+
+    // Listen for user updates
     this.usersService.usersListener(true).pipe(takeUntil(this.onDestroy$)).subscribe(users => {
       if (!this.planetCode) {
         this.setCouncillors(users);
       }
     });
+
+    // Handle child user state updates for specific planet code
     this.stateService.couchStateListener('child_users').pipe(takeUntil(this.onDestroy$)).subscribe(childUsers => {
       if (this.planetCode && childUsers) {
-        const users = childUsers.newData.filter(user => user.planetCode === this.planetCode).map(user => ({ ...user, doc: user }));
+        const users = childUsers.newData
+          .filter(user => user.planetCode === this.planetCode)
+          .map(user => ({ ...user, doc: user }));
         this.setCouncillors(users);
       }
     });


### PR DESCRIPTION
Added loading message to Voices (fixes #7691). Video is quick, so see around 6 seconds. 

[community-voices-screen-record.webm](https://github.com/user-attachments/assets/feaccd54-dd59-4146-91fa-a29befff876b)

Wrapped no voices, services, links placeholders in an i18n span to make them translate (fixes #7682). I don't know how to test translations on my dev environment, but it seems simply having the i18n tag in a paragraph tag wasn't translating. Having it in a span works elsewhere, so it should work here too. 