### PR TITLE
courses: smoother editing (fixes #8631)

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -15,7 +15,7 @@
     <mat-expansion-panel [expanded]="isFormExpanded" class="course-details-panel">
       <mat-expansion-panel-header>
         <mat-panel-title i18n class="course-title-header">
-          Course Details: {{courseForm.controls.courseTitle.value || 'New Course'}}
+          Course Details: {{(courseForm.controls.courseTitle.value || 'New Course') | truncateText:50}}
         </mat-panel-title>
       </mat-expansion-panel-header>
       <div class="form-container">

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -11,13 +11,53 @@
       <mat-icon>{{ isFormExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
     </button>
   </mat-toolbar>
-  <div class="view-container view-full-height">
-    <mat-expansion-panel [expanded]="isFormExpanded" class="course-details-panel" *ngIf="pageType === 'Edit'; else normalForm">
-      <mat-expansion-panel-header>
-        <mat-panel-title i18n class="course-title-header">
-          Course Details: {{courseForm.controls.courseTitle.value}}
-        </mat-panel-title>
-      </mat-expansion-panel-header>
+  <div class="view-container view-full-height" [ngClass]="{'edit-mode': pageType === 'Edit'}">
+    <ng-container *ngIf="pageType === 'Edit'">
+      <mat-expansion-panel [expanded]="isFormExpanded" class="course-details-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title i18n class="course-title-header">
+            Course Details: {{courseForm.controls.courseTitle.value}}
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <div class="form-container">
+          <form [formGroup]="courseForm" class="form-spacing" novalidate>
+            <mat-form-field class="full-width">
+              <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
+              <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+            </mat-form-field>
+            <mat-form-field class="full-width mat-form-field-type-no-underline">
+              <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+              <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+            </mat-form-field>
+            <mat-form-field>
+              <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction" [matAutocomplete]="auto">
+              <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let language of languageNames" [value]="language">
+                  {{ language }}
+                </mat-option>
+              </mat-autocomplete>
+            </mat-form-field>
+            <mat-form-field>
+              <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel" required>
+                <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
+              </mat-select>
+            </mat-form-field>
+            <mat-form-field>
+              <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel" required>
+                <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
+              </mat-select>
+            </mat-form-field>
+            <mat-form-field class="full-width mat-form-field-type-no-underline">
+              <planet-tag-input [formControl]="tags" [db]="dbName" i18n-placeholder placeholder="Labels" mode="add"></planet-tag-input>
+            </mat-form-field>
+          </form>
+        </div>
+      </mat-expansion-panel>
+      <div class="steps-container" *ngIf="steps.length > 0">
+        <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
+      </div>
+    </ng-container>
+    <ng-container *ngIf="pageType === 'Add'">
       <div class="form-container">
         <form [formGroup]="courseForm" class="form-spacing" novalidate>
           <mat-form-field class="full-width">
@@ -51,45 +91,11 @@
           </mat-form-field>
         </form>
       </div>
-    </mat-expansion-panel>
-    <ng-template #normalForm>
-      <div class="form-container">
-        <form [formGroup]="courseForm" class="form-spacing" novalidate>
-          <mat-form-field class="full-width">
-            <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
-            <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
-          </mat-form-field>
-          <mat-form-field class="full-width mat-form-field-type-no-underline">
-            <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-            <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-          </mat-form-field>
-          <mat-form-field>
-            <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction" [matAutocomplete]="auto">
-            <mat-autocomplete #auto="matAutocomplete">
-              <mat-option *ngFor="let language of languageNames" [value]="language">
-                {{ language }}
-              </mat-option>
-            </mat-autocomplete>
-          </mat-form-field>
-          <mat-form-field>
-            <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel" required>
-              <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field>
-            <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel" required>
-              <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field class="full-width mat-form-field-type-no-underline">
-            <planet-tag-input [formControl]="tags" [db]="dbName" i18n-placeholder placeholder="Labels" mode="add"></planet-tag-input>
-          </mat-form-field>
-        </form>
+      <div class="steps-container" *ngIf="steps.length > 0">
+        <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
       </div>
-    </ng-template>
-    <div [ngClass]="{'steps-container': steps.length > 0 }">
-      <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
-    </div>
+    </ng-container>
+    
     <div class="actions-container">
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
       <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -6,41 +6,87 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1">
     <span i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</span>
+    <span class="toolbar-fill"></span>
+    <button mat-icon-button *ngIf="pageType === 'Edit'" (click)="isFormExpanded = !isFormExpanded">
+      <mat-icon>{{ isFormExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+    </button>
   </mat-toolbar>
   <div class="view-container view-full-height">
-    <div class="form-container">
-      <form [formGroup]="courseForm" class="form-spacing" novalidate>
-        <mat-form-field class="full-width">
-          <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
-          <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field class="full-width mat-form-field-type-no-underline">
-          <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-          <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field>
-          <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction" [matAutocomplete]="auto">
-          <mat-autocomplete #auto="matAutocomplete">
-            <mat-option *ngFor="let language of languageNames" [value]="language">
-              {{ language }}
-            </mat-option>
-          </mat-autocomplete>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel" required>
-            <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel" required>
-            <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="full-width mat-form-field-type-no-underline">
-          <planet-tag-input [formControl]="tags" [db]="dbName" i18n-placeholder placeholder="Labels" mode="add"></planet-tag-input>
-        </mat-form-field>
-      </form>
-    </div>
+    <mat-expansion-panel [expanded]="isFormExpanded" class="course-details-panel" *ngIf="pageType === 'Edit'; else normalForm">
+      <mat-expansion-panel-header>
+        <mat-panel-title i18n class="course-title-header">
+          Course Details: {{courseForm.controls.courseTitle.value}}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <div class="form-container">
+        <form [formGroup]="courseForm" class="form-spacing" novalidate>
+          <mat-form-field class="full-width">
+            <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
+            <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+          </mat-form-field>
+          <mat-form-field class="full-width mat-form-field-type-no-underline">
+            <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+            <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction" [matAutocomplete]="auto">
+            <mat-autocomplete #auto="matAutocomplete">
+              <mat-option *ngFor="let language of languageNames" [value]="language">
+                {{ language }}
+              </mat-option>
+            </mat-autocomplete>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel" required>
+              <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel" required>
+              <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="full-width mat-form-field-type-no-underline">
+            <planet-tag-input [formControl]="tags" [db]="dbName" i18n-placeholder placeholder="Labels" mode="add"></planet-tag-input>
+          </mat-form-field>
+        </form>
+      </div>
+    </mat-expansion-panel>
+    <ng-template #normalForm>
+      <div class="form-container">
+        <form [formGroup]="courseForm" class="form-spacing" novalidate>
+          <mat-form-field class="full-width">
+            <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
+            <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+          </mat-form-field>
+          <mat-form-field class="full-width mat-form-field-type-no-underline">
+            <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+            <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction" [matAutocomplete]="auto">
+            <mat-autocomplete #auto="matAutocomplete">
+              <mat-option *ngFor="let language of languageNames" [value]="language">
+                {{ language }}
+              </mat-option>
+            </mat-autocomplete>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel" required>
+              <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel" required>
+              <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="full-width mat-form-field-type-no-underline">
+            <planet-tag-input [formControl]="tags" [db]="dbName" i18n-placeholder placeholder="Labels" mode="add"></planet-tag-input>
+          </mat-form-field>
+        </form>
+      </div>
+    </ng-template>
     <div [ngClass]="{'steps-container': steps.length > 0 }">
       <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
     </div>

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -52,7 +52,7 @@
         </form>
       </div>
     </mat-expansion-panel>
-    <div class="steps-container">
+    <div class="steps-container" [ngClass]="{'has-steps': steps.length > 0}" *ngIf="steps.length > 0">
       <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
     </div>
     <div class="actions-container">

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -53,8 +53,13 @@
           </form>
         </div>
       </mat-expansion-panel>
-      <div class="steps-container" *ngIf="steps.length > 0">
+      <div class="steps-container">
         <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
+      </div>
+      <div class="actions-container">
+        <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
+        <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
+        <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
       </div>
     </ng-container>
     <ng-container *ngIf="pageType === 'Add'">
@@ -91,15 +96,14 @@
           </mat-form-field>
         </form>
       </div>
-      <div class="steps-container" *ngIf="steps.length > 0">
+      <div class="steps-container">
         <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
       </div>
+      <div class="actions-container">
+        <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
+        <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
+        <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
+      </div>
     </ng-container>
-    
-    <div class="actions-container">
-      <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-      <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
-      <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
-    </div>
   </div>
 </div>

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -7,62 +7,17 @@
   <mat-toolbar class="primary-color font-size-1">
     <span i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</span>
     <span class="toolbar-fill"></span>
-    <button mat-icon-button *ngIf="pageType === 'Edit'" (click)="isFormExpanded = !isFormExpanded">
+    <button mat-icon-button (click)="isFormExpanded = !isFormExpanded">
       <mat-icon>{{ isFormExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
     </button>
   </mat-toolbar>
   <div class="view-container view-full-height" [ngClass]="{'edit-mode': pageType === 'Edit'}">
-    <ng-container *ngIf="pageType === 'Edit'">
-      <mat-expansion-panel [expanded]="isFormExpanded" class="course-details-panel">
-        <mat-expansion-panel-header>
-          <mat-panel-title i18n class="course-title-header">
-            Course Details: {{courseForm.controls.courseTitle.value}}
-          </mat-panel-title>
-        </mat-expansion-panel-header>
-        <div class="form-container">
-          <form [formGroup]="courseForm" class="form-spacing" novalidate>
-            <mat-form-field class="full-width">
-              <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
-              <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
-            </mat-form-field>
-            <mat-form-field class="full-width mat-form-field-type-no-underline">
-              <planet-markdown-textbox class="full-width" required="true" i18n-placeholder placeholder="Description" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-              <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-            </mat-form-field>
-            <mat-form-field>
-              <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction" [matAutocomplete]="auto">
-              <mat-autocomplete #auto="matAutocomplete">
-                <mat-option *ngFor="let language of languageNames" [value]="language">
-                  {{ language }}
-                </mat-option>
-              </mat-autocomplete>
-            </mat-form-field>
-            <mat-form-field>
-              <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel" required>
-                <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
-              </mat-select>
-            </mat-form-field>
-            <mat-form-field>
-              <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel" required>
-                <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
-              </mat-select>
-            </mat-form-field>
-            <mat-form-field class="full-width mat-form-field-type-no-underline">
-              <planet-tag-input [formControl]="tags" [db]="dbName" i18n-placeholder placeholder="Labels" mode="add"></planet-tag-input>
-            </mat-form-field>
-          </form>
-        </div>
-      </mat-expansion-panel>
-      <div class="steps-container">
-        <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
-      </div>
-      <div class="actions-container">
-        <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-        <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
-        <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
-      </div>
-    </ng-container>
-    <ng-container *ngIf="pageType === 'Add'">
+    <mat-expansion-panel [expanded]="isFormExpanded" class="course-details-panel">
+      <mat-expansion-panel-header>
+        <mat-panel-title i18n class="course-title-header">
+          Course Details: {{courseForm.controls.courseTitle.value || 'New Course'}}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
       <div class="form-container">
         <form [formGroup]="courseForm" class="form-spacing" novalidate>
           <mat-form-field class="full-width">
@@ -96,14 +51,14 @@
           </mat-form-field>
         </form>
       </div>
-      <div class="steps-container">
-        <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
-      </div>
-      <div class="actions-container">
-        <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-        <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
-        <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
-      </div>
-    </ng-container>
+    </mat-expansion-panel>
+    <div class="steps-container">
+      <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
+    </div>
+    <div class="actions-container">
+      <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
+      <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
+      <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
+    </div>
   </div>
 </div>

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -39,6 +39,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
   hasUnsavedChanges = false;
   private initialState = '';
   private _steps = [];
+  isFormExpanded = true;
   get steps() {
     return this._steps;
   }
@@ -112,8 +113,12 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
       if (saved.error !== 'not_found') {
         this.setDocumentInfo(saved);
         this.pageType = 'Edit';
+        if (saved.steps && saved.steps.length > 0) {
+          this.isFormExpanded = false;
+        }
       } else {
         this.pageType = 'Add';
+        this.isFormExpanded = true;
       }
       const doc = draft === undefined ? saved : draft;
       this.setInitialTags(tags, this.documentInfo, draft);

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -36,8 +36,22 @@
   .course-details-panel {
     margin-bottom: 1rem;
     
+    &:not(.mat-expanded) {
+      overflow: hidden;
+      
+      ::ng-deep .mat-expansion-panel-content {
+        display: none;
+      }
+    }
+    
     ::ng-deep .mat-expansion-panel-body {
       padding: 0 24px 16px;
+    }
+    
+    ::ng-deep .mat-expansion-panel-header {
+      height: 64px;
+      padding: 0 24px;
+      overflow: hidden;
     }
   }
 

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -2,29 +2,60 @@
 
 :host {
   .view-container {
-    display: grid;
-    grid-template-columns: 1.5fr 1fr;
-    grid-template-rows: auto 42px;
-    grid-column-gap: 0.25rem;
-    > * {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    
+    .form-section {
+      flex: 0 0 auto;
+      margin-bottom: 1rem;
+    }
+    
+    .steps-section {
+      flex: 1 1 auto;
       overflow-y: auto;
+      min-height: 200px;
+    }
+    
+    .actions-section {
+      flex: 0 0 auto;
+      padding: 10px 0;
     }
   }
 
-  .steps-container {
-    grid-row: span 2;
+  .course-details-panel {
+    margin-bottom: 1rem;
+    
+    ::ng-deep .mat-expansion-panel-body {
+      padding: 0 24px 16px;
+    }
   }
 
-  .actions-container {
-    align-self: center;
+  .course-title-summary {
+    margin: 0;
+    font-weight: 500;
+    color: rgba(0, 0, 0, 0.85);
+  }
+
+  .course-title-header {
+    font-weight: 500;
+    color: rgba(0, 0, 0, 0.85);
+    font-size: 16px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .form-container {
     width: auto;
+    padding: 0;
   }
 
   .form-spacing {
     width: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
   }
 
   @media (max-width: $screen-md) {
@@ -33,31 +64,11 @@
     }
 
     .view-container {
-      grid-template-columns: 1fr;
-      grid-row-gap: 2rem;
-      grid-template-rows: 1fr;
-      grid-template-areas:
-      'form-area form-area'
-      'steps-area steps-area'
-      'actions-area actions-area';
-      > * {
-        overflow-y: visible;
+      .steps-section {
+        border-top: 2px solid #000;
+        border-bottom: 2px solid #000;
+        padding: 2rem;
       }
-    }
-
-    .steps-container {
-      grid-area: steps-area;
-      border-top: 2px solid #000;
-      border-bottom: 2px solid #000;
-      padding: 2rem;
-    }
-
-    .form-container {
-      grid-area: form-area;
-    }
-
-    .actions-container{
-      grid-area: actions-area;
     }
   }
 }

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -11,11 +11,6 @@
     > * {
       overflow-y: visible;
     }
-    
-    &.edit-mode {
-      display: flex;
-      flex-direction: column;
-    }
   }
 
   .course-details-panel {
@@ -41,47 +36,25 @@
     }
   }
 
-  .course-title-summary {
-    margin: 0;
-    font-weight: 500;
-    color: rgba(0, 0, 0, 0.85);
-  }
-
-  .course-title-header {
-    font-weight: 500;
-    color: rgba(0, 0, 0, 0.85);
-    font-size: 16px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 
   .steps-container {
     flex: 0 1 auto;
     margin-top: 1rem;
     margin-bottom: 1rem;
     overflow-y: visible;
-    min-height: auto;
-    max-height: none;
   }
 
   .actions-container {
-    flex: 0 0 auto;
     align-self: flex-start;
     margin-top: auto;
-    margin-bottom: 1rem;
-    padding: 10px 0;
   }
 
   .form-container {
     width: auto;
-    overflow: visible;
   }
 
   .form-spacing {
     width: auto;
-    height: auto;
-    overflow: visible;
   }
 
   @media (max-width: $screen-md) {
@@ -94,14 +67,9 @@
       grid-row-gap: 2rem;
       grid-template-rows: auto;
       grid-template-areas:
-      'form-area'
-      'steps-area'
-      'actions-area';
-      
-      &.edit-mode {
-        display: flex;
-        flex-direction: column;
-      }
+      'form-area form-area'
+      'steps-area steps-area'
+      'actions-area actions-area';
       
       > * {
         overflow-y: visible;
@@ -121,7 +89,6 @@
 
     .actions-container {
       grid-area: actions-area;
-      align-self: flex-start;
     }
   }
 }

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -2,39 +2,25 @@
 
 :host {
   .view-container {
-    display: grid;
-    grid-template-columns: 1.5fr 1fr;
-    grid-template-rows: auto 42px;
-    grid-column-gap: 0.25rem;
-    height: 100%;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding-bottom: 10px;
+    min-height: 70vh;
+    
+    > * {
+      overflow-y: visible;
+    }
     
     &.edit-mode {
       display: flex;
       flex-direction: column;
-      
-      .course-details-panel {
-        margin-bottom: 1rem;
-      }
-      
-      .steps-container {
-        flex: 1 1 auto;
-        overflow-y: auto;
-        min-height: 200px;
-      }
-      
-      .actions-container {
-        flex: 0 0 auto;
-        align-self: flex-start;
-      }
-    }
-    
-    > * {
-      overflow-y: auto;
     }
   }
 
   .course-details-panel {
     margin-bottom: 1rem;
+    flex: 0 0 auto;
     
     &:not(.mat-expanded) {
       overflow: hidden;
@@ -71,20 +57,31 @@
   }
 
   .steps-container {
-    grid-row: span 2;
+    flex: 0 1 auto;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    overflow-y: visible;
+    min-height: auto;
+    max-height: none;
   }
 
   .actions-container {
-    grid-column: 1;
+    flex: 0 0 auto;
     align-self: flex-start;
+    margin-top: auto;
+    margin-bottom: 1rem;
+    padding: 10px 0;
   }
 
   .form-container {
     width: auto;
+    overflow: visible;
   }
 
   .form-spacing {
     width: auto;
+    height: auto;
+    overflow: visible;
   }
 
   @media (max-width: $screen-md) {

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -36,9 +36,7 @@
     }
   }
 
-
   .steps-container {
-    flex: 0 1 auto;
     margin-top: 1rem;
     margin-bottom: 1rem;
     overflow-y: visible;
@@ -70,7 +68,6 @@
       'form-area form-area'
       'steps-area steps-area'
       'actions-area actions-area';
-      
       > * {
         overflow-y: visible;
       }
@@ -87,7 +84,7 @@
       grid-area: form-area;
     }
 
-    .actions-container {
+    .actions-container{
       grid-area: actions-area;
     }
   }

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -2,7 +2,6 @@
 
 :host {
   .view-container {
-
     display: grid;
     grid-template-columns: 1.5fr 1fr;
     grid-template-rows: auto 42px;
@@ -15,10 +14,6 @@
       
       .course-details-panel {
         margin-bottom: 1rem;
-        
-        ::ng-deep .mat-expansion-panel-body {
-          padding: 0 24px 16px;
-        }
       }
       
       .steps-container {
@@ -29,6 +24,7 @@
       
       .actions-container {
         flex: 0 0 auto;
+        align-self: flex-start;
       }
     }
     
@@ -65,7 +61,8 @@
   }
 
   .actions-container {
-    align-self: center;
+    grid-column: 1;
+    align-self: flex-start;
   }
 
   .form-container {
@@ -111,8 +108,9 @@
       grid-area: form-area;
     }
 
-    .actions-container{
+    .actions-container {
       grid-area: actions-area;
+      align-self: flex-start;
     }
   }
 }

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -2,24 +2,38 @@
 
 :host {
   .view-container {
-    display: flex;
-    flex-direction: column;
+
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    grid-template-rows: auto 42px;
+    grid-column-gap: 0.25rem;
     height: 100%;
     
-    .form-section {
-      flex: 0 0 auto;
-      margin-bottom: 1rem;
+    &.edit-mode {
+      display: flex;
+      flex-direction: column;
+      
+      .course-details-panel {
+        margin-bottom: 1rem;
+        
+        ::ng-deep .mat-expansion-panel-body {
+          padding: 0 24px 16px;
+        }
+      }
+      
+      .steps-container {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        min-height: 200px;
+      }
+      
+      .actions-container {
+        flex: 0 0 auto;
+      }
     }
     
-    .steps-section {
-      flex: 1 1 auto;
+    > * {
       overflow-y: auto;
-      min-height: 200px;
-    }
-    
-    .actions-section {
-      flex: 0 0 auto;
-      padding: 10px 0;
     }
   }
 
@@ -46,16 +60,20 @@
     text-overflow: ellipsis;
   }
 
+  .steps-container {
+    grid-row: span 2;
+  }
+
+  .actions-container {
+    align-self: center;
+  }
+
   .form-container {
     width: auto;
-    padding: 0;
   }
 
   .form-spacing {
     width: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
   }
 
   @media (max-width: $screen-md) {
@@ -64,11 +82,37 @@
     }
 
     .view-container {
-      .steps-section {
-        border-top: 2px solid #000;
-        border-bottom: 2px solid #000;
-        padding: 2rem;
+      grid-template-columns: 1fr;
+      grid-row-gap: 2rem;
+      grid-template-rows: auto;
+      grid-template-areas:
+      'form-area'
+      'steps-area'
+      'actions-area';
+      
+      &.edit-mode {
+        display: flex;
+        flex-direction: column;
       }
+      
+      > * {
+        overflow-y: visible;
+      }
+    }
+
+    .steps-container {
+      grid-area: steps-area;
+      border-top: 2px solid #000;
+      border-bottom: 2px solid #000;
+      padding: 2rem;
+    }
+
+    .form-container {
+      grid-area: form-area;
+    }
+
+    .actions-container{
+      grid-area: actions-area;
     }
   }
 }


### PR DESCRIPTION
fixes #8631

Added a collapsible container for course title and description and moved the steps below the container instead of cramming them in a separate column to the right.

If editing a course with steps, the container is collapsed by default, as the steps are more likely to be edited
![image](https://github.com/user-attachments/assets/e00b3881-b024-486d-9dc8-b59cc915c061)

When you add a new course or edit a course with no steps, the container is expanded by default. 
![image](https://github.com/user-attachments/assets/8f0e1487-2c85-4b36-a604-c92209218ad1)