### PR TITLE
community: smoother calendar links (fixes #8320)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.50",
+  "version": "0.17.53",
   "myplanet": {
-    "latest": "v0.23.75",
-    "min": "v0.22.75"
+    "latest": "v0.23.84",
+    "min": "v0.22.84"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -20,6 +20,12 @@
           <planet-form-error-messages [control]="meetupForm.controls.meetupLocation"></planet-form-error-messages>
         </mat-error>
       </mat-form-field>
+      <mat-form-field>
+        <input matInput i18n-placeholder placeholder="Link" formControlName="meetupLink">
+        <mat-error>
+          <planet-form-error-messages [control]="meetupForm.controls.meetupLink"></planet-form-error-messages>
+        </mat-error>
+      </mat-form-field>
       <mat-form-field class="full-width mat-form-field-type-no-underline">
         <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="meetupForm.controls.description"></planet-markdown-textbox>
         <mat-error><planet-form-error-messages [control]="meetupForm.controls.description"></planet-form-error-messages></mat-error>

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -138,6 +138,7 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
       endTime: [ '', CustomValidators.timeValidator() ],
       category: '',
       meetupLocation: '',
+      meetupLink: ['', [], CustomValidators.validLink],
       createdBy: this.userService.get().name,
       sourcePlanet: this.stateService.configuration.code,
       createdDate: this.couchService.datePlaceholder,

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -138,7 +138,7 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
       endTime: [ '', CustomValidators.timeValidator() ],
       category: '',
       meetupLocation: '',
-      meetupLink: ['', [], CustomValidators.validLink],
+      meetupLink: [ '', [], CustomValidators.validLink ],
       createdBy: this.userService.get().name,
       sourcePlanet: this.stateService.configuration.code,
       createdDate: this.couchService.datePlaceholder,

--- a/src/app/meetups/view-meetups/meetups-view.component.html
+++ b/src/app/meetups/view-meetups/meetups-view.component.html
@@ -39,6 +39,7 @@
       <p *ngIf="meetupDetail?.recurring && meetupDetail?.recurring !== 'none'"><b i18n>Recurring:</b> {{meetupDetail?.recurring | titlecase}} for {{ meetupDetail?.recurringNumber }} {{ meetupDetail?.recurring === 'daily' ? 'days' : 'weeks' }}</p>
       <p *ngIf="meetupDetail?.recurring === 'weekly'"><b i18n>Recurring Days: </b><span *ngFor="let day of meetupDetail?.day; let isLast= last">{{day}}{{isLast ? '' : ', '}}</span></p>
       <p *ngIf="meetupDetail?.meetupLocation"><b i18n>Location:</b> {{meetupDetail?.meetupLocation}}</p>
+      <p *ngIf="meetupDetail?.meetupLink"><b i18n>Link: </b> <a [href]="meetupDetail?.meetupLink" target="_blank" rel="noopener" class="cursor-pointer">{{meetupDetail?.meetupLink}}</a></p>
       <p *ngIf="meetupDetail?.assignee"><b i18n>Assigned to:</b><a class="cursor-pointer" (click)="openProfile(meetupDetail?.assignee?.name, meetupDetail?.assignee?.userPlanetCode)">{{' ' + meetupDetail?.assignee?.name}}</a></p>
       <b *ngIf="meetupDetail?.description" i18n>Description:</b><td-markdown [content]="meetupDetail?.description"></td-markdown>
     </div>


### PR DESCRIPTION
fixes #8320

![image](https://github.com/user-attachments/assets/c6bad3a7-5aa2-4777-ad54-26fc0148d30e)

Links section can be blank, but if there content there, it is validated with the regex 

![image](https://github.com/user-attachments/assets/83084d04-752e-4050-a840-b5cf13c91c0f)
