### PR TITLE
manager: smoother myplanet logs version dropdown (fixes #8349)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.54",
+  "version": "0.17.58",
   "myplanet": {
-    "latest": "v0.23.84",
-    "min": "v0.22.84"
+    "latest": "v0.23.91",
+    "min": "v0.22.91"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/manager-dashboard/reports/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.ts
@@ -95,7 +95,7 @@ export class LogsMyPlanetComponent implements OnInit {
   }
 
   getUniqueVersions(logs: any[]) {
-    this.versions = Array.from(new Set(logs.map(log => log.version))).filter(version => version).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    this.versions = Array.from(new Set(logs.map(log => log.version))).filter(version => version).sort((a, b) => b.localeCompare(a));
   }
 
   getUniqueTypes(logs: any[]) {


### PR DESCRIPTION
fixes #8349

Fixed an issue where, for example, version 0.22.59 was coming before 0.22.6 when sorting by version descending in the version dropdown. 

![image](https://github.com/user-attachments/assets/9c02b9af-0a62-4451-b36b-8cf6c0460c67)
