### PR TITLE
courses: smoother list data language (fixes #8522)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.18",
+  "version": "0.18.33",
   "myplanet": {
     "latest": "v0.24.57",
     "min": "v0.23.57"

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -215,7 +215,7 @@
             <p><ng-container i18n>Subject Level:</ng-container>{{ " " }}<planet-language-label [options]="subjectOptions" [label]="element.doc.subjectLevel"></planet-language-label></p>
             <p *ngIf="element.doc.languageOfInstruction">
               <ng-container i18n>Language:</ng-container>{{ " " }}
-              <planet-language-label [options]="languages" [label]="element.doc.languageOfInstruction"></planet-language-label>
+              {{element.doc.languageOfInstruction}}
             </p>
           </div>
         </mat-cell>

--- a/src/app/courses/view-courses/courses-view-detail.component.html
+++ b/src/app/courses/view-courses/courses-view-detail.component.html
@@ -1,7 +1,7 @@
 <planet-rating [rating]="courseDetail?.rating" [item]="courseDetail" [parent]="false" [ratingType]="'course'"></planet-rating>
 <p><b i18n>Subject Level:</b> <planet-language-label [options]="subjectOptions" [label]="courseDetail?.subjectLevel"></planet-language-label></p>
 <p><b i18n>Grade Level:</b> <planet-language-label [options]="gradeOptions" [label]="courseDetail?.gradeLevel"></planet-language-label></p>
-<p *ngIf="courseDetail?.languageOfInstruction"><b i18n>Language of Instruction:</b> <planet-language-label [options]="languageOptions" [label]="courseDetail?.languageOfInstruction || 'N/A'"></planet-language-label></p>
+<p *ngIf="courseDetail?.languageOfInstruction"><b i18n>Language of Instruction:</b> {{courseDetail?.languageOfInstruction}}</p>
 <p *ngIf="courseDetail?.creatorDoc"><b i18n>Creator:</b> {{courseDetail?.creatorDoc?.fullName}} </p>
 <p><b i18n>Created on:</b> {{(courseDetail?.createdDate | date: 'mediumDate') || 'N/A'}}</p>
 <p *ngIf="courseDetail?.sourcePlanet !== planetConfiguration.code && courseDetail?.sourcePlanet"><b i18n>Source:</b> {{courseDetail?.sourcePlanet}}</p>


### PR DESCRIPTION
fixes: #8522 

![image](https://github.com/user-attachments/assets/85fb6fb6-19b4-48a2-a0b7-6093b62e6b15)

![image](https://github.com/user-attachments/assets/effbbfdf-73ba-4fe6-adfc-624931adba34)

Now ff a language is not in the language list, we will not end up having a blank field.

