### PR TITLE
dashboard: smoother tiles (fixes #7924)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.15.94",
+  "version": "0.15.99",
   "myplanet": {
     "latest": "v0.21.32",
     "min": "v0.20.32"

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -25,7 +25,7 @@
             #dashboardTile
           >
             <p [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false">{{item.firstLine}}</p>
-            <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': tileLines }">{{item.title | slice:0:80}}</p>
+            <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': tileLines,'word-wrap': 'break-word' }">{{item.title | slice:0:80}}</p>
             <button mat-icon-button class="delete-item" (click)="removeFromShelf($event, item)" *ngIf="cardType!=='myLife' && !item?.canRemove">
               <mat-icon i18n-matTooltip [matTooltip]="'Remove from ' + cardTitle" [inline]="true">clear</mat-icon>
             </button>


### PR DESCRIPTION
fixes #7924

![image](https://github.com/user-attachments/assets/af58473a-e33f-47e5-8aff-99c7fd8e1947)

Long single words truncate when dragged, similar to other long titles. 