### PR TITLE
7712 challenge success message trigger mechanics (Not final ui)

### DIFF
--- a/src/app/shared/dialogs/dialogs-announcement.component.html
+++ b/src/app/shared/dialogs/dialogs-announcement.component.html
@@ -32,7 +32,7 @@
   </div>
 
   <div *ngIf="checkAllStepsCompleted" class="steps-complete-message">
-    <span>Congratulations! You have completed all the steps!</span>
+    <span i18n>¡Felicidades, has completado todos los pasos!</span>
   </div>
 
   <div class="thermometer-container">

--- a/src/app/shared/dialogs/dialogs-announcement.component.html
+++ b/src/app/shared/dialogs/dialogs-announcement.component.html
@@ -31,6 +31,10 @@
     </div>
   </div>
 
+  <div *ngIf="checkAllStepsCompleted" class="steps-complete-message">
+    <span>Congratulations! You have completed all the steps!</span>
+  </div>
+
   <div class="thermometer-container">
   <div class="thermometer">
     <div class="thermometer-bar" [style.width.%]="getGoalPercentage()">

--- a/src/app/shared/dialogs/dialogs-announcement.component.scss
+++ b/src/app/shared/dialogs/dialogs-announcement.component.scss
@@ -32,6 +32,11 @@
   flex-grow: 1;
 }
 
+.steps-complete-message{
+  color: green;
+  font-weight: bold;
+}
+
 .thermometer-container {
   display: flex;
   flex-direction: column;

--- a/src/app/shared/dialogs/dialogs-announcement.component.ts
+++ b/src/app/shared/dialogs/dialogs-announcement.component.ts
@@ -99,6 +99,14 @@ export class DialogsAnnouncementComponent implements OnInit, OnDestroy {
     return member.courseIds.includes(this.courseId);
   }
 
+  checkAllStepsCompleted(): boolean {
+    return (
+      this.userStatus.hasPost &&
+      this.userStatus.surveyComplete &&
+      this.userStatus.joinedCourse
+    );
+  }
+  
   fetchCourseAndNews() {
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$))
       .subscribe(news => {


### PR DESCRIPTION
<img width="479" alt="announcmentSuccess" src="https://github.com/user-attachments/assets/378526bd-1afa-4fb9-8f18-e719c16f4370">

This is the first iteration of the success message after all steps are completed. Obviously, this needs to be changed and updated based off of the specific user reqs. Just figured I would start working on it to get an idea of where we want to go with this.
