### PR TITLE
configuration: custom home/community page, logo, and theme (fixes #8224)

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -73,6 +73,7 @@ $form-field-width: 180px;
 
 /*
  * SECOND THEME (based on uPlanet)
+ * Uses values generated with https://m2.material.io/design/color/the-color-system.html#tools-for-picking-colors
  */
 
 $uplanet-primary: (

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -1,5 +1,9 @@
 @import '~@angular/material/theming';
 
+/*
+ * PRIMARY/DEFAULT THEME
+ */
+
 $primary-hue: 500;
 $accent-hue: 500;
 $warn-hue: 500;
@@ -66,6 +70,42 @@ $form-field-width: 180px;
   greyText: $grey-text;
   lightGrey: $light-grey;
 }
+
+/*
+ * SECOND THEME (based on uPlanet)
+ */
+
+$uplanet-primary: (
+  50 : #f2e5f9,
+  100 : #dfbef0,
+  200 : #cb92e6,
+  300 : #b566dc,
+  400 : #a544d5,
+  500 : #951fcc,
+  600 : #851ec6,
+  700 : #6e1cbe,
+  800 : #5919b7,
+  900 : #2515ac,
+  contrast: (
+      50 : #000000,
+      100 : #000000,
+      200 : #000000,
+      300 : #000000,
+      400 : #000000,
+      500 : #ffffff,
+      600 : #ffffff,
+      700 : #ffffff,
+      800 : #ffffff,
+      900 : #ffffff
+  )
+);
+$uplanet-app-primary: mat-palette($uplanet-primary, $primary-hue);
+$uplanet-app-theme: mat-light-theme($uplanet-app-primary, $planet-app-accent, $planet-app-warn);
+
+.uplanet-theme {
+  @include angular-material-color($uplanet-app-theme);
+}
+
 
 /*
  * Old Planet Material Colors

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,9 +7,12 @@ declare let gtag: Function;
 
 @Component({
   selector: 'planet-app',
-  template: '<div i18n-dir dir="ltr"><router-outlet></router-outlet></div>'
+  template: '<div i18n-dir dir="ltr" [ngClass]="mainAppTheme"><router-outlet></router-outlet></div>'
 })
 export class AppComponent {
+
+  mainAppTheme: string;
+
   constructor(
     iconRegistry: MatIconRegistry,
     sanitizer: DomSanitizer,
@@ -59,6 +62,14 @@ export class AppComponent {
       }
       if (event instanceof NavigationEnd) {
         gtag('config', 'UA-118745384-1', { 'page_path': event.urlAfterRedirects });
+      }
+    });
+  }
+
+  ngOnInit() {
+    this.stateService.couchStateListener('configurations').subscribe((res) => {
+      if (res !== undefined) {
+        this.mainAppTheme = this.stateService.configuration?.customization?.colorTheme === 'purple' ? 'uplanet-theme' : '';
       }
     });
   }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -2,7 +2,7 @@
   <span class="navbar-left">
     <button mat-icon-button class="menu-button" (click)="toggleNav()" i18n-title title="Menu" *ngIf="layout === 'modern' || forceModern"><mat-icon>menu</mat-icon></button>
     <a routerLink="/">
-      <img src="assets/cropped-ole-ico-logo-32x32.png" class="ole-logo"/>
+      <img [src]="logoSrc" class="ole-logo"/>
       <h1><ng-container>Planet</ng-container> {{planetName}}</h1>
     </a>
   </span>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -46,6 +46,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   isAndroid: boolean;
   showBanner = true;
   isLoggedIn = false;
+  urlPrefix = environment.couchAddress + '/resources/';
 
   // Sets the margin for the main content to match the sidenav width
   animObs = interval(15).pipe(
@@ -60,6 +61,9 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   onlineStatus = 'offline';
   configuration = this.stateService.configuration;
   planetType = this.stateService.configuration.planetType;
+  logoSrc = this.configuration.customization?.logo ?
+    this.urlPrefix + this.configuration.customization?.logo :
+    'assets/cropped-ole-ico-logo-32x32.png';
 
   private onDestroy$ = new Subject<void>();
   private hasUnsavedChangesSubscription: Subscription;

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -32,6 +32,7 @@
 
     .ole-logo {
       margin-right: 10px;
+      height: 32px;
     }
 
   }

--- a/src/app/manager-dashboard/manager-dashboard-router.module.ts
+++ b/src/app/manager-dashboard/manager-dashboard-router.module.ts
@@ -11,6 +11,7 @@ import { ReportsPendingComponent } from './reports/reports-pending.component';
 import { ReportsMyPlanetComponent } from './reports/reports-myplanet.component';
 import { RequestsComponent } from './requests/requests.component';
 import { LogsMyPlanetComponent } from './reports/logs-myplanet.component';
+import { ThemeComponent } from './theme/theme.component';
 
 const routes: Routes = [
   { path: '', component: ManagerDashboardComponent },
@@ -29,7 +30,8 @@ const routes: Routes = [
   { path: 'reports/pending', component: ReportsPendingComponent },
   { path: 'reports/myplanet', component: ReportsMyPlanetComponent },
   { path: 'logs/myplanet', component: LogsMyPlanetComponent },
-  { path: 'requests', component: RequestsComponent }
+  { path: 'requests', component: RequestsComponent },
+  { path: 'theme', component: ThemeComponent }
 ];
 
 @NgModule({

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -26,6 +26,7 @@
   </ng-container>
   <a routerLink="/manager/users" i18n mat-raised-button>Members</a>
   <a routerLink="/manager/aiservices" i18n mat-raised-button>AI Configurations</a>
+  <a routerLink="/manager/theme" i18n mat-raised-button>Theme Configuration</a>
   <a routerLink="certifications" i18n mat-raised-button *planetBeta>Certifications</a>
   <button *ngIf="devMode"
   (click)="openDeleteCommunityDialog()" i18n mat-raised-button color = "warn">Delete Community</button>

--- a/src/app/manager-dashboard/manager-dashboard.module.ts
+++ b/src/app/manager-dashboard/manager-dashboard.module.ts
@@ -23,6 +23,7 @@ import { ReportsMyPlanetComponent } from './reports/reports-myplanet.component';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { ReportsDetailActivitiesComponent } from './reports/reports-detail-activities.component';
 import { ReportsHealthComponent } from './reports/reports-health.component';
+import { ThemeComponent } from './theme/theme.component';
 
 @NgModule({
   imports: [
@@ -53,7 +54,8 @@ import { ReportsHealthComponent } from './reports/reports-health.component';
     PendingTableComponent,
     ReportsMyPlanetComponent,
     ReportsDetailActivitiesComponent,
-    ReportsHealthComponent
+    ReportsHealthComponent,
+    ThemeComponent
   ]
 })
 export class ManagerDashboardModule {}

--- a/src/app/manager-dashboard/theme/theme.component.ts
+++ b/src/app/manager-dashboard/theme/theme.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+import { ConfigurationService } from '../../configuration/configuration.service';
+import { StateService } from '../../shared/state.service';
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-select i18n-placeholder placeholder="Color Theme" [(ngModel)]="selectedColorTheme">
+        <mat-option [value]="'blue'" i18n>Blue</mat-option>
+        <mat-option [value]="'purple'" i18n>Purple</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button mat-raised-button (click)="updateConfigurationTheme()">Update</button>
+  `
+})
+export class ThemeComponent {
+
+  configuration = this.stateService.configuration;
+  selectedColorTheme: string = this.configuration.customization?.colorTheme || "blue";
+  colorThemeValues = ['blue','purple'];
+
+  constructor(
+    private configurationService: ConfigurationService,
+    private stateService: StateService
+  ) {};
+
+  updateConfigurationTheme() {
+    const newConfiguration = {
+      ...this.configuration,
+      customization: {
+        colorTheme: this.selectedColorTheme
+      }
+    }
+    this.configurationService.updateConfiguration(newConfiguration).subscribe();
+  }
+
+}

--- a/src/app/manager-dashboard/theme/theme.component.ts
+++ b/src/app/manager-dashboard/theme/theme.component.ts
@@ -1,6 +1,8 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { ConfigurationService } from '../../configuration/configuration.service';
 import { StateService } from '../../shared/state.service';
+import { DialogsImagesComponent } from '../../shared/dialogs/dialogs-images.component';
 
 @Component({
   template: `
@@ -10,6 +12,7 @@ import { StateService } from '../../shared/state.service';
         <mat-option [value]="'purple'" i18n>Purple</mat-option>
       </mat-select>
     </mat-form-field>
+    <button mat-raised-button (click)="addLogo()">Update Logo</button>
     <button mat-raised-button (click)="updateConfigurationTheme()">Update</button>
   `
 })
@@ -17,21 +20,37 @@ export class ThemeComponent {
 
   configuration = this.stateService.configuration;
   selectedColorTheme: string = this.configuration.customization?.colorTheme || "blue";
+  selectedLogo: string = this.configuration.customization?.logo || "";
   colorThemeValues = ['blue','purple'];
 
   constructor(
     private configurationService: ConfigurationService,
-    private stateService: StateService
+    private stateService: StateService,
+    private dialog: MatDialog
   ) {};
 
   updateConfigurationTheme() {
     const newConfiguration = {
       ...this.configuration,
       customization: {
-        colorTheme: this.selectedColorTheme
+        colorTheme: this.selectedColorTheme,
+        logo: this.selectedLogo
       }
     }
     this.configurationService.updateConfiguration(newConfiguration).subscribe();
+  }
+  
+  addLogo() {
+    this.dialog.open(DialogsImagesComponent, {
+      width: '500px',
+      data: {
+        imageGroup: 'community'
+      }
+    }).afterClosed().subscribe(image => {
+      if (image) {
+        this.selectedLogo = `${image._id}/${image.title}`;
+      }
+    });
   }
 
 }


### PR DESCRIPTION
Very much a WIP.

Currently includes a dropdown to select between a blue and purple theme and a button to select/upload a new logo.

There is still some "theme" CSS that is more hardcoded (the active top nav button is the most noticeable). I think we can fix those in a follow up PR.