### PR TITLE
courses: smoother exams navigation (fixes #8492)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.11",
+  "version": "0.18.21",
   "myplanet": {
     "latest": "v0.24.45",
     "min": "v0.23.45"

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -6,15 +6,15 @@
 
 <div [ngClass]="{ 'space-container': !isDialog }">
   <mat-toolbar class="primary-color font-size-1">
-    <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
-    <span>
+    <span class="ellipsis-title" *ngIf="!isLoading">{{title ? title + ': ' : ''}}</span>
+    <span *ngIf="!isLoading">
       <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
       <span i18n *ngIf="mode === 'grade' || mode === 'view'"> by{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span>
       <span *ngIf="updatedOn && (updatedOn | date: 'short')" i18n> on {{updatedOn | date: 'short'}}</span>
     </span>
     <span class="toolbar-fill"></span>
-    <button mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>
-    <button mat-icon-button [disabled]="questionNum === maxQuestions" (click)="nextQuestion({ nextClicked: true })" [planetSubmit]="spinnerOn"><mat-icon>navigate_next</mat-icon></button>
+    <button mat-icon-button [disabled]="isLoading || questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>
+    <button mat-icon-button [disabled]="isLoading || questionNum === maxQuestions" (click)="nextQuestion({ nextClicked: true })" [planetSubmit]="spinnerOn"><mat-icon>navigate_next</mat-icon></button>
   </mat-toolbar>
   <div class="view-container" [ngClass]="{ 'view-full-height': !isDialog }">
     <ng-container *ngIf="!isLoading; else LoadingContent">


### PR DESCRIPTION
fixes #8492

The exam info in the toolbar no longer shows premature inaccurate info. Now it waits for the data to load before showing it. 

[recording(7).webm](https://github.com/user-attachments/assets/ada16015-cda9-4f1d-8110-b6404c880794)


