### PR TITLE
teams: smoother voices replies navigation (fixes #8670)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "license": "AGPL-3.0",
   "version": "0.18.90",
   "myplanet": {
-    "latest": "v0.25.42",
-    "min": "v0.24.42"
+    "latest": "v0.25.46",
+    "min": "v0.24.46"
   },
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.90",
+  "version": "0.18.92",
   "myplanet": {
     "latest": "v0.25.46",
     "min": "v0.24.46"

--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -13,7 +13,7 @@
           </ng-container>
           <ng-template #loaded>
             <ng-container *ngIf="news?.length > 0; else noVoices">
-              <planet-news-list [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId"></planet-news-list>
+              <planet-news-list [items]="news" [shareTarget]="shareTarget" (viewChange)="toggleShowButton($event)" [viewableId]="teamId" [useReplyRoutes]="true"></planet-news-list>
             </ng-container>
           </ng-template>
           <ng-template #noVoices>

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -351,11 +351,6 @@ export class CommunityComponent implements OnInit, OnDestroy {
   toggleShowButton(data) {
     this.activeReplyId = data._id;
     this.showNewsButton = data._id === 'root';
-    if (data._id !== 'root') {
-      this.router.navigate([ '/voices', data._id ]);
-    } else {
-      this.router.navigate([ '' ]);
-    }
   }
 
   toggleDeleteMode() {

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -65,7 +65,7 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   ngOnInit() {
 
     this.router.events.subscribe(() => {
-      this.initNews()
+      this.initNews();
     });
 
     this.initNews();


### PR DESCRIPTION
When navigating with the browser back/forward on the community voices page the thread that you are viewing will now change.

To test create some voices posts with replies (and maybe replies of the replies). Click through to the different post threads to build up a browser history then use back/forward on the browser. The voices conversation being viewed should change with the browser navigation.

I tested it 2 replies deep.