### PR TITLE
enterprises: smoother report dialog (fixes #6946)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.9",
+  "version": "0.15.93",
   "myplanet": {
     "latest": "v0.20.64",
     "min": "v0.19.64"

--- a/src/app/teams/teams-reports-dialog.component.html
+++ b/src/app/teams/teams-reports-dialog.component.html
@@ -6,5 +6,5 @@
   <planet-teams-reports-detail [report]="report" [showSummary]="true"></planet-teams-reports-detail>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button class="close-button" mat-raised-button color="primary" mat-dialog-close i18n>Close</button>
+  <button mat-raised-button class = "close-button" color="primary" i18n mat-dialog-close>Close</button>
 </mat-dialog-actions>

--- a/src/app/teams/teams-reports-dialog.component.html
+++ b/src/app/teams/teams-reports-dialog.component.html
@@ -6,5 +6,5 @@
   <planet-teams-reports-detail [report]="report" [showSummary]="true"></planet-teams-reports-detail>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-raised-button class = "close-button" color="primary" i18n mat-dialog-close>Close</button>
+  <button mat-raised-button mat-dialog-close i18n>Close</button>
 </mat-dialog-actions>

--- a/src/app/teams/teams-reports-dialog.component.html
+++ b/src/app/teams/teams-reports-dialog.component.html
@@ -6,5 +6,5 @@
   <planet-teams-reports-detail [report]="report" [showSummary]="true"></planet-teams-reports-detail>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-raised-button color="primary" mat-dialog-close i18n>Close</button>
+  <button class="close-button" mat-raised-button color="primary" mat-dialog-close i18n>Close</button>
 </mat-dialog-actions>

--- a/src/app/teams/teams-reports-dialog.component.ts
+++ b/src/app/teams/teams-reports-dialog.component.ts
@@ -10,18 +10,6 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
     .mat-subheading-1 {
       margin-top: 0;
     }
-    .close-button {
-      color: white;
-      box-shadown:none !important;
-      filter: none !important;
-      outline: none !important;
-    }
-    .close-button:hover,
-    .close-button:focus,
-    .close-button:active {
-      box-shadow: none !important;
-      filter: none !important;
-    }
   ` ]
 })
 export class TeamsReportsDialogComponent {

--- a/src/app/teams/teams-reports-dialog.component.ts
+++ b/src/app/teams/teams-reports-dialog.component.ts
@@ -10,6 +10,10 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
     .mat-subheading-1 {
       margin-top: 0;
     }
+    .close-button {
+      color:white;
+      box-shadown:none;
+    }
   ` ]
 })
 export class TeamsReportsDialogComponent {

--- a/src/app/teams/teams-reports-dialog.component.ts
+++ b/src/app/teams/teams-reports-dialog.component.ts
@@ -11,8 +11,16 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
       margin-top: 0;
     }
     .close-button {
-      color:white;
-      box-shadown:none;
+      color: white;
+      box-shadown:none !important;
+      filter: none !important;
+      outline: none !important;
+    }
+    .close-button:hover,
+    .close-button:focus,
+    .close-button:active {
+      box-shadow: none !important;
+      filter: none !important;
     }
   ` ]
 })


### PR DESCRIPTION
fixes #6946 changed blue close button to grey default close button to match consistency 

![image](https://github.com/user-attachments/assets/440d19a8-8d4e-4f58-84f7-9b202fe8bb7d)
