### PR TITLE
teams: smoother list (fixes #6546)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.70",
+  "version": "0.15.92",
   "myplanet": {
-    "latest": "v0.21.12",
-    "min": "v0.20.12"
+    "latest": "v0.21.32",
+    "min": "v0.20.32"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -51,13 +51,13 @@
       </ng-container>
       <ng-container matColumnDef="visitLog.lastVisit">
         <mat-header-cell *matHeaderCellDef mat-sort-header="visitLog.lastVisit" i18n>Most recent visit</mat-header-cell>
-        <mat-cell class="recent-visit-log" *matCellDef="let element">
+        <mat-cell *matCellDef="let element">
           {{(element.visitLog.lastVisit | date: 'medium') || 'N/A'}}
         </mat-cell>
       </ng-container>
       <ng-container matColumnDef="visitLog.visitCount">
         <mat-header-cell *matHeaderCellDef mat-sort-header="visitLog.visitCount" i18n>Total visits from last 30 days</mat-header-cell>
-        <mat-cell class="visit-log-cell" *matCellDef="let element">
+        <mat-cell *matCellDef="let element">
           {{element.visitLog.visitCount}}
         </mat-cell>
       </ng-container>

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -51,7 +51,7 @@
       </ng-container>
       <ng-container matColumnDef="visitLog.lastVisit">
         <mat-header-cell *matHeaderCellDef mat-sort-header="visitLog.lastVisit" i18n>Most recent visit</mat-header-cell>
-        <mat-cell *matCellDef="let element">
+        <mat-cell class="recent-visit-log" *matCellDef="let element">
           {{(element.visitLog.lastVisit | date: 'medium') || 'N/A'}}
         </mat-cell>
       </ng-container>

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -57,7 +57,7 @@
       </ng-container>
       <ng-container matColumnDef="visitLog.visitCount">
         <mat-header-cell *matHeaderCellDef mat-sort-header="visitLog.visitCount" i18n>Total visits from last 30 days</mat-header-cell>
-        <mat-cell *matCellDef="let element">
+        <mat-cell class="visit-log-cell" *matCellDef="let element">
           {{element.visitLog.visitCount}}
         </mat-cell>
       </ng-container>

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -10,14 +10,16 @@
   .mat-column-visitLog-visitCount {
     max-width: 80px;
     padding-right: 0.5rem;
-  }
-  .mat-column-visitLog-lastVisit {
-    max-width: 180px;
-    padding-right: 0.5rem;
+    text-align: center; // Center-align the text
   }
 
-  .visit-log-cell{
-    margin-left: 3rem;
+  .visit-log-cell {
+    display: flex;
+    justify-content: center;
+    margin-right: 1rem;
+    align-items: center;
+    text-align: center;
+    width: 100%;
   }
 
   mat-row {
@@ -36,6 +38,10 @@
     mat-cell button {
       min-width: 0;
       padding: 0 3px;
+    }
+
+    .visit-log-cell{
+      margin-left: 1rem;
     }
   }
 }

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -7,13 +7,13 @@
     padding-right: 0.5rem;
   }
 
-  .mat-column-visitLog-visitCount {
+  .mat-column-visitLog-visitCount, .mat-column-visitLog.lastVisit {
     max-width: 80px;
     padding-right: 0.5rem;
     text-align: center; // Center-align the text
   }
 
-  .visit-log-cell {
+  .visit-log-cell{
     display: flex;
     justify-content: center;
     margin-right: 1rem;
@@ -22,9 +22,14 @@
     width: 100%;
   }
 
+  .recent-visit-log{
+    margin-left: 2rem;
+  }
+
   mat-row {
     cursor: pointer;
   }
+
   .button-container {
     display: flex;
     flex-direction: row;
@@ -40,7 +45,7 @@
       padding: 0 3px;
     }
 
-    .visit-log-cell{
+    .visit-log-cell, .recent-visit-log{
       margin-left: 1rem;
     }
   }

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -15,6 +15,11 @@
     max-width: 180px;
     padding-right: 0.5rem;
   }
+
+  .visit-log-cell{
+    margin-left: 3rem;
+  }
+
   mat-row {
     cursor: pointer;
   }

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -1,29 +1,16 @@
 @import "../variables.scss";
 
 :host {
-  /* Column Widths */
   .mat-column-doc-teamType {
     max-width: 150px;
     padding-right: 0.5rem;
   }
 
-  .mat-column-visitLog-visitCount, .mat-column-visitLog.lastVisit {
-    max-width: 80px;
-    padding-right: 0.5rem;
-    text-align: center; // Center-align the text
-  }
-
-  .visit-log-cell{
-    display: flex;
+  .mat-column-visitLog-visitCount {
     justify-content: center;
-    margin-right: 1rem;
-    align-items: center;
-    text-align: center;
-    width: 100%;
-  }
-
-  .recent-visit-log{
-    margin-left: 2rem;
+    max-width: 80px;
+    padding-right: 1rem;
+    margin-right: 1rem
   }
 
   mat-row {
@@ -43,10 +30,6 @@
     mat-cell button {
       min-width: 0;
       padding: 0 3px;
-    }
-
-    .visit-log-cell, .recent-visit-log{
-      margin-left: 1rem;
     }
   }
 }


### PR DESCRIPTION
The "Toal visits from last 30 days" column in team/enterprises and when adding links on the services tabs will be more centered and less shifted to the left. Fixes #6546 