### PR TITLE
community: smoother calendar forms (fixes #8293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.42",
+  "version": "0.17.43",
   "myplanet": {
-    "latest": "v0.23.52",
-    "min": "v0.22.52"
+    "latest": "v0.23.53",
+    "min": "v0.22.53"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -87,7 +87,7 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
     }
   }
 
-  
+
   setMeetupData(meetup: any) {
     this.pageType = 'Update';
     this.revision = meetup._rev;

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output, HostListener } from '@angular/core';
 import { CouchService } from '../../shared/couchdb.service';
 import { PlanetMessageService } from '../../shared/planet-message.service';
 import {
@@ -16,6 +16,10 @@ import { switchMap } from 'rxjs/operators';
 import { findDocuments } from '../../shared/mangoQueries';
 import { showFormErrors } from '../../shared/table-helpers';
 import { StateService } from '../../shared/state.service';
+import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
+import { UnsavedChangesService } from '../../shared/unsaved-changes.service';
+import { interval, of, race } from 'rxjs';
+import { debounce } from 'rxjs/operators';
 
 @Component({
   selector: 'planet-meetups-add',
@@ -30,7 +34,7 @@ import { StateService } from '../../shared/state.service';
     }
   ` ]
 })
-export class MeetupsAddComponent implements OnInit {
+export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
 
   @Input() link: any = {};
   @Input() isDialog = false;
@@ -46,6 +50,8 @@ export class MeetupsAddComponent implements OnInit {
   id = null;
   days = constants.days;
   meetupFrequency = [];
+  initialFormValues: any;
+  hasUnsavedChanges = false;
 
   constructor(
     private couchService: CouchService,
@@ -54,7 +60,8 @@ export class MeetupsAddComponent implements OnInit {
     private route: ActivatedRoute,
     private fb: FormBuilder,
     private userService: UserService,
-    private stateService: StateService
+    private stateService: StateService,
+    public unsavedChangesService: UnsavedChangesService
   ) {
     this.createForm();
    }
@@ -67,12 +74,20 @@ export class MeetupsAddComponent implements OnInit {
     }
     if (!this.isDialog && this.route.snapshot.url[0].path === 'update') {
       this.couchService.get('meetups/' + this.route.snapshot.paramMap.get('id')).subscribe(
-        data => this.setMeetupData(data),
+        data => {
+          this.setMeetupData(data);
+          this.captureInitialState();
+          this.onFormChanges();
+        },
         error => console.log(error)
       );
+    } else {
+      this.captureInitialState();
+      this.onFormChanges();
     }
   }
 
+  
   setMeetupData(meetup: any) {
     this.pageType = 'Update';
     this.revision = meetup._rev;
@@ -82,6 +97,43 @@ export class MeetupsAddComponent implements OnInit {
     meetup.endDate = meetup.endDate ? new Date(meetup.endDate) : '';
     this.meetupForm.patchValue(meetup);
     meetup.day.forEach(day => (<FormArray>this.meetupForm.controls.day).push(new FormControl(day)));
+  }
+
+  private normalizeFormValues(formValue: any) {
+    return {
+      ...formValue,
+      startDate: formValue.startDate ? formValue.startDate.valueOf() : null,
+      endDate: formValue.endDate ? formValue.endDate.valueOf() : null
+    };
+  }
+
+  private captureInitialState() {
+    const formValue = this.meetupForm.value;
+    const processedForm = {
+      ...formValue,
+      startDate: formValue.startDate ? formValue.startDate.getTime() : null,
+      endDate: formValue.endDate ? formValue.endDate.getTime() : null,
+      day: formValue.day || []
+    };
+    this.initialFormValues = JSON.stringify(processedForm);
+  }
+
+  onFormChanges() {
+    this.meetupForm.valueChanges
+      .pipe(
+        debounce(() => race(interval(200), of(true)))
+      )
+      .subscribe(formValue => {
+        const processedForm = {
+          ...formValue,
+          startDate: formValue.startDate ? formValue.startDate.getTime() : null,
+          endDate: formValue.endDate ? formValue.endDate.getTime() : null,
+          day: formValue.day || []
+        };
+        const currentState = JSON.stringify(processedForm);
+        this.hasUnsavedChanges = currentState !== this.initialFormValues;
+        this.unsavedChangesService.setHasUnsavedChanges(this.hasUnsavedChanges);
+      });
   }
 
   createForm() {
@@ -120,6 +172,8 @@ onSubmit() {
     } else {
       this.addMeetup(meetup);
   }
+  this.hasUnsavedChanges = false;
+  this.unsavedChangesService.setHasUnsavedChanges(false);
 }
 
   changeTimeFormat(time: string): string {
@@ -165,6 +219,14 @@ onSubmit() {
   }
 
   cancel() {
+    if (this.hasUnsavedChanges) {
+      const confirmLeave = window.confirm($localize`You have unsaved changes. Are you sure you want to leave?`);
+      if (!confirmLeave) {
+        return;
+      }
+    }
+    this.hasUnsavedChanges = false;
+    this.unsavedChangesService.setHasUnsavedChanges(false);
     this.goBack();
   }
 
@@ -173,6 +235,20 @@ onSubmit() {
       this.onGoBack.emit(res);
     } else {
       this.router.navigate([ '/meetups' ]);
+    }
+  }
+
+  canDeactivate(): boolean {
+    if (this.hasUnsavedChanges) {
+      return window.confirm($localize`You have unsaved changes. Are you sure you want to leave?`);
+    }
+    return true;
+  }
+
+  @HostListener('window:beforeunload', [ '$event' ])
+  unloadNotification($event: BeforeUnloadEvent): void {
+    if (this.hasUnsavedChanges) {
+      $event.returnValue = $localize`You have unsaved changes. Are you sure you want to leave?`;
     }
   }
 

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -99,23 +99,14 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
     meetup.day.forEach(day => (<FormArray>this.meetupForm.controls.day).push(new FormControl(day)));
   }
 
-  private normalizeFormValues(formValue: any) {
-    return {
-      ...formValue,
-      startDate: formValue.startDate ? formValue.startDate.valueOf() : null,
-      endDate: formValue.endDate ? formValue.endDate.valueOf() : null
-    };
-  }
-
   private captureInitialState() {
     const formValue = this.meetupForm.value;
-    const processedForm = {
+    this.initialFormValues = JSON.stringify({
       ...formValue,
-      startDate: formValue.startDate ? formValue.startDate.getTime() : null,
-      endDate: formValue.endDate ? formValue.endDate.getTime() : null,
+      startDate: formValue.startDate ? Date.parse(formValue.startDate) : null,
+      endDate: formValue.endDate ? Date.parse(formValue.endDate) : null,
       day: formValue.day || []
-    };
-    this.initialFormValues = JSON.stringify(processedForm);
+    });
   }
 
   onFormChanges() {
@@ -124,13 +115,12 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
         debounce(() => race(interval(200), of(true)))
       )
       .subscribe(formValue => {
-        const processedForm = {
+        const currentState = JSON.stringify({
           ...formValue,
-          startDate: formValue.startDate ? formValue.startDate.getTime() : null,
-          endDate: formValue.endDate ? formValue.endDate.getTime() : null,
+          startDate: formValue.startDate ? Date.parse(formValue.startDate) : null,
+          endDate: formValue.endDate ? Date.parse(formValue.endDate) : null,
           day: formValue.day || []
-        };
-        const currentState = JSON.stringify(processedForm);
+        });
         this.hasUnsavedChanges = currentState !== this.initialFormValues;
         this.unsavedChangesService.setHasUnsavedChanges(this.hasUnsavedChanges);
       });

--- a/src/app/shared/dialogs/dialogs-add-meetups.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-meetups.component.ts
@@ -1,11 +1,12 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { DialogsLoadingService } from './dialogs-loading.service';
+import { MeetupsAddComponent } from '../../meetups/add-meetups/meetups-add.component';
 
 @Component({
   template: `
     <ng-container [ngSwitch]="view">
-      <planet-meetups-add *ngSwitchCase="'add'" [isDialog]="true" [link]="link"
+      <planet-meetups-add #meetupsAdd *ngSwitchCase="'add'" [isDialog]="true" [link]="link"
         [sync]="sync" [meetup]="meetup" (onGoBack)="meetupsChange()">
       </planet-meetups-add>
       <planet-meetups-view *ngSwitchCase="'view'"
@@ -18,6 +19,7 @@ import { DialogsLoadingService } from './dialogs-loading.service';
   `
 })
 export class DialogsAddMeetupsComponent {
+  @ViewChild('meetupsAdd') meetupsAdd: MeetupsAddComponent;
 
   link: any = {};
   view = 'add';
@@ -35,6 +37,19 @@ export class DialogsAddMeetupsComponent {
     this.view = this.data.view || this.view;
     this.meetup = this.data.meetup || this.meetup;
     this.editable = this.data.editable !== undefined && this.data.editable !== null ? this.data.editable : this.editable;
+    this.dialogRef.disableClose = true;
+    this.dialogRef.backdropClick().subscribe(() => {
+      if (this.meetupsAdd && this.meetupsAdd.hasUnsavedChanges) {
+        const confirmClose = window.confirm($localize`You have unsaved changes. Are you sure you want to leave?`);
+        if (confirmClose) {
+          this.meetupsAdd.hasUnsavedChanges = false;
+          this.meetupsAdd.unsavedChangesService.setHasUnsavedChanges(false);
+          this.dialogRef.close();
+        }
+      } else {
+        this.dialogRef.close();
+      }
+    });
   }
 
   meetupsChange() {


### PR DESCRIPTION
fixes #8293

Navigation from the meetup input via browser, clicking away, or cancel button with unsaved changes in any of the text fields, times, or dates will result in a popup confirmation. Reverting changes stops it from popping up. 