### PR TITLE
manager: smoother chat streaming toggle (fixes #8244)(fixes #8247)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.19",
+  "version": "0.17.22",
   "myplanet": {
     "latest": "v0.23.8",
     "min": "v0.22.8"

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -86,11 +86,11 @@
       <a class="margin-lr-8" [routerLink]="['reports', 'detail']" i18n mat-raised-button>Report Detail</a>
     </p>
     <p>
-      <span i18n>Chat streaming</span>
-      <mat-slide-toggle [(ngModel)]="streaming" (ngModelChange)="toggleStreaming()"></mat-slide-toggle>
-      <button mat-icon-button style="margin-left: 1rem;" (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
+      <button mat-icon-button (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
         <mat-icon>info_outline</mat-icon>
       </button>
+      <span i18n>Chat streaming</span>
+      <mat-slide-toggle [(ngModel)]="streaming" (ngModelChange)="toggleStreaming()"></mat-slide-toggle>
       <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="overlayOpen">
         <span class="overlay-text" i18n>Quicker line by line chat responses, could be costlier</span>
       </ng-template>

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -47,6 +47,9 @@ import { StateService } from '../shared/state.service';
     .pinClass {
       font-size: 1.5rem;
     }
+    mat-slide-toggle {
+      padding: 3px;
+    }
   ` ]
 })
 


### PR DESCRIPTION
fixes #8244, #8247

Added some padding between the text and toggle.
Move the information icon next to the text, so it's clearer what it provides information about.

![image](https://github.com/user-attachments/assets/073e8747-aec2-4171-92dc-f73864c598f3)
