### PR TITLE
community: smoother public access (fixes #8220)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.10",
+  "version": "0.17.32",
   "myplanet": {
     "latest": "v0.22.89",
     "min": "v0.21.89"

--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -4,9 +4,10 @@ import { Routes, RouterModule } from '@angular/router';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { AuthService } from './shared/auth-guard.service';
 import { HomeComponent } from './home/home.component';
+import { UserGuard } from './shared/user-guard.service';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent, loadChildren: () => import('./home/home.module').then(m => m.HomeModule) },
+  { path: '', component: HomeComponent, loadChildren: () => import('./home/home.module').then(m => m.HomeModule), canActivateChild: [ UserGuard ] },
   { path: 'login', loadChildren: () => import('./login/login.module').then(m => m.LoginModule), canActivate: [ AuthService ] },
   { path: '**', component: PageNotFoundComponent }
 ];

--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -3,9 +3,10 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { AuthService } from './shared/auth-guard.service';
+import { HomeComponent } from './home/home.component';
 
-export const routes: Routes = [
-  { path: '', loadChildren: () => import('./home/home.module').then(m => m.HomeModule), canActivateChild: [ AuthService ] },
+const routes: Routes = [
+  { path: '', component: HomeComponent, loadChildren: () => import('./home/home.module').then(m => m.HomeModule) },
   { path: 'login', loadChildren: () => import('./login/login.module').then(m => m.LoginModule), canActivate: [ AuthService ] },
   { path: '**', component: PageNotFoundComponent }
 ];

--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -7,7 +7,11 @@ import { HomeComponent } from './home/home.component';
 import { UserGuard } from './shared/user-guard.service';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent, loadChildren: () => import('./home/home.module').then(m => m.HomeModule), canActivateChild: [ UserGuard ] },
+  { path: '',
+    component: HomeComponent,
+    loadChildren: () => import('./home/home.module').then(m => m.HomeModule),
+    canActivateChild: [ UserGuard ]
+  },
   { path: 'login', loadChildren: () => import('./login/login.module').then(m => m.LoginModule), canActivate: [ AuthService ] },
   { path: '**', component: PageNotFoundComponent }
 ];

--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -7,7 +7,8 @@ import { HomeComponent } from './home/home.component';
 import { UserGuard } from './shared/user-guard.service';
 
 const routes: Routes = [
-  { path: '',
+  {
+    path: '',
     component: HomeComponent,
     loadChildren: () => import('./home/home.module').then(m => m.HomeModule),
     canActivateChild: [ UserGuard ]

--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -20,7 +20,7 @@
             <p i18n>No Voices available.</p>
           </ng-template>
         </mat-tab>
-        <mat-tab i18n-label label="Community Leaders">
+        <mat-tab i18n-label label="Community Leaders" *ngIf="isLoggedIn">
           <div class="card-grid">
             <mat-card *ngFor="let councillor of councillors">
               <planet-teams-member
@@ -32,7 +32,7 @@
             </mat-card>
           </div>
         </mat-tab>
-        <mat-tab i18n-label label="Services">
+        <mat-tab i18n-label label="Services" *ngIf="isLoggedIn">
           <ng-container *ngIf="!planetCode">
             <button class="toggle-button" *planetAuthorizedRoles="''" (click)="openDescriptionDialog()" mat-stroked-button i18n>
               { servicesDescriptionLabel, select, Edit {Edit} Add {Add}} { configuration.planetType, select, community {Community} nation {Nation} center {Earth}} Description
@@ -62,13 +62,13 @@
             <p i18n>No links available.</p>
           </ng-template>
         </mat-tab>
-        <mat-tab *ngIf="configuration.planetType==='nation'" i18n-label label="Communities">
+        <mat-tab *ngIf="configuration.planetType==='nation' && isLoggedIn" i18n-label label="Communities">
           <planet-community-list></planet-community-list>
         </mat-tab>
-        <mat-tab i18n-label label="Finances">
+        <mat-tab i18n-label label="Finances" *ngIf="isLoggedIn">
           <planet-teams-view-finances [finances]="finances" [team]="team" (financesChanged)="dataChanged()" [editable]="isCommunityLeader && !planetCode"></planet-teams-view-finances>
         </mat-tab>
-        <mat-tab i18n-label label="Reports">
+        <mat-tab i18n-label label="Reports" *ngIf="isLoggedIn">
           <planet-teams-reports [reports]="reports" [editable]="isCommunityLeader && !planetCode" [team]="team" (reportsChanged)="dataChanged()"></planet-teams-reports>
         </mat-tab>
         <mat-tab i18n-label label="Calendar" *ngIf="deviceType !== deviceTypes.DESKTOP">

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -40,6 +40,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   teamId = planetAndParentId(this.stateService.configuration);
   team: any = { _id: this.teamId, teamType: 'sync', teamPlanetCode: this.stateService.configuration.code, type: 'services' };
   user = this.userService.get();
+  isLoggedIn = this.user._id !== undefined;
   news: any[] = [];
   links: any[] = [];
   finances: any[] = [];

--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { DashboardComponent } from '../dashboard/dashboard.component';
-import { HomeComponent } from './home.component';
 import { NotificationsComponent } from '../notifications/notifications.component';
 import { UpgradeComponent } from '../upgrade/upgrade.component';
 import { UsersAchievementsComponent } from '../users/users-achievements/users-achievements.component';

--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -12,70 +12,75 @@ import { CommunityComponent } from '../community/community.component';
 import { myDashboardRoute } from './router-constants';
 import { CoursesProgressLearnerComponent } from '../courses/progress-courses/courses-progress-learner.component';
 import { LandingComponent } from '../landing/landing.component';
+import { AuthService } from '../shared/auth-guard.service';
+import { BetaThenAuthService } from '../shared/beta-then-auth-guard-service';
 
 export function dashboardPath(route): string {
   return `${myDashboardRoute}/${route}`;
 }
 
+const alwaysGuardedRoutes = [
+  { path: 'community/:code', component: CommunityComponent },
+  { path: 'users', loadChildren: () => import('../users/users.module').then(m => m.UsersModule) },
+  {
+    path: 'manager',
+    loadChildren: () => import('../manager-dashboard/manager-dashboard.module').then(m => m.ManagerDashboardModule),
+    data: { roles: [ '_admin' ] }
+  },
+  { path: 'courses', loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule) },
+  { path: 'feedback', loadChildren: () => import('../feedback/feedback.module').then(m => m.FeedbackModule) },
+  { path: 'resources', loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule) },
+  { path: 'chat', loadChildren: () => import('../chat/chat.module').then(m => m.ChatModule) },
+  { path: 'meetups', loadChildren: () => import('../meetups/meetups.module').then(m => m.MeetupsModule) },
+  { path: 'notifications', component: NotificationsComponent },
+  { path: 'upgrade', component: UpgradeComponent },
+  { path: 'upgrade/myplanet', component: UpgradeComponent, data: { myPlanet: true } },
+  { path: 'teams', loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule) },
+  { path: 'enterprises', loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule), data: { mode: 'enterprise' } },
+  { path: 'health', component: HealthListComponent, data: { roles: [ '_admin', 'health' ] } },
+  { path: 'health/profile/:id', loadChildren: () => import('../health/health.module').then(m => m.HealthModule), data: { roles: [ '_admin', 'health' ] } },
+  { path: 'nation', component: TeamsViewComponent, data: { mode: 'services' } },
+  { path: 'earth', component: TeamsViewComponent, data: { mode: 'services' } },
+  { path: myDashboardRoute, component: DashboardComponent },
+  {
+    path: dashboardPath('mySurveys'),
+    loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule), data: { mySurveys: true }
+  },
+  {
+    path: dashboardPath('submissions'),
+    loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule)
+  },
+  {
+    path: dashboardPath('submissions/:type'),
+    loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule)
+  },
+  {
+    path: dashboardPath('myTeams'),
+    loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule), data: { myTeams: true }
+  },
+  { path: dashboardPath('myAchievements'), component: UsersAchievementsComponent },
+  { path: dashboardPath('myAchievements/update'), component: UsersAchievementsUpdateComponent },
+  { path: dashboardPath('myHealth'), loadChildren: () => import('../health/health.module').then(m => m.HealthModule) },
+  {
+    path: dashboardPath('myCourses'),
+    loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule), data: { myCourses: true }
+  },
+  { path: dashboardPath('myProgress'), component: CoursesProgressLearnerComponent },
+  {
+    path: dashboardPath('myLibrary'),
+    loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule), data: { view: 'myLibrary' }
+  },
+  {
+    path: dashboardPath('myPersonals'),
+    loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule), data: { view: 'myPersonals' }
+  }
+];
+
 const routes: Routes = [
-  { path: '', component: HomeComponent,
-    children: [
-      { path: '', component: CommunityComponent },
-      { path: 'community/:code', component: CommunityComponent },
-      { path: 'users', loadChildren: () => import('../users/users.module').then(m => m.UsersModule) },
-      {
-        path: 'manager',
-        loadChildren: () => import('../manager-dashboard/manager-dashboard.module').then(m => m.ManagerDashboardModule),
-        data: { roles: [ '_admin' ] }
-      },
-      { path: 'courses', loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule) },
-      { path: 'feedback', loadChildren: () => import('../feedback/feedback.module').then(m => m.FeedbackModule) },
-      { path: 'resources', loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule) },
-      { path: 'chat', loadChildren: () => import('../chat/chat.module').then(m => m.ChatModule) },
-      { path: 'meetups', loadChildren: () => import('../meetups/meetups.module').then(m => m.MeetupsModule) },
-      { path: 'notifications', component: NotificationsComponent },
-      { path: 'upgrade', component: UpgradeComponent },
-      { path: 'upgrade/myplanet', component: UpgradeComponent, data: { myPlanet: true } },
-      { path: 'teams', loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule) },
-      { path: 'enterprises', loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule), data: { mode: 'enterprise' } },
-      { path: 'health', component: HealthListComponent, data: { roles: [ '_admin', 'health' ] } },
-      { path: 'health/profile/:id', loadChildren: () => import('../health/health.module').then(m => m.HealthModule), data: { roles: [ '_admin', 'health' ] } },
-      { path: 'nation', component: TeamsViewComponent, data: { mode: 'services' } },
-      { path: 'earth', component: TeamsViewComponent, data: { mode: 'services' } },
-      { path: myDashboardRoute, component: DashboardComponent },
-      {
-        path: dashboardPath('mySurveys'),
-        loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule), data: { mySurveys: true }
-      },
-      {
-        path: dashboardPath('submissions'),
-        loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule)
-      },
-      {
-        path: dashboardPath('submissions/:type'),
-        loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule)
-      },
-      {
-        path: dashboardPath('myTeams'),
-        loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule), data: { myTeams: true }
-      },
-      { path: dashboardPath('myAchievements'), component: UsersAchievementsComponent },
-      { path: dashboardPath('myAchievements/update'), component: UsersAchievementsUpdateComponent },
-      { path: dashboardPath('myHealth'), loadChildren: () => import('../health/health.module').then(m => m.HealthModule) },
-      {
-        path: dashboardPath('myCourses'),
-        loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule), data: { myCourses: true }
-      },
-      { path: dashboardPath('myProgress'), component: CoursesProgressLearnerComponent },
-      {
-        path: dashboardPath('myLibrary'),
-        loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule), data: { view: 'myLibrary' }
-      },
-      {
-        path: dashboardPath('myPersonals'),
-        loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule), data: { view: 'myPersonals' }
-      }
-    ]
+  { path: '', component: CommunityComponent, canActivate: [ BetaThenAuthService ] },
+  { path: '',
+    children: alwaysGuardedRoutes,
+    canActivateChild: [ AuthService ]
   },
   { path: 'landing', component: LandingComponent, data: { requiresAuth: false } },
   { path: 'landing', loadChildren: () => import('../landing/landing.module').then(m => m.LandingModule), data: { requiresAuth: false } }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -63,10 +63,13 @@
       <ng-template #accountIcon><mat-icon>account_circle</mat-icon></ng-template>
     </button>
     <mat-menu #userProfile="matMenu" [overlapTrigger]="false">
-      <button mat-menu-item routerLink="/users/profile/{{user.name}}" i18n>View Profile</button>
-      <button mat-menu-item i18n routerLink="/users/update/{{user.name}}">Edit Profile</button>
-      <button mat-menu-item i18n planetChangePassword *ngIf="user.planetCode === this.configuration.code">Change Password</button>
-      <button mat-menu-item i18n (click)="logoutClick()">Logout</button>
+      <ng-container *ngIf="isLoggedIn">
+        <button mat-menu-item routerLink="/users/profile/{{user.name}}" i18n>View Profile</button>
+        <button mat-menu-item i18n routerLink="/users/update/{{user.name}}">Edit Profile</button>
+        <button mat-menu-item i18n planetChangePassword *ngIf="user.planetCode === this.configuration.code">Change Password</button>
+        <button mat-menu-item i18n (click)="logoutClick()">Logout</button>
+      </ng-container>
+      <button mat-menu-item i18n routerLink="/login" *ngIf="!isLoggedIn">Login</button>
     </mat-menu>
     <!--Notification dropdown menu-->
     <mat-menu #notificationMenu="matMenu" [overlapTrigger]="false" class="notification-menu">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -45,6 +45,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   planetName;
   isAndroid: boolean;
   showBanner = true;
+  isLoggedIn = false;
 
   // Sets the margin for the main content to match the sidenav width
   animObs = interval(15).pipe(
@@ -169,6 +170,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
 
   onUserUpdate() {
     this.user = this.userService.get();
+    this.isLoggedIn = this.user._id !== undefined;
     if (this.user._attachments) {
       const filename = Object.keys(this.user._attachments)[0];
       this.userImgSrc = environment.couchAddress + '/_users/org.couchdb.user:' + this.user.name + '/' + filename;

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -59,7 +59,7 @@ export class ResourcesAddComponent implements OnInit {
   @Input() isDialog = false;
   @Input() privateFor: any;
   @Output() afterSubmit = new EventEmitter<any>();
-  attachmentMarkedForDeletion: boolean = false;
+  attachmentMarkedForDeletion = false;
 
   constructor(
     private router: Router,

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -4,7 +4,6 @@ import { Observable, of } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
 import { Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { PouchAuthService } from './database/pouch-auth.service';
-import { StateService } from './state.service';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +14,6 @@ export class AuthService {
     private userService: UserService,
     private router: Router,
     private pouchAuthService: PouchAuthService,
-    private stateService: StateService
   ) { }
 
   private getSession$() {

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
     return this.getSession$().pipe(
       switchMap((sessionInfo) => {
         if (sessionInfo.userCtx.name) {
-          // If user already matches one on the user service, do not make additional call to CouchDB
+          // User should be set on user-guard. If app user doesn't match session, boot to login
           const user = this.userService.get();
           if (sessionInfo.userCtx.name === user.name) {
             if (roles.length > 0) {
@@ -35,8 +35,6 @@ export class AuthService {
             }
             return of(true);
           }
-          this.stateService.requestBaseData();
-          return this.userService.setUserAndShelf(sessionInfo.userCtx);
         }
         this.userService.unset();
         const returnUrl = url === '/' ? null : url;

--- a/src/app/shared/beta-then-auth-guard-service.ts
+++ b/src/app/shared/beta-then-auth-guard-service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { AuthService } from './auth-guard.service';
+import { UserService } from './user.service';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BetaThenAuthService {
+
+  constructor(
+    private authService: AuthService,
+    private userService: UserService
+  ) { }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    if (this.userService.isBetaEnabled() === true) {
+      return of(true);
+    }
+    return this.authService.canActivateChild(route, state);
+  }
+
+}

--- a/src/app/shared/user-guard.service.ts
+++ b/src/app/shared/user-guard.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from "@angular/core";
-import { UserService } from "./user.service";
-import { PouchAuthService } from "./database/pouch-auth.service";
-import { StateService } from "./state.service";
-import { switchMap } from "rxjs/operators";
-import { of } from "rxjs";
+import { Injectable } from '@angular/core';
+import { UserService } from './user.service';
+import { PouchAuthService } from './database/pouch-auth.service';
+import { StateService } from './state.service';
+import { switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 // Guard simply ensures user data is fetched for application
-@Injectable({ providedIn: 'root' }) 
+@Injectable({ providedIn: 'root' })
 export class UserGuard {
 
   constructor(

--- a/src/app/shared/user-guard.service.ts
+++ b/src/app/shared/user-guard.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@angular/core";
+import { UserService } from "./user.service";
+import { PouchAuthService } from "./database/pouch-auth.service";
+import { StateService } from "./state.service";
+import { switchMap } from "rxjs/operators";
+import { of } from "rxjs";
+
+// Guard simply ensures user data is fetched for application
+@Injectable({ providedIn: 'root' }) 
+export class UserGuard {
+
+  constructor(
+    private userService: UserService,
+    private pouchAuthService: PouchAuthService,
+    private stateService: StateService
+  ) { }
+
+  canActivateChild() {
+    return this.pouchAuthService.getSessionInfo().pipe(
+      switchMap((sessionInfo) => {
+        const user = this.userService.get();
+        if (sessionInfo.userCtx.name && sessionInfo.userCtx.name === user.name) {
+          return of(true);
+        }
+        this.stateService.requestBaseData();
+        return this.userService.setUserAndShelf(sessionInfo.userCtx);
+      })
+    );
+  }
+
+}

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -17,7 +17,7 @@ import { StateService } from './state.service';
   providedIn: 'root'
 })
 export class UserService {
-  private user: any = { name: '' };
+  private user: any = { name: '', roles: [] };
   private usersDb = '_users';
   private logsDb = 'login_activities';
   private _shelf: any = { };


### PR DESCRIPTION
Makes the community page available to a not logged in client if the community is set to beta mode.

1. Set Planet to be in beta mode (advanced options in configuration).
2. Logout
3. Go to `localhost:3000` (or whatever your domain is)

Voices & Calendar can be viewed.

Images are not showing up in voices, this can be a follow up.
User menu in upper right is changed only have "Login" option in the dropdown. Could be a better UX to just have a login button. Also good for a follow up.

![image](https://github.com/user-attachments/assets/c4b4cb51-86f7-4cd9-8307-6a89c4fa70ae)

Fixes #8220 
