### PR TITLE
teams: smoother table search(fixes #4609)

### DIFF
--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -281,6 +281,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
 
   applyFilter(filterValue: string) {
     this.teams.filter = filterValue || (this.myTeamsFilter ? ' ' : '');
+    this.emptyData = this.teams.filteredData.length === 0;
   }
 
 }

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -240,6 +240,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`You have deleted a team.`);
         this.removeTeamFromTable(team);
+        this.emptyData = !this.teams.data.length;
       },
       onError: () => this.planetMessageService.showAlert($localize`There was a problem deleting this team.`)
     };


### PR DESCRIPTION
fixes #4609 

When deleting the last team, it will update the empty data and display `No Team Found`


P.S.
Wondering if we should do it also, when youre searching for a team, that doesnt exist, because right now, it just shows a empty white screen with the headers.