### PR TITLE
all: smoother image uploads (fixes #8800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.27",
+  "version": "0.19.30",
   "myplanet": {
-    "latest": "v0.25.90",
-    "min": "v0.24.90"
+    "latest": "v0.26.0",
+    "min": "v0.25.0"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/dialogs/dialogs-images.component.html
+++ b/src/app/shared/dialogs/dialogs-images.component.html
@@ -17,5 +17,5 @@
 <mat-dialog-actions>
   <button mat-raised-button mat-dialog-close i18n>Cancel</button>
   <button type="button" mat-raised-button color="primary" (click)="fileInput.click()" i18n>Add New Image</button>
-  <input hidden (change)="uploadImage($event)" #fileInput type="file">
+  <input hidden (change)="uploadImage($event)" #fileInput type="file" accept="image/*">
 </mat-dialog-actions>

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -132,7 +132,7 @@
           </button>
           <button *ngIf="uploadImage && currentImgKey" mat-raised-button color="accent" (click)="deleteImageAttachment()">Remove</button>
         </div>
-        <input #fileInput id="fileInput" type="file" (change)="fileChangeEvent($event)" style="display: none;" />
+        <input #fileInput id="fileInput" type="file" accept="image/*" (change)="fileChangeEvent($event)" style="display: none;" />
       </div>
       <div class="profile-image-upload">
         <image-cropper [imageChangedEvent]="imageChangedEvent" format="webp" (imageCropped)="onImageSelect($event)"></image-cropper>


### PR DESCRIPTION
fixes #8800

Now when we upload images (from voices, profile, course description, anywhere there is an "add image" prompt), only  `/image` filetypes populate the dialog (jpg, png, webp, etc).

![image](https://github.com/user-attachments/assets/58aa7eba-32b8-44a3-8528-5e160c58b364)
![image](https://github.com/user-attachments/assets/82e462ea-caf3-4eb8-933f-9f3513a87def)

General file upload dialogs are unchanged 
![image](https://github.com/user-attachments/assets/d1ed1dbd-351b-4344-b08a-3a0d91c79519)
