### PR TITLE
courses:  limit step titles length (fixes #7867)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.72",
+  "version": "0.15.81",
   "myplanet": {
     "latest": "v0.21.12",
     "min": "v0.20.12"

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -1,6 +1,6 @@
 <planet-step-list [steps]="steps" (stepsChange)="stepsMoved($event)" [nameProp]="'stepTitle'" (stepClicked)="stepClick($event)">
   <planet-step-list-item *ngFor="let step of steps; index as i; first as isFirst; last as isLast">
-    <span i18n>{{(step.stepTitle || 'Step ' + (i+1)) | slice:0:11}}{{(step.stepTitle || 'Step ' + (i+1)).length > 11 ? '...' : ''}}</span>
+    <span i18n>{{(step.stepTitle || 'Step ' + (i+1)) | slice:0:50}}{{(step.stepTitle || 'Step ' + (i+1)).length > 50 ? '...' : ''}}</span>
     <planet-course-icon *ngIf="step?.exam?.questions.length" [icon]="'assignment'"></planet-course-icon>
     <planet-course-icon *ngIf="step?.resources?.length" [icon]="'attach_file'"></planet-course-icon>
     <planet-course-icon *ngIf="step?.survey?.questions.length" [icon]="'description'"></planet-course-icon>
@@ -13,7 +13,7 @@
   <div planetStepListForm>
     <form [formGroup]="stepForm">
       <mat-form-field class="full-width">
-        <input matInput i18n-placeholder placeholder="Step title" maxlength="150" formControlName="stepTitle">
+        <input matInput i18n-placeholder placeholder="Step title" maxlength="200" formControlName="stepTitle">
       </mat-form-field>
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <planet-markdown-textbox class="full-width" i18n-placeholder placeholder="Description" [formControl]="stepForm.controls.description" imageGroup="community"></planet-markdown-textbox>

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -13,7 +13,7 @@
   <div planetStepListForm>
     <form [formGroup]="stepForm">
       <mat-form-field class="full-width">
-        <input matInput i18n-placeholder placeholder="Step title" formControlName="stepTitle">
+        <input matInput i18n-placeholder placeholder="Step title" maxlength="150" formControlName="stepTitle">
       </mat-form-field>
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <planet-markdown-textbox class="full-width" i18n-placeholder placeholder="Description" [formControl]="stepForm.controls.description" imageGroup="community"></planet-markdown-textbox>

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -1,6 +1,6 @@
 <planet-step-list [steps]="steps" (stepsChange)="stepsMoved($event)" [nameProp]="'stepTitle'" (stepClicked)="stepClick($event)">
   <planet-step-list-item *ngFor="let step of steps; index as i; first as isFirst; last as isLast">
-    <span i18n>{{step.stepTitle || 'Step ' + (i+1)}}</span>
+    <span i18n>{{(step.stepTitle || 'Step ' + (i+1)) | slice:0:11}}{{(step.stepTitle || 'Step ' + (i+1)).length > 11 ? '...' : ''}}</span>
     <planet-course-icon *ngIf="step?.exam?.questions.length" [icon]="'assignment'"></planet-course-icon>
     <planet-course-icon *ngIf="step?.resources?.length" [icon]="'attach_file'"></planet-course-icon>
     <planet-course-icon *ngIf="step?.survey?.questions.length" [icon]="'description'"></planet-course-icon>


### PR DESCRIPTION
fixes #7867
Added a max length for creating a step title at 150 characters. If we feel like this is too short or too long, I can always make adjustments.  I don't think that there will be an actual need to create titles over 150 chars for steps. 