### PR TITLE
manager: smoother reports export (fixes #8583)

### DIFF
--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -440,7 +440,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
 
   openExportDialog(reportType: 'logins' | 'resourceViews' | 'courseViews' | 'summary' | 'health' | 'stepCompletions' | 'coursesOverview' | 'resourcesOverview' | 'chat') {
     const minDate = new Date(this.activityService.minTime(this.loginActivities.data, 'loginTime')).setHours(0, 0, 0, 0);
-    const commonProps = { type: 'date', required: true, min: new Date(minDate), max: new Date(this.today) };
+    const commonProps = { type: 'date', required: true, max: new Date(this.today) };
     if (reportType === 'coursesOverview' || reportType === 'resourcesOverview') {
       const exportFields = [
         { placeholder: $localize`From`, name: 'startDate', ...commonProps },

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -108,7 +108,7 @@ export class UsersAchievementsComponent implements OnInit {
 
   isClickable(achievement): boolean {
     return (!!achievement.description && achievement.description.length > 0)
-        || (!!achievement.link        && achievement.link.length > 0);
+        || (!!achievement.link && achievement.link.length > 0);
   }
 
   onAchievementClick(achievement: any, index: number): void {
@@ -117,7 +117,7 @@ export class UsersAchievementsComponent implements OnInit {
     }
     this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
   }
-  
+
 
   get profileImg() {
     const attachments = this.userService.get()._attachments;


### PR DESCRIPTION
fixes #8583

I removed the unnecessary min date export restriction. Now even if the start date is before the earliest data, it will still export data if there is data in that range. 

