### PR TITLE
all: smoother content loading (fixes #8500)

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -42,28 +42,30 @@
 
 <div [ngClass]="{ 'space-container': !isForm }" class="primary-link-hover">
   <mat-toolbar class="primary-color font-size-1" *ngIf="!isDialog && !isForm">
-    <ng-container *ngIf="isAuthorized">
-      <button *ngIf="!parent" mat-mini-fab routerLink="add" ><mat-icon>add</mat-icon></button>
-      <div class="column margin-lr-5">
-        <planet-filtered-amount [table]="courses" labelFor="courses"></planet-filtered-amount>
-        <planet-tag-selected-input [selectedIds]="tagFilter.value" [allTags]="tagInputComponent?.tags"></planet-tag-selected-input>
-      </div>
-      <span class="toolbar-fill"></span>
-      <ng-container *ngIf="parent">
-        <button mat-button [disabled]="!selection.selected.length" (click)="shareCourse('pull', selection.selected)">
-          <mat-icon aria-hidden="true" class="margin-lr-3">cloud_download</mat-icon><span i18n>Get Course</span>
-        </button>
-      </ng-container>
-      <ng-container *ngIf="!parent && deviceType !== deviceTypes.DESKTOP">
-        <button class="menu" mat-icon-button [matMenuTriggerFor]="actionsMenu">
-          <mat-icon>more_vert</mat-icon>
-        </button>
-        <mat-menu #actionsMenu="matMenu" class="ellipsis-menu">
+    <ng-container *ngIf="!isLoading">
+      <ng-container *ngIf="isAuthorized">
+        <button *ngIf="!parent" mat-mini-fab routerLink="add" ><mat-icon>add</mat-icon></button>
+        <div class="column margin-lr-5">
+          <planet-filtered-amount [table]="courses" labelFor="courses"></planet-filtered-amount>
+          <planet-tag-selected-input [selectedIds]="tagFilter.value" [allTags]="tagInputComponent?.tags"></planet-tag-selected-input>
+        </div>
+        <span class="toolbar-fill"></span>
+        <ng-container *ngIf="parent">
+          <button mat-button [disabled]="!selection.selected.length" (click)="shareCourse('pull', selection.selected)">
+            <mat-icon aria-hidden="true" class="margin-lr-3">cloud_download</mat-icon><span i18n>Get Course</span>
+          </button>
+        </ng-container>
+        <ng-container *ngIf="!parent && deviceType !== deviceTypes.DESKTOP">
+          <button class="menu" mat-icon-button [matMenuTriggerFor]="actionsMenu">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #actionsMenu="matMenu" class="ellipsis-menu">
+            <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
+          </mat-menu>
+        </ng-container>
+        <ng-container *ngIf="!parent && deviceType === deviceTypes.DESKTOP">
           <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
-        </mat-menu>
-      </ng-container>
-      <ng-container *ngIf="!parent && deviceType === deviceTypes.DESKTOP">
-        <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
+        </ng-container>
       </ng-container>
     </ng-container>
   </mat-toolbar>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -5,7 +5,7 @@
   <span class="closebtn" (click)="closeBanner()">&times;</span>
 </div>
 <mat-card class="horizontal" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-start;">
-  <div style="display: flex; align-items: flex-start;">
+  <div *ngIf="!isLoading" style="display: flex; align-items: flex-start;">
     <a [routerLink]="['/users/profile', user.name]" class="profile-link">
       <img [src]="profileImg" class="profile-avatar">
     </a>
@@ -22,7 +22,7 @@
       </h1>
     </div>
   </div>
-  <div style="display: flex; flex-direction: column; align-items: flex-end;">
+  <div *ngIf="!isLoading" style="display: flex; flex-direction: column; align-items: flex-end;">
     <div class="date" style="text-align: right;">
       <p>{{dateNow | date:'longDate'}}</p>
     </div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -39,6 +39,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   leaderIds = [];
   onDestroy$ = new Subject<void>();
   showBanner = false;
+  isLoading = true;
 
   myLifeItems: any[] = [
     { firstLine: $localize`my`, title: $localize`Submissions`, link: 'submissions', authorization: 'leader,manager',
@@ -76,6 +77,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.isLoading = true;
     this.displayName = this.user.firstName !== undefined ? `${this.user.firstName} ${this.user.lastName}` : this.user.name;
     this.planetName = this.stateService.configuration.name;
     this.getSurveys();
@@ -89,6 +91,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         })
       ).subscribe((res: any) => {
         this.visits = res.length;
+        this.isLoading = false;
       });
     this.reminderBanner();
   }

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -6,15 +6,15 @@
 
 <div [ngClass]="{ 'space-container': !isDialog }">
   <mat-toolbar class="primary-color font-size-1">
-    <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
-    <span>
-      <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
+    <span *ngIf="!isLoading" class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
+    <span *ngIf="!isLoading">
+      <ng-container i18n >Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
       <span i18n *ngIf="mode === 'grade' || mode === 'view'"> by{{' ' + submittedBy}}</span><span i18n *ngIf="!submittedBy">(Preview)</span>
       <span *ngIf="updatedOn && (updatedOn | date: 'short')" i18n> on {{updatedOn | date: 'short'}}</span>
     </span>
     <span class="toolbar-fill"></span>
-    <button mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>
-    <button mat-icon-button [disabled]="questionNum === maxQuestions" (click)="nextQuestion({ nextClicked: true })" [planetSubmit]="spinnerOn"><mat-icon>navigate_next</mat-icon></button>
+    <button *ngIf="!isLoading" mat-icon-button [disabled]="questionNum === 1" (click)="moveQuestion(-1)" [planetSubmit]="spinnerOn"><mat-icon>navigate_before</mat-icon></button>
+    <button *ngIf="!isLoading" mat-icon-button [disabled]="questionNum === maxQuestions" (click)="nextQuestion({ nextClicked: true })" [planetSubmit]="spinnerOn"><mat-icon>navigate_next</mat-icon></button>
   </mat-toolbar>
   <div class="view-container" [ngClass]="{ 'view-full-height': !isDialog }">
     <ng-container *ngIf="!isLoading; else LoadingContent">

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -79,22 +79,22 @@
       <button mat-raised-button i18n (click)="resetPin()">Reset Pin</button>
     </div>
   </ng-container>
-  <div>
+  <div *ngIf="!isLoading">
     <p>
       <span i18n>Activity on</span>
       <b>{{ '  Planet  ' + planetConfiguration.name + ' ' }}</b>
       <a class="margin-lr-8" [routerLink]="['reports', 'detail']" i18n mat-raised-button>Report Detail</a>
     </p>
 
+    <mat-grid-list cols="4" [rowHeight]="gridRowHeight">
+      <mat-grid-tile i18n><b>Last Upgrade</b></mat-grid-tile>
+      <mat-grid-tile i18n><b>Last Sync</b></mat-grid-tile>
+      <mat-grid-tile i18n><b>Resource Views Last 30 Days</b></mat-grid-tile>
+      <mat-grid-tile i18n><b>Total Ratings Last 30 Days</b></mat-grid-tile>
+      <mat-grid-tile>{{activityLogs?.lastUpgrade?.max.time | date: 'medium'}}</mat-grid-tile>
+      <mat-grid-tile>{{activityLogs?.lastSync?.max.time | date: 'medium'}}</mat-grid-tile>
+      <mat-grid-tile>{{activityLogs?.resourceVisits}}</mat-grid-tile>
+      <mat-grid-tile>{{activityLogs?.ratings}}</mat-grid-tile>
+    </mat-grid-list>
   </div>
-  <mat-grid-list cols="4" [rowHeight]="gridRowHeight">
-    <mat-grid-tile i18n><b>Last Upgrade</b></mat-grid-tile>
-    <mat-grid-tile i18n><b>Last Sync</b></mat-grid-tile>
-    <mat-grid-tile i18n><b>Resource Views Last 30 Days</b></mat-grid-tile>
-    <mat-grid-tile i18n><b>Total Ratings Last 30 Days</b></mat-grid-tile>
-    <mat-grid-tile>{{activityLogs?.lastUpgrade?.max.time | date: 'medium'}}</mat-grid-tile>
-    <mat-grid-tile>{{activityLogs?.lastSync?.max.time | date: 'medium'}}</mat-grid-tile>
-    <mat-grid-tile>{{activityLogs?.resourceVisits}}</mat-grid-tile>
-    <mat-grid-tile>{{activityLogs?.ratings}}</mat-grid-tile>
-  </mat-grid-list>
 </div>

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -77,6 +77,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
   overlayOpen = false;
   isMobile: boolean;
   gridRowHeight = '2rem';
+  isLoading = true;
 
   constructor(
     private userService: UserService,
@@ -93,6 +94,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
+    this.isLoading = true;
     this.streaming = this.planetConfiguration.streaming;
     this.isUserAdmin = this.userService.get().isUserAdmin;
     if (this.planetType !== 'center') {
@@ -104,7 +106,10 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
     this.couchService.currentTime().pipe(switchMap((time: number) => {
       const tillDate = new Date(time);
       return this.managerService.getLogs(new Date(tillDate.getFullYear(), tillDate.getMonth(), tillDate.getDate() - 30).getTime());
-    })).subscribe(logs => this.activityLogs = logs);
+    })).subscribe(logs => {
+      this.activityLogs = logs;
+      this.isLoading = false;
+    });
     this.countFetchItemAvailable();
     forkJoin([
       this.couchService.findAll('send_items'),

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -42,30 +42,32 @@
 
 <div class="space-container primary-link-hover">
   <mat-toolbar class="primary-color font-size-1" *ngIf="!isDialog">
-    <ng-container *ngIf="isAuthorized">
-      <button *ngIf="!parent && myView !== 'myPersonals'" mat-mini-fab routerLink="add"><mat-icon>add</mat-icon></button>
-      <div class="column margin-lr-5">
-        <planet-filtered-amount [table]="resources"></planet-filtered-amount>
-        <planet-tag-selected-input *ngIf="myView !== 'myPersonals'" [selectedIds]="tagFilter.value" [allTags]="tagInputComponent?.tags"></planet-tag-selected-input>
-      </div>
-      <span class="toolbar-fill"></span>
-      <ng-container *ngIf="myView !== 'myPersonals'">
-        <span *ngIf="parent">
-          <button mat-button [disabled]="!selection.selected.length" (click)="shareResource('pull', selection.selected)">
-            <mat-icon aria-hidden="true" class="margin-lr-3">cloud_download</mat-icon><span i18n>Get resource</span>
-          </button>
-        </span>
-        <span *ngIf="!parent && isTablet">
-          <button *ngIf="!isDialog" class="menu" mat-icon-button [matMenuTriggerFor]="actionsMenu">
-            <mat-icon>more_vert</mat-icon>
-          </button>
-          <mat-menu #actionsMenu="matMenu" class="ellipsis-menu">
+    <ng-container *ngIf="!isLoading">
+      <ng-container *ngIf="isAuthorized">
+        <button *ngIf="!parent && myView !== 'myPersonals'" mat-mini-fab routerLink="add"><mat-icon>add</mat-icon></button>
+        <div class="column margin-lr-5">
+          <planet-filtered-amount [table]="resources"></planet-filtered-amount>
+          <planet-tag-selected-input *ngIf="myView !== 'myPersonals'" [selectedIds]="tagFilter.value" [allTags]="tagInputComponent?.tags"></planet-tag-selected-input>
+        </div>
+        <span class="toolbar-fill"></span>
+        <ng-container *ngIf="myView !== 'myPersonals'">
+          <span *ngIf="parent">
+            <button mat-button [disabled]="!selection.selected.length" (click)="shareResource('pull', selection.selected)">
+              <mat-icon aria-hidden="true" class="margin-lr-3">cloud_download</mat-icon><span i18n>Get resource</span>
+            </button>
+          </span>
+          <span *ngIf="!parent && isTablet">
+            <button *ngIf="!isDialog" class="menu" mat-icon-button [matMenuTriggerFor]="actionsMenu">
+              <mat-icon>more_vert</mat-icon>
+            </button>
+            <mat-menu #actionsMenu="matMenu" class="ellipsis-menu">
+              <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
+            </mat-menu>
+          </span>
+          <span *ngIf="!parent && !isTablet">
             <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
-          </mat-menu>
-        </span>
-        <span *ngIf="!parent && !isTablet">
-          <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
-        </span>
+          </span>
+        </ng-container>
       </ng-container>
     </ng-container>
   </mat-toolbar>

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -32,7 +32,7 @@
   </mat-toolbar>
 
   <ng-template #editDetails>
-    <button mat-stroked-button class="margin-lr-3" (click)="toggleFullView()" i18n>
+    <button mat-stroked-button class="margin-lr-3" (click)="toggleFullView()" i18n *ngIf="!isLoading">
       {fullView, select, on {Show} off {Hide}} details
     </button>
     <button mat-stroked-button *ngIf="canManage" (click)="updateResource()">

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -68,7 +68,7 @@
   </ng-template>
 
   <div class="view-container view-full-height">
-    <mat-tab-group [(selectedIndex)]="tabSelectedIndex" class="tabs-padding">
+    <mat-tab-group [(selectedIndex)]="tabSelectedIndex" class="tabs-padding" *ngIf="!isLoading">
       <mat-tab i18n-label label="Chat">
         <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot" i18n>New message</button>
         <planet-news-list [items]="news" viewableBy="teams" [viewableId]="team?._id" [shareTarget]="configuration?.planetType" (viewChange)="toggleAdd($event)" editSuccessMessage="Message has been updated successfully" [editable]="userStatus === 'member'"></planet-news-list>

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -69,6 +69,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   configuration = this.stateService.configuration;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
+  isLoading = true;
 
   constructor(
     private couchService: CouchService,
@@ -136,6 +137,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   initTeam(teamId: string) {
+    this.isLoading = true;
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$))
       .subscribe(news => this.news = news.map(post => ({
         ...post, public: ((post.doc.viewIn || []).find(view => view._id === teamId) || {}).public
@@ -163,6 +165,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
       });
       this.setStatus(teamId, this.leader, this.userService.get());
       this.requestTeamNews(teamId);
+      this.isLoading = false;
     });
   }
 

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -4,7 +4,7 @@
   <span class="toolbar-fill"></span>
 </mat-toolbar>
 
-<div class="space-container">
+<div class="space-container" *ngIf="!isLoading">
   <mat-toolbar class="primary-color font-size-1 responsive-toolbar center-text">
     <div>
       <span *ngIf="user?.firstName; else elseBlock" class="center-text">{{ user.firstName}} {{user.middleName}} {{user.lastName }}</span>

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -31,6 +31,7 @@ export class UsersAchievementsComponent implements OnInit {
   openAchievementIndex = -1;
   certifications: any[] = [];
   publicView = this.route.snapshot.data.requiresAuth === false;
+  isLoading = true;
 
   constructor(
     private couchService: CouchService,
@@ -46,6 +47,7 @@ export class UsersAchievementsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
+    this.isLoading = true;
     this.route.paramMap.subscribe((params: ParamMap) => {
       let name = params.get('name'),
           id;
@@ -67,6 +69,7 @@ export class UsersAchievementsComponent implements OnInit {
       this.coursesService.coursesListener$(), this.coursesService.progressListener$(), this.certificationsService.getCertifications()
     ]).pipe(auditTime(500)).subscribe(([ courses, progress, certifications ]) => {
       this.setCertifications(courses, progress, certifications);
+      this.isLoading = false;
     });
     this.coursesService.requestCourses();
   }


### PR DESCRIPTION
fixes #8500

Anywhere there is a counter or some section where the presence of data affects the placement of elements, we now wait for the data before displaying these elements. This prevents inaccurate info from flashing on the screen or elements shifting once the data fully loads.  