### PR TITLE
teams: smoother calendar events display (fixes #8624)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.55",
+  "version": "0.18.61",
   "myplanet": {
     "latest": "v0.25.9",
     "min": "v0.24.9"

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -176,7 +176,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
   }
 
   weeklyEvents(meetup) {
-    if (meetup.day.length === 0 || meetup.recurringNumber === undefined) {
+    if (meetup.day?.length === 0 || meetup.recurringNumber === undefined) {
       return this.eventObject(meetup);
     }
     const events = [];

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -176,7 +176,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
   }
 
   weeklyEvents(meetup) {
-    if (meetup.day?.length === 0 || meetup.recurringNumber === undefined) {
+    if (!Array.isArray(meetup.day) || meetup.day.length === 0 || meetup.recurringNumber === undefined) {
       return this.eventObject(meetup);
     }
     const events = [];
@@ -184,7 +184,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     while (events.length < meetup.recurringNumber) {
       const startDay = meetup.startDate + (i * millisecondsToDay);
       const date = new Date(startDay);
-      if (meetup.day.indexOf(days[date.getDay()]) !== -1) {
+      if (meetup.day.includes(days[date.getDay()])) {
         events.push(this.eventObject(meetup, startDay, meetup.endDate + (i * millisecondsToDay)));
       }
       i++;


### PR DESCRIPTION
Fixes #8624 

Better null checks for the community calendar events, particularly for myPlanet defined events

Currently tested directly on Planet Learning as a hot fix. Is tricky to test given it requires myPlanet generated events to trigger

![image](https://github.com/user-attachments/assets/eb007a3c-367e-4a37-9769-8926a3f5ae7f)
