### PR TITLE
dashboard: smoother tile visibility (fixes #8577)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.46",
+  "version": "0.18.50",
   "myplanet": {
     "latest": "v0.24.90",
     "min": "v0.23.90"

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -52,7 +52,7 @@
           text-align: center;
           padding: 1rem 0.5rem;
           position: relative;
-          word-break: break-word;        
+          word-break: break-word;
           &:nth-child(even):last-child {
             border-right: 1px solid rgba(0, 0, 0, 0.1);
           }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -52,7 +52,10 @@
           text-align: center;
           padding: 1rem 0.5rem;
           position: relative;
-          word-break: break-word;
+          word-break: break-word;        
+          &:nth-child(even):last-child {
+            border-right: 1px solid rgba(0, 0, 0, 0.1);
+          }
           .delete-item {
             position: absolute;
             top: -0.25rem;

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -108,7 +108,7 @@ export class UsersAchievementsComponent implements OnInit {
 
   isClickable(achievement): boolean {
     return (!!achievement.description && achievement.description.length > 0)
-        || (!!achievement.link        && achievement.link.length > 0);
+        || (!!achievement.link && achievement.link.length > 0);
   }
 
   onAchievementClick(achievement: any, index: number): void {
@@ -117,7 +117,7 @@ export class UsersAchievementsComponent implements OnInit {
     }
     this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
   }
-  
+
 
   get profileImg() {
     const attachments = this.userService.get()._attachments;


### PR DESCRIPTION
fixes #8577

If the very last tile in the dashboard is white, I added a subtle right border to prevent it from blending in with the background. 

![Image](https://github.com/user-attachments/assets/30141fe8-4158-443b-86a6-b65f5c7ea244)

The linter also prompted me to make this unrelated fix to users-achievements. 