### PR TITLE
teams: smoother voices deletion (fixes #8016)(fixes #8017)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.30",
+  "version": "0.16.33",
   "myplanet": {
     "latest": "v0.21.55",
     "min": "v0.20.55"

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -115,7 +115,8 @@ export class NewsListComponent implements OnChanges {
       data: {
         okClick: this.deleteNews(news),
         changeType: 'delete',
-        type: 'news'
+        type: 'news',
+        displayName: news.message
       }
     });
   }
@@ -134,7 +135,7 @@ export class NewsListComponent implements OnChanges {
         this.deleteDialog.close();
       },
       onError: (error) => {
-        this.planetMessageService.showAlert($localize`There was a problem deleting this news.`);
+        this.planetMessageService.showAlert($localize`There was a problem deleting this message.`);
       }
     };
   }

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -54,7 +54,7 @@ export class NewsService {
     return ((item.viewIn || []).find(view => view._id === viewId) || {}).sharedDate;
   }
 
-  postNews(post, successMessage = $localize`Thank you for submitting your news`, isMessageEdit = true) {
+  postNews(post, successMessage = $localize`Thank you for submitting your message`, isMessageEdit = true) {
     const { configuration } = this.stateService;
     const message = typeof post.message === 'string' ? post.message : post.message.text;
     const images = this.createImagesArray(post, message);
@@ -76,7 +76,7 @@ export class NewsService {
   }
 
   deleteNews(post) {
-    return this.postNews({ ...post, _deleted: true }, $localize`Post deleted`);
+    return this.postNews({ ...post, _deleted: true }, $localize`Message deleted`);
   }
 
   createImagesArray(post, message) {
@@ -90,7 +90,7 @@ export class NewsService {
     return this.couchService.bulkDocs(this.dbName, replies.map(reply => ({ ...reply.doc, replyTo: newReplyToId })));
   }
 
-  shareNews(news, planets?: any[], successMessage = $localize`News has been successfully shared`) {
+  shareNews(news, planets?: any[], successMessage = $localize`Message has been successfully shared`) {
     const viewInObject = (planet) => (
       { '_id': `${planet.code}@${planet.parentCode}`, section: 'community', sharedDate: this.couchService.datePlaceholder }
     );

--- a/src/app/shared/dialogs/dialogs-prompt.component.html
+++ b/src/app/shared/dialogs/dialogs-prompt.component.html
@@ -17,6 +17,7 @@
         event {event}
         transaction {transaction}
         link {link}
+        news {message}
         report {report}}?
       }
       many


### PR DESCRIPTION
fixes #8016, #8017

Fixed dialog prompt when deleting a Voice. 

Opted to refer to the Voices/news/posts/messages as just "message" in all the snackbars for consistency. 