### PR TITLE
courses: smoother exam preview header (fixes #7949)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.5",
+  "version": "0.16.12",
   "myplanet": {
     "latest": "v0.21.40",
     "min": "v0.20.40"

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -9,7 +9,7 @@
     <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
     <span>
       <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
-      <span i18n *ngIf="mode === 'grade' || mode === 'view'"> by{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span><span *ngIf="updatedOn" i18n> on {{ updatedOn | date: 'short' }}</span>
+      <span i18n *ngIf="mode === 'grade' || mode === 'view'"> by{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span><span *ngIf="updatedOn" i18n> on {{updatedOn | date: 'short'}}</span>
     </span>
     <span class="toolbar-fill"></span>
     <button mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -9,7 +9,7 @@
     <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
     <span>
       <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
-      <span i18n *ngIf="mode === 'grade' || mode === 'view'"> By{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">Unknown</span><span i18n> on {{(updatedOn | date: 'short') || '--'}}</span>
+      <span i18n *ngIf="mode === 'grade' || mode === 'view'"> By{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span><span *ngIf="updatedOn" i18n> on {{ updatedOn | date: 'short' }}</span>
     </span>
     <span class="toolbar-fill"></span>
     <button mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -9,7 +9,7 @@
     <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
     <span>
       <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
-      <span i18n *ngIf="mode === 'grade' || mode === 'view'"> By{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span><span *ngIf="updatedOn" i18n> on {{ updatedOn | date: 'short' }}</span>
+      <span i18n *ngIf="mode === 'grade' || mode === 'view'"> by{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span><span *ngIf="updatedOn" i18n> on {{ updatedOn | date: 'short' }}</span>
     </span>
     <span class="toolbar-fill"></span>
     <button mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>


### PR DESCRIPTION
fixes #7949 

Previewing a test now has a more specific header. 
![image](https://github.com/user-attachments/assets/0cc723bb-1c88-4e22-86e4-8ab2fda73d60)

Works as before when it's a submission. 
![image](https://github.com/user-attachments/assets/3f776adb-f9b2-4ad1-ac18-9af236f1b59e)