### PR TITLE
user: smoother username limits (fixes #7757)

### DIFF
--- a/src/app/login/login-form.component.html
+++ b/src/app/login/login-form.component.html
@@ -1,6 +1,6 @@
 <form (ngSubmit)="onSubmit()" class="login-form" [formGroup]="userForm">
   <mat-form-field class="full-width">
-    <input matInput i18n-placeholder placeholder="Username" name="name" formControlName = "name" planetLowercase planetRestrictDiacritics autofocus/>
+    <input matInput i18n-placeholder placeholder="Username" name="name" formControlName = "name" planetLowercase planetRestrictDiacritics autofocus maxlength="25"/>
     <mat-error>
       <planet-form-error-messages [control]="userForm.controls.name"></planet-form-error-messages>
     </mat-error>


### PR DESCRIPTION
Fixes #7757

![image](https://github.com/user-attachments/assets/17f9f41d-8467-4912-a2f3-cb8712505f24)

When you create a new username, it won't allow you type more than 25 characters.

