### PR TITLE
courses: smoother chat persistence (fixes #8107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.78",
+  "version": "0.16.83",
   "myplanet": {
     "latest": "v0.22.40",
     "min": "v0.21.40"

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -22,7 +22,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   disabled = false;
   clearChat = true;
   provider: AIProvider;
-  conversations: any[] = [];
+  fallbackConversation: any[] = [];
   selectedConversationId: any;
   promptForm: FormGroup;
   data: ConversationForm = {
@@ -36,6 +36,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   };
   providers: AIProvider[] = [];
   @Input() context: any;
+  @Input() conversations: any[] | null = null;
   @ViewChild('chatInput') chatInput: ElementRef;
   @ViewChild('chat') chatContainer: ElementRef;
 
@@ -48,6 +49,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   ) {}
 
   ngOnInit() {
+    if (this.conversations === null) {
+      this.conversations = this.fallbackConversation;
+    }
     this.createForm();
     this.subscribeToNewChatSelected();
     this.subscribeToSelectedConversation();

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -70,7 +70,7 @@
     </div>
   </mat-toolbar>
   <div class="view-container view-full-height" [ngClass]="{'grid-view': showChat, 'flex-view': !isGridView && !showChat}" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">
-    <planet-chat-window *ngIf="showChat" [context]="{type: 'coursestep', data: localizedStepInfo, resource: { id: resource?._id, attachments: resource?._attachments } }"></planet-chat-window>
+    <planet-chat-window *ngIf="showChat" [context]="{type: 'coursestep', data: localizedStepInfo, resource: { id: resource?._id, attachments: resource?._attachments } }" [conversations]="conversations"></planet-chat-window>
     <ng-container *ngIf="showChat; else stepViewContent">
       <div class="flex-view">
         <ng-container *ngTemplateOutlet="stepViewContent"></ng-container>

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -23,6 +23,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   onDestroy$ = new Subject<void>();
   stepNum = 0;
   stepDetail: any = { stepTitle: '', description: '', resources: [] };
+  conversations: any[] = [];
   courseId: string;
   maxStep = 1;
   resourceUrl = '';
@@ -139,6 +140,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   changeStep(direction) {
     this.isLoading = true;
     this.router.navigate([ '../' + (this.stepNum + direction) ], { relativeTo: this.route });
+    this.conversations = [];
     this.resetCourseStep();
     this.countActivity = true;
   }


### PR DESCRIPTION
Fixes #8107 

Now when you type something in course chat, it persist until you switch to another step, or when you navigate away.