### PR TITLE
courses/library: disable rating without enrollment

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -226,7 +226,7 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header"  mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
+          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm" [isEnrolled]="isEnrolled" [type]="'course'"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -226,7 +226,8 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header"  mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm" [isEnrolled]="isEnrolled" [type]="'course'"></planet-rating>
+          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" 
+          [ratingType]="'course'" [disabled]="isDialog || isForm" [isEnrolled]="isEnrolled"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -317,8 +317,8 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   }
 
   isEnrolled(courseId: any): boolean {
-    const { inShelf } = this.userService.countInShelf([courseId], 'courseIds');
-    return inShelf
+    const { inShelf } = this.userService.countInShelf([ courseId ], 'courseIds');
+    return inShelf;
 }
 
   hasSteps(id: string) {

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -316,6 +316,11 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.selectedLocal = selected.filter(id => this.isLocalOrNation(id)).length;
   }
 
+  isEnrolled(courseId: any): boolean {
+    const { inShelf } = this.userService.countInShelf([courseId], 'courseIds');
+    return inShelf
+}
+
   hasSteps(id: string) {
     return this.courses.data.find((course: any) => course._id === id && course.doc.steps.length > 0);
   }

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -203,7 +203,8 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header" mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog" [isEnrolled]="isEnrolled" [type]="'resource'"></planet-rating>
+          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent"
+                        [ratingType]="'resource'" [disabled]="isDialog" [isEnrolled]="isEnrolled"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns" class="hide"></mat-header-row>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -203,7 +203,7 @@
       <ng-container matColumnDef="rating">
         <mat-header-cell *matHeaderCellDef class="rating-header" mat-sort-header="rating" start="desc" i18n>Rating</mat-header-cell>
         <mat-cell *matCellDef="let element" class="rating-cell">
-          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog"></planet-rating>
+          <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'resource'" [disabled]="isDialog" [isEnrolled]="isEnrolled" [type]="'resource'"></planet-rating>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns" class="hide"></mat-header-row>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -382,6 +382,11 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     this.selectedSync = selected.filter(id => this.hasAttachment(id));
   }
 
+  isEnrolled(resourceId: any): boolean {
+    const { inShelf } = this.userService.countInShelf([resourceId], 'resourceIds');
+    return inShelf
+  }
+
   hasAttachment(id: string) {
     return this.resources.data.find((resource: any) => resource._id === id && resource.doc._attachments);
   }

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -383,8 +383,8 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   isEnrolled(resourceId: any): boolean {
-    const { inShelf } = this.userService.countInShelf([resourceId], 'resourceIds');
-    return inShelf
+    const { inShelf } = this.userService.countInShelf([ resourceId ], 'resourceIds');
+    return inShelf;
   }
 
   hasAttachment(id: string) {

--- a/src/app/shared/forms/planet-rating-stars.component.ts
+++ b/src/app/shared/forms/planet-rating-stars.component.ts
@@ -104,11 +104,11 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
   }
 
   onStarClick(rating: number): void {
-    if(!this.isEnrolled) {
-      console.log(`You can't rate this ${this.type}`)
+    if (!this.isEnrolled) {
+      console.log(`You can't rate this ${this.type}`);
       return;
     }
-    console.log("Id is this:", this.courseId)
+    console.log('Id is this:', this.courseId);
     this.writeValue(rating);
   }
 

--- a/src/app/shared/forms/planet-rating-stars.component.ts
+++ b/src/app/shared/forms/planet-rating-stars.component.ts
@@ -51,6 +51,9 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
     this.onChange(rating);
     this.stateChanges.next();
   }
+  @Input() isEnrolled: boolean;
+  @Input() courseId: (id: any) => void;
+  @Input() type: string;
   private _value = 0;
 
   onChange(_: any) {}
@@ -101,6 +104,11 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
   }
 
   onStarClick(rating: number): void {
+    if(!this.isEnrolled) {
+      console.log(`You can't rate this ${this.type}`)
+      return;
+    }
+    console.log("Id is this:", this.courseId)
     this.writeValue(rating);
   }
 

--- a/src/app/shared/forms/planet-rating.component.html
+++ b/src/app/shared/forms/planet-rating.component.html
@@ -14,7 +14,7 @@
 
   <div class="your-rating" *ngIf="!parent">
     <form [formGroup]="rateForm" novalidate>
-      <planet-rating-stars (click)="onStarClick()" formControlName="rate" [disabled]="disabled"></planet-rating-stars>
+      <planet-rating-stars (click)="onStarClick()" formControlName="rate" [disabled]="disabled" [isEnrolled]="enrolled" [courseId]="item._id" [type]="type"></planet-rating-stars>
     </form>
   </div>
 

--- a/src/app/shared/forms/planet-rating.component.html
+++ b/src/app/shared/forms/planet-rating.component.html
@@ -14,7 +14,9 @@
 
   <div class="your-rating" *ngIf="!parent">
     <form [formGroup]="rateForm" novalidate>
-      <planet-rating-stars (click)="onStarClick()" formControlName="rate" [disabled]="disabled" [isEnrolled]="enrolled" [courseId]="item._id" [type]="type"></planet-rating-stars>
+      <planet-rating-stars (click)="onStarClick()" formControlName="rate" [disabled]="disabled" [isEnrolled]="enrolled" 
+                          [courseId]="item._id" [type]="ratingType">
+      </planet-rating-stars>
     </form>
   </div>
 

--- a/src/app/shared/forms/planet-rating.component.ts
+++ b/src/app/shared/forms/planet-rating.component.ts
@@ -40,11 +40,14 @@ export class PlanetRatingComponent implements OnChanges {
   @Input() parent;
   @Input() ratingType = '';
   @Input() disabled = false;
+  @Input() isEnrolled: (id: any) => boolean;
+  @Input() type: string;
 
   rateForm: FormGroup;
   popupForm: FormGroup;
   isPopupOpen = false;
   stackedBarData = [];
+  enrolled: boolean;
   get rateFormField() {
     return { rate: this.rating.userRating.rate || 0 };
   }
@@ -84,6 +87,15 @@ export class PlanetRatingComponent implements OnChanges {
   }
 
   onStarClick(form = this.rateForm) {
+    if (this.isEnrolled) {
+      if (!this.isEnrolled(this.item._id)) {
+        console.log(`${this.type} id:`, this.item._id)
+        this.planetMessage.showMessage($localize`Please join the ${this.type} before rating!`);
+        this.enrolled = false;
+        return;
+      }
+    }
+    this.enrolled = true;
     if (this.disabled || form.controls.rate.value === 0) {
       return;
     }

--- a/src/app/shared/forms/planet-rating.component.ts
+++ b/src/app/shared/forms/planet-rating.component.ts
@@ -41,7 +41,6 @@ export class PlanetRatingComponent implements OnChanges {
   @Input() ratingType = '';
   @Input() disabled = false;
   @Input() isEnrolled: (id: any) => boolean;
-  @Input() type: string;
 
   rateForm: FormGroup;
   popupForm: FormGroup;
@@ -89,8 +88,8 @@ export class PlanetRatingComponent implements OnChanges {
   onStarClick(form = this.rateForm) {
     if (this.isEnrolled) {
       if (!this.isEnrolled(this.item._id)) {
-        console.log(`${this.type} id:`, this.item._id);
-        this.planetMessage.showMessage($localize`Please join the ${this.type} before rating!`);
+        console.log(`${this.ratingType} id:`, this.item._id);
+        this.planetMessage.showMessage($localize`Please join the ${this.ratingType} before rating!`);
         this.enrolled = false;
         return;
       }

--- a/src/app/shared/forms/planet-rating.component.ts
+++ b/src/app/shared/forms/planet-rating.component.ts
@@ -89,7 +89,7 @@ export class PlanetRatingComponent implements OnChanges {
   onStarClick(form = this.rateForm) {
     if (this.isEnrolled) {
       if (!this.isEnrolled(this.item._id)) {
-        console.log(`${this.type} id:`, this.item._id)
+        console.log(`${this.type} id:`, this.item._id);
         this.planetMessage.showMessage($localize`Please join the ${this.type} before rating!`);
         this.enrolled = false;
         return;

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -36,7 +36,7 @@ export const filterSpecificFields = (filterFields: string[]): any => {
     const normalizedFilter = filter.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     for (let i = 0; i < filterFields.length; i++) {
       const fieldValue = getProperty(data, filterFields[i]);
-      if (typeof fieldValue === 'string' && 
+      if (typeof fieldValue === 'string' &&
           fieldValue.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').indexOf(normalizedFilter) > -1) {
         return true;
       }

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -47,7 +47,8 @@ export const filterSpecificFields = (filterFields: string[]): any => {
 
 export const filterSpecificFieldsByWord = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
-    const words = filter.split(' ').map(value => value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')); // Normalize each word
+    const words = filter.split(' ').map(value => value.toLowerCase().normalize('NFD')
+                        .replace(/[\u0300-\u036f]/g, '')); // Normalize each word
     return words.every(word => {
       return filterFields.some(field => {
         const fieldValue = getProperty(data, field);


### PR DESCRIPTION
Currently WIP

Main Issues:
- [ ] When you're enrolled - when you first start rating it, it would not let you do it first, but then it would work after that.
- [ ] Opening the details courses and library would still allow you to rate it.

Other than that -> features that are working (for me to keep track)
- You can't rate courses (and the stars won't get written nor updated) if you haven't enrolled yet
- If you're enrolled, you can rate courses (but only after the second try) (**trying to fix this right now**)