### PR TITLE
manager: smoother myplanet logs filter versions (fixes #8343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.52",
+  "version": "0.17.54",
   "myplanet": {
     "latest": "v0.23.81",
     "min": "v0.22.81"

--- a/src/app/manager-dashboard/reports/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.ts
@@ -95,7 +95,7 @@ export class LogsMyPlanetComponent implements OnInit {
   }
 
   getUniqueVersions(logs: any[]) {
-    this.versions = Array.from(new Set(logs.map(log => log.version))).filter(version => version).sort();
+    this.versions = Array.from(new Set(logs.map(log => log.version))).filter(version => version).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
   }
 
   getUniqueTypes(logs: any[]) {


### PR DESCRIPTION
fixes #8343
The versions are listen in descending order, so we can more easily choose at the most recent one. 

![image](https://github.com/user-attachments/assets/eb0b7406-ea34-4a1c-8519-7db3dfe0cadb)
