### PR TITLE
teams: smoother calendar recursions (fixes #7858)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "myplanet": {
     "latest": "v0.21.12",
     "min": "v0.20.12"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.72",
+  "version": "0.16.0",
   "myplanet": {
     "latest": "v0.21.12",
     "min": "v0.20.12"

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -53,19 +53,24 @@
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.recurring"></planet-form-error-messages></mat-error>
         </mat-radio-group>
       </div>
-      <div *ngIf="meetupForm.controls.recurring.value === 'weekly'" class="full-width">
-        <mat-checkbox
-          *ngFor="let day of days"
-          [checked]="meetupForm.controls.day.value.includes(day)"
-          (change)="onDayChange(day, $event.checked)"
-          class="margin-lr"
-        >
-          {{ day }}
-        </mat-checkbox>
-        <mat-error *ngIf="meetupForm.controls.day.errors?.noDaysSelected">
-          <span i18n>Please select at least one day.</span>
-        </mat-error>
-      </div>      
+
+
+<div *ngIf="meetupForm.controls.recurring.value === 'weekly'" class="full-width">
+    <mat-checkbox
+        *ngFor="let day of days"
+        [checked]="meetupForm.controls.day.value.includes(day)"
+        (change)="onDayChange(day, $event.checked)"
+        class="margin-lr"
+    >
+        {{ day }}
+    </mat-checkbox>
+    <mat-error *ngIf="meetupForm.controls.day.hasError('noDaysSelected')">
+        <span i18n>Please select at least one day.</span>
+    </mat-error>
+</div>
+   
+      
+      
       <ng-container *ngIf="meetupForm.controls.recurring.value==='weekly' || meetupForm.controls.recurring.value==='daily'">
         <mat-form-field>
           <input matInput type="number" min="2" i18n-placeholder placeholder="Number of Recurrences" formControlName="recurringNumber">

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -53,9 +53,19 @@
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.recurring"></planet-form-error-messages></mat-error>
         </mat-radio-group>
       </div>
-      <div *ngIf="meetupForm.controls.recurring.value==='weekly'" class="full-width">
-        <mat-checkbox (change)="onDayChange(day, $event.checked)" *ngFor="let day of days" class="margin-lr" [checked]="isClassDay(day)">{{day}}</mat-checkbox>
-      </div>
+      <div *ngIf="meetupForm.controls.recurring.value === 'weekly'" class="full-width">
+        <mat-checkbox
+          *ngFor="let day of days"
+          [checked]="meetupForm.controls.day.value.includes(day)"
+          (change)="onDayChange(day, $event.checked)"
+          class="margin-lr"
+        >
+          {{ day }}
+        </mat-checkbox>
+        <mat-error *ngIf="meetupForm.controls.day.errors?.noDaysSelected">
+          <span i18n>Please select at least one day.</span>
+        </mat-error>
+      </div>      
       <ng-container *ngIf="meetupForm.controls.recurring.value==='weekly' || meetupForm.controls.recurring.value==='daily'">
         <mat-form-field>
           <input matInput type="number" min="2" i18n-placeholder placeholder="Number of Recurrences" formControlName="recurringNumber">

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -53,24 +53,12 @@
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.recurring"></planet-form-error-messages></mat-error>
         </mat-radio-group>
       </div>
-
-
-<div *ngIf="meetupForm.controls.recurring.value === 'weekly'" class="full-width">
-    <mat-checkbox
-        *ngFor="let day of days"
-        [checked]="meetupForm.controls.day.value.includes(day)"
-        (change)="onDayChange(day, $event.checked)"
-        class="margin-lr"
-    >
-        {{ day }}
-    </mat-checkbox>
-    <mat-error *ngIf="meetupForm.controls.day.hasError('noDaysSelected')">
-        <span i18n>Please select at least one day.</span>
-    </mat-error>
-</div>
-   
-      
-      
+      <div *ngIf="meetupForm.controls.recurring.value === 'weekly'" class="full-width">
+          <mat-checkbox (change)="onDayChange(day, $event.checked)" *ngFor="let day of days"  class="margin-lr" [checked]="meetupForm.controls.day.value.includes(day)"> {{ day }}</mat-checkbox>
+          <mat-error *ngIf="meetupForm.controls.day.hasError('noDaysSelected')">
+            <span i18n>Please select at least one day.</span>
+          </mat-error>
+      </div>
       <ng-container *ngIf="meetupForm.controls.recurring.value==='weekly' || meetupForm.controls.recurring.value==='daily'">
         <mat-form-field>
           <input matInput type="number" min="2" i18n-placeholder placeholder="Number of Recurrences" formControlName="recurringNumber">

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -86,20 +86,20 @@ export class MeetupsAddComponent implements OnInit {
 
   createForm() {
     this.meetupForm = this.fb.group({
-        title: ['', CustomValidators.required],
-        description: ['', CustomValidators.required],
-        startDate: [this.meetup?.startDate || '', CustomValidators.startDateValidator()],
-        endDate: [this.meetup?.endDate || '', CustomValidators.endDateValidator()],
+        title: [ '', CustomValidators.required ],
+        description: [ '', CustomValidators.required ],
+        startDate: [ this.meetup?.startDate || '', CustomValidators.startDateValidator() ],
+        endDate: [ this.meetup?.endDate || '', CustomValidators.endDateValidator() ],
         recurring: 'none',
         day: this.fb.array([]),
-        startTime: ['', CustomValidators.timeValidator()],
-        endTime: ['', CustomValidators.timeValidator()],
+        startTime: [ '', CustomValidators.timeValidator() ],
+        endTime: [ '', CustomValidators.timeValidator() ],
         category: '',
         meetupLocation: '',
         createdBy: this.userService.get().name,
         sourcePlanet: this.stateService.configuration.code,
         createdDate: this.couchService.datePlaceholder,
-        recurringNumber: [10, [Validators.min(2), CustomValidators.integerValidator]],
+        recurringNumber: [ 10, [ Validators.min(2), CustomValidators.integerValidator ] ],
     }, {
         validators: CustomValidators.meetupTimeValidator(),
     });

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -86,54 +86,40 @@ export class MeetupsAddComponent implements OnInit {
 
   createForm() {
     this.meetupForm = this.fb.group({
-        title: [ '', CustomValidators.required ],
-        description: [ '', CustomValidators.required ],
-        startDate: [ this.meetup?.startDate || '', CustomValidators.startDateValidator() ],
-        endDate: [ this.meetup?.endDate || '', CustomValidators.endDateValidator() ],
-        recurring: 'none',
-        day: this.fb.array([]),
-        startTime: [ '', CustomValidators.timeValidator() ],
-        endTime: [ '', CustomValidators.timeValidator() ],
-        category: '',
-        meetupLocation: '',
-        createdBy: this.userService.get().name,
-        sourcePlanet: this.stateService.configuration.code,
-        createdDate: this.couchService.datePlaceholder,
-        recurringNumber: [ 10, [ Validators.min(2), CustomValidators.integerValidator ] ],
+      title: [ '', CustomValidators.required ],
+      description: [ '', CustomValidators.required ],
+      startDate: [ this.meetup?.startDate ? this.meetup.startDate : '', CustomValidators.startDateValidator() ],
+      endDate: [ this.meetup?.endDate ? this.meetup.endDate : '', CustomValidators.endDateValidator() ],
+      recurring: 'none',
+      day: this.fb.array([]),
+      startTime: [ '', CustomValidators.timeValidator() ],
+      endTime: [ '', CustomValidators.timeValidator() ],
+      category: '',
+      meetupLocation: '',
+      createdBy: this.userService.get().name,
+      sourcePlanet: this.stateService.configuration.code,
+      createdDate: this.couchService.datePlaceholder,
+      recurringNumber: [ 10, [ Validators.min(2), CustomValidators.integerValidator ] ],
     }, {
         validators: CustomValidators.meetupTimeValidator(),
     });
-
-    // Initialize the `day` field based on default recurring value
-    this.toggleDaily(this.meetupForm.get('recurring')?.value, false);
 }
 
-
 onSubmit() {
-  const dayFormArray = this.meetupForm.get('day') as FormArray;
-
-  // Dynamically update validators and validity
-  dayFormArray.updateValueAndValidity();
-
   if (this.meetupForm.invalid) {
-      console.log('Form validation errors:', this.meetupForm.errors);
-      console.log('Day field errors:', dayFormArray.errors);
       return;
   }
-
-  // Proceed with submission
+  const dayFormArray = this.meetupForm.get('day') as FormArray;
+  dayFormArray.updateValueAndValidity();
   this.meetupForm.value.startTime = this.changeTimeFormat(this.meetupForm.value.startTime);
   this.meetupForm.value.endTime = this.changeTimeFormat(this.meetupForm.value.endTime);
   const meetup = { ...this.meetupForm.value, link: this.link, sync: this.sync };
-
   if (this.pageType === 'Update') {
       this.updateMeetup(meetup);
   } else {
       this.addMeetup(meetup);
   }
 }
-
-
 
   changeTimeFormat(time: string): string {
     if (time && time.length < 5) {
@@ -203,61 +189,37 @@ onSubmit() {
             dayFormArray.removeAt(index);
         }
     }
-
-    console.log('Updated day control value:', dayFormArray.value);
-    dayFormArray.updateValueAndValidity(); // Force the validation to run
+    dayFormArray.updateValueAndValidity();
 }
-
-
 
 toggleDaily(val: string, showCheckbox: boolean) {
   const dayFormArray = this.meetupForm.get('day') as FormArray;
-
-  // Clear current values and validators in the FormArray
   dayFormArray.clear();
   dayFormArray.clearValidators();
 
   switch (val) {
       case 'daily':
-          // Add all days for daily recurrence
           this.days.forEach((day) => {
               dayFormArray.push(new FormControl(day));
           });
           break;
-
       case 'weekly':
-          // Add validation for weekly recurrence
           dayFormArray.setValidators(CustomValidators.atLeastOneDaySelected());
-
-          // Restore previously selected days if they exist
-          if (this.meetupFrequency && this.meetupFrequency.length > 0) {
-              this.meetupFrequency.forEach((day) => {
-                  dayFormArray.push(new FormControl(day));
-              });
-          } else {
-              const startDate = this.meetupForm.controls.startDate.value;
-
-              if (startDate) {
-                  const startDateObj = new Date(startDate);
-                  const dayOfWeek = this.days[startDateObj.getDay()];
-
-                  if (dayOfWeek) {
-                      dayFormArray.push(new FormControl(dayOfWeek));
-                  }
+          const startDate = this.meetupForm.controls.startDate.value;
+          if (startDate) {
+              const startDateObj = new Date(startDate);
+              const dayOfWeek = this.days[startDateObj.getDay()];
+              if (dayOfWeek) {
+                  dayFormArray.push(new FormControl(dayOfWeek));
               }
           }
           break;
 
       default:
-          // No recurrence (none), no validation required
           break;
   }
-
-  // Update the validity of the FormArray after modifications
   dayFormArray.updateValueAndValidity();
 }
-
-
 
   meetupChangeNotifications(users, meetupInfo, meetupId) {
     return { docs: users.map((user) => ({

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -190,20 +190,44 @@ export class MeetupsAddComponent implements OnInit {
     }
   }
 
-  toggleDaily(val, showCheckbox) {
+  toggleDaily(val: string, showCheckbox: boolean) {
     // empty the array
-    this.meetupForm.setControl('day', this.fb.array([]));
+    const dayFormArray = this.fb.array([]);
     switch (val) {
       case 'daily':
-        // add all days to the array if the course is daily
-        this.meetupForm.setControl('day', this.fb.array(this.days));
+        this.days.forEach((day) => {
+          dayFormArray.push(new FormControl(day));
+        });
         break;
       case 'weekly':
-        this.meetupForm.setControl('day', this.fb.array(this.meetupFrequency));
+        if (this.meetupFrequency && this.meetupFrequency.length > 0) {
+          this.meetupFrequency.forEach((day) => {
+            dayFormArray.push(new FormControl(day));
+          });
+        } else {
+          const startDate = this.meetupForm.controls.startDate.value;
+  
+          if (startDate) {
+            const startDateObj = new Date(startDate);
+            const dayOfWeek = this.days[startDateObj.getDay()];
+  
+            if (dayOfWeek) {
+              dayFormArray.push(new FormControl(dayOfWeek));
+              console.log(`Auto-selected day: ${dayOfWeek}`);
+            } else {
+              console.log('Invalid startDate.');
+            }
+          } else {
+            console.log('No startDate set.');
+          }
+        }
         break;
     }
-  }
-
+    this.meetupForm.setControl('day', dayFormArray);
+    this.meetupForm.controls.day.updateValueAndValidity();
+  } 
+  
+  
   meetupChangeNotifications(users, meetupInfo, meetupId) {
     return { docs: users.map((user) => ({
       'user': user._id,

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -106,8 +106,9 @@ export class MeetupsAddComponent implements OnInit {
 }
 
 onSubmit() {
-  if (this.meetupForm.invalid) {
-      return;
+  if (!this.meetupForm.valid) {
+    showFormErrors(this.meetupForm.controls);
+    return;
   }
   const dayFormArray = this.meetupForm.get('day') as FormArray;
   dayFormArray.updateValueAndValidity();
@@ -183,7 +184,7 @@ onSubmit() {
     const dayFormArray = <FormArray>this.meetupForm.controls.day;
     if (isChecked) {
       // add to day array if checked
-        dayFormArray.push(new FormControl(day));
+      dayFormArray.push(new FormControl(day));
     } else {
         // remove from day array if unchecked
         const index = dayFormArray.controls.findIndex(x => x.value === day);

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -206,11 +206,11 @@ export class MeetupsAddComponent implements OnInit {
           });
         } else {
           const startDate = this.meetupForm.controls.startDate.value;
-  
+
           if (startDate) {
             const startDateObj = new Date(startDate);
             const dayOfWeek = this.days[startDateObj.getDay()];
-  
+
             if (dayOfWeek) {
               dayFormArray.push(new FormControl(dayOfWeek));
               console.log(`Auto-selected day: ${dayOfWeek}`);
@@ -225,9 +225,9 @@ export class MeetupsAddComponent implements OnInit {
     }
     this.meetupForm.setControl('day', dayFormArray);
     this.meetupForm.controls.day.updateValueAndValidity();
-  } 
-  
-  
+  }
+
+
   meetupChangeNotifications(users, meetupInfo, meetupId) {
     return { docs: users.map((user) => ({
       'user': user._id,

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -99,9 +99,9 @@ export class MeetupsAddComponent implements OnInit {
       createdBy: this.userService.get().name,
       sourcePlanet: this.stateService.configuration.code,
       createdDate: this.couchService.datePlaceholder,
-      recurringNumber: [ 10, [ Validators.min(2), CustomValidators.integerValidator ] ],
+      recurringNumber: [ 10, [ Validators.min(2), CustomValidators.integerValidator ] ]
     }, {
-        validators: CustomValidators.meetupTimeValidator(),
+      validators: CustomValidators.meetupTimeValidator()
     });
 }
 
@@ -116,7 +116,7 @@ onSubmit() {
   const meetup = { ...this.meetupForm.value, link: this.link, sync: this.sync };
   if (this.pageType === 'Update') {
       this.updateMeetup(meetup);
-  } else {
+    } else {
       this.addMeetup(meetup);
   }
 }
@@ -182,8 +182,10 @@ onSubmit() {
   onDayChange(day: string, isChecked: boolean) {
     const dayFormArray = <FormArray>this.meetupForm.controls.day;
     if (isChecked) {
+      // add to day array if checked
         dayFormArray.push(new FormControl(day));
     } else {
+        // remove from day array if unchecked
         const index = dayFormArray.controls.findIndex(x => x.value === day);
         if (index >= 0) {
             dayFormArray.removeAt(index);
@@ -198,6 +200,7 @@ toggleDaily(val: string, showCheckbox: boolean) {
   dayFormArray.clearValidators();
 
   switch (val) {
+      // add all days to the array if the course is daily
       case 'daily':
           this.days.forEach((day) => {
               dayFormArray.push(new FormControl(day));

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -176,10 +176,6 @@ onSubmit() {
     }
   }
 
-  isClassDay(day) {
-    return this.meetupFrequency.includes(day) ? true : false;
-  }
-
   onDayChange(day: string, isChecked: boolean) {
     const dayFormArray = <FormArray>this.meetupForm.controls.day;
     if (isChecked) {

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -171,13 +171,16 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
   }
 
   openAddEventDialog(event) {
-    let meetup;
-    if (event?.start) {
-      meetup = {
-        startDate: event?.start,
-        endDate: this.adjustEndDate(event?.end)
-      };
+    const today = new Date();
+    const meetup = event?.start
+    ? {
+      startDate: event.start,
+      endDate: this.adjustEndDate(event.end),
     }
+  : {
+      startDate: today,
+      endDate: today,
+    };
     this.dialog.open(DialogsAddMeetupsComponent, {
       data: { meetup: meetup, link: this.link, sync: this.sync, onMeetupsChange: this.onMeetupsChange.bind(this), editable: this.editable }
     });

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -257,7 +257,7 @@ export class CustomValidators {
 
   static atLeastOneDaySelected(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
-        if (!control.parent) return null;
+        if (!control.parent) { return null; }
 
         const recurringControl = control.parent.get('recurring');
         // Skip validation if not weekly
@@ -270,6 +270,6 @@ export class CustomValidators {
     };
 }
 
- 
-  
+
+
 }

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -258,13 +258,10 @@ export class CustomValidators {
   static atLeastOneDaySelected(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
         if (!control.parent) { return null; }
-
         const recurringControl = control.parent.get('recurring');
-        // Skip validation if not weekly
         if (!recurringControl || recurringControl.value !== 'weekly') {
             return null;
         }
-
         const selectedDays = control.value;
         return selectedDays && selectedDays.length > 0 ? null : { noDaysSelected: true };
     };

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -265,8 +265,5 @@ export class CustomValidators {
         const selectedDays = control.value;
         return selectedDays && selectedDays.length > 0 ? null : { noDaysSelected: true };
     };
-}
-
-
-
+  }
 }

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -255,4 +255,21 @@ export class CustomValidators {
     });
   }
 
+  static atLeastOneDaySelected(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+        if (!control.parent) return null;
+
+        const recurringControl = control.parent.get('recurring');
+        // Skip validation if not weekly
+        if (!recurringControl || recurringControl.value !== 'weekly') {
+            return null;
+        }
+
+        const selectedDays = control.value;
+        return selectedDays && selectedDays.length > 0 ? null : { noDaysSelected: true };
+    };
+}
+
+ 
+  
 }


### PR DESCRIPTION
Fixes #7858

Recurring events now auto populate with the day of week currently selected in Start Date.
![image](https://github.com/user-attachments/assets/8762a211-6388-43a9-8cc6-144ce25f50b7)

A validator prevents creation of recurring weekly events that do not have a day of the week selected
![image](https://github.com/user-attachments/assets/5898b0d8-7b76-4c03-b819-61be45ee1c59)

Works by both clicking the calendar cells or using the Add Event button. 