### PR TITLE
teams: smoother surveys access managing (fixes #8186)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.7",
+  "version": "0.17.13",
   "myplanet": {
     "latest": "v0.22.85",
     "min": "v0.21.85"

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -45,7 +45,7 @@ export class ExamsAddComponent implements OnInit {
   isCourseContent = this.router.url.match(/courses/);
   returnUrl = this.coursesService.returnUrl || 'courses';
   activeQuestionIndex = -1;
-  isManagerRoute = this.router.url.startsWith('/manager/surveys/');
+  isManagerRoute = this.router.url.startsWith('/manager/surveys');
   private _question: FormGroup;
   get question(): FormGroup {
     return this._question;

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -39,6 +39,13 @@
         <mat-cell *matCellDef="let row">
           <mat-checkbox (change)="$event ? selection.toggle(row._id) : null"
             [checked]="selection.isSelected(row._id)"
+            [disabled]="(row.teamId && isManagerRoute) || (!isManagerRoute && !row.teamId)"
+            [matTooltip]="row.teamId && isManagerRoute
+              ? 'This is a team created survey'
+              : !row.teamId && !isManagerRoute
+                ? 'This is a community survey'
+                : ''"
+            i18n-tooltip
             *ngIf="!row.parent === true">
           </mat-checkbox>
         </mat-cell>
@@ -65,15 +72,27 @@
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
         <mat-cell *matCellDef="let element">
           <ng-container *ngIf="!element.parent === true && currentFilter.viewMode !== 'adopt'">
-            <button mat-raised-button color="primary" *ngIf="!teamId" (click)="routeToEditSurvey('update', element._id)" i18n><mat-icon>edit</mat-icon> Edit</button>
-            <button mat-raised-button color="primary" *ngIf="!teamId && !routeTeamId" [disabled]="!element.questions.length" [matMenuTriggerFor]="sendMenu"i18n><mat-icon>arrow_drop_down</mat-icon> Send</button>
+            <button mat-raised-button color="primary"
+              *ngIf="!teamId"
+              (click)="routeToEditSurvey('update', element._id)"
+              [disabled]="(element.teamId && isManagerRoute) || (!isManagerRoute && !element.teamId)"
+              i18n><mat-icon>edit</mat-icon> Edit
+            </button>
+            <button mat-raised-button color="primary"
+              *ngIf="!teamId && !routeTeamId"
+              [matMenuTriggerFor]="sendMenu"
+              [disabled]="!element.questions.length || element.teamId && isManagerRoute"
+              i18n><mat-icon>arrow_drop_down</mat-icon> Send
+            </button>
             <mat-menu #sendMenu="matMenu">
               <button mat-menu-item style="width: 100%;" (click)="openSendSurveyToUsersDialog(element)" i18n>User <mat-icon>send</mat-icon></button>
               <button mat-menu-item style="width: 100%;" (click)="openSendSurveyToTeamsDialog(element)" i18n>Team <mat-icon>send</mat-icon></button>
             </mat-menu>
-            <button mat-raised-button color="primary" [disabled]="!element.questions.length" (click)="recordSurvey(element)"
-              i18n-matTooltip matTooltip="Record survey information from a person who is not a member of {{configuration.name}}" i18n>
-              <mat-icon>fiber_manual_record</mat-icon> Record
+            <button mat-raised-button color="primary"
+              (click)="recordSurvey(element)"
+              [disabled]="!element.questions.length || element.teamId && isManagerRoute"
+              matTooltip="Record survey information from a person who is not a member of {{configuration.name}}"
+              i18n><mat-icon>fiber_manual_record</mat-icon> Record
             </button>
           </ng-container>
           <button mat-raised-button color="primary" *ngIf="routeTeamId && currentFilter.viewMode === 'adopt'" (click)="adoptSurvey(element)" i18n><mat-icon>get_app</mat-icon>  Adopt</button>

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -48,6 +48,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   message = '';
   configuration = this.stateService.configuration;
   parentCount = 0;
+  isManagerRoute = this.router.url.startsWith('/manager/surveys');
   routeTeamId = this.route.parent?.snapshot.paramMap.get('teamId') || null;
   @Input() teamId?: string;
 
@@ -169,6 +170,11 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.selection.selected.length === (itemsShown(this.paginator) - this.parentCount);
   }
 
+  isRowSelectable(row: any): boolean {
+    const isDisabled = (row.teamId && this.isManagerRoute) || (!this.isManagerRoute && !row.teamId);
+    return row.parent !== true && !isDisabled;
+  }
+
   masterToggle() {
     const start = this.paginator.pageIndex * this.paginator.pageSize;
     const end = start + this.paginator.pageSize;
@@ -176,7 +182,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
       this.selection.clear();
     } else {
       this.surveys.filteredData.slice(start, end).forEach((row: any) => {
-        if (row.parent !== true) {
+        if (this.isRowSelectable(row)) {
           this.selection.select(row._id);
         }
       });


### PR DESCRIPTION
Fixes #8186

Manage various access controls for the surveys:
**Teams**: community surveys can no longer be edited & deleted
**Admin**:  team surveys cannot be edited, deleted, sent or recorded
