### PR TITLE
dashboard: smoother profile image reset (fixes #8837)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.41",
+  "version": "0.19.42",
   "myplanet": {
-    "latest": "v0.26.39",
-    "min": "v0.25.39"
+    "latest": "v0.26.47",
+    "min": "v0.25.47"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -130,7 +130,8 @@
           <button mat-raised-button color="secondary" (click)="fileInput.click()">
             Choose Image
           </button>
-          <button *ngIf="uploadImage && currentImgKey" mat-raised-button color="accent" (click)="deleteImageAttachment()">Remove</button>
+          <button *ngIf="imageChangedEvent || attachmentDeleted" mat-raised-button color="accent" (click)="resetSelection()">Reset Selection</button>
+          <button *ngIf="uploadImage && currentImgKey && !imageChangedEvent && !attachmentDeleted" mat-raised-button color="accent" (click)="deleteImageAttachment()">Remove</button>
         </div>
         <input #fileInput id="fileInput" type="file" accept="image/*" (change)="fileChangeEvent($event)" style="display: none;" />
       </div>

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -42,6 +42,8 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
   minBirthDate: Date = this.userService.minBirthDate;
   hasUnsavedChanges = false;
   avatarChanged = false;
+  attachmentDeleted = false;
+  originalAttachments: any = null;
   isFormInitialized = false;
   private isNavigating = false;
   private subscriptions: Subscription = new Subscription();
@@ -86,6 +88,7 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
           this.currentImgKey = Object.keys(data._attachments)[0];
           this.currentProfileImg = this.urlPrefix + '/org.couchdb.user:' + this.urlName + '/' + this.currentImgKey;
           this.uploadImage = true;
+          this.originalAttachments = { ...data._attachments };
         }
         this.previewSrc = this.currentProfileImg;
         console.log('data: ', data);
@@ -228,9 +231,29 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
     this.currentProfileImg = 'assets/image.png';
     this.removeImageFile();
     this.avatarChanged = true;
+    this.attachmentDeleted = true;
     this.unsavedChangesService.setHasUnsavedChanges(true);
   }
 
+  resetSelection() {
+    if (this.attachmentDeleted && this.originalAttachments) {
+      this.user._attachments = { ...this.originalAttachments };
+      this.currentImgKey = Object.keys(this.originalAttachments)[0];
+      this.currentProfileImg = this.urlPrefix + '/org.couchdb.user:' + this.urlName + '/' + this.currentImgKey;
+      this.uploadImage = true;
+      this.attachmentDeleted = false;
+      this.previewSrc = this.currentProfileImg;
+      this.file = null;
+      this.imageChangedEvent = null;
+    } else {
+      this.previewSrc = this.currentProfileImg;
+      this.file = null;
+      this.uploadImage = this.currentProfileImg !== 'assets/image.png';
+      this.imageChangedEvent = null;
+    }
+    this.avatarChanged = false;
+    this.unsavedChangesService.setHasUnsavedChanges(this.isFormPristine() ? false : true);
+  }
 
   appendToSurvey(user) {
     const submissionId = this.route.snapshot.params.id;


### PR DESCRIPTION
Fixes #8837

Implement button to reset image selection

![image](https://github.com/user-attachments/assets/d200cd5b-ade7-4693-9e0f-7a29c9c71815)
