### PR TITLE
all: smoother dependencies (fixes #8139)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.69",
+  "version": "0.16.76",
   "myplanet": {
     "latest": "v0.22.23",
     "min": "v0.21.23"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.8",
+    "@types/ms": "0.7.34",
     "@types/node": "^12.11.1",
     "@types/pouchdb": "^6.4.0",
     "@types/pouchdb-find": "^6.3.4",


### PR DESCRIPTION
The @types/ms package was recently updated and is no longer compatible with TypeScript <4.6.3.

```
ERROR in node_modules/@types/ms/index.d.ts:58:9 - error TS1110: Type expected.

58         `${number}`
           ~~~

** Angular Live Development Server is listening on 0.0.0.0:3000, open your browser on http://localhost:3000/ **

Date: 2025-01-22T21:05:35.731Z - Hash: a6a6ed05705400319e05
5 unchanged chunks

Time: 1652ms

ERROR in node_modules/@types/ms/index.d.ts:58:11 - error TS1110: Type expected.

58         | `${number}`
             ~~~
``` 