### PR TITLE
resources: smoother loading (fixes #7706)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.22",
+  "version": "0.15.29",
   "myplanet": {
     "latest": "v0.20.75",
     "min": "v0.19.75"

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -78,12 +78,19 @@
       <p *ngIf="resource?.doc?.sourcePlanet !== planetConfiguration.code && resource?.doc?.sourcePlanet"><b i18n>Source:</b>{{' ' + resource?.doc?.sourcePlanet}}</p>
     </div>
     <div>
-      <planet-resources-viewer
-        *ngIf="resource?.doc?._attachments; else noAttachment"
-        [resourceId]="resourceId"
-        (resourceUrl)="setResourceUrl($event)">
-      </planet-resources-viewer>
-      <ng-template #noAttachment><span i18n>There is no content for this resource</span></ng-template>
+      <ng-container *ngIf="isLoading; else resourceContent">
+        <span i18n>Loading content...</span>
+      </ng-container>
+      <ng-template #resourceContent>
+        <planet-resources-viewer
+          *ngIf="resource?.doc?._attachments; else noAttachment"
+          [resourceId]="resourceId"
+          (resourceUrl)="setResourceUrl($event)">
+        </planet-resources-viewer>
+      </ng-template>
+      <ng-template #noAttachment>
+        <span i18n>There is no content for this resource</span>
+      </ng-template>
     </div>
   </div>
 </div>

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -44,6 +44,7 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
   pdfSrc: any;
   contentType = '';
   isUserEnrolled = false;
+  isLoading: boolean;
   // If parent route, url will use parent domain.  If not uses this domain.
   parent = this.route.snapshot.data.parent;
   planetConfiguration = this.stateService.configuration;
@@ -67,6 +68,7 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.isLoading = true;
     this.route.paramMap
       .pipe(debug('Getting resource id from parameters'), takeUntil(this.onDestroy$))
       .subscribe((params: ParamMap) => {
@@ -85,6 +87,7 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
           this.router.navigate([ '/resources' ]);
         }
         this.dialogsLoadingService.stop();
+        this.isLoading = false;
         this.isUserEnrolled = this.userService.shelf.resourceIds.includes(this.resource._id);
         this.canManage = (this.currentUser.isUserAdmin && !this.parent) ||
           (this.currentUser.name === this.resource.doc.addedBy && this.resource.doc.sourcePlanet === this.planetConfiguration.code);


### PR DESCRIPTION
Library resources no longer say "There is no content for this resource while loading." A loading message appears instead. 
fixes #7706 


[Library loading content.webm](https://github.com/user-attachments/assets/4f8b6422-1b9d-4460-b70b-fe1a23b0c1d5)


