### PR TITLE
enterprises: smoother delete dialog (fixes #8083)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.55",
+  "version": "0.16.58",
   "myplanet": {
     "latest": "v0.21.96",
     "min": "v0.20.96"

--- a/src/app/shared/dialogs/dialogs-prompt.component.html
+++ b/src/app/shared/dialogs/dialogs-prompt.component.html
@@ -12,6 +12,7 @@
         user {member}
         change {change}
         team {team}
+        enterprise {enterprise}
         task {task}
         certification {certification}
         event {event}

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -195,7 +195,8 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     this.teamsService.addTeamDialog(this.user._id, this.mode, { ...team, teamType }).subscribe(() => {
       this.getTeams();
       const action = $localize`${team._id ? 'updated' : 'created'}`;
-      const msg = $localize`${toProperCase(this.mode)} ${action} successfully`;
+      const entityType = this.mode === 'enterprise' ? 'Enterprise' : 'Team';
+      const msg = $localize`${entityType} ${action} successfully`;
       this.planetMessageService.showMessage(msg);
     });
   }
@@ -220,12 +221,13 @@ export class TeamsComponent implements OnInit, AfterViewInit {
           onNext: () => {
             this.leaveDialog.close();
             this.teams.data = this.teamList(this.teams.data);
-            const msg = 'left';
-            this.planetMessageService.showMessage($localize`You have ${msg} ${team.name}`);
+            const entityType = this.mode === 'enterprise' ? 'enterprise' : 'team';
+            const msg = $localize`You have left ${entityType} ${team.name}`;
+            this.planetMessageService.showMessage(msg);
           },
         },
         changeType: 'leave',
-        type: 'team',
+        type: this.mode === 'enterprise' ? 'enterprise' : 'team',
         displayName: team.name
       }
     });
@@ -240,7 +242,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
         this.planetMessageService.showMessage($localize`You have deleted ${entityType} ${team.name}.`);
         this.removeTeamFromTable(team);
       },
-      onError: () => this.planetMessageService.showAlert($localize`There was a problem deleting this team.`)
+      onError: () => this.planetMessageService.showAlert($localize`There was a problem deleting this ${this.mode === 'enterprise' ? 'enterprise' : 'team'}.`)
     };
   }
 
@@ -249,7 +251,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       data: {
         okClick: this.archiveTeam(team),
         changeType: 'delete',
-        type: 'team',
+        type: this.mode === 'enterprise' ? 'enterprise' : 'team',
         displayName: team.name
       }
     });
@@ -268,7 +270,8 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       finalize(() => this.dialogsLoadingService.stop())
     ).subscribe(() => {
       this.teams.data = this.teamList(this.teams.data);
-      this.planetMessageService.showMessage($localize`Request to join ${team.name} sent`);
+      const entityType = this.mode === 'enterprise' ? 'enterprise' : 'team';
+      this.planetMessageService.showMessage($localize`Request to join ${entityType} ${team.name} sent`);
     });
   }
 


### PR DESCRIPTION
fixes #8083

Now it dynamically refers to it as an enterprise or a team in the dialog and snackbars.

![image](https://github.com/user-attachments/assets/8ecccfe6-af1e-47bc-848b-f0249f6e2af1)
![image](https://github.com/user-attachments/assets/c11d00af-e14b-477d-805e-413a95fbf531)
