### PR TITLE
manager: smoother myplanet reports date filtering (fixes #8502)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.24",
+  "version": "0.18.26",
   "myplanet": {
     "latest": "v0.24.64",
     "min": "v0.23.64"

--- a/src/app/manager-dashboard/reports/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/logs-myplanet.component.ts
@@ -9,6 +9,7 @@ import { attachNamesToPlanets, areNoChildren, filterByDate } from './reports.uti
 import { CsvService } from '../../shared/csv.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
+import { ReportsService } from './reports.service';
 
 @Component({
   templateUrl: './logs-myplanet.component.html',
@@ -38,15 +39,9 @@ export class LogsMyPlanetComponent implements OnInit {
   showFiltersRow = false;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
-  selectedTimeFilter = 'all';
+  selectedTimeFilter = '24h';
   showCustomDateFields = false;
-  timeFilterOptions = [
-    { value: '24h', label: $localize`Last 24 Hours` },
-    { value: '7d', label: $localize`Last 7 Days` },
-    { value: '30d', label: $localize`Last 30 Days` },
-    { value: 'all', label: $localize`All Time` },
-    { value: 'custom', label: $localize`Custom` },
-  ];
+  timeFilterOptions = this.activityService.standardTimeFilters;
 
   constructor(
     private csvService: CsvService,
@@ -56,6 +51,7 @@ export class LogsMyPlanetComponent implements OnInit {
     private managerService: ManagerService,
     private fb: FormBuilder,
     private deviceInfoService: DeviceInfoService,
+    private activityService: ReportsService,
   ) {
     this.deviceType = this.deviceInfoService.getDeviceType({ tablet: 1350 });
     this.logsForm = this.fb.group({
@@ -150,6 +146,7 @@ export class LogsMyPlanetComponent implements OnInit {
       );
       this.apklogs = this.allPlanets;
       this.isEmpty = areNoChildren(this.apklogs);
+      this.onTimeFilterChange('24h');
     }, (error) => this.planetMessageService.showAlert($localize`There was a problem getting myPlanet activity.`));
   }
 
@@ -165,38 +162,16 @@ export class LogsMyPlanetComponent implements OnInit {
 
   onTimeFilterChange(timeFilter: string) {
     this.selectedTimeFilter = timeFilter;
-    this.showCustomDateFields = timeFilter === 'custom';
+    const { startDate, endDate, showCustomDateFields } = this.activityService.getDateRange(timeFilter, this.minDate);
+    this.showCustomDateFields = showCustomDateFields;
     if (timeFilter === 'custom') {
       return;
     }
-    const now = new Date();
-    let newStartDate: Date;
-    const newEndDate: Date = now;
-
-    switch (timeFilter) {
-      case '24h':
-        newStartDate = new Date(now);
-        newStartDate.setDate(now.getDate() - 1);
-        break;
-      case '7d':
-        newStartDate = new Date(now);
-        newStartDate.setDate(now.getDate() - 7);
-        break;
-      case '30d':
-        newStartDate = new Date(now);
-        newStartDate.setDate(now.getDate() - 30);
-        break;
-      case 'all':
-        newStartDate = this.minDate;
-        break;
-      default:
-        return;
-    }
-    this.startDate = newStartDate;
-    this.endDate = newEndDate;
+    this.startDate = startDate;
+    this.endDate = endDate;
     this.logsForm.patchValue({
-      startDate: newStartDate,
-      endDate: newEndDate,
+      startDate,
+      endDate
     });
     this.applyFilters();
   }
@@ -242,7 +217,7 @@ export class LogsMyPlanetComponent implements OnInit {
   }
 
   resetDateFilter() {
-    this.onTimeFilterChange('all');
+    this.onTimeFilterChange('24h');
   }
 
   clearFilters() {

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -70,14 +70,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
   };
   selectedTimeFilter = '12m';
   showCustomDateFields = false;
-  timeFilterOptions = [
-    { value: '7d', label: 'Last 7 days' },
-    { value: '1m', label: 'Last 30 days' },
-    { value: '6m', label: 'Last 6 Months' },
-    { value: '12m', label: 'Last 12 Months' },
-    { value: 'all', label: 'All Time' },
-    { value: 'custom', label: 'Custom' },
-  ];
+  timeFilterOptions = this.activityService.standardTimeFilters;
 
   constructor(
     private activityService: ReportsService,
@@ -752,12 +745,11 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
 
   onTimeFilterChange(timeFilter: string) {
     this.selectedTimeFilter = timeFilter;
-    this.showCustomDateFields = timeFilter === 'custom';
-    const now = new Date();
-    let newStartDate: Date;
-    const newEndDate: Date = now;
+    const { startDate, endDate, showCustomDateFields } = this.activityService.getDateRange(timeFilter, this.minDate);
+    this.showCustomDateFields = showCustomDateFields;
+
     if (timeFilter === 'custom') {
-      const currentStartDate = new Date(now);
+      const currentStartDate = new Date();
       currentStartDate.setMonth(currentStartDate.getMonth() - 12);
       const currentEndDate = this.filter.endDate || this.today;
       this.dateFilterForm.patchValue({
@@ -766,32 +758,9 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       });
       return;
     }
-    switch (timeFilter) {
-      case '7d':
-        newStartDate = new Date(now);
-        newStartDate.setDate(now.getDate() - 7);
-        break;
-      case '1m':
-        newStartDate = new Date(now);
-        newStartDate.setMonth(now.getMonth() - 1);
-        break;
-      case '6m':
-        newStartDate = new Date(now);
-        newStartDate.setMonth(now.getMonth() - 6);
-        break;
-      case '12m':
-        newStartDate = new Date(now);
-        newStartDate.setMonth(now.getMonth() - 12);
-        break;
-      case 'all':
-        newStartDate = this.minDate;
-        break;
-      default:
-        return;
-    }
-    this.resetDateFilter({ startDate: newStartDate, endDate: newEndDate });
-    this.filter.startDate = newStartDate;
-    this.filter.endDate = newEndDate;
+    this.resetDateFilter({ startDate, endDate });
+    this.filter.startDate = startDate;
+    this.filter.endDate = endDate;
     this.filterData();
   }
 

--- a/src/app/manager-dashboard/reports/reports-myplanet.component.html
+++ b/src/app/manager-dashboard/reports/reports-myplanet.component.html
@@ -11,7 +11,7 @@
         <mat-option *ngFor="let version of versions" [value]="version">{{version}}</mat-option>
       </mat-select>
     </mat-form-field>
-    <form [formGroup]="reportsForm">
+    <form [formGroup]="reportsForm" *ngIf="showCustomDateFields">
       <mat-form-field class="margin-lr-5 font-size-1">
         <input matInput [matDatepicker]="startPicker" i18n-placeholder placeholder="Start Date" formControlName="startDate" [min]="minDate" [max]="reportsForm.get('endDate').value">
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
@@ -24,9 +24,11 @@
         <mat-datepicker #endPicker></mat-datepicker>
       </mat-form-field>
     </form>
-    <button mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="disableShowAllTime" class="margin-lr-5">
-      Show All Time
-    </button>
+    <mat-form-field class="margin-lr-5 font-size-1">
+      <mat-select i18n-placeholder placeholder="Time Frame" (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
+        <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
+      </mat-select>
+    </mat-form-field>
     <button mat-raised-button color="primary" (click)="clearFilters()" [disabled]="!searchValue && !selectedVersion && disableShowAllTime" class="margin-lr-5">
       Clear
     </button>
@@ -52,6 +54,28 @@
           <mat-option *ngFor="let version of versions" [value]="version">{{version}}</mat-option>
         </mat-select>
       </mat-form-field>
+    </mat-toolbar-row>
+    <mat-toolbar-row *ngIf="showFiltersRow">
+      <mat-form-field class="margin-lr-5 font-size-1">
+        <mat-select i18n-placeholder placeholder="Time Frame" (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
+          <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </mat-toolbar-row>
+    <mat-toolbar-row *ngIf="showFiltersRow">
+      <form [formGroup]="reportsForm" *ngIf="showCustomDateFields">
+        <mat-form-field class="margin-lr-5 font-size-1" style="width: 100%;">
+          <input matInput [matDatepicker]="startPicker" i18n-placeholder placeholder="Start Date" formControlName="startDate" [min]="minDate" [max]="reportsForm.get('endDate').value">
+          <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+          <mat-datepicker #startPicker></mat-datepicker>
+          <mat-error i18n *ngIf="reportsForm.errors?.invalidDates">Start date must be before end date</mat-error>
+        </mat-form-field>
+        <mat-form-field class="margin-lr-5 font-size-1" style="width: 100%;">
+          <input matInput [matDatepicker]="endPicker" i18n-placeholder placeholder="End Date" formControlName="endDate" [min]="reportsForm.get('startDate').value" [max]="today">
+          <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+          <mat-datepicker #endPicker></mat-datepicker>
+        </mat-form-field>
+      </form>
     </mat-toolbar-row>
     <mat-toolbar-row *ngIf="showFiltersRow">
       <form [formGroup]="reportsForm">

--- a/src/app/manager-dashboard/reports/reports-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/reports-myplanet.component.ts
@@ -42,6 +42,15 @@ export class ReportsMyPlanetComponent implements OnInit {
   versions: string[] = [];
   selectedVersion = '';
   disableShowAllTime = true;
+  selectedTimeFilter = 'all'; // Default to All Time
+  timeFilterOptions = [
+    { value: '24h', label: $localize`Last 24 Hours` },
+    { value: '7d', label: $localize`Last 7 Days` },
+    { value: '30d', label: $localize`Last 30 Days` },
+    { value: 'all', label: $localize`All Time` },
+    { value: 'custom', label: $localize`Custom` },
+  ];
+  showCustomDateFields = false;
 
   constructor(
     private csvService: CsvService,
@@ -69,6 +78,7 @@ export class ReportsMyPlanetComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.onTimeFilterChange('all'); // Apply All Time filter by default
     this.getMyPlanetList(this.route.snapshot.params.hubId);
     this.reportsForm.valueChanges.subscribe(() => {
       this.startDate = this.reportsForm.get('startDate').value;
@@ -93,6 +103,7 @@ export class ReportsMyPlanetComponent implements OnInit {
   clearFilters() {
     this.searchValue = '';
     this.selectedVersion = '';
+    this.selectedTimeFilter = 'all';
     this.resetDateFilter();
     this.applyFilters();
   }
@@ -146,6 +157,44 @@ export class ReportsMyPlanetComponent implements OnInit {
 
   onVersionChange(version: string) {
     this.selectedVersion = version;
+    this.applyFilters();
+  }
+
+  onTimeFilterChange(timeFilter: string) {
+    this.selectedTimeFilter = timeFilter;
+    this.showCustomDateFields = timeFilter === 'custom';
+    if (timeFilter === 'custom') {
+      return;
+    }
+    const now = new Date();
+    let newStartDate: Date;
+    const newEndDate: Date = now;
+
+    switch (timeFilter) {
+      case '24h':
+        newStartDate = new Date(now);
+        newStartDate.setDate(now.getDate() - 1);
+        break;
+      case '7d':
+        newStartDate = new Date(now);
+        newStartDate.setDate(now.getDate() - 7);
+        break;
+      case '30d':
+        newStartDate = new Date(now);
+        newStartDate.setDate(now.getDate() - 30);
+        break;
+      case 'all':
+        newStartDate = this.minDate;
+        break;
+      default:
+        return;
+    }
+    this.startDate = newStartDate;
+    this.endDate = newEndDate;
+    this.reportsForm.patchValue({
+      startDate: newStartDate,
+      endDate: newEndDate,
+    });
     this.applyFilters();
   }
 

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -34,7 +34,7 @@ export class ReportsService {
   readonly standardTimeFilters = [
     { value: '24h', label: $localize`Last 24 Hours` },
     { value: '7d', label: $localize`Last 7 Days` },
-    { value: '1m', label: $localize`Last 30 Days` },
+    { value: '1m', label: $localize`Last Month` },
     { value: '6m', label: $localize`Last 6 Months` },
     { value: '12m', label: $localize`Last 12 Months` },
     { value: 'all', label: $localize`All Time` },
@@ -310,7 +310,6 @@ export class ReportsService {
         startDate.setDate(now.getDate() - 7);
         break;
       case '1m':
-      case '30d':
         startDate = new Date(now);
         startDate.setMonth(now.getMonth() - 1);
         break;

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -22,8 +22,6 @@ interface ActivityRequestObject {
 })
 export class ReportsService {
 
-  users: any[] = [];
-
   constructor(
     private couchService: CouchService,
     private usersService: UsersService,
@@ -31,6 +29,17 @@ export class ReportsService {
     private stateService: StateService,
     private coursesService: CoursesService
   ) {}
+
+  users: any[] = [];
+  readonly standardTimeFilters = [
+    { value: '24h', label: $localize`Last 24 Hours` },
+    { value: '7d', label: $localize`Last 7 Days` },
+    { value: '1m', label: $localize`Last 30 Days` },
+    { value: '6m', label: $localize`Last 6 Months` },
+    { value: '12m', label: $localize`Last 12 Months` },
+    { value: 'all', label: $localize`All Time` },
+    { value: 'custom', label: $localize`Custom` },
+  ];
 
   groupBy(array, fields, { sumField = '', maxField = '', uniqueField = '', includeDocs = false } = {}) {
     return array.reduce((group, item) => {
@@ -281,4 +290,44 @@ export class ReportsService {
     });
   }
 
+  getDateRange(timeFilter: string, minDate: Date): { startDate: Date, endDate: Date, showCustomDateFields: boolean } {
+    const now = new Date();
+    const endDate = now;
+    let startDate: Date;
+    const showCustomDateFields = timeFilter === 'custom';
+
+    if (timeFilter === 'custom') {
+      return { startDate: null, endDate: null, showCustomDateFields };
+    }
+
+    switch (timeFilter) {
+      case '24h':
+        startDate = new Date(now);
+        startDate.setDate(now.getDate() - 1);
+        break;
+      case '7d':
+        startDate = new Date(now);
+        startDate.setDate(now.getDate() - 7);
+        break;
+      case '1m':
+      case '30d':
+        startDate = new Date(now);
+        startDate.setMonth(now.getMonth() - 1);
+        break;
+      case '6m':
+        startDate = new Date(now);
+        startDate.setMonth(now.getMonth() - 6);
+        break;
+      case '12m':
+        startDate = new Date(now);
+        startDate.setMonth(now.getMonth() - 12);
+        break;
+      case 'all':
+        startDate = minDate;
+        break;
+      default:
+        return { startDate: null, endDate: null, showCustomDateFields: false };
+    }
+    return { startDate, endDate, showCustomDateFields };
+  }
 }

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -22,14 +22,6 @@ interface ActivityRequestObject {
 })
 export class ReportsService {
 
-  constructor(
-    private couchService: CouchService,
-    private usersService: UsersService,
-    private dialog: MatDialog,
-    private stateService: StateService,
-    private coursesService: CoursesService
-  ) {}
-
   users: any[] = [];
   readonly standardTimeFilters = [
     { value: '24h', label: $localize`Last 24 Hours` },
@@ -40,6 +32,14 @@ export class ReportsService {
     { value: 'all', label: $localize`All Time` },
     { value: 'custom', label: $localize`Custom` },
   ];
+
+  constructor(
+    private couchService: CouchService,
+    private usersService: UsersService,
+    private dialog: MatDialog,
+    private stateService: StateService,
+    private coursesService: CoursesService
+  ) {}
 
   groupBy(array, fields, { sumField = '', maxField = '', uniqueField = '', includeDocs = false } = {}) {
     return array.reduce((group, item) => {


### PR DESCRIPTION
fixes #8502

Added a dropdown menu for date filtering to match the other reports pages. Currently, All Time is the default range, but this can be adjust if something else makes more sense or is more convenient. 

![image](https://github.com/user-attachments/assets/1454204d-9d48-49d5-9c4b-89945c08505d)
![image](https://github.com/user-attachments/assets/81149ef8-4f23-4f22-a0e6-238ca1093c05)
