### PR TITLE
community: smoother profile dialog closing (fixes #8430)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.77",
+  "version": "0.17.93",
   "myplanet": {
     "latest": "v0.24.22",
     "min": "v0.23.22"

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -91,7 +91,7 @@
         <mat-card-title i18n class="primary-text-color">Teams</mat-card-title>
         <mat-card-content>
           <mat-list>
-            <mat-list-item *ngFor="let team of teams" [routerLink]="['/teams/view', team.doc._id]" class="cursor-pointer">
+            <mat-list-item *ngFor="let team of teams" [routerLink]="['/teams/view', team.doc._id]" mat-dialog-close class="cursor-pointer">
               <h4 matLine><b>{{team.doc.name}}</b></h4>
             </mat-list-item>
             <mat-list-item *ngIf="teams.length === 0">
@@ -104,7 +104,7 @@
         <mat-card-title i18n class="primary-text-color">Enterprises</mat-card-title>
         <mat-card-content>
           <mat-list>
-            <mat-list-item *ngFor="let enterprise of enterprises" [routerLink]="['/enterprises/view', enterprise.doc._id]" class="cursor-pointer">
+            <mat-list-item *ngFor="let enterprise of enterprises" [routerLink]="['/enterprises/view', enterprise.doc._id]" mat-dialog-close class="cursor-pointer">
               <h4 matLine><b>{{enterprise.doc.name}}</b></h4>
             </mat-list-item>
             <mat-list-item *ngIf="enterprises.length === 0">


### PR DESCRIPTION
fixes #8430

When viewing a profile as a dialog (e.g. from clicking the user icon in voices) and navigating to the team, the dialog closes upon navigation. 