### PR TITLE
resources: smoother creation filename preview (fixes #8212)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.10",
+  "version": "0.17.12",
   "myplanet": {
     "latest": "v0.22.89",
     "min": "v0.21.89"

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -59,7 +59,7 @@ export class ResourcesAddComponent implements OnInit {
   @Input() isDialog = false;
   @Input() privateFor: any;
   @Output() afterSubmit = new EventEmitter<any>();
-  attachmentMarkedForDeletion: boolean = false;
+  attachmentMarkedForDeletion = false;
 
   constructor(
     private router: Router,

--- a/src/app/shared/forms/file-input.component.ts
+++ b/src/app/shared/forms/file-input.component.ts
@@ -6,7 +6,7 @@ import { Component, Output, EventEmitter } from '@angular/core';
     <div class="inner-gaps by-column">
       <button type="button" mat-raised-button (click)="fileInput.click()" color="primary" i18n>Choose File</button>
       <input hidden (change)="onFileSelected($event)" #fileInput type="file">
-      <span class="file-name" i18n>{{selectedFile?.name || 'No file chosen'}}</span>
+      <span class="file-name" i18n>{{ getTruncatedFileName() }}</span>
     </div>
   `,
 })
@@ -18,6 +18,15 @@ export class FileInputComponent {
   onFileSelected(event: any): void {
       this.selectedFile = event.target.files[0] ?? null;
       this.fileChange.emit(event);
+  }
+
+  getTruncatedFileName(): string {
+    const maxLength = 25;
+    if (!this.selectedFile?.name) {
+      return 'No file chosen';
+    }
+    const fileName = this.selectedFile.name;
+    return fileName.length > maxLength ? `${fileName.slice(0, maxLength)}...` : fileName;
   }
 
 }


### PR DESCRIPTION
fixes #8212

Long file name previews no longer overflow in the add/edit courses page. 

![image](https://github.com/user-attachments/assets/ef8286df-4110-4044-9868-0df1aa629eb7)


