### PR TITLE
all: smoother icons permissions (fixes #8827)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.38",
+  "version": "0.19.41",
   "myplanet": {
-    "latest": "v0.26.28",
-    "min": "v0.25.28"
+    "latest": "v0.26.39",
+    "min": "v0.25.39"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -210,13 +210,15 @@
             <label i18n>{{ 'Messages' | truncateText:12 }}</label>
           </a>
         </li>
-        <ng-container *planetAuthorizedRoles="'manager'">
-          <li>
-            <a mat-button routerLink="/manager" i18n-title title="Manager Settings">
-              <mat-icon svgIcon="usersettings"></mat-icon>
-              <label i18n>{{ 'Manager Settings' | truncateText:12 }}</label>
-            </a>
-          </li>
+        <ng-container *ngIf="isLoggedIn">
+          <ng-container *planetAuthorizedRoles="'manager'">
+            <li>
+              <a mat-button routerLink="/manager" i18n-title title="Manager Settings">
+                <mat-icon svgIcon="usersettings"></mat-icon>
+                <label i18n>{{ 'Manager Settings' | truncateText:12 }}</label>
+              </a>
+            </li>
+          </ng-container>
         </ng-container>
         <li>
           <a mat-button class="language-button" i18n-title title="Language" (click)="openLanguageSelector()">
@@ -224,20 +226,22 @@
             <label *ngIf="sidenavState === 'open'" class="language-label" i18n>{{ 'Language' | truncateText:12 }}</label>
           </a>
         </li>
-        <ng-container *planetAuthorizedRoles="''">
-          <li *ngIf="onlineStatus === 'accepted'">
-            <a mat-button planetSync i18n-title title="Sync">
-              <mat-icon svgIcon="sync"></mat-icon>
-              <label i18n>{{ 'Sync' | truncateText:12 }}</label>
+        <ng-container *ngIf="isLoggedIn">
+          <ng-container *planetAuthorizedRoles="''">
+            <li *ngIf="onlineStatus === 'accepted'">
+              <a mat-button planetSync i18n-title title="Sync">
+                <mat-icon svgIcon="sync"></mat-icon>
+                <label i18n>{{ 'Sync' | truncateText:12 }}</label>
+              </a>
+            </li>
+          </ng-container>
+          <li>
+            <a mat-button (click)="logoutClick()" i18n-title title="Logout">
+              <mat-icon svgIcon="logout"></mat-icon>
+              <label i18n>{{ 'Logout' | truncateText:12 }}</label>
             </a>
           </li>
         </ng-container>
-        <li>
-          <a mat-button (click)="logoutClick()" i18n-title title="Logout">
-            <mat-icon svgIcon="logout"></mat-icon>
-            <label i18n>{{ 'Logout' | truncateText:12 }}</label>
-          </a>
-        </li>
       </ul>
     </div>
   </mat-sidenav>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -46,10 +46,10 @@
       <button mat-icon-button routerLink="/chat" i18n-title title="Chat"><mat-icon>question_answer</mat-icon></button>
       <button mat-icon-button planetFeedback i18n-title title="Submit Feedback"><mat-icon svgIcon="feedback"></mat-icon></button>
       <button mat-icon-button routerLink="/feedback" i18n-title title="Review Feedback"><mat-icon svgIcon="feedbacklist"></mat-icon></button>
-      <ng-container *planetAuthorizedRoles="''">
-        <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="sync"></mat-icon></button>
-      </ng-container>
       <ng-container *ngIf="isLoggedIn">
+        <ng-container *planetAuthorizedRoles="''">
+          <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="sync"></mat-icon></button>
+        </ng-container>
         <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
       </ng-container>
       <planet-language i18n-title title="Language"></planet-language>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -49,14 +49,18 @@
       <ng-container *planetAuthorizedRoles="''">
         <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="sync"></mat-icon></button>
       </ng-container>
-      <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
+      <ng-container *ngIf="isLoggedIn">
+        <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
+      </ng-container>
       <planet-language i18n-title title="Language"></planet-language>
     </span>
-    <ng-container *planetAuthorizedRoles="'learner'">
-      <button mat-icon-button *ngIf="notifications.length > 0" [matMenuTriggerFor]="notificationMenu" i18n-title title="Notifications">
-        <mat-icon matBadge={{notifications.length}} matBadgeColor="warn" MatBadgeSize="small">notifications</mat-icon>
-      </button>
-      <button mat-icon-button *ngIf="notifications.length === 0" routerLink="/notifications" i18n-title title="No Notification"><mat-icon>notifications_none</mat-icon></button>
+    <ng-container *ngIf="isLoggedIn">
+      <ng-container *planetAuthorizedRoles="'learner'">
+        <button mat-icon-button *ngIf="notifications.length > 0" [matMenuTriggerFor]="notificationMenu" i18n-title title="Notifications">
+          <mat-icon matBadge={{notifications.length}} matBadgeColor="warn" MatBadgeSize="small">notifications</mat-icon>
+        </button>
+        <button mat-icon-button *ngIf="notifications.length === 0" routerLink="/notifications" i18n-title title="No Notification"><mat-icon>notifications_none</mat-icon></button>
+      </ng-container>
     </ng-container>
     <button mat-icon-button [matMenuTriggerFor]="userProfile">
       <img *ngIf="user._attachments; else accountIcon" class="profile-image-large" [src]="userImgSrc">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -83,6 +83,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
     this.userService.userChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe(() => {
         this.onUserUpdate();
+        this.getNotification();
       });
     this.couchService.get('_node/nonode@nohost/_config/planet').subscribe((res: any) => this.layout = res.layout || 'classic');
     this.onlineStatus = this.stateService.configuration.registrationRequest;


### PR DESCRIPTION
Fixes #8827

Improves the state of the icons across the home on login.
- Notification count displayed on login (via the community page)
- Manager Settings wheel & notification icons no longer visible on logout (also in the mobile sidebar)

![image](https://github.com/user-attachments/assets/233a4d0c-5a86-4faf-95be-9c92a21588b0)
