### PR TITLE
community: smoother navigation leaders (fixes #8376)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.65",
+  "version": "0.17.67",
   "myplanet": {
-    "latest": "v0.23.96",
-    "min": "v0.22.96"
+    "latest": "v0.24.6",
+    "min": "v0.23.6"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -20,7 +20,10 @@
             <p i18n>No Voices available.</p>
           </ng-template>
         </mat-tab>
-        <mat-tab i18n-label label="Community Leaders" *ngIf="isLoggedIn">
+        <mat-tab 
+          [label]="configuration.planetType === 'nation' ? 'Nation Leaders' : 'Community Leaders'"
+          i18n-label
+          *ngIf="isLoggedIn">
           <div class="card-grid">
             <mat-card *ngFor="let councillor of councillors">
               <planet-teams-member


### PR DESCRIPTION
Updated the community to check whether the configuration is nation or community and accordingly made the changes to display the Nation Leaders label.

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/f5c8aa0f-b370-4cee-8869-5302eb1c08b3" />
