### PR TITLE
dashboard: smoother tile ordering (fixes #4653)(fixes #7884)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.46",
+  "version": "0.18.47",
   "myplanet": {
-    "latest": "v0.24.90",
-    "min": "v0.23.90"
+    "latest": "v0.25.3",
+    "min": "v0.24.3"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -17,8 +17,8 @@
         <ng-container *planetAuthorizedRoles="item.authorization || '_any'">
           <div
             class="dashboard-item"
-            [ngClass]="{'bg-grey': even, 'cursor-pointer': item.link}"
-            [routerLink]="item.link"
+            [ngClass]="{'bg-grey': even, 'cursor-pointer': item.link && !recentlyDragged}"
+            [routerLink]="recentlyDragged ? null : item.link"
             [matTooltip]="item.tooltip"
             cdkDrag
             [cdkDragDisabled]="cardType==='myLife'"

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -96,6 +96,7 @@ export class DashboardTileComponent implements AfterViewChecked {
         moveItemInArray(this.itemData, event.currentIndex, event.previousIndex);
       }
     );
+    this.userService.skipNextShelfRefresh = true;
     setTimeout(() => {
       this.recentlyDragged = false;
     }, 300);

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -87,6 +87,15 @@ export class DashboardTileComponent implements AfterViewChecked {
   drop(event: CdkDragDrop<string[]>) {
     this.recentlyDragged = true;
     moveItemInArray(this.itemData, event.previousIndex, event.currentIndex);
+    const uniqueItems = [];
+    const seen = new Set();
+    for (const item of this.itemData) {
+      if (item && item._id && !seen.has(item._id)) {
+        seen.add(item._id);
+        uniqueItems.push(item);
+      }
+    }
+    this.itemData = uniqueItems;
     const ids = this.itemData
       .filter(item => item !== null && item !== undefined)
       .map(item => item._id || item);

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -87,8 +87,9 @@ export class DashboardTileComponent implements AfterViewChecked {
   drop(event: CdkDragDrop<string[]>) {
     this.recentlyDragged = true;
     moveItemInArray(this.itemData, event.previousIndex, event.currentIndex);
-    const ids = [ ...this.userService.shelf[this.shelfName] ];
-    ids.splice(event.currentIndex, 0, ids.splice(event.previousIndex, 1)[0]);
+    const ids = this.itemData
+      .filter(item => item !== null && item !== undefined)
+      .map(item => item._id || item);
     this.userService.updateShelf(ids, this.shelfName).subscribe(
       () => {},
       () => {

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -25,6 +25,7 @@ export class DashboardTileComponent implements AfterViewChecked {
   @ViewChild('items') itemDiv: ElementRef;
   dialogPrompt: MatDialogRef<DialogsPromptComponent>;
   tileLines = 2;
+  recentlyDragged = false;
 
   constructor(
     private planetMessageService: PlanetMessageService,
@@ -84,6 +85,7 @@ export class DashboardTileComponent implements AfterViewChecked {
   }
 
   drop(event: CdkDragDrop<string[]>) {
+    this.recentlyDragged = true;
     moveItemInArray(this.itemData, event.previousIndex, event.currentIndex);
     const ids = [ ...this.userService.shelf[this.shelfName] ];
     ids.splice(event.currentIndex, 0, ids.splice(event.previousIndex, 1)[0]);
@@ -94,6 +96,9 @@ export class DashboardTileComponent implements AfterViewChecked {
         moveItemInArray(this.itemData, event.currentIndex, event.previousIndex);
       }
     );
+    setTimeout(() => {
+      this.recentlyDragged = false;
+    }, 300);
   }
 }
 

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -6,7 +6,7 @@ import { CouchService } from '../shared/couchdb.service';
 import { HttpClientModule } from '@angular/common/http';
 import { DashboardComponent } from './dashboard.component';
 import { UserService } from '../shared/user.service';
-import { of } from 'rxjs/observable/of';
+import { of } from 'rxjs';
 
 describe('Dashboard', () => {
 

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -6,7 +6,7 @@ import { CouchService } from '../shared/couchdb.service';
 import { HttpClientModule } from '@angular/common/http';
 import { DashboardComponent } from './dashboard.component';
 import { UserService } from '../shared/user.service';
-import { of } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 describe('Dashboard', () => {
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -115,7 +115,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.data.resources = dashboardItems[0];
       this.data.courses = dashboardItems[1];
       this.data.meetups = dashboardItems[2];
-      this.data.myTeams = [ ...dashboardItems[3].map(team => ({ ...team, fromShelf: true })), ...dashboardItems[4] ]
+      const allTeams = [ ...dashboardItems[3].map(team => ({ ...team, fromShelf: true })), ...dashboardItems[4] ];
+      this.data.myTeams = dedupeObjectArray(allTeams, [ '_id' ])
         .filter(team => team.status !== 'archived');
     });
   }

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -21,14 +21,17 @@ export class UserService {
   private usersDb = '_users';
   private logsDb = 'login_activities';
   private _shelf: any = { };
+  skipNextShelfRefresh = false;
+
   get shelf(): any {
     return this._shelf;
   }
   set shelf(shelf: any) {
     this._shelf = shelf;
-    if (Object.keys(shelf).length > 0) {
+    if (Object.keys(shelf).length > 0 && !this.skipNextShelfRefresh) {
       this.shelfChange.next(shelf);
     }
+    this.skipNextShelfRefresh = false;
   }
   currentSession: any;
   userProperties: string[] = [];


### PR DESCRIPTION
fixes #4653, #7884

Reordering tiles no longer gets reverted.
Navigation is briefly blocked while reordering to prevent accidentally navigating away. 