### PR TITLE
 login: smoother dialog closing (fixes #8389)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.77",
+  "version": "0.17.89",
   "myplanet": {
     "latest": "v0.24.22",
     "min": "v0.23.22"

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -50,7 +50,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   showNewsButton = true;
   deleteMode = false;
   onDestroy$ = new Subject<void>();
-  isCommunityLeader = this.user.isUserAdmin || this.user.roles.indexOf('leader') > -1;
+  isCommunityLeader = this.user.isUserAdmin || this.user?.roles?.indexOf('leader') > -1;
   planetCode: string | null;
   shareTarget: string;
   servicesDescriptionLabel: 'Add' | 'Edit';

--- a/src/app/login/login-dialog.component.ts
+++ b/src/app/login/login-dialog.component.ts
@@ -19,7 +19,7 @@ export class LoginDialogComponent {
 
   login(loginState: 'loggedOut' | 'loggedIn') {
     if (loginState === 'loggedIn') {
-      this.dialogRef.close();
+      this.dialogRef.close(loginState);
     }
   }
 

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -40,7 +40,16 @@ export class AuthService {
         this.userService.unset();
         if (this.userService.isBetaEnabled()) {
           const dialogRef = this.dialog.open(LoginDialogComponent);
-          return dialogRef.afterClosed().pipe(switchMap(() => {
+          return dialogRef.afterClosed().pipe(switchMap(loginState => {
+            if (loginState === undefined) {
+              // If the current routerState snapshot url is a blank string, the user got here via
+              // directly pasting in a link to a guarded route. Need to reroute to the community page
+              // before closing the dialog.
+              if (this.router.routerState.snapshot.url === '') {
+                this.router.navigate(['/']);
+              }
+              return of(false);
+            }
             return this.checkUser(url, roles);
           }));
         }

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
               // directly pasting in a link to a guarded route. Need to reroute to the community page
               // before closing the dialog.
               if (this.router.routerState.snapshot.url === '') {
-                this.router.navigate(['/']);
+                this.router.navigate([ '/' ]);
               }
               return of(false);
             }

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -254,7 +254,7 @@ export class UserService {
   }
 
   doesUserHaveRole(searchRoles: string[]) {
-    return this.user.roles.findIndex(userRole => searchRoles.findIndex(searchRole => searchRole === userRole) > -1) > -1;
+    return this.user?.roles?.findIndex(userRole => searchRoles.findIndex(searchRole => searchRole === userRole) > -1) > -1;
   }
 
   isBetaEnabled(): boolean {


### PR DESCRIPTION
Allows the login dialog to be closed. If the user was navigating directly to a guarded route via a pasted url, they will be redirected to the community page.

To test:

1. Open the community page in a logged out state.
2. Click a guarded link like resources.
3. Click out of the dialog to close.
4. Dialog should be closed
5. Paste a guarded route.
6. Click outside the login dialog.
7. Dialog should be closed and you should be routed to the community page.