### PR TITLE
myLife: smoother health exam creation (fixes #8285)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -36,8 +36,8 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
   private isSaved = false;
   private stepsChange$ = new Subject<any[]>();
   private navigationViaCancel = false;
-  hasUnsavedChanges: boolean = false;
-  private initialState: string = '';
+  hasUnsavedChanges = false;
+  private initialState = '';
   private _steps = [];
   get steps() {
     return this._steps;

--- a/src/app/health/health-event.component.ts
+++ b/src/app/health/health-event.component.ts
@@ -105,7 +105,24 @@ export class HealthEventComponent implements OnInit, CanComponentDeactivate {
   }
 
   isFormPristine(): boolean {
-    return JSON.stringify(this.healthForm.value) === JSON.stringify(this.initialFormValues);
+    const form = this.healthForm.value;
+    const initial = this.initialFormValues;
+    const numericFields = [ 'temperature', 'pulse', 'height', 'weight' ];
+
+    return Object.keys(form).every(key => {
+      if (key === 'conditions') {
+        const formConditions = form[key] || {};
+        const initialConditions = initial[key] || {};
+        return Object.keys({ ...formConditions, ...initialConditions })
+          .every(condition => Boolean(formConditions[condition]) === Boolean(initialConditions[condition]));
+      }
+      if (numericFields.includes(key)) {
+        const formVal = form[key] === '' || form[key] === null ? undefined : Number(form[key]);
+        const initialVal = initial[key] === '' || initial[key] === null ? undefined : Number(initial[key]);
+        return formVal === initialVal;
+      }
+      return JSON.stringify(form[key]) === JSON.stringify(initial[key]);
+    });
   }
 
   onSubmit() {


### PR DESCRIPTION
fixes #8285

Added unsaved changes guard to health exams. Navigating away via the browser, back button, cancel button, or nav bar with unsaved changes will result in a popup to confirm the navigation. 