### PR TITLE
teams: smoother finances export (fixed #7702)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.22",
+  "version": "0.15.30",
   "myplanet": {
     "latest": "v0.20.75",
     "min": "v0.19.75"

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -11,9 +11,7 @@
     <mat-datepicker #dateFilterEnd></mat-datepicker>
   </mat-form-field>
   <button mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
-  <button class="margin-lr-10" color="accent" mat-raised-button i18n (click)="exportTableData()">
-    Export Transactions
-  </button>
+  <button class="margin-lr-10" color="accent" mat-raised-button i18n (click)="exportTableData()" *ngIf="!emptyTable">Export Transactions</button>
 </div>
 <mat-card class="margin-lr" *ngIf="showBalanceWarning">
   <mat-icon color="accent">warning</mat-icon><span i18n>The current balance is negative!</span>


### PR DESCRIPTION
Fixes #7702 

When there is no transaction, export button is hidden
![image](https://github.com/user-attachments/assets/5c8c6e5d-b1e4-43e0-b934-2b5504c5a663)

When there is transaction, then export button is visible
![image](https://github.com/user-attachments/assets/992a9ab1-71c8-40cc-887e-92a8300349ec)
