### PR TITLE
resources: smoother collections sorting (fixes #8367)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.64",
+  "version": "0.17.66",
   "myplanet": {
-    "latest": "v0.23.93",
-    "min": "v0.22.93"
+    "latest": "v0.23.99",
+    "min": "v0.22.99"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/forms/tags.service.ts
+++ b/src/app/shared/forms/tags.service.ts
@@ -28,6 +28,7 @@ export class TagsService {
             {}
           );
         return tags
+          .sort((a, b) => a.name.trim().localeCompare(b.name.trim()))
           .map((tag: any) => ({ ...tag, count: tagCounts[tag._id] || 0 }))
           .filter((tag: any) => tag.db === db && tag.docType === 'definition')
           .map(this.fillSubTags);

--- a/src/app/submissions/submissions.component.ts
+++ b/src/app/submissions/submissions.component.ts
@@ -143,7 +143,7 @@ export class SubmissionsComponent implements OnInit, AfterViewChecked, OnDestroy
     ]);
     this.submissions.sortingDataAccessor = (item: any, property) => {
       switch (property) {
-        case 'name': return (item.parent.name || '').trim().toLowerCase();
+        case 'name': return item.parent.name.trim().toLowerCase();
         case 'courseTitle': return (item.courseTitle || '').trim().toLowerCase();
         case 'user': return item.submittedBy.toLowerCase();
         default: return typeof item[property] === 'string' ? item[property].toLowerCase() : item[property];

--- a/src/app/submissions/submissions.component.ts
+++ b/src/app/submissions/submissions.component.ts
@@ -143,7 +143,8 @@ export class SubmissionsComponent implements OnInit, AfterViewChecked, OnDestroy
     ]);
     this.submissions.sortingDataAccessor = (item: any, property) => {
       switch (property) {
-        case 'name': return item.parent.name.toLowerCase();
+        case 'name': return (item.parent.name || '').trim().toLowerCase();
+        case 'courseTitle': return (item.courseTitle || '').trim().toLowerCase();
         case 'user': return item.submittedBy.toLowerCase();
         default: return typeof item[property] === 'string' ? item[property].toLowerCase() : item[property];
       }


### PR DESCRIPTION
fixes #8367

Sorting submissions by name or courseTitle ignores leading whitespace.
Collections, which is alphabetical by default, ignores leading whitespace in its sorting.  