### PR TITLE
courses: smoother list images preview (fixes #8521)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.15",
+  "version": "0.18.29",
   "myplanet": {
     "latest": "v0.24.50",
     "min": "v0.23.50"

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -237,12 +237,14 @@
       </ng-container>
       <ng-container matColumnDef="expandedDetail">
         <mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
-          <div [@detailExpand]="isExpanded(element) ? 'expanded' : 'collapsed'" *ngIf="isExpanded(element)">
-            <planet-markdown
-              class="img-resize"
-              [imageSource]="parent ? 'parent' : 'local'"
-              [content]="element.doc.description">
-            </planet-markdown>
+          <div [@detailExpand]="isExpanded(element) ? 'expanded' : 'collapsed'" (@detailExpand.done)="onExpansionDone($event, element)">
+            <ng-container *ngIf="element.renderContent && isExpanded(element)">
+              <planet-markdown
+                class="img-resize"
+                [imageSource]="parent ? 'parent' : 'local'"
+                [content]="element.doc.description">
+              </planet-markdown>
+            </ng-container>
           </div>
         </mat-cell>
       </ng-container>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -155,9 +155,6 @@
             </ng-container>
           </mat-chip-list>
           <div class="content">
-            <span i18n *ngIf="element.doc.sourcePlanet !== planetConfiguration.code && element.doc.sourcePlanet">
-              (source:{{ element.doc.sourcePlanet }})
-            </span>
             <planet-markdown *ngIf="!isExpanded(element)" [content]="element.doc.description" [imageSource]="parent ? 'parent' : 'local'" [previewMode]="!isExpanded(element)" [limit]="350"></planet-markdown>
             <div *ngIf="element.doc.description.length > 350"  style="text-align: center;" (click)="toggleRow(element); $event.stopPropagation()">
               <button mat-icon-button>
@@ -218,6 +215,9 @@
             <p *ngIf="element.doc.languageOfInstruction">
               <ng-container i18n>Language:</ng-container>{{ " " }}
               <planet-language-label [options]="languages" [label]="element.doc.languageOfInstruction"></planet-language-label>
+            </p>
+            <p *ngIf="element.doc.sourcePlanet !== planetConfiguration.code && element.doc.sourcePlanet">
+              <ng-container i18n>Source: </ng-container>{{ element.doc.sourcePlanet }}
             </p>
           </div>
         </mat-cell>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -105,7 +105,7 @@
   </ng-template>
 
   <div [ngClass]="{ 'view-container view-full-height view-table': !isForm }">
-    <mat-table #table [dataSource]="courses" matSort [matSortDisableClear]="true" [trackBy]="trackById">
+    <mat-table #table [dataSource]="courses" matSort [matSortDisableClear]="true" [trackBy]="trackById" multiTemplateDataRows>
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>
           <mat-checkbox (change)="$event ? masterToggle() : null"
@@ -155,13 +155,15 @@
             </ng-container>
           </mat-chip-list>
           <div class="content">
-            <planet-markdown
-              class="img-wrap"
-              [imageSource]="parent ? 'parent' : 'local'"
-              i18n-content [content]="element.doc.sourcePlanet !== planetConfiguration.code && element.doc.sourcePlanet ?
-              '(source: ' + element.doc.sourcePlanet + ') ' + element.doc.description :
-              element.doc.description">
-            </planet-markdown>
+            <span i18n *ngIf="element.doc.sourcePlanet !== planetConfiguration.code && element.doc.sourcePlanet">
+              (source:{{ element.doc.sourcePlanet }})
+            </span>
+            <planet-markdown *ngIf="!isExpanded(element)" [content]="element.doc.description" [imageSource]="parent ? 'parent' : 'local'" [previewMode]="!isExpanded(element)" [limit]="350"></planet-markdown>
+            <div *ngIf="element.doc.description.length > 350"  style="text-align: center;" (click)="toggleRow(element); $event.stopPropagation()">
+              <button mat-icon-button>
+                <mat-icon>{{ isExpanded(element) ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}</mat-icon>
+              </button>
+            </div>
           </div>
           <planet-local-status [status]="element.localStatus"></planet-local-status>
           <button *ngIf="!parent && !isDialog && !isForm" class="menu" mat-icon-button [matMenuTriggerFor]="resourceMenu">
@@ -233,8 +235,20 @@
           <planet-rating class="rating-item compress-rating" [rating]="element.rating" [item]="element.doc" [parent]="parent" [ratingType]="'course'" [disabled]="isDialog || isForm"></planet-rating>
         </mat-cell>
       </ng-container>
+      <ng-container matColumnDef="expandedDetail">
+        <mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+          <div [@detailExpand]="isExpanded(element) ? 'expanded' : 'collapsed'" *ngIf="isExpanded(element)">
+            <planet-markdown
+              class="img-resize"
+              [imageSource]="parent ? 'parent' : 'local'"
+              [content]="element.doc.description">
+            </planet-markdown>
+          </div>
+        </mat-cell>
+      </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns;" [ngClass]="{highlight:selection.isSelected(row._id)}"></mat-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns;" [class.expanded-row]="isExpanded(row)"></mat-row>
+      <mat-row *matRowDef="let row; columns: ['expandedDetail'];" [@detailExpand]="isExpanded(row) ? 'expanded' : 'collapsed'"></mat-row>
       <tr class="mat-row" *matNoDataRow>
         <td><div class="view-container" i18n>{{ isLoading ? 'Courses Loading...' : 'No Course Found' }}</div></td>
       </tr>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -44,7 +44,7 @@ import { CoursesSearchComponent } from './search-courses/courses-search.componen
       state('expanded', style({ height: '*' })),
       transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
     ]),
-  ],
+  ]
 })
 
 export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDestroy {
@@ -487,6 +487,10 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
 
   toggleRow(element: any) {
     this.expandedElement = this.expandedElement === element ? null : element;
+  }
+
+  onExpansionDone(event: any, element: any) {
+    element.renderContent = (event.toState === 'expanded');
   }
 
   isExpanded(element: any): boolean {

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -1,15 +1,12 @@
 import { Component, OnInit, AfterViewInit, ViewChild, OnDestroy, HostListener, Input, OnChanges } from '@angular/core';
-import { CouchService } from '../shared/couchdb.service';
-import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { PlanetMessageService } from '../shared/planet-message.service';
 import { SelectionModel } from '@angular/cdk/collections';
 import { Router, ActivatedRoute, } from '@angular/router';
 import { FormBuilder, FormGroup, FormControl, } from '@angular/forms';
-import { UserService } from '../shared/user.service';
 import { Subject, of } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import {
@@ -22,6 +19,10 @@ import { languages } from '../shared/languages';
 import { SyncService } from '../shared/sync.service';
 import { DialogsListService } from '../shared/dialogs/dialogs-list.service';
 import { DialogsListComponent } from '../shared/dialogs/dialogs-list.component';
+import { UserService } from '../shared/user.service';
+import { CouchService } from '../shared/couchdb.service';
+import { PlanetMessageService } from '../shared/planet-message.service';
+import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { CoursesService } from './courses.service';
 import { dedupeShelfReduce, findByIdInArray } from '../shared/utils';
 import { StateService } from '../shared/state.service';
@@ -36,7 +37,14 @@ import { CoursesSearchComponent } from './search-courses/courses-search.componen
 @Component({
   selector: 'planet-courses',
   templateUrl: './courses.component.html',
-  styleUrls: [ './courses.scss' ]
+  styleUrls: [ './courses.scss' ],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({ height: '0px', minHeight: '0' })),
+      state('expanded', style({ height: '*' })),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
 })
 
 export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDestroy {
@@ -105,6 +113,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   deviceTypes: typeof DeviceType = DeviceType;
   showFilters = false;
   showFiltersRow = false;
+  expandedElement: any = null;
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;
@@ -474,6 +483,14 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     if (tag.trim()) {
       this.tagInputComponent.writeValue([ tag ]);
     }
+  }
+
+  toggleRow(element: any) {
+    this.expandedElement = this.expandedElement === element ? null : element;
+  }
+
+  isExpanded(element: any): boolean {
+    return this.expandedElement === element;
   }
 
 }

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -67,6 +67,18 @@ $label-height: 1rem;
   display: inline-block;
 }
 
+.mat-row.expanded-row {
+  border: none;
+}
+
+.mat-row.expanded-row td {
+  padding: 0;
+}
+
+.content {
+  max-height: 13rem !important;
+}
+
 @media(max-width: $screen-md) {
   .mat-column-info {
     max-width: 120px;

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -75,19 +75,6 @@ $label-height: 1rem;
   padding: 0;
 }
 
-.expandable-container {
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-}
-
-.expandable-content {
-  position: relative;
-  padding: 16px;
-  width: 100%;
-}
-
 @media(max-width: $screen-md) {
   .mat-column-info {
     max-width: 120px;

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -75,10 +75,6 @@ $label-height: 1rem;
   padding: 0;
 }
 
-.content {
-  max-height: 18rem !important;
-}
-
 .expandable-container {
   overflow: hidden;
   display: flex;

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -76,7 +76,7 @@ $label-height: 1rem;
 }
 
 .content {
-  max-height: 15rem !important;
+  max-height: 18rem !important;
 }
 
 .expandable-container {

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -76,7 +76,20 @@ $label-height: 1rem;
 }
 
 .content {
-  max-height: 13rem !important;
+  max-height: 15rem !important;
+}
+
+.expandable-container {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.expandable-content {
+  position: relative;
+  padding: 16px;
+  width: 100%;
 }
 
 @media(max-width: $screen-md) {

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -67,14 +67,6 @@ $label-height: 1rem;
   display: inline-block;
 }
 
-.mat-row.expanded-row {
-  border: none;
-}
-
-.mat-row.expanded-row td {
-  padding: 0;
-}
-
 @media(max-width: $screen-md) {
   .mat-column-info {
     max-width: 120px;

--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -4,7 +4,17 @@ import { StateService } from './state.service';
 
 @Component({
   selector: 'planet-markdown',
-  template: '<td-markdown [content]="content" [hostedUrl]="couchAddress"></td-markdown>',
+  template: `
+    <ng-container *ngIf="previewMode; else noPreview">
+      <td-markdown [content]="limitedContent"></td-markdown>
+      <div class="image-gallery" *ngIf="images?.length">
+        <img *ngFor="let image of images" [src]="image" class="minified-image" alt="Preview Image" />
+      </div>
+    </ng-container>
+    <ng-template #noPreview>
+      <td-markdown [content]="content" [hostedUrl]="couchAddress"></td-markdown>
+    </ng-template>
+  `,
   styleUrls: [ './planet-markdown.scss' ],
   encapsulation: ViewEncapsulation.None
 })
@@ -12,7 +22,11 @@ export class PlanetMarkdownComponent implements OnChanges {
 
   @Input() content: string;
   @Input() imageSource: 'parent' | 'local' = 'local';
+  @Input() previewMode: boolean;
+  @Input() limit: number;
   couchAddress: string;
+  images: string[] = [];
+  limitedContent: string;
 
   constructor(
     private stateService: StateService,
@@ -22,5 +36,28 @@ export class PlanetMarkdownComponent implements OnChanges {
     this.couchAddress = this.imageSource === 'parent' ?
       `${environment.parentProtocol}://${this.stateService.configuration.parentDomain}/` :
       `${environment.couchAddress}/`;
+
+    this.images = this.extractImageUrls(this.content);
+    this.limitedContent = this.applyCharacterLimit(this.content, this.limit);
+  }
+
+  private extractImageUrls(content: string): string[] {
+    const imageRegex = /!\[.*?\]\((.*?)\)/g;
+    const matches: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = imageRegex.exec(content)) !== null) {
+      const url = match[1];
+      matches.push(url.startsWith('http') ? url : `${this.couchAddress}${url}`);
+    }
+    return matches;
+  }
+
+  private applyCharacterLimit(content: string, limit: number): string {
+    if (!limit) {
+      return content;
+    }
+    const textOnly = content.replace(/!\[.*?\]\(.*?\)/g, '');
+
+    return textOnly.length > limit ? textOnly.slice(0, limit) + '...' : textOnly;
   }
 }

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -17,7 +17,7 @@ planet-markdown.img-resize td-markdown.td-markdown {
   }
 
   img {
-    max-width: 50%;
+    max-width: 25%;
   }
 }
 

--- a/src/app/shared/planet-markdown.scss
+++ b/src/app/shared/planet-markdown.scss
@@ -20,3 +20,22 @@ planet-markdown.img-resize td-markdown.td-markdown {
     max-width: 50%;
   }
 }
+
+.image-gallery {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.minified-image {
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out;
+}
+
+.minified-image:hover {
+  transform: scale(1.1);
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -191,6 +191,14 @@ body {
 
   }
 
+  .mat-row.expanded-row {
+    border: none;
+  }
+
+  .mat-row.expanded-row td {
+    padding: 0;
+  }
+
   .list-content-menu-auto {
     grid-template-rows: auto 1fr min-content;
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -171,7 +171,7 @@ body {
       grid-area: cn;
       text-align: justify;
       text-justify: inter-word;
-      max-height: 6rem;
+      max-height: 15rem;
       overflow-y: auto;
       margin: 0.5rem 0;
     }


### PR DESCRIPTION
Fixes #8521

Improvements on the courses list
- Use mat table expansions instead of scrollbars & allow for more flexible table row length
- Upgrade planet markdown component to support new image gallery for preview mode in non-expanded mode
- While expanding using `img-resize` class for planet markdown as well as reduce image resizing to 25%
- Move the source info to the information column


https://github.com/user-attachments/assets/6ad467eb-0bf2-401e-9ae6-7b481af42e81


