### PR TITLE
Courses: more accurate label

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -180,8 +180,8 @@
               <span i18n>Feedback</span>
             </a>
             <a mat-menu-item *ngIf="element.canManage" (click)="updateCourse(element.doc)">
-              <mat-icon>folder</mat-icon>
-              <span i18n>Manage</span>
+              <mat-icon>edit</mat-icon>
+              <span i18n>Edit Course</span>
             </a>
             <a mat-menu-item [routerLink]="['/courses/view', element._id]">
               <mat-icon>visibility</mat-icon>


### PR DESCRIPTION
fixes #4019

The old manage button just took you edit the course, so changed the label to Edit Course and logo changed to reflect it.

![image](https://github.com/user-attachments/assets/d27ef178-2948-484a-b90e-4e0fd67cee57)
