### PR TITLE
courses: smoother progress navigation (fixes #7911)(fixes #7936)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.2",
+  "version": "0.16.7",
   "myplanet": {
     "latest": "v0.21.40",
     "min": "v0.20.40"

--- a/src/app/courses/progress-courses/courses-progress-chart.component.html
+++ b/src/app/courses/progress-courses/courses-progress-chart.component.html
@@ -41,6 +41,6 @@
   <div class="errors" *ngFor="let set of sets">
     <div>{{set.total}}</div>
     <planet-avatar *ngIf="showAvatar" class="cursor-pointer" (click)="labelClick(set)" [username]="set.label" [planetCode]="set.planetCode" imgClass="profile-image-large"></planet-avatar>
-    <div class="wrap-content cursor-pointer" (click)="labelClick(set)" i18n-matTooltip [matTooltip]="set.label?.length > 3 ? set.label : null "><p>{{set.label}}</p></div>
-  </div>
+    <div class="wrap-content cursor-pointer" (click)="labelClick(set)" i18n-matTooltip [matTooltip]="set.label && set.label.length > 3 ? (set.label.length > 180 ? (set.label | slice:0:180) + '...' : set.label) : null"><p>{{set.label}}</p></div>
+    </div>
 </div>

--- a/src/app/courses/progress-courses/courses-progress-chart.component.html
+++ b/src/app/courses/progress-courses/courses-progress-chart.component.html
@@ -42,5 +42,5 @@
     <div>{{set.total}}</div>
     <planet-avatar *ngIf="showAvatar" class="cursor-pointer" (click)="labelClick(set)" [username]="set.label" [planetCode]="set.planetCode" imgClass="profile-image-large"></planet-avatar>
     <div class="wrap-content cursor-pointer" (click)="labelClick(set)" i18n-matTooltip [matTooltip]="set.label && set.label.length > 3 ? (set.label.length > 180 ? (set.label | slice:0:180) + '...' : set.label) : null"><p>{{set.label}}</p></div>
-    </div>
+  </div>
 </div>

--- a/src/app/courses/progress-courses/courses-progress-learner.component.html
+++ b/src/app/courses/progress-courses/courses-progress-learner.component.html
@@ -7,7 +7,7 @@
     <span i18n>Courses: myProgress</span>
   </mat-toolbar>
   <div class="view-container view-full-height">
-    <planet-courses-progress-chart *ngIf="chartData?.length; else noProgress" [inputs]="chartData" [height]="yAxisLength" [showTotals]="false" (changeData)="changeData($event)">
+    <planet-courses-progress-chart *ngIf="chartData?.length; else noProgress" [inputs]="chartData" [height]="yAxisLength" [showTotals]="false" (clickAction)="handleCourseClick($event)" (changeData)="changeData($event)">
     </planet-courses-progress-chart>
     <ng-template #noProgress i18n>No Progress record available</ng-template>
   </div>

--- a/src/app/courses/progress-courses/courses-progress-learner.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-learner.component.ts
@@ -110,8 +110,6 @@ export class CoursesProgressLearnerComponent implements OnInit, OnDestroy {
   handleCourseClick(event: any) {
     if (event.courseId) {
       this.router.navigate([ '/courses', 'view', event.courseId ]);
-    } else {
-      console.error('Missing Course ID');
     }
   }
 

--- a/src/app/courses/progress-courses/courses-progress-learner.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-learner.component.ts
@@ -62,6 +62,7 @@ export class CoursesProgressLearnerComponent implements OnInit, OnDestroy {
   createChartData(courses = [], submissions) {
     return courses.map((course: any) => ({
       label: course.doc.courseTitle,
+      courseId: course._id,
       items: this.courseBySteps(
         course,
         submissions.filter(submission => submission.parentId.indexOf(course._id) > -1)
@@ -105,5 +106,13 @@ export class CoursesProgressLearnerComponent implements OnInit, OnDestroy {
   }
 
   changeData(event) {}
+
+  handleCourseClick(event: any) {
+    if (event.courseId) {
+      this.router.navigate([ '/courses', 'view', event.courseId ]);
+    } else {
+      console.error('Missing Course ID');
+    }
+  }
 
 }


### PR DESCRIPTION
fixes #7911, #7936

Clicking on a course in myProgress now links to that course. Also, cleaned up messy tooltip from long course names. 

![image](https://github.com/user-attachments/assets/d6dd4a20-6b2f-4f49-8e5d-b49515c59fc7)
