### PR TITLE
community: smoother login dialog (fixes #8496)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.11",
+  "version": "0.18.14",
   "myplanet": {
     "latest": "v0.24.45",
     "min": "v0.23.45"

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -90,7 +90,14 @@ export class AuthService {
   }
 
   checkAuthenticationStatus(): Observable<boolean> {
-    return this.checkUser('/', []);
+    return this.checkUser('/', []).pipe(
+      map(isLoggedIn => {
+        if (!isLoggedIn) {
+          throw new Error('Not authorized');
+        }
+        return isLoggedIn;
+      })
+    );
   }
 
 }


### PR DESCRIPTION
To test:

1. Go to community page in not logged in state
2. Click the calendar to try to create a meetup
3. When you see the login dialog, click outside to close it
4. You should not see the meetup dialog open
5. In the console, you should see a `Not authorized` error

fixes #8496 