### PR TITLE
all: less navigation is more (fixes #8427)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.90",
+  "version": "0.17.91",
   "myplanet": {
-    "latest": "v0.24.34",
-    "min": "v0.23.34"
+    "latest": "v0.24.36",
+    "min": "v0.23.36"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/authorized-roles.directive.ts
+++ b/src/app/shared/authorized-roles.directive.ts
@@ -11,6 +11,7 @@ export class AuthorizedRolesDirective implements OnInit, OnDestroy {
   private onDestroy$ = new Subject<void>();
   private rolesString: string;
   private isLoggedOut = false;
+  private viewCreated = false;
 
   constructor(
     private templateRef: TemplateRef<any>,
@@ -38,14 +39,16 @@ export class AuthorizedRolesDirective implements OnInit, OnDestroy {
   }
 
   checkRoles() {
-    if (this.isLoggedOut) {
+    if (this.isLoggedOut || this.viewCreated) {
       return;
     }
     const authorizedRoles = (this.rolesString || '').split(',').map(val => val.trim());
     const allowedAdmins = authorizedRoles[0] === 'only' ? [] : [ '_admin', 'manager' ];
     if (this.rolesString === '_any' || this.userService.doesUserHaveRole([ ...allowedAdmins, ...authorizedRoles ])) {
       this.viewContainer.createEmbeddedView(this.templateRef);
+      this.viewCreated = true;
     } else {
+      this.viewCreated = false;
       this.viewContainer.clear();
     }
   }


### PR DESCRIPTION
Fix for double icons showing up on the toolbar. Easiest way to test is to update your user profile and check if any toolbar icons have doubled.

Another testing option is to logout in another tab and go back to the original tab and log back in. Icons should not double.

Fixes #8427 