### PR TITLE
manager: smoother survey export (fixes #8282)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.33",
+  "version": "0.17.36",
   "myplanet": {
-    "latest": "v0.23.39",
-    "min": "v0.22.39"
+    "latest": "v0.23.45",
+    "min": "v0.22.45"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -23,7 +23,7 @@ import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
   templateUrl: 'courses-add.component.html',
   styleUrls: [ './courses-add.scss' ]
 })
-export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeactivate  {
+export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeactivate {
 
   readonly dbName = 'courses'; // make database name a constant
   courseForm: FormGroup;
@@ -36,8 +36,8 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
   private isSaved = false;
   private stepsChange$ = new Subject<any[]>();
   private navigationViaCancel = false;
-  hasUnsavedChanges: boolean = false;
-  private initialState: string = '';
+  hasUnsavedChanges = false;
+  private initialState = '';
   private _steps = [];
   get steps() {
     return this._steps;

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CouchService } from '../shared/couchdb.service';
-import { Subject, of, forkJoin } from 'rxjs';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { Subject, of, forkJoin, throwError } from 'rxjs';
+import { catchError, finalize, map, switchMap, tap } from 'rxjs/operators';
 import { findDocuments } from '../shared/mangoQueries';
 import { StateService } from '../shared/state.service';
 import { CoursesService } from '../courses/courses.service';
@@ -286,6 +286,9 @@ export class SubmissionsService {
   }
 
   answerIndexes(questionTexts: string[], submission: any) {
+    if (!submission || !submission.parent || !Array.isArray(submission.parent.questions) || !questionTexts) {
+      return questionTexts.map(() => -1);
+    }
     return questionTexts.map(text => submission.parent.questions.findIndex(question => question.body === text));
   }
 
@@ -298,6 +301,9 @@ export class SubmissionsService {
 
   getPDFAnswerText(submission: any, index, answerIndexes: number[]) {
     const answerText = this.getAnswerText(submission.answers, index, answerIndexes);
+    if (!submission.parent ||!Array.isArray(submission.parent.questions) || !submission.parent.questions[index]) {
+      return answerText;
+    }
     return submission.parent.questions[index] && submission.parent.questions[index].type !== 'textarea' ?
       '<pre>'.concat(answerText, '</pre>') :
       answerText;
@@ -307,7 +313,13 @@ export class SubmissionsService {
     forkJoin([
       this.getSubmissionsExport(exam, type),
       this.managerService.getChildPlanets(true)
-    ]).subscribe(([ [ submissions, time, questionTexts ], planets ]: [ [ any[], number, string[] ], any[] ]) => {
+    ]).pipe(
+      finalize(() => this.dialogsLoadingService.stop()),
+      catchError((error) => {
+        this.planetMessageService.showAlert($localize`Error exporting PDF: ${error.message}`);
+        return throwError(error);
+      })
+    ).subscribe(([ [ submissions, time, questionTexts ], planets ]: [ [ any[], number, string[] ], any[] ]) => {
       const filteredSubmissions = team
         ? submissions.filter((s) => s.team === team)
         : submissions;

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -301,7 +301,7 @@ export class SubmissionsService {
 
   getPDFAnswerText(submission: any, index, answerIndexes: number[]) {
     const answerText = this.getAnswerText(submission.answers, index, answerIndexes);
-    if (!submission.parent ||!Array.isArray(submission.parent.questions) || !submission.parent.questions[index]) {
+    if (!submission.parent || !Array.isArray(submission.parent.questions) || !submission.parent.questions[index]) {
       return answerText;
     }
     return submission.parent.questions[index] && submission.parent.questions[index].type !== 'textarea' ?


### PR DESCRIPTION
Fixes #8282

More robust error catching and handling when exporting survey csvs and pdf


Initially the issue resulted from myPlanet survey submission data being added to the db via emulator so might be tricky to replicate.
Can manually be replicated by updating a submission doc and removing the questions array