### PR TITLE
achievements: smoother deletion (fixes #8097)

### DIFF
--- a/src/app/shared/forms/planet-step-list.component.ts
+++ b/src/app/shared/forms/planet-step-list.component.ts
@@ -58,6 +58,12 @@ export class PlanetStepListItemComponent {
 
   moveStep(event, direction = 0) {
     event.stopPropagation();
+    if (direction === this.index) {
+      const confirmDelete = window.confirm($localize`Are you sure you want to delete this item?`);
+      if (!confirmDelete) {
+        return;
+      }
+    }
     this.planetStepListService.moveStep(this.index, direction, this.listId);
   }
 
@@ -152,6 +158,10 @@ export class PlanetStepListComponent implements AfterContentChecked, OnDestroy {
   }
 
   removeStep() {
+    const confirmDelete = window.confirm($localize`Are you sure you want to delete this item?`);
+    if (!confirmDelete) {
+      return;
+    }
     this.moveStep({ index: this.openIndex, direction: 0, listId: this.listId });
     this.toList();
   }


### PR DESCRIPTION
fixes #8097 

Opted to use a window.confirm message instead of dialogs-prompt component, as the planet-step-list is s reused component and requires a more general message. Covers both of the built-in planet-step-list deletion methods.

![image](https://github.com/user-attachments/assets/cb905a09-54ea-41ca-9a82-9962d7b9e080)
