### PR TITLE
teams: smoother voices replies (fixes #8580)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.42",
+  "version": "0.18.46",
   "myplanet": {
     "latest": "v0.24.80",
     "min": "v0.23.80"

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -436,9 +436,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
     if (index === 0) {
       const activeReplyId = this.newsService.getActiveReplyId();
       const targetUrl = activeReplyId ? `/voices/${activeReplyId}` : '';
-      this.router.navigate([targetUrl]);
+      this.router.navigate([ targetUrl ]);
     } else {
-      this.router.navigate(['']);
+      this.router.navigate([ '' ]);
     }
     this.resizeCalendar = index === 5;
   }

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -433,8 +433,12 @@ export class CommunityComponent implements OnInit, OnDestroy {
   }
 
   tabChanged({ index }: { index: number }) {
-    if (index !== 0) {
-      this.router.navigate([ '' ]);
+    if (index === 0) {
+      const activeReplyId = this.newsService.getActiveReplyId();
+      const targetUrl = activeReplyId ? `/voices/${activeReplyId}` : '';
+      this.router.navigate([targetUrl]);
+    } else {
+      this.router.navigate(['']);
     }
     this.resizeCalendar = index === 5;
   }

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -89,8 +89,10 @@ export class NewsListComponent implements OnInit, OnChanges {
 
     const isHomeRoute = this.router.url === '/';
     if (isHomeRoute && news._id !== 'root') {
+      this.newsService.setActiveReplyId(news._id);
       this.router.navigate([ '/voices', news._id ]);
     } else if (isHomeRoute || this.replyViewing._id === 'root') {
+      this.newsService.setActiveReplyId(null);
       this.router.navigate([ '' ]);
     }
   }

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -87,9 +87,10 @@ export class NewsListComponent implements OnInit, OnChanges {
       );
     this.viewChange.emit(this.replyViewing);
 
-    if (news._id !== 'root') {
+    const isHomeRoute = this.router.url === '/';
+    if (isHomeRoute && news._id !== 'root') {
       this.router.navigate([ '/voices', news._id ]);
-    } else {
+    } else if (isHomeRoute || this.replyViewing._id === 'root') {
       this.router.navigate([ '' ]);
     }
   }

--- a/src/app/news/news.service.ts
+++ b/src/app/news/news.service.ts
@@ -19,6 +19,7 @@ export class NewsService {
   imgUrlPrefix = environment.couchAddress;
   newsUpdated$ = new Subject<any[]>();
   currentOptions: { selectors: any, viewId: string } = { selectors: {}, viewId: '' };
+  private activeReplyId: string | null = null;
 
   constructor(
     private couchService: CouchService,
@@ -127,6 +128,14 @@ export class NewsService {
 
   postSharedWithCommunity(post) {
     return post && post.doc && (post.doc.viewIn || []).some(({ _id }) => _id === planetAndParentId(this.stateService.configuration));
+  }
+
+  setActiveReplyId(replyId: string | null) {
+    this.activeReplyId = replyId;
+  }
+
+  getActiveReplyId(): string | null {
+    return this.activeReplyId;
   }
 
 }

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -107,8 +107,7 @@ export class UsersAchievementsComponent implements OnInit {
   }
 
   isClickable(achievement): boolean {
-    return (!!achievement.description && achievement.description.length > 0)
-        || (!!achievement.link        && achievement.link.length > 0);
+    return (!!achievement.description && achievement.description.length > 0) || (!!achievement.link && achievement.link.length > 0);
   }
 
   onAchievementClick(achievement: any, index: number): void {
@@ -117,7 +116,6 @@ export class UsersAchievementsComponent implements OnInit {
     }
     this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
   }
-  
 
   get profileImg() {
     const attachments = this.userService.get()._attachments;


### PR DESCRIPTION
Fixes #8580

![image](https://github.com/user-attachments/assets/bae480a5-f4e1-4bbf-8638-71233606c582)

Main: Fix the **team** replies redirecting to the community voices.
- Should be able to view the voice reply in the teams

Sub issue: Improve **community voices** state management on url routing
- Should be able to switch community tabs and return to the reply voice which updates with the correct url