### PR TITLE
courses: smoother list language (fixes #8374)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.65",
+  "version": "0.17.69",
   "myplanet": {
     "latest": "v0.23.96",
     "min": "v0.22.96"

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -213,7 +213,7 @@
           <div>
             <p><ng-container i18n>Grade Level:</ng-container>{{ " " }}<planet-language-label [options]="gradeOptions" [label]="element.doc.gradeLevel"></planet-language-label></p>
             <p><ng-container i18n>Subject Level:</ng-container>{{ " " }}<planet-language-label [options]="subjectOptions" [label]="element.doc.subjectLevel"></planet-language-label></p>
-            <p><ng-container i18n>Language:</ng-container>{{ " " }}<planet-language-label [options]="languages" [label]="element.doc.languages"></planet-language-label></p>
+            <p *ngIf="element.doc.languages"><ng-container i18n>Language:</ng-container>{{ " " }}<planet-language-label [options]="languages" [label]="element.doc.languages"></planet-language-label></p>
           </div>
         </mat-cell>
       </ng-container>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -213,7 +213,10 @@
           <div>
             <p><ng-container i18n>Grade Level:</ng-container>{{ " " }}<planet-language-label [options]="gradeOptions" [label]="element.doc.gradeLevel"></planet-language-label></p>
             <p><ng-container i18n>Subject Level:</ng-container>{{ " " }}<planet-language-label [options]="subjectOptions" [label]="element.doc.subjectLevel"></planet-language-label></p>
-            <p *ngIf="element.doc.languages"><ng-container i18n>Language:</ng-container>{{ " " }}<planet-language-label [options]="languages" [label]="element.doc.languages"></planet-language-label></p>
+            <p *ngIf="element.doc.languageOfInstruction">
+              <ng-container i18n>Language:</ng-container>{{ " " }}
+              <planet-language-label [options]="languages" [label]="element.doc.languageOfInstruction"></planet-language-label>
+            </p>
           </div>
         </mat-cell>
       </ng-container>


### PR DESCRIPTION
Updated the courses file, like if the language is not set, it doesn't appear in the course information tab
<img width="1565" alt="image" src="https://github.com/user-attachments/assets/bbc30411-6c5f-46c4-8bc5-bddf248a91ed" />
