### PR TITLE
all: smoother navigation icons (fixes #8167)(fixes #8168)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.16.86",
+  "version": "0.16.90",
   "myplanet": {
     "latest": "v0.22.57",
     "min": "v0.21.57"

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -45,7 +45,7 @@
     <span *ngIf="layout === 'classic' && !forceModern">
       <button mat-icon-button routerLink="/chat" i18n-title title="Chat"><mat-icon>question_answer</mat-icon></button>
       <button mat-icon-button planetFeedback i18n-title title="Submit Feedback"><mat-icon>feedback_outline</mat-icon></button>
-      <button mat-icon-button routerLink="/feedback" i18n-title title="Review Feedback"><mat-icon>mail_outline</mat-icon></button>
+      <button mat-icon-button routerLink="/feedback" i18n-title title="Review Feedback"><mat-icon>mail</mat-icon></button>
       <ng-container *planetAuthorizedRoles>
         <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="feedback"></mat-icon></button>
       </ng-container>
@@ -211,12 +211,9 @@
             </a>
           </li>
         </ng-container>
+        <li style="text-align: center;">
+          <planet-language [iconOnly]="layout === 'modern' || forceModern"></planet-language>
         <li>
-          <a mat-button (click)="openLanguageDialog()" i18n-title title="Change Language">
-            <mat-icon>translate</mat-icon>
-            <label *ngIf="sidenavState === 'open'" i18n>Language</label>
-          </a>
-        </li>
         <ng-container *planetAuthorizedRoles>
           <li *ngIf="onlineStatus === 'accepted'">
             <a mat-button planetSync i18n-title title="Sync">

--- a/src/app/shared/planet-language.component.html
+++ b/src/app/shared/planet-language.component.html
@@ -1,5 +1,5 @@
 <button mat-button [matMenuTriggerFor]="languageMenu">
-  <mat-icon>language</mat-icon>
+  <mat-icon>translate</mat-icon>
   <span *ngIf="!iconOnly">{{this.currentLanguage.name}}</span>
 </button>
 


### PR DESCRIPTION
fixes #8167, #8168

Made icons consistent in mobile and desktop view. 

Translate nav bar icon should work on mobile view now. 