### PR TITLE
chat: smoother input autofocus (fixes #7836)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.67",
+  "version": "0.15.72",
   "myplanet": {
     "latest": "v0.21.10",
     "min": "v0.20.10"

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, EventEmitter, Output, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
@@ -19,6 +19,7 @@ import { UserService } from '../../shared/user.service';
   styleUrls: [ './chat-sidebar.scss' ],
 })
 export class ChatSidebarComponent implements OnInit, OnDestroy {
+  @Output() conversationSelected = new EventEmitter<Conversation>();
   readonly dbName = 'chat_history';
   private onDestroy$ = new Subject<void>();
   private _titleSearch = '';
@@ -171,6 +172,7 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   selectConversation(conversation, index: number) {
     this.selectedConversation = conversation;
+    this.conversationSelected.emit(conversation);
     const aiProvider: AIProvider = {
       name: this.selectedConversation['aiProvider'],
     };

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
@@ -19,7 +19,6 @@ import { UserService } from '../../shared/user.service';
   styleUrls: [ './chat-sidebar.scss' ],
 })
 export class ChatSidebarComponent implements OnInit, OnDestroy {
-  @Output() conversationSelected = new EventEmitter<Conversation>();
   readonly dbName = 'chat_history';
   private onDestroy$ = new Subject<void>();
   private _titleSearch = '';
@@ -172,7 +171,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
 
   selectConversation(conversation, index: number) {
     this.selectedConversation = conversation;
-    this.conversationSelected.emit(conversation);
     const aiProvider: AIProvider = {
       name: this.selectedConversation['aiProvider'],
     };

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -11,8 +11,7 @@
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <mat-label i18n>Chat</mat-label>
         <div class="textarea-container">
-          <textarea #chatInput matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder>    
-          </textarea>
+          <textarea #chatInput matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
           <button
             mat-icon-button
             [planetSubmit]="promptForm.valid && spinnerOn"

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -14,14 +14,8 @@
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <mat-label i18n>Chat</mat-label>
         <div class="textarea-container">
-          <textarea
-            #chatInput
-            matInput
-            [formControl]="promptForm.controls.prompt"
-            rows="5"
-            placeholder="Send a message"
-            i18n-placeholder
-          ></textarea>
+          <textarea #chatInput matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder>    
+          </textarea>
           <button
             mat-icon-button
             [planetSubmit]="promptForm.valid && spinnerOn"

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -2,10 +2,7 @@
   <div class="chat-container" #chat>
     <div *ngFor="let conversation of conversations">
       <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
-      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}"
-        class="conversation-err"
-        [planetChatOutput]="conversation.response"
-      ></p>
+      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" class="conversation-err" [planetChatOutput]="conversation.response"></p>
     </div>
   </div>
 

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -2,7 +2,10 @@
   <div class="chat-container" #chat>
     <div *ngFor="let conversation of conversations">
       <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
-      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" class="conversation-err" [planetChatOutput]="conversation.response"></p>
+      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}"
+        class="conversation-err"
+        [planetChatOutput]="conversation.response"
+      ></p>
     </div>
   </div>
 
@@ -11,7 +14,14 @@
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <mat-label i18n>Chat</mat-label>
         <div class="textarea-container">
-          <textarea matInput [formControl]="promptForm.controls.prompt" rows="5" placeholder="Send a message" i18n-placeholder></textarea>
+          <textarea
+            #chatInput
+            matInput
+            [formControl]="promptForm.controls.prompt"
+            rows="5"
+            placeholder="Send a message"
+            i18n-placeholder
+          ></textarea>
           <button
             mat-icon-button
             [planetSubmit]="promptForm.valid && spinnerOn"

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -243,10 +243,6 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  onNewChatSelected() {
-    this.focusInput();
-  }
-
   focusInput() {
     this.chatInput?.nativeElement.focus();
   }

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, ElementRef, ChangeDetectorRef, Input } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef, ChangeDetectorRef, Input, AfterViewInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -16,7 +16,7 @@ import { Conversation } from '../chat.model';
   templateUrl: './chat-window.component.html',
   styleUrls: [ './chat-window.scss' ],
 })
-export class ChatWindowComponent implements OnInit, OnDestroy {
+export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   private onDestroy$ = new Subject<void>();
   spinnerOn = true;
   streaming: boolean;

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -36,6 +36,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
   providers: AIProvider[] = [];
 
   @Input() context: any;
+  @ViewChild('chatInput') chatInput: ElementRef;
   @ViewChild('chat') chatContainer: ElementRef;
 
   constructor(
@@ -69,6 +70,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.selectedConversationId = null;
         this.conversations = [];
+        this.focusInput();
       }, error => {
         console.error('Error subscribing to newChatSelected$', error);
       });
@@ -233,5 +235,13 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
         }
       );
     }
+  }
+
+  onNewChatSelected() {
+    this.focusInput(); // Focus the input when a new chat is selected
+  }
+
+  focusInput() {
+    this.chatInput?.nativeElement.focus(); // Focus the input element
   }
 }

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -9,7 +9,6 @@ import { ChatService } from '../../shared/chat.service';
 import { showFormErrors } from '../../shared/table-helpers';
 import { UserService } from '../../shared/user.service';
 import { StateService } from '../../shared/state.service';
-import { Conversation } from '../chat.model';
 
 @Component({
   selector: 'planet-chat-window',
@@ -35,7 +34,6 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     context: '',
   };
   providers: AIProvider[] = [];
-  @Input() selectedConversation: Conversation;
   @Input() context: any;
   @ViewChild('chatInput') chatInput: ElementRef;
   @ViewChild('chat') chatContainer: ElementRef;
@@ -100,6 +98,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
         this.provider = {
           name: aiService
         };
+        this.focusInput();
       }));
   }
 

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -9,6 +9,7 @@ import { ChatService } from '../../shared/chat.service';
 import { showFormErrors } from '../../shared/table-helpers';
 import { UserService } from '../../shared/user.service';
 import { StateService } from '../../shared/state.service';
+import { Conversation } from '../chat.model';
 
 @Component({
   selector: 'planet-chat-window',
@@ -34,7 +35,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
     context: '',
   };
   providers: AIProvider[] = [];
-
+  @Input() selectedConversation: Conversation;
   @Input() context: any;
   @ViewChild('chatInput') chatInput: ElementRef;
   @ViewChild('chat') chatContainer: ElementRef;
@@ -56,6 +57,10 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
     this.chatService.listAIProviders().subscribe((providers) => {
       this.providers = providers;
     });
+  }
+
+  ngAfterViewInit() {
+    this.focusInput();
   }
 
   ngOnDestroy() {
@@ -82,6 +87,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
       .subscribe((conversationId) => {
         this.selectedConversationId = conversationId;
         this.fetchConversation(this.selectedConversationId?._id);
+        this.focusInput();
       }, error => {
         console.error('Error subscribing to selectedConversationId$', error);
       });
@@ -238,10 +244,10 @@ export class ChatWindowComponent implements OnInit, OnDestroy {
   }
 
   onNewChatSelected() {
-    this.focusInput(); // Focus the input when a new chat is selected
+    this.focusInput();
   }
 
   focusInput() {
-    this.chatInput?.nativeElement.focus(); // Focus the input element
+    this.chatInput?.nativeElement.focus();
   }
 }


### PR DESCRIPTION
Fixes #7836 

When navigating to the chat page, creating a new chat, or selecting an existing one, the input field is focused so the learner can begin typing immediately.