### PR TITLE
teams: smoother members card (fixes #8493)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.8",
+  "version": "0.18.20",
   "myplanet": {
     "latest": "v0.24.42",
     "min": "v0.23.42"

--- a/src/app/teams/teams-member.component.html
+++ b/src/app/teams/teams-member.component.html
@@ -1,6 +1,6 @@
 <mat-card-header>
   <img mat-card-avatar [src]="member?.avatar" class="cursor-pointer" (click)="openMemberDialog(member)">
-  <a mat-card-title class="cursor-pointer" (click)="openMemberDialog(member)">{{ member?.userDoc?.fullName || member?.userDoc?.firstName || member?.name }}</a>
+  <a mat-card-title class="cursor-pointer member-name" (click)="openMemberDialog(member)">{{ truncateText( member?.userDoc?.fullName || member?.userDoc?.firstName || member?.name ) }}</a>
   <mat-card-subtitle>
     <p class="primary-text-color" *ngIf="member?.userPlanetCode !== planetCode"><ng-container i18n>Member of Planet</ng-container> {{member?.userPlanetCode}}</p>
     <span i18n *ngIf="member?.userId === user._id && member?.userPlanetCode === planetCode">(You)</span>{{' '}}

--- a/src/app/teams/teams-member.component.ts
+++ b/src/app/teams/teams-member.component.ts
@@ -23,6 +23,13 @@ import { UserProfileDialogComponent } from '../users/users-profile/users-profile
       font-size: 16px;
       font-weight: bold;
     }
+    .member-name {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      word-break: break-word;
+    }
   ` ]
 })
 export class TeamsMemberComponent implements OnInit, OnChanges {

--- a/src/app/teams/teams-view.scss
+++ b/src/app/teams/teams-view.scss
@@ -24,8 +24,6 @@
     }
 
     mat-card {
-      height: 90%;
-      width: 90%;
       display: flex;
       flex-direction: column;
 

--- a/src/app/teams/teams-view.scss
+++ b/src/app/teams/teams-view.scss
@@ -8,7 +8,7 @@
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     grid-auto-rows: 180px;
     &.member-cards {
-      grid-auto-rows: 280px;
+      grid-auto-rows: 320px;
       mat-card-content {
         max-height: 149px;
       }
@@ -24,6 +24,8 @@
     }
 
     mat-card {
+      height: 90%;
+      width: 90%;
       display: flex;
       flex-direction: column;
 


### PR DESCRIPTION
fixes #8493

Added truncation to the members name. Made the cards a bit bigger to make room for an additional line of content. 

![image](https://github.com/user-attachments/assets/50a32630-d1a9-4c9f-80de-11019cec817c)
