### PR TITLE
resources: smoother collections message (fixes #8144)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.76",
+  "version": "0.16.81",
   "myplanet": {
     "latest": "v0.22.33",
     "min": "v0.21.33"

--- a/src/app/shared/forms/planet-tag-selected-input.component.ts
+++ b/src/app/shared/forms/planet-tag-selected-input.component.ts
@@ -8,8 +8,8 @@ import { DeviceInfoService, DeviceType } from '../../shared/device-info.service'
       <span *ngSwitchCase="0" i18n>No collections selected</span>
       <span *ngSwitchCase="1"><span i18n>Selected:</span>
         {{ truncatedTooltip }}
-      <span *ngSwitchDefault [matTooltip]="tooltipLabels" i18n>Hover to see selected collections</span>
     </span>
+    <span *ngSwitchDefault [matTooltip]="tooltipLabels"><span i18n>Hover to see selected collections</span></span>
   `,
   selector: 'planet-tag-selected-input'
 })


### PR DESCRIPTION
fixes #8144

Fixed an issue where this message was not appearing when multiple collections were selected. 
![image](https://github.com/user-attachments/assets/d1c9187d-309e-448c-949b-91427803375c)


