### PR TITLE
manager: smoother reports health (fixes #8334) (fixes #8391)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.66",
+  "version": "0.17.79",
   "myplanet": {
     "latest": "v0.23.99",
     "min": "v0.22.99"

--- a/src/app/shared/label.component.ts
+++ b/src/app/shared/label.component.ts
@@ -4,7 +4,6 @@ import { Component, Input } from '@angular/core';
   selector: 'planet-label',
   template: `
     <span i18n>{label, select,
-      // Form labels
       temperature {Temperature (°C)}
       pulse {Pulse (bpm)}
       bp {Blood Pressure}
@@ -16,10 +15,9 @@ import { Component, Input } from '@angular/core';
       offer {Offer}
       advice {Request for Advice}
       shared chat {Shared Chat}
-      // Diseases
-      Amebiasis {Amebiasis}
       Acute Otitis Media {Acute Otitis Media}
       Acute Respiratory Infection {Acute Respiratory Infection}
+      Amebiasis {Amebiasis}
       Brucellosis {Brucellosis}
       Cancer {Cancer}
       Cardiovascular disorders {Cardiovascular disorders}
@@ -27,6 +25,7 @@ import { Component, Input } from '@angular/core';
       Chancroid {Chancroid}
       Chikungunya {Chikungunya}
       Chlamydia {Chlamydia}
+      Chronic Kidney Disease {Chronic Kidney Disease}
       Cirrhosis of the liver {Cirrhosis of the liver}
       Conjunctivitis {Conjunctivitis}
       COVID-19 {COVID-19}
@@ -41,6 +40,9 @@ import { Component, Input } from '@angular/core';
       Epilepsy {Epilepsy}
       FGM {FGM}
       Fungal Infection {Fungal Infections}
+      Giardiasis {Giardiasis}
+      Gonorrhea {Gonorrhea}
+      Heatstroke {Heatstroke}
       Hepatitis A {Hepatitis A}
       Hepatitis B {Hepatitis B}
       Hepatitis C {Hepatitis C}
@@ -55,7 +57,7 @@ import { Component, Input } from '@angular/core';
       Leishmaniasis {Leishmaniasis}
       Leptospirosis {Leptospirosis}
       Low Birth Weight {Low Birth Weight}
-      Lymphogranuloma Venereum (LGV) {Lymphogranuloma Venereum}
+      Lymphogranuloma Venereum {Lymphogranuloma Venereum}
       Malaria {Malaria}
       Malnutrition {Malnutrition}
       Maternal Hemorrhage {Maternal Hemorrhage}
@@ -71,12 +73,14 @@ import { Component, Input } from '@angular/core';
       Rotavirus {Rotavirus}
       Scabies {Scabies}
       Schistosomiasis {Schistosomiasis}
+      Soil-Transmitted Helminths {Soil-Transmitted Helminths}
       Stroke {Stroke}
       Syphilis {Syphilis}
       Trauma {Trauma}
       Trichomoniasis {Trichomoniasis}
       Tuberculosis {Tuberculosis}
       Typhoid Fever {Typhoid Fever}
+      Vitamin A Deficiency {Vitamin A Deficiency}
       Zika {Zika}
     }</span>
   `


### PR DESCRIPTION
fixes #8334, #8391

Fixed an issue where some disease labels were showing up as blank. 

![image](https://github.com/user-attachments/assets/fb61671e-eaa7-46c3-93d1-cec85786d382)

Also fixes an issue where temperature range validator popup was missing label
![image](https://github.com/user-attachments/assets/87769454-eeaf-466f-96c5-6af4d2d1815a)

