### PR TITLE
dashboard: smoother profile groups (fixes #8441)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.85",
+  "version": "0.17.92",
   "myplanet": {
     "latest": "v0.24.30",
     "min": "v0.23.30"

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -86,11 +86,11 @@
         <mat-divider></mat-divider>
       </mat-list>
     </div>
-    <div>
+    <div class="cards-container">
       <mat-card>
         <mat-card-title i18n class="primary-text-color">Teams</mat-card-title>
         <mat-card-content>
-          <mat-list>
+          <mat-list class="cards-list">
             <mat-list-item *ngFor="let team of teams" [routerLink]="['/teams/view', team.doc._id]" class="cursor-pointer">
               <h4 matLine><b>{{team.doc.name}}</b></h4>
             </mat-list-item>
@@ -100,10 +100,10 @@
           </mat-list>
         </mat-card-content>
       </mat-card>
-      <mat-card class="margin-t-10">
+      <mat-card>
         <mat-card-title i18n class="primary-text-color">Enterprises</mat-card-title>
         <mat-card-content>
-          <mat-list>
+          <mat-list class="cards-list">
             <mat-list-item *ngFor="let enterprise of enterprises" [routerLink]="['/enterprises/view', enterprise.doc._id]" class="cursor-pointer">
               <h4 matLine><b>{{enterprise.doc.name}}</b></h4>
             </mat-list-item>

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -90,7 +90,7 @@
       <mat-card>
         <mat-card-title i18n class="primary-text-color">Teams</mat-card-title>
         <mat-card-content>
-          <mat-list class="cards-list">
+          <mat-list>
             <mat-list-item *ngFor="let team of teams" [routerLink]="['/teams/view', team.doc._id]" class="cursor-pointer">
               <h4 matLine><b>{{team.doc.name}}</b></h4>
             </mat-list-item>
@@ -103,7 +103,7 @@
       <mat-card>
         <mat-card-title i18n class="primary-text-color">Enterprises</mat-card-title>
         <mat-card-content>
-          <mat-list class="cards-list">
+          <mat-list>
             <mat-list-item *ngFor="let enterprise of enterprises" [routerLink]="['/enterprises/view', enterprise.doc._id]" class="cursor-pointer">
               <h4 matLine><b>{{enterprise.doc.name}}</b></h4>
             </mat-list-item>

--- a/src/app/users/users-profile/users-profile.scss
+++ b/src/app/users/users-profile/users-profile.scss
@@ -20,32 +20,12 @@
 
   .cards-container {
     display: flex;
-    flex-wrap: wrap; 
     gap: 16px; 
     margin-top: 10px;
   
     mat-card {
-      width: 100%; 
-      box-sizing: border-box; 
-    }
-  
-    .cards-list {
-      display: flex;
-      flex-wrap: wrap; 
-      gap: 12px; 
-  
-      mat-list-item {
-        flex: 1 1 calc(50% - 12px); 
-        box-sizing: border-box; 
-        word-wrap: break-word; 
-      white-space: normal; 
-    }
-
-    h4, p {
-      overflow-wrap: break-word; 
-      word-break: break-word; 
-      white-space: normal; 
-    }
+      flex: 1;
+      min-width: 300px; 
     }
   }
 

--- a/src/app/users/users-profile/users-profile.scss
+++ b/src/app/users/users-profile/users-profile.scss
@@ -18,6 +18,37 @@
     -webkit-box-orient: vertical;
   }
 
+  .cards-container {
+    display: flex;
+    flex-wrap: wrap; 
+    gap: 16px; 
+    margin-top: 10px;
+  
+    mat-card {
+      width: 100%; 
+      box-sizing: border-box; 
+    }
+  
+    .cards-list {
+      display: flex;
+      flex-wrap: wrap; 
+      gap: 12px; 
+  
+      mat-list-item {
+        flex: 1 1 calc(50% - 12px); 
+        box-sizing: border-box; 
+        word-wrap: break-word; 
+      white-space: normal; 
+    }
+
+    h4, p {
+      overflow-wrap: break-word; 
+      word-break: break-word; 
+      white-space: normal; 
+    }
+    }
+  }
+
   @media (max-width: $screen-sm) {
     .profile-image-section {
       grid-area: icon;


### PR DESCRIPTION
fixes: #8441 

![image](https://github.com/user-attachments/assets/62b4fa0c-8f30-48bc-980b-41ebf0aca877)

Aligned teams and enterprises cards list side by side, along with text wrapping for the names with slightly longer text.