### PR TITLE
resources: smoother creation file downloadable (fixes #8401)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.80",
+  "version": "0.17.86",
   "myplanet": {
-    "latest": "v0.24.23",
-    "min": "v0.23.23"
+    "latest": "v0.24.34",
+    "min": "v0.23.34"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -264,7 +264,8 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     this.attachmentMarkedForDeletion = true;
     this.resourceFilename = '';
     this.disableDelete = true;
-    this.disableDownload = !this.file;
+    this.disableDownload = true;
+    this.resourceForm.patchValue({ isDownloadable: false });
     this.hasUnsavedChanges = true;
     this.unsavedChangesService.setHasUnsavedChanges(true);
   }


### PR DESCRIPTION
fixes #8401 

https://github.com/user-attachments/assets/fea963a2-cc7c-4410-a5e4-155414923cdf

The File downloadable checkbox now works fine as the user deletes the attached pdf file.