### PR TITLE
manager: smoother myplanet logs version dropdown (fixes #8370)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "license": "AGPL-3.0",
   "version": "0.17.64",
   "myplanet": {
-    "latest": "v0.23.93",
-    "min": "v0.22.93"
+    "latest": "v0.23.96",
+    "min": "v0.22.96"
   },
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.64",
+  "version": "0.17.65",
   "myplanet": {
     "latest": "v0.23.96",
     "min": "v0.22.96"

--- a/src/app/manager-dashboard/reports/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.ts
@@ -96,8 +96,9 @@ export class LogsMyPlanetComponent implements OnInit {
 
   getUniqueVersions(logs: any[]) {
     this.versions = Array.from(
-      new Set(logs.map(log => log.version))).filter(version => version).sort((a, b) => b.localeCompare(a, undefined, { numeric: true })
-    );
+      new Set(logs.map(log => log.version)))
+      .filter(version => version)
+      .sort((a, b) => b.localeCompare(a));
   }
 
   getUniqueTypes(logs: any[]) {


### PR DESCRIPTION
fixes #8370

This had broken again, so 0.22.59 was above 0.22.6 in version descending. Opted to just compare versions as strings for sorting. 

![image](https://github.com/user-attachments/assets/b16dd03d-5887-4297-914f-8e174fcd67d9)
