### PR TITLE
resources: smoother collections dialog (fixes #8058)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.52",
+  "version": "0.16.54",
   "myplanet": {
     "latest": "v0.21.88",
     "min": "v0.20.88"

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -22,6 +22,7 @@ import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.comp
     :host mat-dialog-content {
       overflow-y: auto;
       max-height: calc(100vh - 100px);
+      width: 600px;
     }
     :host .mat-list-option span {
       font-weight: inherit;
@@ -34,6 +35,9 @@ import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.comp
     }
     :host mat-dialog-actions {
       padding: 0;
+    }
+    button[mat-stroked-button] {
+      min-width: 64px;
     }
   ` ]
 })


### PR DESCRIPTION
fixes #8058

It's now the same size for admins and non admins. 

![image](https://github.com/user-attachments/assets/65b40804-cf07-49ac-a35c-545ece7ff755)

![image](https://github.com/user-attachments/assets/4a8ecb3d-3031-4e5c-b1f4-7dff1697c06d)
