### PR TITLE
team surveys: smoother deletion (fixes #8186)

### DIFF
--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -21,7 +21,7 @@
       <mat-button-toggle value="adopt" i18n>Adopt a survey</mat-button-toggle>
     </mat-button-toggle-group>
     <ng-container *planetAuthorizedRoles="'manager'">
-      <button mat-button (click)="deleteSelected()" [disabled]="!selection.selected.length">
+      <button mat-button (click)="deleteSelected()" [disabled]="routeTeamId && (currentFilter.viewMode === 'team' || currentFilter.viewMode === 'adopt') || !selection.selected.length" class="delete-button">
         <mat-icon aria-hidden="true" class="margin-lr-3">delete_forever</mat-icon><span i18n>Delete</span>
         <span *ngIf="selection?.selected?.length"> ({{selection?.selected?.length}})</span>
       </button>


### PR DESCRIPTION
fixes #8186

Surveys can only be deleted from the manage surveys page. 