### PR TITLE
teams: smoother voices editing (fixes #8421)(fixes #8423)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.75",
+  "version": "0.17.85",
   "myplanet": {
     "latest": "v0.24.20",
     "min": "v0.23.20"

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -127,10 +127,11 @@ export class NewsListItemComponent implements OnInit, OnChanges, AfterViewChecke
     const label = this.formLabel(news);
     const editTimestamp = $localize`Edited on ${new Date().toLocaleString()}`;
     const sharedSourceInfo = this.item.sharedSourceInfo;
+    const initialValue = news.message === '</br>' ? '' : news.message;
     this.updateNews.emit({
       title: $localize`Edit ${label}`,
       placeholder: $localize`Your ${label}`,
-      initialValue: news.message,
+      initialValue,
       news: {
         ...news,
         editTimestamp,

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -57,7 +57,8 @@ export class NewsService {
   postNews(post, successMessage = $localize`Thank you for submitting your message`, isMessageEdit = true) {
     const { configuration } = this.stateService;
     const message = typeof post.message === 'string' ? post.message : post.message.text;
-    const images = this.createImagesArray(post, message);
+    const processedMessage = message === '' ? '</br>' : message;
+    const images = this.createImagesArray(post, processedMessage);
     const newPost = {
       docType: 'message',
       time: this.couchService.datePlaceholder,
@@ -65,7 +66,7 @@ export class NewsService {
       parentCode: configuration.parentCode,
       user: this.userService.get(),
       ...post,
-      message,
+      message: processedMessage,
       images,
       updatedDate: isMessageEdit ? this.couchService.datePlaceholder : post.updatedDate,
       viewIn: post.viewIn || []


### PR DESCRIPTION
fixes #8421, #8423

Edit dialog for a shared AI chat no longer populates with '< / br >'

Clearing the text for shared AI chat reflects immediately.