### PR TITLE
chat: improve error handling (fixes #8218)

### DIFF
--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -2,7 +2,7 @@
   <div class="chat-container" #chat>
     <div *ngFor="let conversation of conversations">
       <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
-      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" class="conversation-err" [planetChatOutput]="conversation.response"></p>
+      <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" [planetChatOutput]="conversation.response"></p>
     </div>
   </div>
 

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -182,14 +182,15 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   initializeErrorStream() {
-    // Subscribe to WebSocket error messages
     this.chatService.getErrorStream().subscribe((errorMessage) => {
-      this.conversations.push({
-        query: errorMessage,
+      const lastQuery = this.conversations[this.conversations.length - 1]?.query;
+      this.conversations[this.conversations.length - 1] = {
+        query: lastQuery,
         response: 'Error: ' + errorMessage,
-        error: true,
-      });
-      this.postSubmit();
+        error: true
+      };
+      this.spinnerOn = true;
+      this.promptForm.controls['prompt'].setValue('');
     });
   }
 
@@ -254,11 +255,11 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
             '_rev': completion.couchDBResponse?.rev
           };
           this.postSubmit();
-          this.chatService.sendNewChatAddedSignal();
         },
         (error: any) => {
           this.conversations.push({ query: content, response: 'Error: ' + error.message, error: true });
-          this.postSubmit();
+          this.spinnerOn = true;
+          this.promptForm.controls['prompt'].setValue('');
         }
       );
     }

--- a/src/app/shared/chat.service.ts
+++ b/src/app/shared/chat.service.ts
@@ -37,16 +37,25 @@ import { AIServices, AIProvider } from '../chat/chat.model';
     private couchService: CouchService
   ) {
     this.fetchAIProviders();
-   }
+  }
 
   initializeWebSocket() {
     if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
       this.socket = new WebSocket('ws' + this.baseUrl.slice(4));
       this.socket.onerror = (error) => {
-        this.errorSubject.next('WebSocket error');
+        this.errorSubject.next('WebSocket connection error');
       };
       this.socket.addEventListener('message', (event) => {
-        this.chatStreamSubject.next(event.data);
+        try {
+          const message = JSON.parse(event.data);
+          if (message.type === 'error') {
+            this.errorSubject.next(message.error);
+          } else {
+            this.chatStreamSubject.next(event.data);
+          }
+        } catch (error) {
+          this.errorSubject.next('Invalid message format');
+        }
       });
     }
   }


### PR DESCRIPTION
Fixes #8218

Error handling fix i.e display an error message when there is an error response. Can be tested with a faulty api key
Both on normal mode & streaming
