### PR TITLE
manager: smoother surveys export formating (fixes #8477)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.8",
+  "version": "0.18.11",
   "myplanet": {
     "latest": "v0.24.42",
     "min": "v0.23.42"

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -397,12 +397,19 @@ export class SubmissionsService {
           header: function(currentPage) {
             if (currentPage === 1) {
               return [
-                htmlToPdfmake(converter.makeHtml(`<h1 style="text-align: center">${exam.name}${exam.description ? ': ' + exam.description : ''}</h1>`)),
+                htmlToPdfmake(converter.makeHtml(`<h1 style="text-align: center">${exam.name}</h1>`)),
               ];
             }
             return null;
           },
-          content: [ htmlToPdfmake(converter.makeHtml(markdown)) ],
+          content: [
+            htmlToPdfmake(converter.makeHtml(`
+              ${exam.description || ''}
+              <p style="text-align: center">Number of Responses: ${updatedSubmissions.length}</p>
+            `)),
+            { text: '', pageBreak: 'after' },
+            htmlToPdfmake(converter.makeHtml(markdown))
+          ],
           pageBreakBefore: (currentNode) =>
             currentNode.style && currentNode.style.indexOf('pdf-break') > -1
         }).download(`${toProperCase(type)} - ${exam.name}.pdf`);

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -403,10 +403,9 @@ export class SubmissionsService {
             return null;
           },
           content: [
-            htmlToPdfmake(converter.makeHtml(`
-              ${exam.description || ''}
-              <p style="text-align: center">Number of Responses: ${updatedSubmissions.length}</p>
-            `)),
+            { text: exam.description || '' },
+            { text: '\n' },
+            { text: `Number of Submissions: ${updatedSubmissions.length}`, alignment: 'center' },
             { text: '', pageBreak: 'after' },
             htmlToPdfmake(converter.makeHtml(markdown))
           ],
@@ -433,13 +432,15 @@ export class SubmissionsService {
         : submission.user.age;
       const userGender = submission.user.gender;
       const communityOrNation = submission.planetName;
-      const teamName = submission.teamName;
+      const teamName = submission.teamName
+      ? submission.teamName.replace(/^(Team|Enterprise):/, (match) => `<strong>${match}</strong>`)
+      : '';
       return [
-        `<h3${index === 0 ? '' : ' class="pdf-break"'}>Response ${index + 1}</h3>`,
+        `<h3${index === 0 ? '' : ' class="pdf-break"'}>Submission ${index + 1}</h3>`,
         `<ul>`,
         `<li><strong>Planet ${communityOrNation}</strong></li>`,
         `<li><strong>Date:</strong> ${shortDate}</li>`,
-        teamName ? `<li><strong>Team:</strong> ${teamName}</li>` : '',
+        teamName ? `<li>${teamName}</li>` : '',
         userGender ? `<li><strong>Gender:</strong> ${userGender}</li>` : '',
         userAge ? `<li><strong>Age:</strong> ${userAge}</li>` : '',
         `</ul>`,

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -451,7 +451,10 @@ export class SubmissionsService {
   }
 
   questionOutput(submission, answerIndexes, includeQuestions, includeAnswers) {
-    const exportText = (text, index, label: 'Question' | 'Response') => `**${label} ${index + 1}:**  \n\n${text}  \n\n`;
+    const exportText = (text, index, label: 'Question' | 'Response') => {
+      const alignment = label === 'Response' ? 'right' : 'left';
+      return `<div style="text-align: ${alignment};"><strong>${label} ${index + 1}:</strong><br>${text}</div>`;
+    };
     return (question, questionIndex) =>
       (includeQuestions ? exportText(question, questionIndex, 'Question') : '') +
       (includeAnswers ? exportText(this.getPDFAnswerText(submission, questionIndex, answerIndexes), questionIndex, 'Response') : '');

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -428,13 +428,23 @@ export class SubmissionsService {
   surveyHeader(responseHeader: boolean, exam, index: number, submission): string {
     if (responseHeader) {
       const shortDate = this.formatShortDate(submission.lastUpdateTime);
-      const mainHeader = `<h3${index === 0 ? '' : ' class="pdf-break"'}>Response from ${submission.planetName} on ${shortDate}</h3>`;
-      if (submission.teamName) {
-        const teamHeader = `<h5>${submission.teamName}</h5>`;
-        return `${mainHeader}\n${teamHeader}\n`;
-      } else {
-        return `${mainHeader}\n`;
-      }
+      const userAge = submission.user.birthDate
+        ? ageFromBirthDate(submission.lastUpdateTime, submission.user.birthDate)
+        : submission.user.age;
+      const userGender = submission.user.gender;
+      const communityOrNation = submission.planetName;
+      const teamName = submission.teamName;
+      return [
+        `<h3${index === 0 ? '' : ' class="pdf-break"'}>Response ${index + 1}</h3>`,
+        `<ul>`,
+        `<li><strong>Planet ${communityOrNation}</strong></li>`,
+        `<li><strong>Date:</strong> ${shortDate}</li>`,
+        teamName ? `<li><strong>Team:</strong> ${teamName}</li>` : '',
+        userGender ? `<li><strong>Gender:</strong> ${userGender}</li>` : '',
+        userAge ? `<li><strong>Age:</strong> ${userAge}</li>` : '',
+        `</ul>`,
+        `<hr>`
+      ].filter(Boolean).join('\n');
     } else {
       return `### ${exam.name} Questions\n`;
     }


### PR DESCRIPTION
Fixes #8477

Improve formatting for exported pdfs
- Add an info page with the submission name, description(was previously getting cut off in the header) and no of submissions
- Simplify the question headers for more straightforward info
- Add more data to the submissions
- Improve overall formatting of Question - Response structure

Info page:
![image](https://github.com/user-attachments/assets/8b9bbd1e-0ef4-4224-9754-a84f321fd0ef)

Page format:
![image](https://github.com/user-attachments/assets/7bf25553-0416-4fbe-851f-6fd3f104dca9)

