### PR TITLE
teams: smoother survey exports (fixes #8674)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.76",
+  "version": "0.18.88",
   "myplanet": {
-    "latest": "v0.25.25",
-    "min": "v0.24.25"
+    "latest": "v0.25.42",
+    "min": "v0.24.42"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Subject, of, forkJoin, throwError } from 'rxjs';
-import { catchError, finalize, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { Chart } from 'chart.js';
 import htmlToPdfmake from 'html-to-pdfmake';
 import { findDocuments } from '../shared/mangoQueries';
@@ -364,9 +364,14 @@ export class SubmissionsService {
         }),
         switchMap(([ submissionsTuple, planets ]: [ [ any[], number, string[] ], any[] ]) => {
           const [ submissions, time, questionTexts ] = submissionsTuple;
-          const filteredSubmissions = team
-            ? submissions.filter(s => s.team === team)
-            : submissions;
+          const normalizedSubmissions = submissions.map(sub => ({
+            ...sub,
+            parent: {
+              ...sub.parent,
+              questions: Array.isArray(sub.parent.questions) ? sub.parent.questions : exam.questions
+            }
+          }));
+          const filteredSubmissions = team ? normalizedSubmissions.filter(s => s.team === team) : normalizedSubmissions;
           if (!filteredSubmissions.length) {
             this.dialogsLoadingService.stop();
             this.planetMessageService.showMessage($localize`There is no survey response`);
@@ -380,17 +385,14 @@ export class SubmissionsService {
           return forkJoin(
             submissionsWithPlanetName.map(submission => {
               if (submission.team) {
-                return this.teamsService.getTeamName(submission.team).pipe(
-                  map(teamName => ({ ...submission, teamName }))
-                );
+                return this.teamsService.getTeamName(submission.team).pipe(map(teamName => ({ ...submission, teamName })));
               }
               return of(submission);
             })
           ).pipe(map((updatedSubmissions: any[]): [ any[], number, string[] ] => [ updatedSubmissions, time, questionTexts ])
           );
         })
-      )
-      .subscribe(async tuple => {
+      ).subscribe(async tuple => {
         if (!tuple) {
           return;
         }


### PR DESCRIPTION
Fixes #8674

Normalize the data to handle cases where the parent.questions is not previosly defined.

![image](https://github.com/user-attachments/assets/0ff0e574-6fe5-4c85-ba47-67851c228aeb)
