### PR TITLE
resources/courses: smoother sorting (Fixes #7715)

### DIFF
--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -168,7 +168,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
       this.tagFilterValue = tags;
       this.titleSearch = this.titleSearch;
       this.removeFilteredFromSelection();
-      this.setupSorting()
+      this.setupSorting();
     });
   }
 

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -143,7 +143,6 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.getCourses();
     this.userShelf = this.userService.shelf;
     this.courses.filterPredicate = this.filterPredicate;
-    this.courses.sortingDataAccessor = commonSortingDataAccessor;
     this.coursesService.coursesListener$(this.parent).pipe(
       takeUntil(this.onDestroy$),
       switchMap((courses: any) => this.parent && courses !== undefined ?
@@ -169,6 +168,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
       this.tagFilterValue = tags;
       this.titleSearch = this.titleSearch;
       this.removeFilteredFromSelection();
+      this.setupSorting()
     });
   }
 
@@ -198,7 +198,6 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   }
 
   ngAfterViewInit() {
-    this.courses.sort = this.sort;
     this.courses.paginator = this.paginator;
     if (this.tagInputComponent) {
       this.tagInputComponent.addTags(this.route.snapshot.paramMap.get('collections'));
@@ -207,6 +206,11 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
 
   onPaginateChange(e: PageEvent) {
     this.selection.clear();
+  }
+
+  setupSorting() {
+    this.courses.sortingDataAccessor = commonSortingDataAccessor;
+    this.courses.sort = this.sort;
   }
 
   searchFilter(filterValue: string) {

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -144,11 +144,11 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     });
     this.resourcesService.requestResourcesUpdate(this.parent);
     this.resources.filterPredicate = this.filterPredicate;
-    this.resources.sortingDataAccessor = commonSortingDataAccessor;
     this.tagFilter.valueChanges.subscribe((tags) => {
       this.tagFilterValue = tags;
       this.titleSearch = this.titleSearch;
       this.removeFilteredFromSelection();
+      this.setupSorting();
     });
     this.selection.changed.subscribe(({ source }) => this.onSelectionChange(source.selected));
     this.couchService.checkAuthorization('resources').subscribe((isAuthorized) => this.isAuthorized = isAuthorized);
@@ -177,7 +177,6 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    this.resources.sort = this.sort;
     this.resources.paginator = this.paginator;
     if (this.tagInputComponent) {
       this.tagInputComponent.addTags(this.route.snapshot.paramMap.get('collections'));
@@ -198,6 +197,11 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   applyResFilter(filterResValue: string) {
     this.resources.filter = filterResValue;
+  }
+
+  setupSorting() {
+    this.resources.sortingDataAccessor = commonSortingDataAccessor;
+    this.resources.sort = this.sort;
   }
 
   /** Selects all rows if they are not all selected; otherwise clear selection. */


### PR DESCRIPTION
Fixes #7715 

**This image, if you're wondering why `Github` is the first one, it's because there's a space in first character**
![image](https://github.com/user-attachments/assets/b76e389e-03eb-4aaf-b489-726a8d0da17f)

![image](https://github.com/user-attachments/assets/6bc2a49f-1090-4239-a658-f77c490db44a)

