### PR TITLE
surveys: add charts to pdf exports (fixes #8478)

### DIFF
--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@angular/core';
-import { CouchService } from '../shared/couchdb.service';
-import { Subject, of, forkJoin, throwError } from 'rxjs';
+import { Subject, of, forkJoin, throwError, from } from 'rxjs';
 import { catchError, finalize, map, switchMap, tap } from 'rxjs/operators';
+import { Chart } from 'chart.js';
+import htmlToPdfmake from 'html-to-pdfmake';
 import { findDocuments } from '../shared/mangoQueries';
+import { CouchService } from '../shared/couchdb.service';
 import { StateService } from '../shared/state.service';
 import { CoursesService } from '../courses/courses.service';
 import { UserService } from '../shared/user.service';
 import { dedupeShelfReduce, toProperCase, ageFromBirthDate, markdownToPlainText } from '../shared/utils';
 import { CsvService } from '../shared/csv.service';
-import htmlToPdfmake from 'html-to-pdfmake';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { ManagerService } from '../manager-dashboard/manager.service';
@@ -19,6 +20,7 @@ const showdown = require('showdown');
 const pdfMake = require('pdfmake/build/pdfmake');
 const pdfFonts = require('pdfmake/build/vfs_fonts');
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
+const converter = new showdown.Converter();
 
 @Injectable({
   providedIn: 'root'
@@ -342,10 +344,10 @@ export class SubmissionsService {
       answerText;
   }
 
-  exportSubmissionsPdf(
+  async exportSubmissionsPdf(
     exam,
     type: 'exam' | 'survey',
-    exportOptions: { includeQuestions, includeAnswers },
+    exportOptions: { includeQuestions, includeAnswers, includeCharts },
     team?: string
   ) {
     forkJoin([
@@ -386,13 +388,40 @@ export class SubmissionsService {
           );
         })
       )
-      .subscribe(tuple => {
+      .subscribe(async tuple => {
         if (!tuple) {
           return;
         }
         const [ updatedSubmissions, time, questionTexts ] = tuple as [any[], number, string[]];
         const markdown = this.preparePDF(exam, updatedSubmissions, questionTexts, exportOptions);
-        const converter = new showdown.Converter();
+        const docContent = [ htmlToPdfmake(converter.makeHtml(markdown)) ];
+        if (exportOptions.includeCharts) {
+          docContent.push({
+            canvas: [ { type: 'line', x1: 0, y1: 0, x2: 515, y2: 0, lineWidth: 1 } ],
+            margin: [ 0, 20, 0, 10 ]
+          });
+          docContent.push({
+            text: $localize`Charts`,
+            style: 'header',
+            margin: [ 0, 20, 0, 10 ]
+          });
+          for (let i = 0; i < exam.questions.length; i++) {
+            if (exam.questions[i].type !== 'select' && exam.questions[i].type !== 'selectMultiple') {
+              continue;
+            }
+            const question = exam.questions[i];
+            question.index = i;
+            const aggregated = this.aggregateQuestionResponses(question, updatedSubmissions);
+            const chartImage = await this.generateChartImage(aggregated);
+            docContent.push({ text: question.body });
+            docContent.push({
+              image: chartImage,
+              width: 200,
+              alignment: 'center',
+              margin: [ 0, 10, 0, 10 ]
+            });
+          }
+        }
         pdfMake.createPdf({
           header: function(currentPage) {
             if (currentPage === 1) {
@@ -402,7 +431,13 @@ export class SubmissionsService {
             }
             return null;
           },
-          content: [ htmlToPdfmake(converter.makeHtml(markdown)) ],
+          content: [ docContent ],
+          styles: {
+            header: {
+              fontSize: 20,
+              bold: true
+            }
+          },
           pageBreakBefore: (currentNode) =>
             currentNode.style && currentNode.style.indexOf('pdf-break') > -1
         }).download(`${toProperCase(type)} - ${exam.name}.pdf`);
@@ -438,6 +473,85 @@ export class SubmissionsService {
     return (question, questionIndex) =>
       (includeQuestions ? exportText(question, questionIndex, 'Question') : '') +
       (includeAnswers ? exportText(this.getPDFAnswerText(submission, questionIndex, answerIndexes), questionIndex, 'Response') : '');
+  }
+
+  async generateChartImage(data: any): Promise<string> {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 300;
+    const ctx = canvas.getContext('2d');
+
+    const chartRendered = new Promise<string>((resolve) => {
+      const chartConfig = {
+        type: 'pie',
+        data: {
+          labels: data.labels,
+          datasets: [ {
+            data: data.data,
+            backgroundColor: [
+              '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40', '#C9CBCF', '#8DD4F2', '#A8E6CF', '#DCE775'
+            ]
+          } ]
+        },
+        options: {
+          animation: {
+            onComplete: function() {
+              this.ctx.font = '12px sans-serif';
+              this.ctx.fillStyle = '#fff';
+              this.ctx.textAlign = 'center';
+              this.ctx.textBaseline = 'middle';
+              this.getDatasetMeta(0).data.forEach((element, index) => {
+                const count = data.data[index];
+                const total = data.data.reduce((sum, val) => sum + val, 0);
+                const percentage = total > 0 ? ((count / total) * 100).toFixed(1) : '0';
+                if (count > 0) {
+                  const pos = element.tooltipPosition();
+                  ctx.fillText(`${count.toString()}(${percentage}%)`, pos.x, pos.y);
+                }
+              });
+              resolve(this.toBase64Image());
+            }
+          },
+          responsive: false,
+          maintainAspectRatio: false
+        }
+      };
+      const chart = new Chart(ctx, chartConfig);
+    });
+
+    return chartRendered;
+  }
+
+  aggregateQuestionResponses(question: any, submissions: any[]): { labels: string[], data: number[] } {
+    const counts: { [choiceText: string]: number } = {};
+    question.choices.forEach((choice: any) => {
+      counts[choice.text] = 0;
+    });
+
+    submissions.forEach(submission => {
+      const answer = submission.answers[question.index];
+      if (!answer) { return; }
+
+      if (question.type === 'select') {
+        const choiceText = answer.value.text;
+        if (counts[choiceText] !== undefined) {
+          counts[choiceText]++;
+        }
+      } else if (question.type === 'selectMultiple') {
+        if (Array.isArray(answer.value)) {
+          answer.value.forEach((selected: any) => {
+            const choiceText = selected.text;
+            if (counts[choiceText] !== undefined) {
+              counts[choiceText]++;
+            }
+          });
+        }
+      }
+    });
+
+    const labels = Object.keys(counts);
+    const data = labels.map(label => counts[label]);
+    return { labels, data };
   }
 
 }

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -16,7 +16,7 @@ import { PlanetMessageService } from '../shared/planet-message.service';
 import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { SelectionModel } from '@angular/cdk/collections';
-import { findByIdInArray, filterById, itemsShown } from '../shared/utils';
+import { findByIdInArray, filterById } from '../shared/utils';
 import { debug } from '../debug-operator';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { UserService } from '../shared/user.service';
@@ -374,13 +374,14 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
       'Records to Export',
       [
         { name: 'includeQuestions', placeholder: $localize`Include Questions`, type: 'checkbox' },
-        { name: 'includeAnswers', placeholder: $localize`Include Answers`, type: 'checkbox' }
+        { name: 'includeAnswers', placeholder: $localize`Include Answers`, type: 'checkbox' },
+        { name: 'includeCharts', placeholder: $localize`Include Charts`, type: 'checkbox' }
       ],
-      { includeQuestions: true, includeAnswers: true },
+      { includeQuestions: true, includeAnswers: true, includeCharts: false },
       {
         autoFocus: true,
         disableIfInvalid: true,
-        onSubmit: (options: { includeQuestions, includeAnswers}) => {
+        onSubmit: (options: { includeQuestions, includeAnswers, includeCharts }) => {
           this.dialogsFormService.closeDialogsForm();
           this.submissionsService.exportSubmissionsPdf(survey, 'survey', options, this.teamId || this.routeTeamId || '');
         },


### PR DESCRIPTION
Fixes #8478

Add charts to the exported pdfs

![image](https://github.com/user-attachments/assets/e1048211-b2f6-4222-ae1c-6d15877ef132)


![image](https://github.com/user-attachments/assets/8e2b5eb7-b933-4580-9452-31d352b3a2c1)
