### PR TITLE
home: smoother Planet name (fixes #8617)

### DIFF
--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -24,6 +24,10 @@
     h1 {
       display: inline;
       font-size: 1.5rem;
+      
+      @media (max-width: 480px) {
+        font-size: clamp(0.5rem, calc(0.1rem + 3vw), 1.5rem);
+      }
     }
 
     .menu-button {


### PR DESCRIPTION
fixes #8617 

Even a long Planet name like mine will now shrink to fit small screens. Previously, the Planet name was not shrinking, which limited the narrowness of screens and required horizontal scrolling. 

480px
![image](https://github.com/user-attachments/assets/4c71174d-c540-4db7-a6bf-1da71e8f6e8f)

350px
![image](https://github.com/user-attachments/assets/f6eb30c6-41e5-496a-b64b-599500966962)

Waiting on https://github.com/open-learning-exchange/planet/pull/8610 so that I can use the new screen-xs variable. 
