### PR TITLE
courses: smoother attached resource titles (fixes #7661)

### DIFF
--- a/src/app/courses/add-courses/courses-step.scss
+++ b/src/app/courses/add-courses/courses-step.scss
@@ -11,3 +11,16 @@ planet-courses-step .mat-chip-list-wrapper {
     overflow-y: auto;
   }
 }
+
+.mat-chip {
+  max-width: 300px;
+  
+  a {
+    display: inline-block;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+  }
+}


### PR DESCRIPTION
fixes #7661

Added truncation to long attached resource titles.
![image](https://github.com/user-attachments/assets/591839f7-af88-4c22-a022-4638c55740dc)
