### PR TITLE
manager: smoother community delete warning (fixes #7893)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.93",
+  "version": "0.16.94",
   "myplanet": {
-    "latest": "v0.22.68",
-    "min": "v0.21.68"
+    "latest": "v0.22.70",
+    "min": "v0.21.70"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -15,8 +15,6 @@
     <a [routerLink]="['surveys']" mat-raised-button i18n>Surveys</a>
     <button *ngIf="planetType !== center && showResendConfiguration"
       (click)="resendConfig()" i18n mat-raised-button>Resend Registration Request</button>
-    <button *ngIf="devMode"
-      (click)="openDeleteCommunityDialog()" i18n mat-raised-button>Delete Community</button>
     <a routerLink="/feedback" i18n mat-raised-button>Feedback</a>
     <a routerLink="configuration" i18n mat-raised-button>Configuration</a>
     <a routerLink="fetch" mat-raised-button *ngIf="fetchItemCount > 0"><span i18n>Fetch Items</span>{{ ' (' + fetchItemCount + ')' }}</a>
@@ -29,6 +27,8 @@
   <a routerLink="/manager/users" i18n mat-raised-button>Members</a>
   <a routerLink="/manager/aiservices" i18n mat-raised-button>AI Configurations</a>
   <a routerLink="certifications" i18n mat-raised-button *planetBeta>Certifications</a>
+  <button *ngIf="devMode"
+  (click)="openDeleteCommunityDialog()" i18n mat-raised-button color = "warn">Delete Community</button>
   <ng-container *planetAuthorizedRoles="'manager'">
     <div *ngIf="pendingPushCount > 0">
       <p>

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -199,7 +199,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
         changeType: 'delete',
         type: 'community',
         displayName: this.userService.get().name,
-        extraMessage: '(This is a destructive action that cannot be undone)'
+        extraMessage: '(This is a destructive action that cannot be undone.git ad)'
       }
     });
     // Reset the message when the dialog closes

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -198,7 +198,8 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
         okClick: this.deleteCommunity(),
         changeType: 'delete',
         type: 'community',
-        displayName: this.userService.get().name
+        displayName: this.userService.get().name,
+        extraMessage: '(This is a destructive action that cannot be undone)'
       }
     });
     // Reset the message when the dialog closes

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -198,7 +198,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
         okClick: this.deleteCommunity(),
         changeType: 'delete',
         type: 'community',
-        displayName: this.userService.get().name
+        displayName: this.planetConfiguration.name
       }
     });
     // Reset the message when the dialog closes

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -198,8 +198,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
         okClick: this.deleteCommunity(),
         changeType: 'delete',
         type: 'community',
-        displayName: this.userService.get().name,
-        extraMessage: '(This is a destructive action that cannot be undone!)'
+        displayName: this.userService.get().name
       }
     });
     // Reset the message when the dialog closes

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -199,7 +199,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
         changeType: 'delete',
         type: 'community',
         displayName: this.userService.get().name,
-        extraMessage: '(This is a destructive action that cannot be undone.git ad)'
+        extraMessage: '(This is a destructive action that cannot be undone!)'
       }
     });
     // Reset the message when the dialog closes


### PR DESCRIPTION
fixes #7893 

Moved the Delete Community button to the end of the list, made it red, and made the confirmation prompt a little more clear. We could in theory make the confirmation stronger, such as having a second dialog prompt, making them type out the community name, etc, but  I think this is an improvement for now. 
![image](https://github.com/user-attachments/assets/958186fc-fad0-42d3-8227-fa243c0a5ded)