### PR TITLE
resouces: smoother search (fixes #7689)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.17",
+  "version": "0.15.32",
   "myplanet": {
     "latest": "v0.20.69",
     "min": "v0.19.69"

--- a/src/app/shared/diacritic-insensitive-match.ts
+++ b/src/app/shared/diacritic-insensitive-match.ts
@@ -1,0 +1,5 @@
+export function diacriticInsensitiveMatch(value: string, filter: string): boolean {
+    const normalizedValue = value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+    const normalizedFilter = filter.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+    return normalizedValue.includes(normalizedFilter);
+  }

--- a/src/app/shared/diacritic-insensitive-match.ts
+++ b/src/app/shared/diacritic-insensitive-match.ts
@@ -1,5 +1,0 @@
-export function diacriticInsensitiveMatch(value: string, filter: string): boolean {
-    const normalizedValue = value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-    const normalizedFilter = filter.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-    return normalizedValue.includes(normalizedFilter);
-  }

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -33,7 +33,7 @@ const checkFilterItems = (data: any) => ((includeItem: boolean, [ field, val ]) 
 // Multi level field filter by spliting each field by '.'
 export const filterSpecificFields = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
-    const normalizedFilter = filter.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, ''); // Diacritic insensitive filter
+    const normalizedFilter = filter.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     for (let i = 0; i < filterFields.length; i++) {
       const fieldValue = getProperty(data, filterFields[i]);
       if (typeof fieldValue === 'string' && 
@@ -57,7 +57,6 @@ export const filterSpecificFieldsByWord = (filterFields: string[]): any => {
     });
   };
 };
-
 
 // Takes an object and string of dot seperated property keys.  Returns the nested value of the succession of
 // keys or undefined.


### PR DESCRIPTION
Fixes #7689 
When searching courses and library, characters a and á, e and é, n and ñ, etc, are now treated as equivalent. This makes searching Spanish titles easier and requires less precision from the user.

![image](https://github.com/user-attachments/assets/24c0cb58-94f6-4588-aca0-4f5d3bb20b4e)
![image](https://github.com/user-attachments/assets/8a69b7be-a46b-499c-a6b9-b9752963f039)
![image](https://github.com/user-attachments/assets/a2a38647-bc3d-4a9a-9926-18f8844519f7)
![image](https://github.com/user-attachments/assets/44b864d8-dffd-4d79-897b-c6ee04ff4993)
