### PR TITLE
First Iteration of Acheivements Page Revamp (fixes #7639)

### DIFF
--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -23,19 +23,24 @@
   </mat-toolbar>
   <div class="view-container">
     <div *ngIf="achievements !== undefined" class="achievements-container">
-      <h2>{{user.firstName}} {{user.middleName}} {{user.lastName}}</h2>
-      <div>
-        <ng-container *ngIf="user.birthDate"><span i18n>Birthdate: {{' ' + (user.birthDate | date: medium) + ' '}}</span></ng-container><br/><br/>
-        <span *ngIf="user.birthplace" i18n>Birthplace: {{' ' + user.birthplace}} </span>
+      <div class="user-info">
+        <h2>{{user.firstName}} {{user.middleName}} {{user.lastName}}</h2>
+        <div class="birth-info">
+          <ng-container *ngIf="user.birthDate"><span i18n>Birthdate: {{' ' + (user.birthDate | date: medium) + ' '}}</span></ng-container><br/><br/>
+          <span *ngIf="user.birthplace" i18n>Birthplace: {{' ' + user.birthplace}} </span>
+        </div>
       </div>
+      <mat-divider></mat-divider>
       <div *ngIf="achievements.purpose">
         <h3 i18n>My Purpose</h3>
         <td-markdown [content]="achievements.purpose"></td-markdown>
       </div>
+      <mat-divider></mat-divider>
       <div *ngIf="achievements.goals">
         <h3 i18n>My Goals</h3>
         <td-markdown [content]="achievements.goals"></td-markdown>
       </div>
+      <mat-divider></mat-divider>
       <ng-container *planetBeta>
         <div *ngIf="certifications.length > 0">
           <h3 i18n>My Certifications</h3>
@@ -46,6 +51,7 @@
           </mat-list>
         </div>
       </ng-container>
+      <mat-divider></mat-divider>
       <div *ngIf="achievements?.links?.length > 0">
         <h3 i18n>My Links</h3>
         <mat-list>
@@ -55,6 +61,7 @@
           </mat-list-item>
         </mat-list>
       </div>
+      <mat-divider></mat-divider>
       <div *ngIf="achievements.achievementsHeader || achievements.achievements.length > 0">
         <h3 i18n>My Achievements</h3>
         <td-markdown [content]="achievements.achievementsHeader"></td-markdown>
@@ -77,6 +84,7 @@
           </mat-list-item>
         </mat-list>
       </div>
+      <mat-divider></mat-divider>
       <div *ngIf="achievements.references.length > 0">
         <h3 i18n>My References</h3>
         <mat-list>
@@ -89,6 +97,7 @@
         </mat-list>
       </div>
     </div>
+    <mat-divider></mat-divider>
     <div *ngIf="achievementNotFound">
       <ng-container *ngIf="ownAchievements"><span i18n>You haven't entered any achievements yet. Click </span><a routerLink="update" i18n>Add Achievements</a><span i18n> to add your achievements!</span></ng-container>
       <ng-container *ngIf="!ownAchievements" i18n>No achievements found.</ng-container>

--- a/src/app/users/users-achievements/users-achievements.scss
+++ b/src/app/users/users-achievements/users-achievements.scss
@@ -1,14 +1,32 @@
 @import '../../variables';
 
 .achievements-container {
-  max-width: 800px;
+  max-width: 95%;
   margin: 0 auto;
-  text-align: center;
 
   & mat-list, & ul, & ol {
     text-align: left;
   }
 
+  mat-divider {
+    margin-top: 1rem;
+  }
+
+  .user-info{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .birth-info{
+    display: flex;
+    justify-content: center;
+    flex-direction: row;
+    gap: 1rem;
+  }
+  
   .mat-list-base .mat-list-item {
     &.mat-list-item-word-wrap {
       height: initial;
@@ -44,7 +62,6 @@
         margin-right: 0;
       }
     }
-
   }
 
   .styled-link {


### PR DESCRIPTION
Revamped the Achievements page to take up more real estate, open to feedback and suggestions to improve this even further. 
<img width="1251" alt="revamp" src="https://github.com/user-attachments/assets/2ddb9453-8199-4d06-b35f-3ae5e267169a">

fixes #7639 