### PR TITLE
chat: smoother provider switching (fixes #7638)(fixes #7809)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.55",
+  "version": "0.15.64",
   "myplanet": {
     "latest": "v0.20.99",
     "min": "v0.19.99"

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -141,6 +141,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   selectConversation(conversation, index: number) {
     this.selectedConversation = conversation;
+    this.chatService.setAIProvider(this.selectedConversation['aiProvider']);
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,
       '_rev': conversation?._rev

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -94,8 +94,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   }
 
   hasProviderChanged() {
-    console.log('log: ', this.chatService.getChatAIProvider());
-    console.log('log: ', this.provider);
     if (this.chatService.getChatAIProvider() === undefined) {
       return; // that means that it's a brand new chat
     } else if (this.chatService.getChatAIProvider().name === this.provider.name) {

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -94,9 +94,11 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   }
 
   hasProviderChanged() {
+    console.log('log: ', this.chatService.getChatAIProvider());
+    console.log('log: ', this.provider);
     if (this.chatService.getChatAIProvider() === undefined) {
       return; // that means that it's a brand new chat
-    } else if (this.chatService.getChatAIProvider() === this.provider.name) {
+    } else if (this.chatService.getChatAIProvider().name === this.provider.name) {
       return; // that means that the it still the same model being used
     }
     this.newChat();
@@ -164,7 +166,10 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   selectConversation(conversation, index: number) {
     this.selectedConversation = conversation;
-    this.chatService.setChatAIProvider(this.selectedConversation['aiProvider']);
+    const aiProvider: AIProvider = {
+      name: this.selectedConversation['aiProvider'],
+    }
+    this.chatService.setChatAIProvider(aiProvider);
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,
       '_rev': conversation?._rev

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -95,8 +95,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   hasProviderChanged() {
     const currentProvider = this.chatService.getChatAIProvider();
-    console.log('log: chat provider', currentProvider);
-    console.log('log: provider chat selected', this.provider);
     if (!currentProvider) {
       // That means it's a brand-new chat
       return;
@@ -105,7 +103,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
       // That means the same model is still being used
       return;
     }
-    console.log('log: new chat is created');
     this.newChat();
   }
 
@@ -176,7 +173,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
     };
     this.chatService.setChatAIProvider(aiProvider);
     const currentProvider = this.chatService.getChatAIProvider();
-    console.log('log chat sidebar: ', currentProvider);
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,
       '_rev': conversation?._rev

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -168,7 +168,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
     this.selectedConversation = conversation;
     const aiProvider: AIProvider = {
       name: this.selectedConversation['aiProvider'],
-    }
+    };
     this.chatService.setChatAIProvider(aiProvider);
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -94,11 +94,18 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   }
 
   hasProviderChanged() {
-    if (this.chatService.getChatAIProvider() === undefined) {
-      return; // that means that it's a brand new chat
-    } else if (this.chatService.getChatAIProvider().name === this.provider.name) {
-      return; // that means that the it still the same model being used
+    const currentProvider = this.chatService.getChatAIProvider();
+    console.log('log: chat provider', currentProvider);
+    console.log('log: provider chat selected', this.provider);
+    if (!currentProvider) {
+      // That means it's a brand-new chat
+      return;
     }
+    if (currentProvider.name === this.provider.name) {
+      // That means the same model is still being used
+      return;
+    }
+    console.log('log: new chat is created');
     this.newChat();
   }
 
@@ -117,7 +124,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
         title: title !== undefined && title !== null ? title : conversation.title,
         shared: shared,
         updatedDate: this.couchService.datePlaceholder
-     }
+      }
     ).subscribe((data) => {
       this.getChatHistory();
       return data;
@@ -168,6 +175,8 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
       name: this.selectedConversation['aiProvider'],
     };
     this.chatService.setChatAIProvider(aiProvider);
+    const currentProvider = this.chatService.getChatAIProvider();
+    console.log('log chat sidebar: ', currentProvider);
     this.chatService.setSelectedConversationId({
       '_id': conversation?._id,
       '_rev': conversation?._rev

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -205,6 +205,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
     const content = this.promptForm.get('prompt').value;
     this.data = { ...this.data, content, aiProvider: this.provider };
 
+    this.chatService.setChatAIProvider(this.data.aiProvider.name);
     this.setSelectedConversation();
 
     if (this.context) {

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -205,7 +205,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
     const content = this.promptForm.get('prompt').value;
     this.data = { ...this.data, content, aiProvider: this.provider };
 
-    this.chatService.setChatAIProvider(this.data.aiProvider.name);
+    this.chatService.setChatAIProvider(this.data.aiProvider);
     this.setSelectedConversation();
 
     if (this.context) {

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -27,6 +27,18 @@ export class ChatComponent implements OnInit {
       this.displayToggle = this.aiServices.length > 0;
       this.chatService.toggleAIServiceSignal(this.activeService);
     });
+    this.subscribeToAIService();
+  }
+
+  subscribeToAIService() {
+    this.chatService.currentChatAIProvider$
+      .subscribe((aiService => {
+        console.log('log chat component: ', aiService);
+        if (aiService) {
+          this.activeService = aiService.name;
+          this.toggleAIService();
+        }
+      }));
   }
 
   goBack(): void {

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -33,7 +33,6 @@ export class ChatComponent implements OnInit {
   subscribeToAIService() {
     this.chatService.currentChatAIProvider$
       .subscribe((aiService => {
-        console.log('log chat component: ', aiService);
         if (aiService) {
           this.activeService = aiService.name;
           this.toggleAIService();

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -34,6 +34,7 @@ export class ChatComponent implements OnInit {
   }
 
   toggleAIService(): void {
+    console.log("log: ", this.chatService.getAIProvider())
     this.chatService.toggleAIServiceSignal(this.activeService);
   }
 

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -34,7 +34,6 @@ export class ChatComponent implements OnInit {
   }
 
   toggleAIService(): void {
-    console.log('log: ', this.chatService.getAIProvider());
     this.chatService.toggleAIServiceSignal(this.activeService);
   }
 

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -34,7 +34,7 @@ export class ChatComponent implements OnInit {
   }
 
   toggleAIService(): void {
-    console.log("log: ", this.chatService.getAIProvider())
+    console.log('log: ', this.chatService.getAIProvider());
     this.chatService.toggleAIServiceSignal(this.activeService);
   }
 

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -30,7 +30,7 @@ import { AIServices, AIProvider } from '../chat/chat.model';
   aiProviders$ = this.aiProvidersSubject.asObservable();
   selectedConversationId$: Observable<object | null> = this.selectedConversationIdSubject.asObservable();
 
-  currentAIProvider: string;
+  currentChatAIProvider: string;
 
   constructor(
     private httpClient: HttpClient,
@@ -124,12 +124,12 @@ import { AIServices, AIProvider } from '../chat/chat.model';
     this.toggleAIService.next(aiService);
   }
 
-  setAIProvider(aiProvider: string) {
-    this.currentAIProvider = aiProvider;
+  setChatAIProvider(aiProvider: string) {
+    this.currentChatAIProvider = aiProvider;
   }
 
-  getAIProvider(): string {
-    return this.currentAIProvider;
+  getChatAIProvider(): string {
+    return this.currentChatAIProvider;
   }
 
   setSelectedConversationId(conversationId: object) {

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -23,14 +23,14 @@ import { AIServices, AIProvider } from '../chat/chat.model';
   private toggleAIService = new Subject<string>();
   private selectedConversationIdSubject = new BehaviorSubject<object | null>(null);
   private aiProvidersSubject = new BehaviorSubject<Array<AIProvider>>([]);
+  private currentChatAIProvider = new BehaviorSubject<AIProvider>(undefined);
 
   newChatAdded$ = this.newChatAdded.asObservable();
   newChatSelected$ = this.newChatSelected.asObservable();
   toggleAIService$ = this.toggleAIService.asObservable();
   aiProviders$ = this.aiProvidersSubject.asObservable();
   selectedConversationId$: Observable<object | null> = this.selectedConversationIdSubject.asObservable();
-
-  currentChatAIProvider: AIProvider;
+  currentChatAIProvider$: Observable<AIProvider> = this.currentChatAIProvider.asObservable();
 
   constructor(
     private httpClient: HttpClient,
@@ -125,11 +125,11 @@ import { AIServices, AIProvider } from '../chat/chat.model';
   }
 
   setChatAIProvider(aiProvider: AIProvider) {
-    this.currentChatAIProvider = aiProvider;
+    this.currentChatAIProvider.next(aiProvider);
   }
 
   getChatAIProvider(): AIProvider {
-    return this.currentChatAIProvider;
+    return this.currentChatAIProvider.getValue();
   }
 
   setSelectedConversationId(conversationId: object) {

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -30,7 +30,7 @@ import { AIServices, AIProvider } from '../chat/chat.model';
   aiProviders$ = this.aiProvidersSubject.asObservable();
   selectedConversationId$: Observable<object | null> = this.selectedConversationIdSubject.asObservable();
 
-  currentChatAIProvider: string;
+  currentChatAIProvider: AIProvider;
 
   constructor(
     private httpClient: HttpClient,
@@ -124,11 +124,11 @@ import { AIServices, AIProvider } from '../chat/chat.model';
     this.toggleAIService.next(aiService);
   }
 
-  setChatAIProvider(aiProvider: string) {
+  setChatAIProvider(aiProvider: AIProvider) {
     this.currentChatAIProvider = aiProvider;
   }
 
-  getChatAIProvider(): string {
+  getChatAIProvider(): AIProvider {
     return this.currentChatAIProvider;
   }
 

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -30,6 +30,7 @@ import { AIServices, AIProvider } from '../chat/chat.model';
   aiProviders$ = this.aiProvidersSubject.asObservable();
   selectedConversationId$: Observable<object | null> = this.selectedConversationIdSubject.asObservable();
 
+  currentAIProvider: string;
 
   constructor(
     private httpClient: HttpClient,
@@ -121,6 +122,14 @@ import { AIServices, AIProvider } from '../chat/chat.model';
 
   toggleAIServiceSignal(aiService: string) {
     this.toggleAIService.next(aiService);
+  }
+
+  setAIProvider(aiProvider: string) {
+    this.currentAIProvider = aiProvider;
+  }
+
+  getAIProvider(): string {
+    return this.currentAIProvider;
   }
 
   setSelectedConversationId(conversationId: object) {


### PR DESCRIPTION
Fixes #7638
Fixes #7809 

New chat:
If you are currently on a chat with a specific provider, then switching provider will create a new chat.
If you haven't selected an existing chat with a model, than switching chat does nothing.

Select existing chat:
If you select an existing chat, it will switch over to the model that the chat previously used (since we want to let a chat be tied to a specific model)