### PR TITLE
all: smoother navigation admin sync (fixes #8403)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.17.90",
+  "version": "0.17.94",
   "myplanet": {
-    "latest": "v0.24.34",
-    "min": "v0.23.34"
+    "latest": "v0.24.37",
+    "min": "v0.23.37"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -46,7 +46,7 @@
       <button mat-icon-button routerLink="/chat" i18n-title title="Chat"><mat-icon>question_answer</mat-icon></button>
       <button mat-icon-button planetFeedback i18n-title title="Submit Feedback"><mat-icon svgIcon="feedback"></mat-icon></button>
       <button mat-icon-button routerLink="/feedback" i18n-title title="Review Feedback"><mat-icon svgIcon="feedbacklist"></mat-icon></button>
-      <ng-container *planetAuthorizedRoles>
+      <ng-container *planetAuthorizedRoles="''">
         <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="sync"></mat-icon></button>
       </ng-container>
       <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
@@ -220,7 +220,7 @@
             <label *ngIf="sidenavState === 'open'" class="language-label" i18n>Language</label>
           </a>
         </li>
-        <ng-container *planetAuthorizedRoles>
+        <ng-container *planetAuthorizedRoles="''">
           <li *ngIf="onlineStatus === 'accepted'">
             <a mat-button planetSync i18n-title title="Sync">
               <mat-icon svgIcon="sync"></mat-icon>


### PR DESCRIPTION
The sync button on the navbar now shows up again. It seems the `planetAuthorizedRoles` directive was not running correctly with no input.

I think it is a question if we want to restore this since it's been gone for so long, but I figured I would open this PR since it's such a small fix.

Fixes #8403 (or at least makes it irrelevant.)