### PR TITLE
all: smoother table filter (fixes #7823)

### DIFF
--- a/src/app/feedback/feedback.component.ts
+++ b/src/app/feedback/feedback.component.ts
@@ -48,6 +48,7 @@ export class FeedbackComponent implements OnInit, AfterViewInit, OnDestroy {
     // When setting the titleSearch, also set the feedback filter
     this.feedback.filter = value ? value : this.dropdownsFill();
     this._titleSearch = value;
+    this.emptyData = !this.feedback.filteredData.length;
   }
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
@@ -144,6 +145,7 @@ export class FeedbackComponent implements OnInit, AfterViewInit, OnDestroy {
         this.feedback.data = this.feedback.data.filter((fback: any) => data.id !== fback._id);
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`You have deleted feedback.`);
+        this.emptyData = !this.feedback.data.length;
       },
       onError: (error) => this.planetMessageService.showAlert($localize`There is a problem deleting this feedback.`)
     };

--- a/src/app/submissions/submissions.component.ts
+++ b/src/app/submissions/submissions.component.ts
@@ -144,6 +144,7 @@ export class SubmissionsComponent implements OnInit, AfterViewChecked, OnDestroy
 
   applyFilter(filterValue: string) {
     this.submissions.filter = filterValue || this.dropdownsFill();
+    this.emptyData = !this.submissions.filteredData.length;
   }
 
   onFilterChange(filterValue: string, field: string) {

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -126,6 +126,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   applyFilter(filterValue: string) {
     this.surveys.filter = filterValue;
     this.selection.deselect(...selectedOutOfFilter(this.surveys.filteredData, this.selection, this.paginator));
+    this.emptyData = !this.surveys.filteredData.length;
   }
 
   isAllSelected() {
@@ -168,6 +169,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
         this.selection.clear();
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`You have deleted ${deleteArray.length} surveys`);
+        this.emptyData = !this.surveys.data.length;
       },
       onError: () => this.planetMessageService.showAlert($localize`There was a problem deleting survey.`)
     };

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -240,6 +240,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`You have deleted a team.`);
         this.removeTeamFromTable(team);
+        this.emptyData = !this.teams.data.length;
       },
       onError: () => this.planetMessageService.showAlert($localize`There was a problem deleting this team.`)
     };
@@ -280,6 +281,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
 
   applyFilter(filterValue: string) {
     this.teams.filter = filterValue || (this.myTeamsFilter ? ' ' : '');
+    this.emptyData = !this.teams.filteredData.length;
   }
 
 }

--- a/src/app/users/users-table.component.html
+++ b/src/app/users/users-table.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="containerClass">
+<div [ngClass]="containerClass" *ngIf="!emptyData; else notFoundMessage">
   <mat-table #table [dataSource]="usersTable" [trackBy]="trackByFn" matSort [matSortActive]="matSortActive" matSortDirection="desc">
     <ng-container matColumnDef="select">
       <mat-header-cell *matHeaderCellDef>
@@ -143,3 +143,6 @@
     (page)="onPaginateChange($event)">
   </mat-paginator>
 </div>
+<ng-template #notFoundMessage>
+  <div class="view-container" i18n>No User Found</div>
+</ng-template>

--- a/src/app/users/users-table.component.ts
+++ b/src/app/users/users-table.component.ts
@@ -84,6 +84,7 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
   deleteDialog: MatDialogRef<DialogsPromptComponent>;
   deviceType: DeviceType;
   isMobile: boolean;
+  emptyData = false;
 
   constructor(
     private dialog: MatDialog,
@@ -126,6 +127,7 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
     if (this.isDialog) {
       this.displayedColumns = [ 'select', 'profile', 'name', 'visitCount', 'joinDate', 'lastLogin', 'roles' ];
     }
+    this.emptyData = !this.usersTable.filteredData.length;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Fixes #7823

update the filter for empty data, so it will display `No {name} Found` if there's no more items on the list after filtering or deleting

- [x] surveys
- [x] mySurveys and submission
- [x] teams and enterprise
- [x] members
- [x] feedback

if there any more table here that needs to be fixed, then please let me know :), or you can also contribute, its up to you
