### PR TITLE
manager: smoother surveys submissions view (fixes #8816)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.35",
+  "version": "0.19.36",
   "myplanet": {
-    "latest": "v0.26.22",
-    "min": "v0.25.22"
+    "latest": "v0.26.26",
+    "min": "v0.25.26"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -226,7 +226,7 @@ export class SubmissionsService {
     );
   }
 
-  createSubmission(parent: any, type: string, user: any = '', team?: string) {
+  createSubmission(parent: any, type: string, user: any = {}, team?: string) {
     return this.couchService.updateDocument('submissions', this.createNewSubmission({ parentId: parent._id, parent, user, type, team }));
   }
 

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -362,7 +362,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   recordSurvey(survey: any) {
-    this.submissionsService.createSubmission(survey, 'survey', '', this.teamId || this.routeTeamId || '' ).subscribe((res: any) => {
+    this.submissionsService.createSubmission(survey, 'survey', {}, this.teamId || this.routeTeamId || '' ).subscribe((res: any) => {
       this.router.navigate([
         this.teamId ? 'surveys/dispense' : 'dispense',
         { questionNum: 1, submissionId: res.id, status: 'pending', mode: 'take', snap: this.route.snapshot.url }


### PR DESCRIPTION
Fixes #8816

Surveys complete without the user details will be displayed correctly in the myDashboard/mySubmissions