### PR TITLE
teams: smoother calendar events list (fixes #8553)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.24",
+  "version": "0.18.41",
   "myplanet": {
     "latest": "v0.24.64",
     "min": "v0.23.64"

--- a/src/app/meetups/meetups.component.html
+++ b/src/app/meetups/meetups.component.html
@@ -65,7 +65,7 @@
                 <span *ngIf="element.participate; else joinMeetup"><mat-icon>clear</mat-icon><span i18n>Leave</span></span>
                 <ng-template #joinMeetup><mat-icon>done</mat-icon><span i18n>Join</span></ng-template>
               </a>
-              <a mat-menu-item planetFeedback [feedbackOf]="{'state': 'meetups', 'item': element._id, name: element.doc.title}" i18n-title title="Feedback">
+              <a mat-menu-item planetFeedback [feedbackOf]="{'state': 'meetups', 'item': element._id, name: element.title}" i18n-title title="Feedback">
                 <mat-icon>feedback</mat-icon>
                 <span i18n>Feedback</span>
               </a>


### PR DESCRIPTION
Fixes #8553 

Meetups list now renders correctly without the infinite looping

![image](https://github.com/user-attachments/assets/f0f2c4e8-9311-4b5e-95d1-cb3ee03150f8)
