### PR TITLE
teams: smoother surveys rights (fixes #8229) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.13",
+  "version": "0.17.15",
   "myplanet": {
     "latest": "v0.22.93",
     "min": "v0.21.93"

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -59,7 +59,7 @@ export class ResourcesAddComponent implements OnInit {
   @Input() isDialog = false;
   @Input() privateFor: any;
   @Output() afterSubmit = new EventEmitter<any>();
-  attachmentMarkedForDeletion: boolean = false;
+  attachmentMarkedForDeletion = false;
 
   constructor(
     private router: Router,

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -74,11 +74,11 @@ export class SubmissionsService {
     this.submission = this.createNewSubmission({ parentId, parent, user, type });
   }
 
-  private createNewSubmission({ parentId, parent, user, type, sender }: { parentId, parent, user, type, sender? }) {
+  private createNewSubmission({ parentId, parent, user, type, sender, team }: { parentId, parent, user, type, sender?, team? }) {
     const date = this.couchService.datePlaceholder;
     const times = { startTime: date, lastUpdateTime: date };
     const configuration = this.stateService.configuration;
-    return { parentId, parent, user, type, answers: [], grade: 0, status: 'pending', sender,
+    return { parentId, parent, user, type, answers: [], grade: 0, status: 'pending', sender, team,
       ...this.submissionSource(configuration, user), ...times };
   }
 
@@ -214,8 +214,8 @@ export class SubmissionsService {
     );
   }
 
-  createSubmission(parent: any, type: string, user: any = '') {
-    return this.couchService.updateDocument('submissions', this.createNewSubmission({ parentId: parent._id, parent, user, type }));
+  createSubmission(parent: any, type: string, user: any = '', team: string = '') {
+    return this.couchService.updateDocument('submissions', this.createNewSubmission({ parentId: parent._id, parent, user, type, team }));
   }
 
   submissionName(user) {

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -112,7 +112,9 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
             ...survey,
             teamIds: teamIds,
             course: courses.find((course: any) => findSurveyInSteps(course.steps, survey) > -1),
-            taken: relatedSubmissions.filter(data => data.status !== 'pending').length
+            taken: this.teamId || this.routeTeamId
+              ? relatedSubmissions.filter((data) => data.status !== 'pending' && (data.team === this.teamId || data.team === this.routeTeamId)).length
+              : relatedSubmissions.filter(data => data.status !== 'pending').length
           };
         }),
         ...this.createParentSurveys(submissions)
@@ -336,7 +338,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   recordSurvey(survey: any) {
-    this.submissionsService.createSubmission(survey, 'survey', '', this.teamId ? this.teamId : '').subscribe((res: any) => {
+    this.submissionsService.createSubmission(survey, 'survey', '', this.teamId || this.routeTeamId || '' ).subscribe((res: any) => {
       this.router.navigate([
         this.teamId ? 'surveys/dispense' : 'dispense',
         { questionNum: 1, submissionId: res.id, status: 'pending', mode: 'take' }
@@ -345,7 +347,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   exportCSV(survey) {
-    this.submissionsService.exportSubmissionsCsv(survey, 'survey').subscribe(res => {
+    this.submissionsService.exportSubmissionsCsv(survey, 'survey', this.teamId || this.routeTeamId || '').subscribe(res => {
       if (!res.length) {
         this.planetMessageService.showMessage($localize`There is no survey response`);
       }
@@ -365,7 +367,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
         disableIfInvalid: true,
         onSubmit: (options: { includeQuestions, includeAnswers}) => {
           this.dialogsFormService.closeDialogsForm();
-          this.submissionsService.exportSubmissionsPdf(survey, 'survey', options);
+          this.submissionsService.exportSubmissionsPdf(survey, 'survey', options, this.teamId || this.routeTeamId || '');
         },
         formOptions: {
           validator: (ac: FormGroup) => Object.values(ac.controls).some(({ value }) => value) ? null : { required: true }

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -170,10 +170,6 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
     this.selection.deselect(...selectedOutOfFilter(this.surveys.filteredData, this.selection, this.paginator));
   }
 
-  isRowSelectable(row: any): boolean {
-    return row.parent !== true && !this.isManagerRoute && !row.teamId;
-  }
-
   isAllSelected() {
     const start = this.paginator.pageIndex * this.paginator.pageSize;
     const end = start + this.paginator.pageSize;

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -336,7 +336,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   recordSurvey(survey: any) {
-    this.submissionsService.createSubmission(survey, 'survey').subscribe((res: any) => {
+    this.submissionsService.createSubmission(survey, 'survey', '', this.teamId ? this.teamId : '').subscribe((res: any) => {
       this.router.navigate([
         this.teamId ? 'surveys/dispense' : 'dispense',
         { questionNum: 1, submissionId: res.id, status: 'pending', mode: 'take' }

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -169,8 +169,19 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
     this.selection.deselect(...selectedOutOfFilter(this.surveys.filteredData, this.selection, this.paginator));
   }
 
+  isRowSelectable(row: any): boolean {
+    return row.parent !== true && !this.isManagerRoute && !row.teamId;
+  }
+
   isAllSelected() {
-    return this.selection.selected.length === (itemsShown(this.paginator) - this.parentCount);
+    const start = this.paginator.pageIndex * this.paginator.pageSize;
+    const end = start + this.paginator.pageSize;
+
+    const selectableRowsInPage = this.surveys.filteredData
+      .slice(start, end)
+      .filter(row => this.isRowSelectable(row));
+
+    return selectableRowsInPage.every(row => this.selection.isSelected(row._id));
   }
 
   masterToggle() {
@@ -180,7 +191,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
       this.selection.clear();
     } else {
       this.surveys.filteredData.slice(start, end).forEach((row: any) => {
-        if (row.parent !== true) {
+        if (this.isRowSelectable(row)) {
           this.selection.select(row._id);
         }
       });

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -113,7 +113,9 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
             teamIds: teamIds,
             course: courses.find((course: any) => findSurveyInSteps(course.steps, survey) > -1),
             taken: this.teamId || this.routeTeamId
-              ? relatedSubmissions.filter((data) => data.status !== 'pending' && (data.team === this.teamId || data.team === this.routeTeamId)).length
+              ? relatedSubmissions.filter(
+                (data) => data.status !== 'pending' &&
+                (data.team === this.teamId || data.team === this.routeTeamId)).length
               : relatedSubmissions.filter(data => data.status !== 'pending').length
           };
         }),


### PR DESCRIPTION
Fixes #8229

Enhance the data boundaries of the teams and manager surveys
- `No of times taken` for teams only shows the times taken in teams
- In teams, can only export surveys data taken from teams
- In manager surveys, can view all the `no of times taken` and export all data