### PR TITLE
chat: smoother dev port (fixes #8760)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docker/planet-*.yml
 planet.yml
 
 .env
+
+# Dev environment
+environment.dev.ts

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Run `cd chatapi` and add a .env file in the `chatapi` directory with the followi
 
 Configure the models(API keys & Models & Assistant settings) through the `manager dashboard -> AI Configurations` or in the `configurations` database directly in CouchDB. Currently we support *OpenAI*, *Perplexity*, *Deepseek*, and *Gemini* models.
 
-**Note:** The dev chatapi runs on port 5000 similar to the production environment. Therefore, only one of them can run at a time. To deactivate the production chatapi run `docker stop planet_chatapi_1(or container id)`
+**Note:** The dev(npm) chatapi runs on port 5000(linux) similar to the production(docker) environment. Therefore, only one of them can run at a time. To deactivate the production chatapi run `docker stop planet_chatapi_1(or container id)`
+
+If you are using a different chatapi port number, while developing or testing the chatapi, use `npm run dev` and ensure that the `CHAT_PORT` in the root directory `.env` file is the same as the `SERVE_PORT` in the `/chatapi/.env` file.
 
 To run the chatapi locally, you need to use node v18. You can use nvm(linux) or fnm(windows/macos) to manage your node versions. To start the chatapi:
 ```

--- a/README.md
+++ b/README.md
@@ -72,28 +72,11 @@ ng serve
 Visit localhost:3000 to access the Planet app.
 If port 3000 is in use, try ```ng serve --port 3001```
 
-## Chatapi Development Notes
-
-Run `cd chatapi` and add a .env file in the `chatapi` directory with the following configs in the .env file(change the username and password to your CouchDB admin credentials):
-  ```
-    SERVE_PORT=5000
-    COUCHDB_HOST=http://localhost:2200
-    COUCHDB_USER=username
-    COUCHDB_PASS=password
-  ```
+## Chatapi Notes
 
 Configure the models(API keys & Models & Assistant settings) through the `manager dashboard -> AI Configurations` or in the `configurations` database directly in CouchDB. Currently we support *OpenAI*, *Perplexity*, *Deepseek*, and *Gemini* models.
 
-**Note:** The dev(npm) chatapi runs on port 5000(linux) similar to the production(docker) environment. Therefore, only one of them can run at a time. To deactivate the production chatapi run `docker stop planet_chatapi_1(or container id)`
-
-If you are using a different chatapi port number, while developing or testing the chatapi, use `npm run dev` and ensure that the `CHAT_PORT` in the root directory `.env` file is the same as the `SERVE_PORT` in the `/chatapi/.env` file.
-
-To run the chatapi locally, you need to use node v18. You can use nvm(linux) or fnm(windows/macos) to manage your node versions. To start the chatapi:
-```
-  npm install
-  nvm use 18
-  npm run dev
-```
+For chatapi development instructions, refer to the [chatapi README](chatapi/README.md).
 
 ## Project Guidelines
 
@@ -196,14 +179,5 @@ npm i @types/mime@3.0.0
 ### Error on initial npm install
 
 If your npm install fails on your first try, first check if you are using Node v14. Other versions of Node may throw errors when installing dependencies.
-
-### Fatal error in chatapi using an arm32 device
-
-If you are using an 32bit arm device and encounter a fatal error while running the chatapi container run the following:
-```
-  wget http://ftp.us.debian.org/debian/pool/main/libs/libseccomp/libseccomp2_2.5.1-1~bpo10+1_armhf.deb
-
-  dpkg -i libseccomp2_2.5.1-1~bpo10+1_armhf.deb
-```
 
 This project is tested with [BrowserStack](https://www.browserstack.com/).

--- a/angular.json
+++ b/angular.json
@@ -87,6 +87,14 @@
                 }
               ]
             },
+            "dev": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.dev.ts"
+                }
+              ]
+            },
             "test": {
               "budgets": [
                 {
@@ -173,6 +181,9 @@
           "configurations": {
             "production": {
               "browserTarget": "planet-app:build:production"
+            },
+            "dev": {
+              "browserTarget": "planet-app:build:dev"
             },
             "test": {
               "browserTarget": "planet-app:build:test"

--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -9,25 +9,35 @@ For model choices view:
   - Gemini: https://deepmind.google/technologies/gemini/
 
 ## Development Notes
-For development environment add a .env file in the `chatapi` directory
-
-Add the following configs in the .env file:
+Run `cd chatapi` and add a .env file in the `chatapi` directory with the following configs in the .env file(ensure the username & password match your admin credentials):
   ```
     SERVE_PORT=5000
     COUCHDB_HOST=http://localhost:2200
-    COUCHDB_USER=username
-    COUCHDB_PASS=password
+    COUCHDB_USER=planet
+    COUCHDB_PASS=planet
   ```
 
-For *linux* users we recommend using `5000` as the serve port, while for *windows* and *macOS* users we recommend using `5400` as the serve port to avoid conflicts with other services.
+By default(linux), the chatapi uses 5000 as the serve port. For *windows* and *macOS* users we recommend using `5400` as the serve port to avoid conflicts with other services.
 
-**Note**: To run the development environment, ensure that you are using node 18. and then use `npm run dev` to start the development server. This will use nodemon to automatically restart the server on file changes.
+While developing or testing, if you are using a different port number or 5400(windows & macOs users), use `npm run dev` instead of `ng s` and ensure that the `CHAT_PORT` in the root directory `.env` file is the same as the `SERVE_PORT` in the `/chatapi/.env` file.
 
-## Additional Notes
+To run the chatapi locally, you need to use node v18. You can use nvm(linux) or fnm(windows/macos) to manage your node versions. To start the chatapi:
+```
+  npm install
+  nvm use 18
+  npm run dev
+```
 
-By default the local production(docker containers) and local development environment run on same port. To use both at the same time, ensure that you change one of the port numbers.(preferably the development environment in the .env file). Alternatively, turn off the local production environment when developing using docker desktop or docker stop {{chatapi container id}}.
+**Note:** The dev(npm) chatapi by default runs on port 5000(linux) similar to the production(docker) environment. Therefore, only one of them can run at a time. To deactivate the production chatapi run `docker stop planet_chatapi_1(or container id)`
 
-In the production environment these configs are set in the `planet.yml` file.
+### Fatal error in chatapi using an arm32 device
+
+If you are using an 32bit arm device and encounter a fatal error while running the chatapi container run the following:
+```
+  wget http://ftp.us.debian.org/debian/pool/main/libs/libseccomp/libseccomp2_2.5.1-1~bpo10+1_armhf.deb
+
+  dpkg -i libseccomp2_2.5.1-1~bpo10+1_armhf.deb
+```
 
 ## API Overview
 

--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -25,7 +25,7 @@ For *linux* users we recommend using `5000` as the serve port, while for *window
 
 ## Additional Notes
 
-By default the local production(docker containers) and local development environment run on port 5000. To use both at the same time, ensure you change the port for one of them.(preferably the development environment in the .env file). Alternatively, turn off the local production environment when developing using docker desktop or docker stop {{chatapi container id}}.
+By default the local production(docker containers) and local development environment run on same port. To use both at the same time, ensure that you change one of the port numbers.(preferably the development environment in the .env file). Alternatively, turn off the local production environment when developing using docker desktop or docker stop {{chatapi container id}}.
 
 In the production environment these configs are set in the `planet.yml` file.
 

--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -19,7 +19,9 @@ Add the following configs in the .env file:
     COUCHDB_PASS=password
   ```
 
-*Note*: To run the development environment, ensure that you are using node 18. and then use `npm run dev` to start the development server. This will use nodemon to automatically restart the server on file changes.
+For *linux* users we recommend using `5000` as the serve port, while for *windows* and *macOS* users we recommend using `5400` as the serve port to avoid conflicts with other services.
+
+**Note**: To run the development environment, ensure that you are using node 18. and then use `npm run dev` to start the development server. This will use nodemon to automatically restart the server on file changes.
 
 ## Additional Notes
 

--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -3,13 +3,10 @@
 Ensure you have set the chatapi configs via the manager -> AI Configurations or in the `configurations` database in couchdb:
 
 For model choices view:
-  Openai: https://platform.openai.com/docs/models
-  Perplexity: https://docs.perplexity.ai/guides/model-cards
-  deepseek: https://api-docs.deepseek.com/quick_start/pricing
-  Gemini: https://deepmind.google/technologies/gemini/
-
-
-Note: This applies for both production and development environments.
+  - Openai: https://platform.openai.com/docs/models
+  - Perplexity: https://docs.perplexity.ai/models/model-cards
+  - Deepseek: https://api-docs.deepseek.com/quick_start/pricing
+  - Gemini: https://deepmind.google/technologies/gemini/
 
 ## Development Notes
 For development environment add a .env file in the `chatapi` directory
@@ -21,6 +18,12 @@ Add the following configs in the .env file:
     COUCHDB_USER=username
     COUCHDB_PASS=password
   ```
+
+*Note*: To run the development environment, ensure that you are using node 18. and then use `npm run dev` to start the development server. This will use nodemon to automatically restart the server on file changes.
+
+## Additional Notes
+
+By default the local production(docker containers) and local development environment run on port 5000. To use both at the same time, ensure you change the port for one of them.(preferably the development environment in the .env file). Alternatively, turn off the local production environment when developing using docker desktop or docker stop {{chatapi container id}}.
 
 In the production environment these configs are set in the `planet.yml` file.
 

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# load .env if it exists
+[ -f .env ] && source .env
+
+CHAT_PORT="${CHAT_PORT:-5000}"
+
+sed \
+  -e "s/{{CHAT_PORT}}/${CHAT_PORT}/g" \
+  src/environments/environment.template > src/environments/environment.dev.ts
+
+echo "chatapi running on port: ${CHAT_PORT}"

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # load .env if it exists
 [ -f .env ] && source .env
 
-CHAT_PORT="${CHAT_PORT:-5400}"
+CHAT_PORT="${CHAT_PORT:-5000}"
 
 sed \
   -e "s/{{CHAT_PORT}}/${CHAT_PORT}/g" \

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # load .env if it exists
 [ -f .env ] && source .env
 
-CHAT_PORT="${CHAT_PORT:-5000}"
+CHAT_PORT="${CHAT_PORT:-5400}"
 
 sed \
   -e "s/{{CHAT_PORT}}/${CHAT_PORT}/g" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ Docker means many things to many people. In simplest form we can say that docker
 ### Components
 We have several docker components in our application there are
 * Planet. There are two version, one is for production and one is for development.
-  * Planet for production. It basically our production optimized Planet that served via Nginx.
+  * Planet for production. It basically our production optimized Planet (sometimes served via Nginx).
   * Planet for development. It basically a runtime that make it possible for Planet to run (mostly node.js)
 * CouchDB. It basically a CouchDB container and it developed in the different project. You can access it here in [ole-vi/rpi-couchdb](https://github.com/ole-vi/rpi-couchdb)
 * CouchDB initialization data a.k.a. `db-init`. It contains all the schema necessary for our Planet to run.
@@ -29,16 +29,14 @@ This docker compose can be use for your development environment and very handy, 
 ## How to use
 I will divide this how to use into two sections, for development and for production. It is interesting to run our development environment on top of isolated docker container.
 
-### For Development
-
 ### For Production
 
-1. Move to `docker` folder
+1. Move to `srv/planet` folder
 2. Run the following command to spawn your environment for the first time
-   (Optional: update planet.yml with specific images from https://hub.docker.com/r/treehouses/planet/tags/)
+   (Optional: update planet.yml with the latest or a specific images from https://hub.docker.com/r/treehouses/planet/tags/)
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet up -d --build
+docker-compose -f planet.yml -p planet up -d --build
 ```
 
 See if the docker containers running
@@ -50,12 +48,14 @@ docker ps
 You'll see you containers like this
 
 ```
-CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS              PORTS                                                                NAMES
-ea3b914c3193        planetdev_planet    "/bin/sh -c 'bash ..."   About a minute ago   Up 58 seconds       0.0.0.0:3000->3000/tcp                                               planetdev_planet_1
-57f30698ccda        klaemo/couchdb      "tini -- /docker-e..."   About a minute ago   Up About a minute   4369/tcp, 9100/tcp, 0.0.0.0:2200->5984/tcp, 0.0.0.0:2201->5986/tcp   planetdev_couchdb_1
+CONTAINER ID   IMAGE                      COMMAND                  CREATED         STATUS         PORTS                                                             NAMES
+0914c167f20e   d14b10ade528               "/bin/sh -c ./docker…"   2 weeks ago     Up 2 seconds   0.0.0.0:80->80/tcp, [::]:80->80/tcp, 443/tcp                      planet-prod-planet-1
+42d4b4ea3826   898294509ee6               "npm run start"          2 weeks ago     Up 2 seconds   0.0.0.0:5400->5400/tcp, [::]:5400->5400/tcp                       planet-prod-chatapi-1
+c03b86dfede9   9859c264e24e               "/bin/sh -c 'bash ./…"   2 weeks ago     Up 2 seconds                                                                     planet-prod-db-init-1
+f7ddb76ae6b6   treehouses/couchdb:2.3.1   "tini -- /docker-ent…"   14 months ago   Up 2 seconds   4369/tcp, 9100/tcp, 0.0.0.0:2200->5984/tcp, [::]:2200->5984/tcp   planet-prod-couchdb-1
 ```
 
-Connect to your `planetdev_planet` with
+Connect to your `planet-prod-planet-1` with
 
 ```
 docker logs {{id}}
@@ -64,7 +64,7 @@ docker logs {{id}}
 in this case
 
 ```
-docker logs ea3b914c3193 -f
+docker logs 0914c167f20e -f
 ```
 
 press `CTRL+C` to exit logs view
@@ -72,19 +72,19 @@ press `CTRL+C` to exit logs view
 3. When you're done, you can do the following command
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet stop
+docker-compose -f planet.yml -p planet stop
 ```
 
 4. When you go back to code
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet start
+docker-compose -f planet.yml -p planet start
 ```
 
 5. When you have to delete the environment
 
 ```
-docker-compose -f planet.yml -f install.yml -p planet down
+docker-compose -f planet.yml -p planet down
 ```
 
 Remember when your containers active you can always look to your containers logs to see whats going on on the background.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.31",
+  "version": "0.19.43",
   "myplanet": {
     "latest": "v0.26.0",
     "min": "v0.25.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ng": "ng",
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "ng serve --aot --configuration=$CONF",
+    "dev": "./dev-env.sh && ng serve --aot --configuration=dev",
     "build": "npm run ng-high-memory -- build --prod --configuration=$CONF",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -1,0 +1,11 @@
+export const environment = {
+  production: false,
+  test: false,
+  chatAddress: window.location.protocol + '//' + window.location.hostname + ':{{CHAT_PORT}}',
+  couchAddress: window.location.protocol + '//' + window.location.hostname + ':2200',
+  centerAddress: 'planet.earth.ole.org/db',
+  centerProtocol: 'https',
+  parentProtocol: 'https',
+  upgradeAddress: window.location.origin + '/upgrade',
+  syncAddress: window.location.protocol + '//localhost:5984'
+};


### PR DESCRIPTION
Fixes #8760

- Allow port selection in dev env
- Update the docker readme file

To test:
1. Ensure your dev chatapi is running(reference `/chatapi/README.md`)
2. Create a .env file in the planet root dir and set the `CHAT_PORT` variable. Ensure that the `CHAT_PORT` set in the .env is the same as the `SERVE_PORT`  in the `/chatapi/.env`.

Visit localhost:{{port}}/checkproviders to confirm