### PR TITLE
chat: smoother share (fixes #7812)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.62",
+  "version": "0.15.63",
   "myplanet": {
-    "latest": "v0.21.4",
-    "min": "v0.20.4"
+    "latest": "v0.21.7",
+    "min": "v0.20.7"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -211,14 +211,19 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
   }
 
   openShareDialog(conversation) {
-    this.dialog.open(DialogsChatShareComponent, {
+    const dialogRef = this.dialog.open(DialogsChatShareComponent, {
       width: '50vw',
       maxHeight: '90vh',
       data: {
         news: conversation,
       }
     });
-    this.updateConversation(conversation, null, true);
-  }
 
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        console.log('log: update conversation!')
+        this.updateConversation(conversation, null, true);
+      }
+    });
+  }
 }

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -221,7 +221,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        console.log('log: update conversation!')
         this.updateConversation(conversation, null, true);
       }
     });

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -124,7 +124,6 @@ export class DialogsChatShareComponent implements OnInit {
       })
     ).subscribe((membersData) => {
       this.conversation.chat = true;
-
       this.newsService.postNews({
         viewIn: [ { '_id': linkId, section: 'teams', public: false } ],
         messageType: teamType,
@@ -134,6 +133,7 @@ export class DialogsChatShareComponent implements OnInit {
         switchMap(() => this.sendNotifications('message', membersData, teamType)),
       ).subscribe();
     });
+    this.interact();
   }
 
   shareWithCommunity() {
@@ -142,6 +142,7 @@ export class DialogsChatShareComponent implements OnInit {
       this.conversation.message = message ? { text: message, images: [] } : { text: '</br>', images: [] };
     }
     this.conversation.chat = true;
+    this.interact();
     this.newsService.shareNews(this.conversation, null, $localize`Chat has been successfully shared to community`).subscribe(() => {});
     if (
       this.userStatusService.getStatus('joinedCourse') &&
@@ -155,4 +156,8 @@ export class DialogsChatShareComponent implements OnInit {
     }
   }
 
+  interact() {
+    console.log('log: interacted!');
+    this.dialogRef.close({  interacted: true });
+  }
 }

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -157,7 +157,6 @@ export class DialogsChatShareComponent implements OnInit {
   }
 
   interact() {
-    console.log('log: interacted!');
     this.dialogRef.close({  interacted: true });
   }
 }


### PR DESCRIPTION
Fixes #7812

When you click on share, it doesn't marked as share, it waits until you complete an action (either sharing into community or team / enterprise).