### PR TITLE
manager: smoother surveys tooltips (fixes #8268)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.39",
+  "version": "0.17.42",
   "myplanet": {
     "latest": "v0.23.49",
     "min": "v0.22.49"

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -72,29 +72,36 @@
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
         <mat-cell *matCellDef="let element">
           <ng-container *ngIf="!element.parent === true && currentFilter.viewMode !== 'adopt'">
-            <button mat-raised-button color="primary"
-              *ngIf="!teamId"
-              (click)="routeToEditSurvey('update', element._id)"
-              [disabled]="(element.teamId && isManagerRoute) || (!isManagerRoute && !element.teamId)"
-              i18n><mat-icon>edit</mat-icon> Edit
-            </button>
-            <button mat-raised-button color="primary"
-              *ngIf="!teamId && !routeTeamId"
-              [matMenuTriggerFor]="sendMenu"
-              [disabled]="!element.questions.length || element.teamId && isManagerRoute"
-              i18n><mat-icon>arrow_drop_down</mat-icon> Send
-            </button>
+            <div [matTooltip]="(element.teamId && isManagerRoute) ? 'This is a team created survey' : 
+                               (!isManagerRoute && !element.teamId) ? 'This is a community survey' : ''">
+              <button mat-raised-button color="primary"
+                *ngIf="!teamId"
+                (click)="routeToEditSurvey('update', element._id)"
+                [disabled]="(element.teamId && isManagerRoute) || (!isManagerRoute && !element.teamId)"
+                i18n><mat-icon>edit</mat-icon> Edit
+              </button>
+            </div>
+            <div [matTooltip]="element.teamId && isManagerRoute ? 'This is a team created survey' : ''">
+              <button mat-raised-button color="primary"
+                *ngIf="!teamId && !routeTeamId"
+                [matMenuTriggerFor]="sendMenu"
+                [disabled]="!element.questions.length || (element.teamId && isManagerRoute)"
+                i18n><mat-icon>arrow_drop_down</mat-icon> Send
+              </button>
+            </div>
             <mat-menu #sendMenu="matMenu">
               <button mat-menu-item style="width: 100%;" (click)="openSendSurveyToUsersDialog(element)" i18n>User <mat-icon>send</mat-icon></button>
               <button mat-menu-item style="width: 100%;" (click)="openSendSurveyToTeamsDialog(element)" i18n>Team <mat-icon>send</mat-icon></button>
             </mat-menu>
-            <button mat-raised-button color="primary"
-              (click)="recordSurvey(element)"
-              [disabled]="!element.questions.length || element.teamId && isManagerRoute"
-              [matTooltip]="isManagerRoute ? 'Record survey information from a person who is not a member of ' + configuration.name : 'Record Survey'"
-              i18n-matTooltip
-              i18n><mat-icon>fiber_manual_record</mat-icon> Record
-            </button>
+            <div [matTooltip]="element.teamId && isManagerRoute ? 'This is a team created survey' :
+                               isManagerRoute ? 'Record survey information from a person who is not a member of ' + configuration.name :
+                               'Record Survey'">
+              <button mat-raised-button color="primary"
+                (click)="recordSurvey(element)"
+                [disabled]="!element.questions.length || (element.teamId && isManagerRoute)"
+                i18n><mat-icon>fiber_manual_record</mat-icon> Record
+              </button>
+            </div>
           </ng-container>
           <button mat-raised-button color="primary" *ngIf="routeTeamId && currentFilter.viewMode === 'adopt'" (click)="adoptSurvey(element)" i18n><mat-icon>get_app</mat-icon>  Adopt</button>
           <div *ngIf="currentFilter.viewMode !== 'adopt'" i18n-matTooltip matTooltip="There is no data to export" [matTooltipDisabled]="!!element.taken">


### PR DESCRIPTION
fixes #8268

When edit, send, record buttons are disabled due to teams/community permissions issues, a tooltip lets the user know why. 

![image](https://github.com/user-attachments/assets/5f729098-a266-4cc1-85be-ddc6c3454896)

![image](https://github.com/user-attachments/assets/09380df1-ce07-42a9-8b70-a0f7826c10d6)
