### PR TITLE
manager: smoother survey count (fixes #8707)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.18.96",
+  "version": "0.18.97",
   "myplanet": {
-    "latest": "v0.25.47",
-    "min": "v0.24.47"
+    "latest": "v0.25.52",
+    "min": "v0.24.52"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -247,7 +247,8 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ submission }) => {
       this.submittedBy = this.submissionsService.submissionName(submission.user);
       this.updatedOn = submission.lastUpdateTime;
-      this.unansweredQuestions = submission.parent.questions.reduce((unanswered, q, index) => [
+      const questions = Array.isArray(submission.parent.questions) ? submission.parent.questions : (this.exam?.questions || []);
+      this.unansweredQuestions = questions.reduce((unanswered, q, index) => [
         ...unanswered, ...((submission.answers[index] && submission.answers[index].passed) ? [] : [ index + 1 ])
       ], []);
       this.submissionId = submission._id;
@@ -255,7 +256,7 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
       if (this.fromSubmission === true) {
         this.examType = submission.parent.type === 'surveys' ? 'survey' : 'exam';
         this.title = submission.parent.name;
-        this.setQuestion(submission.parent.questions);
+        this.setQuestion(questions);
         this.grade = (ans && ans.grade !== undefined) ? ans.grade : this.grade;
         this.comment = ans && ans.gradeComment;
       }

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -247,7 +247,10 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ submission }) => {
       this.submittedBy = this.submissionsService.submissionName(submission.user);
       this.updatedOn = submission.lastUpdateTime;
-      const questions = Array.isArray(submission.parent.questions) ? submission.parent.questions : (this.exam?.questions || []);
+      const questions = Array.isArray(submission.parent.questions) ? submission.parent.questions : (this.exam?.questions);
+      console.log('sub exam questions', this.exam?.questions);
+      console.log('sub questions', questions);
+
       this.unansweredQuestions = questions.reduce((unanswered, q, index) => [
         ...unanswered, ...((submission.answers[index] && submission.answers[index].passed) ? [] : [ index + 1 ])
       ], []);

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -247,10 +247,7 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ submission }) => {
       this.submittedBy = this.submissionsService.submissionName(submission.user);
       this.updatedOn = submission.lastUpdateTime;
-      const questions = Array.isArray(submission.parent.questions) ? submission.parent.questions : (this.exam?.questions);
-      console.log('sub exam questions', this.exam?.questions);
-      console.log('sub questions', questions);
-
+      const questions = submission.parent.questions || [];
       this.unansweredQuestions = questions.reduce((unanswered, q, index) => [
         ...unanswered, ...((submission.answers[index] && submission.answers[index].passed) ? [] : [ index + 1 ])
       ], []);

--- a/src/app/submissions/submissions.component.html
+++ b/src/app/submissions/submissions.component.html
@@ -73,7 +73,8 @@
         <mat-cell *matCellDef="let element" [ngSwitch]="element.status">
           <mat-chip-list *ngSwitchCase="'pending'"><mat-chip  class="chip-no-style" i18n>pending</mat-chip></mat-chip-list>
           <mat-chip-list *ngSwitchCase="'requires grading'"><mat-chip class="chip-no-style" selected color="accent" i18n>requires grading</mat-chip></mat-chip-list>
-          <mat-chip-list *ngSwitchDefault><mat-chip class="chip-no-style" selected color="primary" i18n>complete</mat-chip></mat-chip-list>
+          <mat-chip-list *ngSwitchCase="'complete"><mat-chip class="chip-no-style" selected color="primary" i18n>complete</mat-chip></mat-chip-list>
+          <mat-chip-list *ngSwitchDefault><mat-chip class="chip-no-style" selected color="warn" i18n>incomplete</mat-chip></mat-chip-list>
         </mat-cell>
       </ng-container>
       <ng-container matColumnDef="grade">

--- a/src/app/submissions/submissions.component.html
+++ b/src/app/submissions/submissions.component.html
@@ -102,7 +102,7 @@
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns" class="hide"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="submissionAction(row)" [ngClass]="{'cursor-pointer': row.status!=='pending' || mode === 'survey'}"></mat-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="submissionAction(row)" [ngClass]="{'cursor-pointer': row.status==='complete' || mode === 'survey'}"></mat-row>
       <tr class="mat-row" *matNoDataRow>
         <td><div class="view-container" i18n>No Record Found</div></td>
       </tr>

--- a/src/app/submissions/submissions.component.html
+++ b/src/app/submissions/submissions.component.html
@@ -73,7 +73,7 @@
         <mat-cell *matCellDef="let element" [ngSwitch]="element.status">
           <mat-chip-list *ngSwitchCase="'pending'"><mat-chip  class="chip-no-style" i18n>pending</mat-chip></mat-chip-list>
           <mat-chip-list *ngSwitchCase="'requires grading'"><mat-chip class="chip-no-style" selected color="accent" i18n>requires grading</mat-chip></mat-chip-list>
-          <mat-chip-list *ngSwitchCase="'complete"><mat-chip class="chip-no-style" selected color="primary" i18n>complete</mat-chip></mat-chip-list>
+          <mat-chip-list *ngSwitchCase="'complete'"><mat-chip class="chip-no-style" selected color="primary" i18n>complete</mat-chip></mat-chip-list>
           <mat-chip-list *ngSwitchDefault><mat-chip class="chip-no-style" selected color="warn" i18n>incomplete</mat-chip></mat-chip-list>
         </mat-cell>
       </ng-container>

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -292,7 +292,7 @@ export class SubmissionsService {
       const filteredSubmissions = team
           ? normalizedSubmissions.filter(s => s.team === team)
           : normalizedSubmissions;
-        return forkJoin(
+      return forkJoin(
           filteredSubmissions.map(submission => {
             if (submission.team) {
               return this.teamsService.getTeamName(submission.team).pipe(

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -282,9 +282,16 @@ export class SubmissionsService {
 
   exportSubmissionsCsv(exam, type: 'exam' | 'survey', team?: string) {
     return this.getSubmissionsExport(exam, type).pipe(switchMap(([ submissions, time, questionTexts ]: [any[], number, string[]]) => {
-        const filteredSubmissions = team
-          ? submissions.filter(s => s.team === team)
-          : submissions;
+      const normalizedSubmissions = submissions.map(sub => ({
+        ...sub,
+        parent: {
+          ...sub.parent,
+          questions: Array.isArray(sub.parent.questions) ? sub.parent.questions : exam.questions
+        }
+      }));
+      const filteredSubmissions = team
+          ? normalizedSubmissions.filter(s => s.team === team)
+          : normalizedSubmissions;
         return forkJoin(
           filteredSubmissions.map(submission => {
             if (submission.team) {

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -123,9 +123,9 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
             course: courses.find((course: any) => findSurveyInSteps(course.steps, survey) > -1),
             taken: this.teamId || this.routeTeamId
               ? relatedSubmissions.filter(
-                (data) => data.status !== 'pending' &&
+                (data) => data.status === 'complete' &&
                 (data.team === this.teamId || data.team === this.routeTeamId)).length
-              : relatedSubmissions.filter(data => data.status !== 'pending').length
+              : relatedSubmissions.filter(data => data.status === 'complete').length
           };
         }),
         ...this.createParentSurveys(submissions)


### PR DESCRIPTION
Fixes #8707

- Ensure only complete surveys are taken into consideration with the surveys count and displayed correctly in the submissions list
- Handle undefined exports of csv surveys missing the questions array

Difficult to replicate on local dev systems since issues are generated from myPlanet submissions.

![image](https://github.com/user-attachments/assets/485499c2-1d93-4c47-ae56-2a134eb86e8d)


Tested on [Planet Learning](https://planet.learning.ole.org)