### PR TITLE
voices: smoother conversations (fixes #8724)

### DIFF
--- a/src/app/news/news-list.component.html
+++ b/src/app/news/news-list.component.html
@@ -19,18 +19,22 @@
   </planet-news-list-item>
   <mat-divider></mat-divider>
 </ng-container>
-<planet-news-list-item *ngFor="let item of displayedItems; trackBy: trackById"
-  [item]="item"
-  [isMainPostShared]="isMainPostShared"
-  [replyObject]="replyObject"
-  [editable]="editable"
-  [shareTarget]="shareTarget"
-  (changeReplyViewing)="showReplies($event)"
-  (updateNews)="openUpdateDialog($event)"
-  (deleteNews)="openDeleteDialog($event)"
-  (shareNews)="shareNews($event)"
-  (changeLabels)="changeLabels($event)">
-</planet-news-list-item>
+<ng-container *ngFor="let item of displayedItems; trackBy: trackById">
+  <div [attr.id]="'news-' + item._id">
+    <planet-news-list-item
+      [item]="item"
+      [isMainPostShared]="isMainPostShared"
+      [replyObject]="replyObject"
+      [editable]="editable"
+      [shareTarget]="shareTarget"
+      (changeReplyViewing)="showReplies($event)"
+      (updateNews)="openUpdateDialog($event)"
+      (deleteNews)="openDeleteDialog($event)"
+      (shareNews)="shareNews($event)"
+      (changeLabels)="changeLabels($event)">
+    </planet-news-list-item>
+  </div>
+</ng-container>
 <div #anchor class="loading-anchor"></div>
 <div class="spinner-container" style="text-align: center;">
   <mat-spinner *ngIf="isLoadingMore"></mat-spinner>

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -51,6 +51,8 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   nextStartIndex = 0;
   // Key value store for max number of posts viewed per conversation
   pageEnd = { root: 10 };
+  // store the last opened thread’s root post id
+  lastRootPostId: string;
 
   constructor(
     private dialog: MatDialog,
@@ -111,6 +113,10 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   }
 
   showReplies(news) {
+    // remember which thread was opened
+    if (news._id !== 'root') {
+      this.lastRootPostId = news._id;
+    }
     if (this.useReplyRoutes) {
       this.navigateToReply(news._id);
       return;
@@ -141,6 +147,16 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
         this.newsService.postSharedWithCommunity(this.items.find(item => item._id === this.replyViewing.doc.replyTo))
       );
     this.viewChange.emit(this.replyViewing);
+
+    // when going back to the main conversation, scroll down to the previously viewed post
+    if (newsId === 'root' && this.lastRootPostId) {
+      setTimeout(() => {
+        const el = document.getElementById(`news-${this.lastRootPostId}`);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 0);
+    }
   }
 
   showPreviousReplies() {


### PR DESCRIPTION
fixes #8724

We store the ID of the last-opened reply thread and mark each post wrapper with id="news-<postId>". When you hit “Show main conversation,” we smoothly scroll back to that saved element so you land right where you left off.