### PR TITLE
manager: smoother survey error message (fixes #8570)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.36",
+  "version": "0.18.44",
   "myplanet": {
     "latest": "v0.24.75",
     "min": "v0.23.75"

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -641,8 +641,14 @@ export class SubmissionsService {
       this.planetMessageService.showMessage($localize`AI analysis completed successfully.`);
       return response;
     } catch (error) {
-      this.planetMessageService.showAlert($localize`Error analyzing responses: ${error.message}`);
-      return $localize`Unable to analyze responses`;
+      let message = '';
+      if (error && error.status === 0) {
+        message = $localize`Error analyzing responses: Chat API is not available.`;
+      } else {
+        message = $localize`Error analyzing responses: ${error.message || error}`;
+      }
+      this.planetMessageService.showAlert(message);
+      return { chat: message };
     }
   }
 


### PR DESCRIPTION
fixes #8570

When the chatapi is unavailable, such as when the container is not running, the error message is now more accurate. 

![image](https://github.com/user-attachments/assets/113d6364-5cdb-4f50-b5b9-4516a12f1e5e)
