### PR TITLE
markdown: smoother images zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jszip": "^3.2.2",
     "material-design-icons": "^3.0.1",
     "material-icons": "^0.3.1",
+    "medium-zoom": "^1.1.0",
     "mime": "^2.4.3",
     "ngx-img": "^10.15.0",
     "pdfmake": "^0.1.63",

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -58,3 +58,11 @@ mat-tab-group, mat-tab {
   background-color: white;
   padding-bottom: 0.5rem;
 }
+
+// planet-markdown img {
+//   transition: transform 0.3s ease;
+// }
+
+// planet-markdown img:hover {
+//   transform: scale(1.5);
+// }

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -58,11 +58,3 @@ mat-tab-group, mat-tab {
   background-color: white;
   padding-bottom: 0.5rem;
 }
-
-// planet-markdown img {
-//   transition: transform 0.3s ease;
-// }
-
-// planet-markdown img:hover {
-//   transform: scale(1.5);
-// }

--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewEncapsulation, OnChanges, ElementRef } from '@angular/core';
+import { Component, Input, ViewEncapsulation, OnChanges, ElementRef, AfterViewInit } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { StateService } from './state.service';
 import mediumZoom from 'medium-zoom';
@@ -9,7 +9,7 @@ import mediumZoom from 'medium-zoom';
   styleUrls: [ './planet-markdown.scss' ],
   encapsulation: ViewEncapsulation.None
 })
-export class PlanetMarkdownComponent implements OnChanges {
+export class PlanetMarkdownComponent implements OnChanges, AfterViewInit {
 
   @Input() content: string;
   @Input() imageSource: 'parent' | 'local' = 'local';

--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, ViewEncapsulation, OnChanges } from '@angular/core';
+import { Component, Input, ViewEncapsulation, OnChanges, ElementRef } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { StateService } from './state.service';
+import mediumZoom from 'medium-zoom';
 
 @Component({
   selector: 'planet-markdown',
@@ -16,11 +17,16 @@ export class PlanetMarkdownComponent implements OnChanges {
 
   constructor(
     private stateService: StateService,
+    private el: ElementRef
   ) {}
 
   ngOnChanges() {
     this.couchAddress = this.imageSource === 'parent' ?
       `${environment.parentProtocol}://${this.stateService.configuration.parentDomain}/` :
       `${environment.couchAddress}/`;
+  }
+
+  ngAfterViewInit() {
+    mediumZoom(this.el.nativeElement.querySelectorAll('planet-markdown img'));
   }
 }

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -20,3 +20,13 @@ planet-markdown.img-resize td-markdown.td-markdown {
     max-width: 50%;
   }
 }
+
+.medium-zoom-image {
+  z-index: 1000;
+  background: #000;
+}
+
+.medium-zoom-overlay {
+  z-index: 999 !important; /* Ensure the overlay is above all other elements */
+  background-color: rgba(0, 0, 0, 0.8); /* Customize the overlay color */
+}

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -27,6 +27,6 @@ planet-markdown.img-resize td-markdown.td-markdown {
 }
 
 .medium-zoom-overlay {
-  z-index: 999 !important; /* Ensure the overlay is above all other elements */
-  background-color: rgba(0, 0, 0, 0.8); /* Customize the overlay color */
+  z-index: 999 !important;
+  background-color: rgba(0, 0, 0, 0.8);
 }


### PR DESCRIPTION
Fixes #7747 

Should work with any images with markdown, please see pictures below to see an example:
![image](https://github.com/user-attachments/assets/0229f81c-1f42-400d-b400-25dfa2f24e7a)

If you click on an image, it should center, and be bigger (most of the time, the images will try to get bigger, unless its the maximum size already)
![image](https://github.com/user-attachments/assets/25ea6a15-5487-4b10-829b-6856387b20ac)
