### PR TITLE
teams: smoother voices pagination (fixes #8671)(fixes #8672)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.80",
+  "version": "0.18.81",
   "myplanet": {
-    "latest": "v0.25.28",
-    "min": "v0.24.28"
+    "latest": "v0.25.30",
+    "min": "v0.24.30"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -40,6 +40,8 @@ export class NewsListComponent implements OnInit, OnChanges {
   hasMoreNews = false;
   pageSize = 10;
   nextStartIndex = 0;
+  // Key value store for max number of posts viewed per conversation
+  pageEnd = { root: 10 };
 
   constructor(
     private dialog: MatDialog,
@@ -74,7 +76,6 @@ export class NewsListComponent implements OnInit, OnChanges {
       }
     });
     this.displayedItems = this.replyObject[this.replyViewing._id];
-    this.nextStartIndex = 0;
     this.loadPagedItems(true);
     if (this.replyViewing._id !== 'root') {
       this.replyViewing = this.items.find(item => item._id === this.replyViewing._id);
@@ -84,7 +85,6 @@ export class NewsListComponent implements OnInit, OnChanges {
   showReplies(news) {
     this.replyViewing = news;
     this.displayedItems = this.replyObject[news._id];
-    this.nextStartIndex = 0;
     this.loadPagedItems(true);
     this.isMainPostShared = this.replyViewing._id === 'root' || this.newsService.postSharedWithCommunity(this.replyViewing);
     this.showMainPostShare = !this.replyViewing.doc || !this.replyViewing.doc.replyTo ||
@@ -215,10 +215,18 @@ export class NewsListComponent implements OnInit, OnChanges {
   }
 
   loadPagedItems(initial = true) {
+    let pageSize = this.pageSize;
+    if (initial) {
+      this.displayedItems = [];
+      this.nextStartIndex = 0;
+      // Take maximum so if fewer posts than page size adding a post doesn't add a "Load More" button
+      pageSize = Math.max(this.pageEnd[this.replyViewing._id] || this.pageSize, this.pageSize);
+    }
     const news = this.getCurrentItems();
-    const { items, endIndex, hasMore } = this.paginateItems(news, this.nextStartIndex, this.pageSize);
+    const { items, endIndex, hasMore } = this.paginateItems(news, this.nextStartIndex, pageSize);
 
-    this.displayedItems = initial ? items : [ ...this.displayedItems, ...items ];
+    this.displayedItems = [ ...this.displayedItems, ...items ];
+    this.pageEnd[this.replyViewing._id] = this.displayedItems.length;
     this.nextStartIndex = endIndex;
     this.hasMoreNews = hasMore;
     this.isLoadingMore = false;


### PR DESCRIPTION
I went with a solution that fixes both #8671 and #8672 with one change.

The maximum number of posts viewed for each reply thread is stored in an object `pageEnd`. This means that while the user stays on the community page (or teams) the next time they go to that reply thread it will load up to that many posts.

In theory this could cause issues in load time if the user had opened a lot of posts in a reply thread and then returns to the reply thread.

It's also not ideal at this point for when the user looks at replies of an older post and then goes back to the main conversation. The older post will be rendered, but well below the scroll instead of in the users view.