### PR TITLE
mylife: smoother myhealth emergency contact (fixes #8034)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.35",
+  "version": "0.16.41",
   "myplanet": {
     "latest": "v0.21.62",
     "min": "v0.20.62"

--- a/src/app/health/health.component.html
+++ b/src/app/health/health.component.html
@@ -57,7 +57,7 @@
           </div>
           <mat-divider></mat-divider>
         </div>
-        <div>
+        <div class="full-width">
           <div>
             <h4 class="primary-text-color" i18n>Emergency Contact</h4>
             <p><b i18n>Name: </b>{{healthDetail?.emergencyContactName || 'N/A'}}</p>


### PR DESCRIPTION
fixes #8034)

Moved Emergency Contact to its own row, in order to avoid messy uneven rows. 

![image](https://github.com/user-attachments/assets/202b6427-ce58-4554-8ef3-a36f3c4c1e1b)
