### PR TITLE
challenges: smoother progress bar label

### DIFF
--- a/src/app/shared/dialogs/dialogs-announcement.component.html
+++ b/src/app/shared/dialogs/dialogs-announcement.component.html
@@ -34,7 +34,7 @@
   <div class="thermometer-container">
   <div class="thermometer">
     <div class="thermometer-bar" [style.width.%]="getGoalPercentage()">
-      <div class="thermometer-label">
+      <div class="thermometer-label" [ngClass]="{'outside': getGoalPercentage() < 8}">
         {{ getGoalPercentage() | number:'1.0-2' }}% ({{ groupSummary?.length }})
       </div>
     </div>

--- a/src/app/shared/dialogs/dialogs-announcement.component.scss
+++ b/src/app/shared/dialogs/dialogs-announcement.component.scss
@@ -66,6 +66,11 @@
   border-radius: 3px;
 }
 
+.thermometer-label.outside {
+  position: absolute;
+  left: 0.5rem;
+}
+
 .thermometer-goal {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Problem:
<img width="614" alt="Screenshot 2024-11-04 at 12 01 41 PM" src="https://github.com/user-attachments/assets/8ea11915-ca17-4221-bf55-c6cf66ef757c">

Fixes:
![image](https://github.com/user-attachments/assets/895f6587-5729-40b7-97b1-a6466517e47f)

If there is enough space for the label, it will act as previous code

![image](https://github.com/user-attachments/assets/dbbabbf0-db63-4e72-a20d-a374b11851d1)
