### PR TITLE
community: smoother voices loading (fixes #8551)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.28",
+  "version": "0.18.30",
   "myplanet": {
     "latest": "v0.24.68",
     "min": "v0.23.68"

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -149,7 +149,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
       }),
       switchMap(configurations => {
         this.configuration = configurations[0];
-        this.team = this.teamObject(this.planetCode);
+        this.team = this.teamObject(this.configuration, this.planetCode);
         this.teamId = this.team._id;
         this.requestNewsAndUsers(this.planetCode);
         return this.getLinks(this.planetCode);
@@ -240,9 +240,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
     };
   }
 
-  teamObject(planetCode?: string) {
-    const code = planetCode || this.stateService.configuration.code;
-    const parentCode = planetCode ? this.stateService.configuration.code : this.stateService.configuration.parentCode;
+  teamObject(configuration, planetCode?: string) {
+    const code = planetCode || configuration.code;
+    const parentCode = planetCode ? configuration.code : configuration.parentCode;
     const teamId = `${code}@${parentCode}`;
     return { _id: teamId, teamType: 'sync', teamPlanetCode: code, type: 'services' };
   }

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -148,8 +148,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
           of([ this.stateService.configuration ]);
       }),
       switchMap(configurations => {
+        // Configuration is for planet that is being viewed, not planet the user is on
         this.configuration = configurations[0];
-        this.team = this.teamObject(this.configuration, this.planetCode);
+        this.team = this.teamObject(this.configuration);
         this.teamId = this.team._id;
         this.requestNewsAndUsers(this.planetCode);
         return this.getLinks(this.planetCode);
@@ -240,9 +241,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
     };
   }
 
-  teamObject(configuration, planetCode?: string) {
-    const code = planetCode || configuration.code;
-    const parentCode = planetCode ? configuration.code : configuration.parentCode;
+  teamObject(configuration) {
+    const code = configuration.code;
+    const parentCode = configuration.parentCode;
     const teamId = `${code}@${parentCode}`;
     return { _id: teamId, teamType: 'sync', teamPlanetCode: code, type: 'services' };
   }


### PR DESCRIPTION
fixes #8551 

It appears that sometimes in production the request for voices runs before the configuration is set on `stateService`. Since we are already fetching the configuraiton in `CommunityComponent`, we can use that configuration to make sure it is up to date.