### PR TITLE
resources: smoother collection tags (fixes #5776)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.44",
+  "version": "0.15.53",
   "myplanet": {
     "latest": "v0.20.96",
     "min": "v0.19.96"

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -203,6 +203,7 @@ export class PlanetTagInputDialogComponent {
         this.data.initTags();
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`Tag deleted: ${tag.name}`);
+        this.resetValidationAndCheck(this.addTagForm);
       },
       onError: (error) => this.planetMessageService.showAlert($localize`There was a problem deleting this tag.`)
     };
@@ -228,6 +229,15 @@ export class PlanetTagInputDialogComponent {
       'tags', '_id', ac,
       { exceptions: [ exception ], selectors: { _id: `${this.data.db}_${ac.value.toLowerCase()}` } }
     );
+  }
+
+  resetValidationAndCheck(form: FormGroup) {
+    Object.keys(form.controls).forEach(key => {
+      const control = form.get(key);
+      control?.clearValidators();
+      control?.markAsUntouched();
+      control?.updateValueAndValidity();
+    });
   }
 
   toggleSubcollection(event, tagId) {

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -235,6 +235,12 @@ export class PlanetTagInputDialogComponent {
     Object.keys(form.controls).forEach(key => {
       const control = form.get(key);
       control?.clearValidators();
+
+      if (key === 'name') {
+        control?.setValidators(this.tagNameSyncValidator());
+        control?.setAsyncValidators(ac => this.tagNameAsyncValidator(ac));
+      }
+
       control?.markAsUntouched();
       control?.updateValueAndValidity();
     });


### PR DESCRIPTION
Fixes #5776 

After deleting a tag, if the tag is available, you can instantly add it to the collection.

If you delete `b` but trying to insert `a` while `a` is still exist, it will not let you do it