### PR TITLE
courses: smoother steps icons (fixes #7870)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.76",
+  "version": "0.15.77",
   "myplanet": {
-    "latest": "v0.21.20",
-    "min": "v0.20.20"
+    "latest": "v0.21.24",
+    "min": "v0.20.24"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/view-courses/courses-view.scss
+++ b/src/app/courses/view-courses/courses-view.scss
@@ -26,6 +26,16 @@
     grid-column-gap: 0;
   }
 
+.mat-expansion-panel-header-description {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.mat-expansion-panel-header-description planet-course-icon {
+  margin-left: 8px;
+}
+
   @media (max-width: $screen-sm) {
     .course-container {
       grid-template-columns: 1fr;

--- a/src/app/courses/view-courses/courses-view.scss
+++ b/src/app/courses/view-courses/courses-view.scss
@@ -26,15 +26,15 @@
     grid-column-gap: 0;
   }
 
-.mat-expansion-panel-header-description {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-}
+  .mat-expansion-panel-header-description {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
 
-.mat-expansion-panel-header-description planet-course-icon {
-  margin-left: 8px;
-}
+  .mat-expansion-panel-header-description planet-course-icon {
+    margin-left: 8px;
+  }
 
   @media (max-width: $screen-sm) {
     .course-container {

--- a/src/app/courses/view-courses/courses-view.scss
+++ b/src/app/courses/view-courses/courses-view.scss
@@ -27,8 +27,6 @@
   }
 
   .mat-expansion-panel-header-description {
-    display: flex;
-    align-items: center;
     justify-content: flex-end;
   }
 


### PR DESCRIPTION
fixes #7870 

Icons are now aligned to the right and have a little bit of extra space between them. 

![image](https://github.com/user-attachments/assets/05936f3f-05ec-4926-a6f2-0d775b96599f)

![image](https://github.com/user-attachments/assets/0b0c1056-2959-43ee-b132-541d79f9b623)
