### PR TITLE
courses: smoother creation forms (fixes #8135)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.26",
+  "version": "0.17.30",
   "myplanet": {
     "latest": "v0.23.26",
     "min": "v0.22.26"

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -17,12 +17,13 @@ import { PlanetStepListService } from '../../shared/forms/planet-step-list.compo
 import { PouchService } from '../../shared/database/pouch.service';
 import { TagsService } from '../../shared/forms/tags.service';
 import { showFormErrors } from '../../shared/table-helpers';
+import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
 
 @Component({
   templateUrl: 'courses-add.component.html',
   styleUrls: [ './courses-add.scss' ]
 })
-export class CoursesAddComponent implements OnInit, OnDestroy {
+export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeactivate  {
 
   readonly dbName = 'courses'; // make database name a constant
   courseForm: FormGroup;
@@ -34,6 +35,9 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   private isDestroyed = false;
   private isSaved = false;
   private stepsChange$ = new Subject<any[]>();
+  private navigationViaCancel = false;
+  hasUnsavedChanges: boolean = false;
+  private initialState: string = '';
   private _steps = [];
   get steps() {
     return this._steps;
@@ -115,6 +119,10 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       this.setInitialTags(tags, this.documentInfo, draft);
       if (!continued) {
         this.setFormAndSteps({ form: doc, steps: doc.steps, tags: doc.tags, initialTags: this.coursesService.course.initialTags });
+        this.initialState = JSON.stringify({
+          form: this.courseForm.value,
+          steps: this.steps
+        });
       }
     });
     if (continued) {
@@ -169,7 +177,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
 
   onFormChanges() {
     combineLatest(this.courseForm.valueChanges, this.stepsChange$, this.tags.valueChanges).pipe(
-      debounce(() => race(interval(2000), this.onDestroy$)),
+      debounce(() => race(interval(200), this.onDestroy$)),
       takeWhile(() => this.isDestroyed === false, true)
     ).subscribe(([ value, steps, tags ]) => {
       if (this.isSaved) {
@@ -178,8 +186,15 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       const course = this.convertMarkdownImagesText({ ...value, images: this.images }, steps);
       this.coursesService.course = { form: course, steps: course.steps, tags };
       this.pouchService.saveDocEditing(
-        { ...course, tags, initialTags: this.coursesService.course.initialTags }, this.dbName, this.courseId
+        { ...course, tags, initialTags: this.coursesService.course.initialTags },
+        this.dbName,
+        this.courseId
       );
+      const currentState = JSON.stringify({
+        form: this.courseForm.value,
+        steps: this.steps
+      });
+      this.hasUnsavedChanges = currentState !== this.initialState;
     });
   }
 
@@ -247,8 +262,23 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   }
 
   cancel() {
+    this.navigationViaCancel = true;
+    if (this.hasUnsavedChanges) {
+      const confirmCancel = window.confirm('You have unsaved changes. Are you sure you want to cancel?');
+      if (!confirmCancel) {
+        this.navigationViaCancel = false;
+        return;
+      }
+    }
     this.pouchService.deleteDocEditing(this.dbName, this.courseId);
     this.navigateBack();
+  }
+
+  canDeactivate(): boolean {
+    if (this.navigationViaCancel) {
+      return true;
+    }
+    return true;
   }
 
   navigateBack() {

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -270,7 +270,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
   cancel() {
     this.navigationViaCancel = true;
     if (this.hasUnsavedChanges) {
-      const confirmCancel = window.confirm('You have unsaved changes. Are you sure you want to cancel?');
+      const confirmCancel = window.confirm('You have unsaved changes. Are you sure you want to leave?');
       if (!confirmCancel) {
         this.navigationViaCancel = false;
         return;

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -121,7 +121,8 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
         this.setFormAndSteps({ form: doc, steps: doc.steps, tags: doc.tags, initialTags: this.coursesService.course.initialTags });
         this.initialState = JSON.stringify({
           form: this.courseForm.value,
-          steps: this.steps
+          steps: this.steps,
+          tags: this.tags.value
         });
       }
     });
@@ -176,7 +177,11 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
   }
 
   onFormChanges() {
-    combineLatest(this.courseForm.valueChanges, this.stepsChange$, this.tags.valueChanges).pipe(
+    combineLatest([
+      this.courseForm.valueChanges,
+      this.stepsChange$,
+      this.tags.valueChanges
+    ]).pipe(
       debounce(() => race(interval(200), this.onDestroy$)),
       takeWhile(() => this.isDestroyed === false, true)
     ).subscribe(([ value, steps, tags ]) => {
@@ -192,12 +197,13 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
       );
       const currentState = JSON.stringify({
         form: this.courseForm.value,
-        steps: this.steps
+        steps: this.steps,
+        tags: this.tags.value
       });
       this.hasUnsavedChanges = currentState !== this.initialState;
     });
   }
-
+  
   updateCourse(courseInfo, shouldNavigate) {
     if (courseInfo.createdDate.constructor === Object) {
       courseInfo.createdDate = this.couchService.datePlaceholder;

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -203,7 +203,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
       this.hasUnsavedChanges = currentState !== this.initialState;
     });
   }
-  
+
   updateCourse(courseInfo, shouldNavigate) {
     if (courseInfo.createdDate.constructor === Object) {
       courseInfo.createdDate = this.couchService.datePlaceholder;

--- a/src/app/shared/forms/planet-step-list.component.ts
+++ b/src/app/shared/forms/planet-step-list.component.ts
@@ -76,6 +76,7 @@ export class PlanetStepListComponent implements AfterContentChecked, OnDestroy {
   @Input() defaultName = 'Step';
   @Input() ignoreClick = false;
   @Output() stepClicked = new EventEmitter<number>();
+  @Output() stepsChange = new EventEmitter<any[]>();
 
   @ContentChildren(PlanetStepListItemComponent) stepListItems;
 
@@ -125,6 +126,9 @@ export class PlanetStepListComponent implements AfterContentChecked, OnDestroy {
       this.moveArrayStep(index, direction, this.steps);
     } else if (this.steps instanceof FormArray) {
       this.moveFormArrayStep(index, direction, this.steps);
+    }
+    if (Array.isArray(this.steps)) {
+      this.stepsChange.emit(this.steps);
     }
   }
 


### PR DESCRIPTION
fixes #8135

Making changes to any of the form fields, tags, or add/removing steps and then trying to navigate away via the cancel button results in a popup to let the user know there are unsaved changes. If the user navigates away via any other method (back button, refresh, nav bar, etc), the changes are saved anyway, so no popup is necessary. 