### PR TITLE
mylife: smoother achievements view (fixes #8557)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.31",
+  "version": "0.18.40",
   "myplanet": {
     "latest": "v0.24.68",
     "min": "v0.23.68"

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -74,7 +74,7 @@
           <h3 i18n>My Achievements</h3>
           <td-markdown [content]="achievements.achievementsHeader"></td-markdown>
           <mat-list>
-            <mat-list-item class="mat-list-item-word-wrap" [ngClass]="{'cursor-pointer':isClickable(achievement)}" *ngFor="let achievement of achievements.achievements; index as i" (click)="toggleOpenAchievementIndex(i)">
+            <mat-list-item class="mat-list-item-word-wrap" [ngClass]="{'cursor-pointer':isClickable(achievement)}" *ngFor="let achievement of achievements.achievements; index as i" (click)="onAchievementClick(achievement, i)">
               <p class="achievement-header" mat-line>
                 <span class="achievement-text">{{achievement.title || achievement}}
                   <ng-container *ngIf="isClickable(achievement)">

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -106,9 +106,18 @@ export class UsersAchievementsComponent implements OnInit {
     this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
   }
 
-  isClickable(achievement) {
-    return achievement.description.length > 0;
+  isClickable(achievement): boolean {
+    return (!!achievement.description && achievement.description.length > 0)
+        || (!!achievement.link        && achievement.link.length > 0);
   }
+
+  onAchievementClick(achievement: any, index: number): void {
+    if (!this.isClickable(achievement)) {
+      return;
+    }
+    this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
+  }
+  
 
   get profileImg() {
     const attachments = this.userService.get()._attachments;


### PR DESCRIPTION
fixes #8557
The empty achievements is not clickable now. I also optimized the logic that the isclickable method will also test the link
https://github.com/user-attachments/assets/8400dff5-2738-48d3-af8b-923125c78d6c

