### PR TITLE
all: smoother navigation icons (fixes #8402)

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -49,7 +49,7 @@
       <ng-container *planetAuthorizedRoles>
         <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="sync"></mat-icon></button>
       </ng-container>
-      <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager,monitor'"><mat-icon>settings</mat-icon></button>
+      <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
       <planet-language i18n-title title="Language"></planet-language>
     </span>
     <ng-container *planetAuthorizedRoles="'learner'">


### PR DESCRIPTION
fixes #8402 

Monitors no longer have a manager settings icon, since it didn't take them anywhere anyway. 