### PR TITLE
dashboard: smoother UI (fixes #7739)

### DIFF
--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -23,7 +23,7 @@
             #dashboardTile
           >
             <p [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false">{{item.firstLine}}</p>
-            <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': tileLines }">{{item.title | slice:0:80}}</p>
+            <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': tileLines,'word-wrap': 'break-word' }">{{item.title | slice:0:80}}</p>
             <button mat-icon-button class="delete-item" (click)="removeFromShelf($event, item)" *ngIf="cardType!=='myLife' && !item?.canRemove">
               <mat-icon i18n-matTooltip [matTooltip]="'Remove from ' + cardTitle" [inline]="true">clear</mat-icon>
             </button>

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -8,8 +8,6 @@
         <planet-dashboard-tile-title [cardTitle]="cardTitle" [cardType]="cardType"></planet-dashboard-tile-title>
       </span>
     </ng-template>
-    <a class="small" *ngIf="cardType==='myLibrary'" routerLink="/chat" i18n>myChat</a>
-    <a class="small" *ngIf="cardType==='myCourses'" routerLink="myProgress" i18n>myProgress</a>
   </div>
   <div class="right-tile" #items>
     <div class="dashboard-items" [ngClass]="{'dashboard-empty': itemData.length === 0}" cdkDropList cdkDropListOrientation="horizontal" (cdkDropListDropped)="drop($event)">
@@ -25,7 +23,7 @@
             #dashboardTile
           >
             <p [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false">{{item.firstLine}}</p>
-            <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': tileLines,'word-wrap': 'break-word' }">{{item.title | slice:0:80}}</p>
+            <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': tileLines }">{{item.title | slice:0:80}}</p>
             <button mat-icon-button class="delete-item" (click)="removeFromShelf($event, item)" *ngIf="cardType!=='myLife' && !item?.canRemove">
               <mat-icon i18n-matTooltip [matTooltip]="'Remove from ' + cardTitle" [inline]="true">clear</mat-icon>
             </button>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -107,7 +107,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.data = { resources: [], courses: [], meetups: [], myTeams: [] };
     }
 
-
     forkJoin([
       this.getData('resources', userShelf.resourceIds, { linkPrefix: '/resources/view/', addId: true }),
       this.getData('courses', userShelf.courseIds, { titleField: 'courseTitle', linkPrefix: '/courses/view/', addId: true }),
@@ -175,7 +174,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }));
   }
 
-
   getSurveys() {
     this.getSubmissions('survey', 'pending', this.user.name).subscribe((surveys) => {
       this.surveysCount = dedupeObjectArray(surveys, [ 'parentId' ]).length;
@@ -189,7 +187,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.myLifeItems = this.myLifeItems.map(item => item.link === 'submissions' ? { ...item, badge: this.examsCount } : item);
     });
   }
-
 
   teamRemoved(team: any) {
     this.data.myTeams = this.data.myTeams.filter(myTeam => team._id !== myTeam._id);
@@ -228,7 +225,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.showBanner = profileBanner && !profileComplete;
     });
   }
-
 
   closeBanner() {
     this.userService.profileBanner.next(false);

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,10 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
-
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
-
 
 import { map, catchError, switchMap, auditTime, takeUntil } from 'rxjs/operators';
 import { of, forkJoin, Subject, combineLatest } from 'rxjs';
@@ -18,13 +16,11 @@ import { CoursesViewDetailDialogComponent } from '../courses/view-courses/course
 import { foundations, foundationIcons } from '../courses/constants';
 import { CertificationsService } from '../manager-dashboard/certifications/certifications.service';
 
-
 @Component({
   templateUrl: './dashboard.component.html',
   styleUrls: [ './dashboard.scss' ]
 })
 export class DashboardComponent implements OnInit, OnDestroy {
-
 
   user = this.userService.get();
   data = { resources: [], courses: [], meetups: [], myTeams: [] };
@@ -36,7 +32,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   badgeGroups = [ ...foundations, 'none' ];
   badgeIcons = foundationIcons;
 
-
   dateNow: any;
   visits = 0;
   surveysCount = 0;
@@ -44,7 +39,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   leaderIds = [];
   onDestroy$ = new Subject<void>();
   showBanner = false;
-
 
   myLifeItems: any[] = [
     { firstLine: $localize`my`, title: $localize`Submissions`, link: 'submissions', authorization: 'leader,manager',
@@ -57,7 +51,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     { firstLine: $localize`my`, title: $localize`Chat`, link: '/chat' }
   ];
   cardTitles = { myLibrary: $localize`myLibrary`, myCourses: $localize`myCourses`, myTeams: $localize`myTeams`, myLife: $localize`myLife` };
-
 
   constructor(
     private userService: UserService,
@@ -84,7 +77,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-
   ngOnInit() {
     this.displayName = this.user.firstName !== undefined ? `${this.user.firstName} ${this.user.lastName}` : this.user.name;
     this.planetName = this.stateService.configuration.name;
@@ -103,15 +95,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.reminderBanner();
   }
 
-
   ngOnDestroy() {
     this.onDestroy$.next();
     this.onDestroy$.complete();
   }
 
-
   initDashboard() {
-
 
     const userShelf = this.userService.shelf;
     if (this.isEmptyShelf(userShelf)) {
@@ -134,7 +123,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {
     return this.couchService.bulkGet(db, shelf.filter(id => id))
       .pipe(
@@ -146,7 +134,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
         })
       );
   }
-
 
   getTeamMembership() {
     const configuration = this.stateService.configuration;
@@ -165,7 +152,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     );
   }
 
-
   get profileImg() {
     const attachments = this.user._attachments;
     if (attachments) {
@@ -174,14 +160,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return 'assets/image.png';
   }
 
-
   isEmptyShelf(shelf) {
     return shelf.courseIds.length === 0
       && shelf.meetupIds.length === 0
       && shelf.myTeamIds.length === 0
       && shelf.resourceIds.length === 0;
   }
-
 
   getSubmissions(type: string, status: string, username?: string) {
     return this.submissionsService.getSubmissions(findDocuments({
@@ -199,7 +183,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-
   getExams() {
     this.getSubmissions('exam', 'requires grading').subscribe((exams) => {
       this.examsCount = exams.length;
@@ -212,7 +195,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.data.myTeams = this.data.myTeams.filter(myTeam => team._id !== myTeam._id);
   }
 
-
   openCourseView(course: any) {
     this.dialog.open(CoursesViewDetailDialogComponent, {
       data: { courseId: course._id },
@@ -222,7 +204,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       autoFocus: false
     });
   }
-
 
   setBadgesCourses(courses, certifications) {
     this.badgesCourses = courses
@@ -237,7 +218,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       }), { none: [] });
     this.badgeGroups = [ ...foundations, 'none' ].filter(group => this.badgesCourses[group] && this.badgesCourses[group].length);
   }
-
 
   reminderBanner() {
     this.userService.isProfileComplete();
@@ -254,6 +234,5 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.userService.profileBanner.next(false);
     this.showBanner = false;
   }
-
 
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
+
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
+
 
 import { map, catchError, switchMap, auditTime, takeUntil } from 'rxjs/operators';
 import { of, forkJoin, Subject, combineLatest } from 'rxjs';
@@ -16,11 +18,13 @@ import { CoursesViewDetailDialogComponent } from '../courses/view-courses/course
 import { foundations, foundationIcons } from '../courses/constants';
 import { CertificationsService } from '../manager-dashboard/certifications/certifications.service';
 
+
 @Component({
   templateUrl: './dashboard.component.html',
   styleUrls: [ './dashboard.scss' ]
 })
 export class DashboardComponent implements OnInit, OnDestroy {
+
 
   user = this.userService.get();
   data = { resources: [], courses: [], meetups: [], myTeams: [] };
@@ -32,6 +36,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   badgeGroups = [ ...foundations, 'none' ];
   badgeIcons = foundationIcons;
 
+
   dateNow: any;
   visits = 0;
   surveysCount = 0;
@@ -40,15 +45,19 @@ export class DashboardComponent implements OnInit, OnDestroy {
   onDestroy$ = new Subject<void>();
   showBanner = false;
 
+
   myLifeItems: any[] = [
     { firstLine: $localize`my`, title: $localize`Submissions`, link: 'submissions', authorization: 'leader,manager',
     badge: this.examsCount },
+    { firstLine: $localize`my`, title: $localize`Progress`, link: 'myProgress' },
     { firstLine: $localize`my`, title: $localize`Personals`, link: 'myPersonals' },
     { firstLine: $localize`my`, title: $localize`Achievements`, link: 'myAchievements' },
     { firstLine: $localize`my`, title: $localize`Surveys`, link: 'mySurveys', badge: this.surveysCount },
-    { firstLine: $localize`my`, title: $localize`Health`, link: 'myHealth' }
+    { firstLine: $localize`my`, title: $localize`Health`, link: 'myHealth' },
+    { firstLine: $localize`my`, title: $localize`Chat`, link: '/chat' }
   ];
   cardTitles = { myLibrary: $localize`myLibrary`, myCourses: $localize`myCourses`, myTeams: $localize`myTeams`, myLife: $localize`myLife` };
+
 
   constructor(
     private userService: UserService,
@@ -75,6 +84,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+
   ngOnInit() {
     this.displayName = this.user.firstName !== undefined ? `${this.user.firstName} ${this.user.lastName}` : this.user.name;
     this.planetName = this.stateService.configuration.name;
@@ -93,17 +103,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.reminderBanner();
   }
 
+
   ngOnDestroy() {
     this.onDestroy$.next();
     this.onDestroy$.complete();
   }
 
+
   initDashboard() {
+
 
     const userShelf = this.userService.shelf;
     if (this.isEmptyShelf(userShelf)) {
       this.data = { resources: [], courses: [], meetups: [], myTeams: [] };
     }
+
 
     forkJoin([
       this.getData('resources', userShelf.resourceIds, { linkPrefix: '/resources/view/', addId: true }),
@@ -120,6 +134,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {
     return this.couchService.bulkGet(db, shelf.filter(id => id))
       .pipe(
@@ -131,6 +146,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         })
       );
   }
+
 
   getTeamMembership() {
     const configuration = this.stateService.configuration;
@@ -149,6 +165,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     );
   }
 
+
   get profileImg() {
     const attachments = this.user._attachments;
     if (attachments) {
@@ -157,12 +174,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return 'assets/image.png';
   }
 
+
   isEmptyShelf(shelf) {
     return shelf.courseIds.length === 0
       && shelf.meetupIds.length === 0
       && shelf.myTeamIds.length === 0
       && shelf.resourceIds.length === 0;
   }
+
 
   getSubmissions(type: string, status: string, username?: string) {
     return this.submissionsService.getSubmissions(findDocuments({
@@ -172,12 +191,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }));
   }
 
+
   getSurveys() {
     this.getSubmissions('survey', 'pending', this.user.name).subscribe((surveys) => {
       this.surveysCount = dedupeObjectArray(surveys, [ 'parentId' ]).length;
       this.myLifeItems = this.myLifeItems.map(item => item.link === 'mySurveys' ? { ...item, badge: this.surveysCount } : item);
     });
   }
+
 
   getExams() {
     this.getSubmissions('exam', 'requires grading').subscribe((exams) => {
@@ -186,9 +207,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+
   teamRemoved(team: any) {
     this.data.myTeams = this.data.myTeams.filter(myTeam => team._id !== myTeam._id);
   }
+
 
   openCourseView(course: any) {
     this.dialog.open(CoursesViewDetailDialogComponent, {
@@ -199,6 +222,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       autoFocus: false
     });
   }
+
 
   setBadgesCourses(courses, certifications) {
     this.badgesCourses = courses
@@ -214,6 +238,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.badgeGroups = [ ...foundations, 'none' ].filter(group => this.badgesCourses[group] && this.badgesCourses[group].length);
   }
 
+
   reminderBanner() {
     this.userService.isProfileComplete();
     combineLatest([
@@ -224,9 +249,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+
   closeBanner() {
     this.userService.profileBanner.next(false);
     this.showBanner = false;
   }
+
 
 }


### PR DESCRIPTION
fixes #7739

Moved myChat and myProgress to their own tiles instead of crowding the myCourses and myLibrary tiles. 

admin view

![image](https://github.com/user-attachments/assets/27a78c07-e516-4665-bdb0-31f481293d17)

learner view

![image](https://github.com/user-attachments/assets/b28a0bae-2ef2-4e63-b0e3-dba23f3ea9ae)

