### PR TITLE
enterprises: smoother csv exports (fixes #7887)(fixes #7888)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.83",
+  "version": "0.15.89",
   "myplanet": {
-    "latest": "v0.21.28",
-    "min": "v0.20.28"
+    "latest": "v0.21.29",
+    "min": "v0.20.29"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -165,17 +165,14 @@ export class TeamsReportsComponent implements DoCheck {
       'Profit/Loss': report.sales + report.otherIncome - report.wages - report.otherExpenses,
       'Ending Balance': report.beginningBalance + report.sales + report.otherIncome - report.wages - report.otherExpenses
     }));
-  
-    const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
     const planetName = this.stateService.configuration.name || 'Unnamed';
-    const teamName = this.team.name
-      ? `${this.team.name} ${entityLabel}`
-      : `${entityLabel} ${planetName}`;
-  
+    const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
+    const titleName = this.team.name || `${entityLabel} ${planetName}`;
     this.csvService.exportCSV({
       data: exportData,
-      title: $localize`Financial Summary for ${teamName}`
+      title: $localize`Financial Summary for ${titleName}`
     });
   }
+
 
 }

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -27,7 +27,7 @@ export class TeamsReportsComponent implements DoCheck {
   columns = 4;
   minColumnWidth = 300;
   configuration: any = {};
-  planetName;
+  planetName: any;
 
   constructor(
     private couchService: CouchService,
@@ -173,6 +173,5 @@ export class TeamsReportsComponent implements DoCheck {
       title: $localize`Financial Summary for ${titleName}`
     });
   }
-
 
 }

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -11,6 +11,7 @@ import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.compone
 import { tap } from 'rxjs/operators';
 import { convertUtcDate } from './teams.utils';
 import { CsvService } from '../shared/csv.service';
+import { StateService } from '../shared/state.service';
 
 @Component({
   selector: 'planet-teams-reports',
@@ -25,6 +26,8 @@ export class TeamsReportsComponent implements DoCheck {
   @Output() reportsChanged = new EventEmitter<void>();
   columns = 4;
   minColumnWidth = 300;
+  configuration: any = {};
+  planetName;
 
   constructor(
     private couchService: CouchService,
@@ -33,7 +36,8 @@ export class TeamsReportsComponent implements DoCheck {
     private dialogsLoadingService: DialogsLoadingService,
     private teamsService: TeamsService,
     private csvService: CsvService,
-    private elementRef: ElementRef
+    private elementRef: ElementRef,
+    private stateService: StateService,
   ) {}
 
   ngDoCheck() {
@@ -161,7 +165,17 @@ export class TeamsReportsComponent implements DoCheck {
       'Profit/Loss': report.sales + report.otherIncome - report.wages - report.otherExpenses,
       'Ending Balance': report.beginningBalance + report.sales + report.otherIncome - report.wages - report.otherExpenses
     }));
-    this.csvService.exportCSV({ data: exportData, title: $localize`${this.team.name} Financial Report Summary` });
+  
+    const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
+    const planetName = this.stateService.configuration.name || 'Unnamed';
+    const teamName = this.team.name
+      ? `${this.team.name} ${entityLabel}`
+      : `${entityLabel} ${planetName}`;
+  
+    this.csvService.exportCSV({
+      data: exportData,
+      title: $localize`Financial Summary for ${teamName}`
+    });
   }
 
 }

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -35,7 +35,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   showBalanceWarning = false;
   curCode = this.stateService.configuration.currency || {};
   configuration: any = {};
-  planetName;
+  planetName: any;
   constructor(
     private csvService: CsvService,
     private couchService: CouchService,

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -191,7 +191,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   exportTableData() {
     let updatedData = [ ...this.table.filteredData ];
     updatedData.shift();
-  
+
     updatedData = updatedData.map(row => ({
       date: row.date,
       description: row.description,
@@ -199,16 +199,13 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
       debit: row.debit,
       balance: row.balance
     }));
-    const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
     const planetName = this.stateService.configuration.name || 'Unnamed';
-    const teamName = this.team.name
-      ? `${this.team.name} ${entityLabel}`
-      : `${entityLabel} ${planetName}`;
+    const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
+    const titleName = this.team.name || `${entityLabel} ${planetName}`;
+    this.csvService.exportCSV({
+      data: updatedData,
+      title: $localize`Financial Transactions for ${titleName}`
+    });
+  }
 
-  this.csvService.exportCSV({
-    data: updatedData,
-    title: $localize`Financial Transactions for ${teamName}`
-  });
-}
-  
 }

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -34,7 +34,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   emptyTable = true;
   showBalanceWarning = false;
   curCode = this.stateService.configuration.currency || {};
-
+  configuration: any = {};
   constructor(
     private csvService: CsvService,
     private couchService: CouchService,
@@ -190,7 +190,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   exportTableData() {
     let updatedData = [ ...this.table.filteredData ];
     updatedData.shift();
-
+  
     updatedData = updatedData.map(row => ({
       date: row.date,
       description: row.description,
@@ -198,11 +198,15 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
       debit: row.debit,
       balance: row.balance
     }));
+    const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
+    const teamName = this.team.name
+    ? `${this.team.name} ${entityLabel}`
+    : entityLabel;
 
-    this.csvService.exportCSV({
-      data: updatedData,
-      title: $localize`Financial Transactions for ${this.team.name} Enterprise`
-    });
-  }
-
+  this.csvService.exportCSV({
+    data: updatedData,
+    title: $localize`Financial Transactions for ${teamName}`
+  });
+}
+  
 }

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -35,6 +35,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
   showBalanceWarning = false;
   curCode = this.stateService.configuration.currency || {};
   configuration: any = {};
+  planetName;
   constructor(
     private csvService: CsvService,
     private couchService: CouchService,
@@ -199,9 +200,10 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
       balance: row.balance
     }));
     const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
+    const planetName = this.stateService.configuration.name || 'Unnamed';
     const teamName = this.team.name
-    ? `${this.team.name} ${entityLabel}`
-    : entityLabel;
+      ? `${this.team.name} ${entityLabel}`
+      : `${entityLabel} ${planetName}`;
 
   this.csvService.exportCSV({
     data: updatedData,


### PR DESCRIPTION
fixes #7887, #7888

It no longer says 'undefined' when you export transactions or reports from the community page. Now it says whether the export comes from a community or a nation and supplies the name of the community/nation. If you export directly from the team, it still supplies the team name. 

![image](https://github.com/user-attachments/assets/d8f5004d-0e23-4258-937b-09994cda90f4)


