### PR TITLE
meetups: only show edit and delete buttons if user logged in (fixes #8548)

### DIFF
--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -28,7 +28,7 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   @Input() editable = true;
   @Output() switchView = new EventEmitter<'close' | 'add'>();
   private onDestroy$ = new Subject<void>();
-  canManage = true;
+  canManage = false;
   members = [];
   parent = this.route.snapshot.data.parent;
   listDialogRef: MatDialogRef<DialogsListComponent>;
@@ -51,6 +51,7 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.canManage = this.userService.get()?._id;
     this.getEnrolledUsers();
     this.meetupService.meetupUpdated$.pipe(takeUntil(this.onDestroy$))
       .subscribe((meetupArray) => {


### PR DESCRIPTION
Fixes #8548 

To test:
- From logged in state create a meetup on the calendar
- Confirm by clicking to view the meetup that the edit and delete buttons are there
- Log out
- Go to community page & confirm the buttons do not appear when viewing the meetup details


Logged in expected:
![image](https://github.com/user-attachments/assets/74452ec6-164a-40c2-9177-27871bf81379)

Logged out expected:
![image](https://github.com/user-attachments/assets/02ff561d-839c-4568-8d79-c8f87fbdb571)

