### PR TITLE
courses: smoother details creation date (fixes #7839)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.67",
+  "version": "0.15.71",
   "myplanet": {
     "latest": "v0.21.10",
     "min": "v0.20.10"

--- a/src/app/courses/view-courses/courses-view-detail.component.html
+++ b/src/app/courses/view-courses/courses-view-detail.component.html
@@ -3,6 +3,7 @@
 <p><b i18n>Grade Level:</b> <planet-language-label [options]="gradeOptions" [label]="courseDetail?.gradeLevel"></planet-language-label></p>
 <p *ngIf="courseDetail?.languageOfInstruction"><b i18n>Language of Instruction:</b> <planet-language-label [options]="languageOptions" [label]="courseDetail?.languageOfInstruction || 'N/A'"></planet-language-label></p>
 <p *ngIf="courseDetail?.creatorDoc"><b i18n>Creator:</b> {{courseDetail?.creatorDoc?.fullName}} </p>
+<p><b i18n>Created on:</b> {{(courseDetail?.createdDate | date: 'mediumDate') || 'N/A'}}</p>
 <p *ngIf="courseDetail?.sourcePlanet !== planetConfiguration.code && courseDetail?.sourcePlanet"><b i18n>Source:</b> {{courseDetail?.sourcePlanet}}</p>
 <p><b i18n>Description:</b></p>
 <planet-markdown [content]="courseDetail?.description" [imageSource]="imageSource" class="img-resize"></planet-markdown>


### PR DESCRIPTION
fixes #7839 

Course detail now has a date to show when course was created.