### PR TITLE
chatapi: smoother port number (fixes #8760)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If port 3000 is in use, try ```ng serve --port 3001```
 
 Run `cd chatapi` and add a .env file in the `chatapi` directory with the following configs in the .env file(change the username and password to your CouchDB admin credentials):
   ```
-    SERVE_PORT=5000
+    SERVE_PORT=5050
     COUCHDB_HOST=http://localhost:2200
     COUCHDB_USER=username
     COUCHDB_PASS=password
@@ -84,7 +84,7 @@ Run `cd chatapi` and add a .env file in the `chatapi` directory with the followi
 
 Configure the models(API keys & Models & Assistant settings) through the `manager dashboard -> AI Configurations` or in the `configurations` database directly in CouchDB. Currently we support *OpenAI*, *Perplexity*, *Deepseek*, and *Gemini* models.
 
-**Note:** The dev chatapi runs on port 5000 similar to the production environment. Therefore, only one of them can run at a time. To deactivate the production chatapi run `docker stop planet_chatapi_1(or container id)`
+**Note:** The dev chatapi runs on port 5050 similar to the production environment. Therefore, only one of them can run at a time. To deactivate the production chatapi run `docker stop planet_chatapi_1(or container id)`
 
 To run the chatapi locally, you need to use node v18. You can use nvm(linux) or fnm(windows/macos) to manage your node versions. To start the chatapi:
 ```

--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -16,7 +16,7 @@ For development environment add a .env file in the `chatapi` directory
 
 Add the following configs in the .env file:
   ```
-    SERVE_PORT=5000
+    SERVE_PORT=5050
     COUCHDB_HOST=http://localhost:2200
     COUCHDB_USER=username
     COUCHDB_PASS=password

--- a/chatapi/src/index.ts
+++ b/chatapi/src/index.ts
@@ -93,6 +93,6 @@ app.get('/checkproviders', async (req: any, res: any) => {
   });
 });
 
-const port = process.env.SERVE_PORT || 5000;
+const port = process.env.SERVE_PORT || 5050;
 
 server.listen(port, () => console.log(`Server running on port ${port}`)); // eslint-disable-line no-console

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ Docker means many things to many people. In simplest form we can say that docker
 ### Components
 We have several docker components in our application there are
 * Planet. There are two version, one is for production and one is for development.
-  * Planet for production. It basically our production optimized Planet that served via Nginx.
+  * Planet for production. It basically our production optimized Planet(sometimes served via Nginx).
   * Planet for development. It basically a runtime that make it possible for Planet to run (mostly node.js)
 * CouchDB. It basically a CouchDB container and it developed in the different project. You can access it here in [ole-vi/rpi-couchdb](https://github.com/ole-vi/rpi-couchdb)
 * CouchDB initialization data a.k.a. `db-init`. It contains all the schema necessary for our Planet to run.
@@ -29,16 +29,14 @@ This docker compose can be use for your development environment and very handy, 
 ## How to use
 I will divide this how to use into two sections, for development and for production. It is interesting to run our development environment on top of isolated docker container.
 
-### For Development
-
 ### For Production
 
-1. Move to `docker` folder
+1. Move to `srv/planet` folder
 2. Run the following command to spawn your environment for the first time
-   (Optional: update planet.yml with specific images from https://hub.docker.com/r/treehouses/planet/tags/)
+   (Optional: update planet.yml with the latest or a specific images from https://hub.docker.com/r/treehouses/planet/tags/)
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet up -d --build
+docker-compose -f planet.yml -p planet up -d --build
 ```
 
 See if the docker containers running
@@ -50,12 +48,15 @@ docker ps
 You'll see you containers like this
 
 ```
-CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS              PORTS                                                                NAMES
-ea3b914c3193        planetdev_planet    "/bin/sh -c 'bash ..."   About a minute ago   Up 58 seconds       0.0.0.0:3000->3000/tcp                                               planetdev_planet_1
-57f30698ccda        klaemo/couchdb      "tini -- /docker-e..."   About a minute ago   Up About a minute   4369/tcp, 9100/tcp, 0.0.0.0:2200->5984/tcp, 0.0.0.0:2201->5986/tcp   planetdev_couchdb_1
+CONTAINER ID   IMAGE                      COMMAND                  CREATED         STATUS         PORTS                                                             NAMES
+0914c167f20e   d14b10ade528               "/bin/sh -c ./docker…"   2 weeks ago     Up 2 seconds   0.0.0.0:80->80/tcp, [::]:80->80/tcp, 443/tcp                      planet-prod-planet-1
+42d4b4ea3826   898294509ee6               "npm run start"          2 weeks ago     Up 2 seconds   0.0.0.0:5000->5000/tcp, [::]:5000->5000/tcp                       planet-prod-chatapi-1
+c03b86dfede9   9859c264e24e               "/bin/sh -c 'bash ./…"   2 weeks ago     Up 2 seconds                                                                     planet-prod-db-init-1
+f7ddb76ae6b6   treehouses/couchdb:2.3.1   "tini -- /docker-ent…"   14 months ago   Up 2 seconds   4369/tcp, 9100/tcp, 0.0.0.0:2200->5984/tcp, [::]:2200->5984/tcp   planet-prod-couchdb-1
+
 ```
 
-Connect to your `planetdev_planet` with
+Connect to your `planet-prod-planet-1` with
 
 ```
 docker logs {{id}}
@@ -64,7 +65,7 @@ docker logs {{id}}
 in this case
 
 ```
-docker logs ea3b914c3193 -f
+docker logs 0914c167f20e -f
 ```
 
 press `CTRL+C` to exit logs view
@@ -72,19 +73,19 @@ press `CTRL+C` to exit logs view
 3. When you're done, you can do the following command
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet stop
+docker-compose -f planet.yml -p planet stop
 ```
 
 4. When you go back to code
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet start
+docker-compose -f planet.yml -p planet start
 ```
 
 5. When you have to delete the environment
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet down
+docker-compose -f planet.yml -p planet down -v
 ```
 
 Remember when your containers active you can always look to your containers logs to see whats going on on the background.

--- a/docker/chatapi/amd64-Dockerfile
+++ b/docker/chatapi/amd64-Dockerfile
@@ -11,6 +11,6 @@ RUN npm install --production
 COPY ./chatapi/src ./src/
 COPY ./chatapi/tsconfig.json ./tsconfig.json
 
-EXPOSE 5000
+EXPOSE 5050
 
 CMD ["npm", "run", "start"]

--- a/docker/chatapi/arm-Dockerfile
+++ b/docker/chatapi/arm-Dockerfile
@@ -16,6 +16,6 @@ RUN npm install --production
 COPY ./chatapi/src ./src/
 COPY ./chatapi/tsconfig.json ./tsconfig.json
 
-EXPOSE 5000
+EXPOSE 5050
 
 CMD ["npm", "run", "start"]

--- a/docker/chatapi/arm64-Dockerfile
+++ b/docker/chatapi/arm64-Dockerfile
@@ -16,6 +16,6 @@ RUN npm install --production
 COPY ./chatapi/src ./src/
 COPY ./chatapi/tsconfig.json ./tsconfig.json
 
-EXPOSE 5000
+EXPOSE 5050
 
 CMD ["npm", "run", "start"]

--- a/docker/planet.yml
+++ b/docker/planet.yml
@@ -7,17 +7,15 @@ services:
       - "2200:5984"
   chatapi:
     expose:
-      - 5000
+      - 5050
     image: treehouses/planet:chatapi-local
     depends_on:
       - couchdb
     ports:
-      - "5000:5000"
+      - "5050:5050"
     environment:
       - COUCHDB_HOST=http://couchdb:5984
-      - SERVE_PORT=5000
-    env_file:
-      - .chat.env
+      - SERVE_PORT=5050
   db-init:
     image: treehouses/planet:db-init-local
     depends_on:

--- a/docker/planet/default.conf.template
+++ b/docker/planet/default.conf.template
@@ -135,7 +135,7 @@ server {
   }
 
   location /ml/ {
-    proxy_pass       http://chatapi:5000/;
+    proxy_pass       http://chatapi:5050/;
     proxy_set_header Host      $host;
     proxy_set_header X-Real-IP $remote_addr;
     client_max_body_size 1024M;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,7 @@
 export const environment = {
   production: false,
   test: false,
-  chatAddress: window.location.protocol + '//' + window.location.hostname + ':5000',
+  chatAddress: window.location.protocol + '//' + window.location.hostname + ':5050',
   couchAddress: window.location.protocol + '//' + window.location.hostname + ':2200',
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',


### PR DESCRIPTION
Fixes #8760

- Update the chatapi port to `5050`, switching from `5000`
- Update the docker readme file

To test:
First stop the chatapi docker container using
-  docker desktop or
-  docker stop planet-chatapi-1 or docker stop {{id}} if using the planet chatapi container id(docker ps to find it)

Then _(if you don't have node 18 installed run `nvm install 18 or fnm install 18`)_:
```
  cd chatapi
  nvm use 18 // fnm use 18 
  npm run dev
```

Visit localhost:5050/checkproviders to confirm

![image](https://github.com/user-attachments/assets/2b883903-eb2d-42aa-b79c-85bf9eb8af40)

![image](https://github.com/user-attachments/assets/817cae86-f004-4d5f-8b74-bdf713aa48bb)
