### PR TITLE
all: bump `ramda` to 0.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.84",
+  "version": "0.18.85",
   "myplanet": {
-    "latest": "v0.25.33",
-    "min": "v0.24.33"
+    "latest": "v0.25.35",
+    "min": "v0.24.35"
   },
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "pouchdb": "^7.1.1",
     "pouchdb-authentication": "^1.1.3",
     "pouchdb-find": "^7.1.1",
-    "ramda": "^0.28.0",
+    "ramda": "^0.29.0",
     "rxjs": "6.5.4",
     "showdown": "1.9.1",
     "tslib": "^1.10.0",


### PR DESCRIPTION
Bumping the version on ramda to confirm the prebuild step is working as intended when merging into master.

Checking the upgrade guide for ramda none of the functions we use are mentioned when going from 0.28.0 -> 0.29.0
https://github.com/ramda/ramda/issues/3369

Functions we use
```
isEmpty
filter
pluck
head
```