### PR TITLE
myPlanet logs: smoother date filtering

### DIFF
--- a/src/app/manager-dashboard/reports/logs-myplanet.component.html
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.html
@@ -17,7 +17,7 @@
         <mat-option *ngFor="let version of versions" [value]="version">{{version}}</mat-option>
       </mat-select>
     </mat-form-field>
-    <form [formGroup]="logsForm">
+    <form [formGroup]="logsForm" *ngIf="showCustomDateFields">
       <mat-form-field class="margin-lr-5 font-size-1">
         <input matInput [matDatepicker]="startPicker" i18n-placeholder placeholder="Start Date" formControlName="startDate" [min]="minDate" [max]="logsForm.get('endDate').value">
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
@@ -30,9 +30,11 @@
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>
     </form>
-    <button mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="disableShowAllTime" class="margin-lr-5">
-      Show All Time
-    </button>
+    <mat-form-field class="margin-lr-5 font-size-1">
+      <mat-select i18n-placeholder placeholder="Time Frame" (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
+        <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
+      </mat-select>
+    </mat-form-field>
     <button mat-raised-button color="primary" (click)="clearFilters()" [disabled]="!searchValue && !selectedVersion && !selectedType && disableShowAllTime" class="margin-lr-5">
       Clear
     </button>
@@ -66,6 +68,13 @@
       </mat-form-field>
     </mat-toolbar-row>
     <mat-toolbar-row *ngIf="showFiltersRow">
+      <mat-form-field class="margin-lr-5 font-size-1">
+        <mat-select i18n-placeholder placeholder="Time Frame" (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
+          <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </mat-toolbar-row>
+    <mat-toolbar-row *ngIf="showFiltersRow && showCustomDateFields">
       <form [formGroup]="logsForm">
         <mat-form-field class="margin-lr-5 font-size-1">
           <input matInput [matDatepicker]="startPicker" i18n-placeholder placeholder="Start Date" formControlName="startDate" [min]="minDate" [max]="logsForm.get('endDate').value">
@@ -75,7 +84,7 @@
         </mat-form-field>
       </form>
     </mat-toolbar-row>
-    <mat-toolbar-row *ngIf="showFiltersRow">
+    <mat-toolbar-row *ngIf="showFiltersRow && showCustomDateFields">
       <form [formGroup]="logsForm">
         <mat-form-field class="margin-lr-5 font-size-1">
           <input matInput [matDatepicker]="endPicker" i18n-placeholder placeholder="End Date" formControlName="endDate" [min]="logsForm.get('startDate').value" [max]="today">
@@ -85,9 +94,6 @@
       </form>
     </mat-toolbar-row>
     <mat-toolbar-row *ngIf="showFiltersRow">
-      <button mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="disableShowAllTime" class="margin-lr-5">
-        Show All Time
-      </button>
       <button mat-raised-button color="primary" (click)="clearFilters()" [disabled]="!searchValue && !selectedVersion && !selectedType && disableShowAllTime" class="margin-lr-5">
         Clear
       </button>

--- a/src/app/manager-dashboard/reports/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.ts
@@ -38,6 +38,16 @@ export class LogsMyPlanetComponent implements OnInit {
   showFiltersRow = false;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
+  selectedTimeFilter: string = 'all';
+  showCustomDateFields = false;
+  timeFilterOptions = [
+    { value: '24h', label: $localize`Last 24 Hours` },
+    { value: '7d', label: $localize`Last 7 Days` },
+    { value: '30d', label: $localize`Last 30 Days` },
+    { value: 'all', label: $localize`All Time` },
+    { value: 'custom', label: $localize`Custom` },
+  ];  
+
 
   constructor(
     private csvService: CsvService,
@@ -154,6 +164,45 @@ export class LogsMyPlanetComponent implements OnInit {
     this.applyFilters();
   }
 
+  onTimeFilterChange(timeFilter: string) {
+  this.selectedTimeFilter = timeFilter;
+  this.showCustomDateFields = timeFilter === 'custom';
+  if (timeFilter === 'custom') {
+    return;
+  }
+  const now = new Date();
+  let newStartDate: Date;
+  let newEndDate: Date = now;
+
+  switch (timeFilter) {
+    case '24h':
+      newStartDate = new Date(now);
+      newStartDate.setDate(now.getDate() - 1);
+      break;
+    case '7d':
+      newStartDate = new Date(now);
+      newStartDate.setDate(now.getDate() - 7);
+      break;
+    case '30d':
+      newStartDate = new Date(now);
+      newStartDate.setDate(now.getDate() - 30);
+      break;
+    case 'all':
+      newStartDate = this.minDate;
+      break;
+    default:
+      return;
+  }
+  this.startDate = newStartDate;
+  this.endDate = newEndDate;
+  this.logsForm.patchValue({
+    startDate: newStartDate,
+    endDate: newEndDate,
+  });
+  this.applyFilters();
+}
+
+
   applyFilters() {
     this.apklogs = this.allPlanets.map(planet => ({
       ...planet,
@@ -195,10 +244,8 @@ export class LogsMyPlanetComponent implements OnInit {
   }
 
   resetDateFilter() {
-    this.logsForm.patchValue({
-      startDate: this.minDate,
-      endDate: this.today
-    });
+    this.onTimeFilterChange('all');
+
   }
 
   clearFilters() {

--- a/src/app/manager-dashboard/reports/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.ts
@@ -38,7 +38,7 @@ export class LogsMyPlanetComponent implements OnInit {
   showFiltersRow = false;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
-  selectedTimeFilter: string = 'all';
+  selectedTimeFilter = 'all';
   showCustomDateFields = false;
   timeFilterOptions = [
     { value: '24h', label: $localize`Last 24 Hours` },
@@ -46,7 +46,7 @@ export class LogsMyPlanetComponent implements OnInit {
     { value: '30d', label: $localize`Last 30 Days` },
     { value: 'all', label: $localize`All Time` },
     { value: 'custom', label: $localize`Custom` },
-  ];  
+  ];
 
 
   constructor(
@@ -172,7 +172,7 @@ export class LogsMyPlanetComponent implements OnInit {
   }
   const now = new Date();
   let newStartDate: Date;
-  let newEndDate: Date = now;
+  const newEndDate: Date = now;
 
   switch (timeFilter) {
     case '24h':


### PR DESCRIPTION
fixes #8461

filtered to last 24hrs by default
![image](https://github.com/user-attachments/assets/2a0c5335-ae4d-4e5a-a349-4e617ef7a3e9)
Has a few other options
![image](https://github.com/user-attachments/assets/78d29352-cea8-4db0-be3d-9cb261a9d6d3)
start and end date fields only show up when "custom" is selected
![image](https://github.com/user-attachments/assets/c22e6750-6f17-4f81-b848-34f4d0bca00a)

