### PR TITLE
enterprises: smoother finances transactions (fixes #8637)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.61",
+  "version": "0.18.67",
   "myplanet": {
     "latest": "v0.25.13",
     "min": "v0.24.13"

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -126,7 +126,7 @@ export class TeamsViewFinancesComponent implements OnInit, OnChanges {
         {
           type: [ transaction.type || 'credit', CustomValidators.required ],
           description: [ transaction.description || '', CustomValidators.required ],
-          amount: [ transaction.amount || '', [ CustomValidators.positiveNumberValidator ] ],
+          amount: [ transaction.amount || '', [ CustomValidators.nonNegativeNumberValidator ] ],
           date: [ transaction.date ? new Date(new Date(transaction.date).setHours(0, 0, 0)) : new Date(time), CustomValidators.required ]
         },
         {

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -35,6 +35,13 @@ export class CustomValidators {
     return (ac.value > 0) ? null : { invalidPositive : true };
   }
 
+  static nonNegativeNumberValidator(ac: AbstractControl): ValidationErrors {
+    if (!ac.value) {
+      return null;
+    }
+    return (ac.value >= 0) ? null : { invalidPositive: true };
+  }
+
   static choiceSelected(requireCorrect: boolean) {
     return (ac: AbstractControl): ValidationErrors => {
       if (!ac.parent || !requireCorrect) {


### PR DESCRIPTION
fixes #8637

You can now now add a $0 transaction, so the validation message is accurate. 

Note that a $0 transaction makes sense as a valid option, as it allows user to include a reminder, a placeholder, status update, etc in the books, in which case there is no associated dollar amount. 