### PR TITLE
manager: smoother configuration language dropdown (fixes #8487)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.3",
+  "version": "0.18.12",
   "myplanet": {
     "latest": "v0.24.39",
     "min": "v0.23.39"

--- a/src/app/configuration/configuration.component.html
+++ b/src/app/configuration/configuration.component.html
@@ -49,8 +49,12 @@
         <mat-error><planet-form-error-messages [control]="configurationFormGroup.controls.code"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Language" formControlName="preferredLang" required>
-        <mat-error><planet-form-error-messages [control]="configurationFormGroup.controls.preferredLang"></planet-form-error-messages></mat-error>
+        <input matInput i18n-placeholder placeholder="Language" formControlName="preferredLang" [matAutocomplete]="auto" required>
+        <mat-autocomplete #auto="matAutocomplete">
+          <mat-option *ngFor="let language of languageNames" [value]="language">
+            {{ language }}
+          </mat-option>
+        </mat-autocomplete>
       </mat-form-field>
       <div class="full-width" *ngIf="showAdvancedOptions">
         <span i18n>Advanced Options:</span>

--- a/src/app/configuration/configuration.component.ts
+++ b/src/app/configuration/configuration.component.ts
@@ -1,14 +1,15 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+import { MatStepper } from '@angular/material/stepper';
+import { finalize } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { languages } from '../shared/languages';
 import { CouchService } from '../shared/couchdb.service';
 import { ValidatorService } from '../validators/validator.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { CustomValidators } from '../validators/custom-validators';
 import { findDocuments } from '../shared/mangoQueries';
-import { MatStepper } from '@angular/material/stepper';
-import { Router, ActivatedRoute } from '@angular/router';
-import { environment } from '../../environments/environment';
-import { finalize } from 'rxjs/operators';
 import { ConfigurationService } from './configuration.service';
 import { StateService } from '../shared/state.service';
 
@@ -49,6 +50,7 @@ export class ConfigurationComponent implements OnInit {
   spinnerOn = true;
   configuration: any = {};
   defaultLocal = environment.couchAddress.indexOf('http') > -1 ? removeProtocol(environment.couchAddress) : environment.couchAddress;
+  languageNames = languages.map(list => list.name);
 
   constructor(
     private formBuilder: FormBuilder,


### PR DESCRIPTION
Fixes #8487

Implement an autocomplete dropdown for the configurations language field

![image](https://github.com/user-attachments/assets/d4761144-8e7a-4315-8e8f-015c6208d1d9)
