### PR TITLE
mylife: smoother achievements spacing (fixes #7996)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.20",
+  "version": "0.16.25",
   "myplanet": {
     "latest": "v0.21.51",
     "min": "v0.20.51"

--- a/src/app/meetups/meetups.service.ts
+++ b/src/app/meetups/meetups.service.ts
@@ -96,9 +96,16 @@ export class MeetupService {
   openDeleteDialog(meetups: any[] | any, callback) {
     const isMany = meetups.length > 1;
     const displayName = isMany ? '' : (meetups[0] || meetups).title;
-    const recurringInfo = (meetups[0] || meetups).recurring && (meetups[0] || meetups).recurring !== 'none' && (meetups[0] || meetups).recurringNumber
-      ? `(Recurs ${ (meetups[0] || meetups).recurring} for ${ (meetups[0] || meetups).recurringNumber } ${ (meetups[0] || meetups).recurring === 'daily' ? 'days' : 'weeks' })`
-      : '';
+    const recurringInfo =
+      (meetups[0] || meetups).recurring &&
+      (meetups[0] || meetups).recurring !== 'none' &&
+      (meetups[0] || meetups).recurringNumber
+        ? `(Recurs ${(meetups[0] || meetups).recurring} for ${
+            (meetups[0] || meetups).recurringNumber
+          } ${
+            (meetups[0] || meetups).recurring === 'daily' ? 'days' : 'weeks'
+          })`
+        : '';
     this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
         okClick: this.deleteMeetups([ meetups ].flat(), displayName, callback),

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -21,7 +21,7 @@ import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.comp
     }
     :host mat-dialog-content {
       overflow-y: auto;
-      max-height: calc(100vh - 100px); 
+      max-height: calc(100vh - 100px);
     }
     :host .mat-list-option span {
       font-weight: inherit;

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -57,7 +57,7 @@
         <h3 i18n>My Links</h3>
         <mat-list>
           <mat-list-item class="mat-list-item-word-wrap" *ngFor="let link of achievements.links">
-            <h4 mat-line>{{link.title}}:</h4>
+            <h4 class="link-title" mat-line>{{link.title}}:</h4>
             <a href="{{link.url}}" target="_blank" class="styled-link"> {{link.url}} </a>
           </mat-list-item>
         </mat-list>

--- a/src/app/users/users-achievements/users-achievements.scss
+++ b/src/app/users/users-achievements/users-achievements.scss
@@ -93,7 +93,7 @@
     }
   }
 
-  .link-title{
+  .link-title {
     max-width: 75%;
   }
 

--- a/src/app/users/users-achievements/users-achievements.scss
+++ b/src/app/users/users-achievements/users-achievements.scss
@@ -76,6 +76,7 @@
         grid-area: txt;
         display: flex;
         align-items: center;
+        max-width: 75%;
       }
 
       .achievement-date {
@@ -90,6 +91,10 @@
         margin-right: 0;
       }
     }
+  }
+
+  .link-title{
+    max-width: 75%;
   }
 
   .styled-link {


### PR DESCRIPTION
Fixes #7996 

Add width spacing between the link/achievement and the link/date
![image](https://github.com/user-attachments/assets/0d3bb78d-e84a-42f7-b860-b9d4680bde0c)


