### PR TITLE
teams: smoother courses linking (fixes #8860)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.45",
+  "version": "0.19.48",
   "myplanet": {
     "latest": "v0.26.64",
     "min": "v0.25.64"

--- a/src/app/courses/view-courses/courses-view-detail.component.ts
+++ b/src/app/courses/view-courses/courses-view-detail.component.ts
@@ -65,6 +65,7 @@ export class CoursesViewDetailDialogComponent implements OnInit {
   }
 
   routeToCourses(courseId) {
-    this.router.navigate([ '../../courses/view/', courseId ], { relativeTo: this.route });
+    const navigationExtras = this.data.returnState ? { state: { returnState: this.data.returnState } } : { relativeTo: this.route };
+    this.router.navigate([ '../../courses/view/', courseId ], navigationExtras);
   }
 }

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -184,9 +184,15 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     this.router.navigate([ 'update' ], { relativeTo: this.route });
   }
   /**
+   * If returnState is set in history, it will navigate to that page.(teams/enterprises)
    * Returns routing to previous parent page on Courses
    */
   goBack() {
+    const returnState = history.state?.returnState;
+    if (returnState) {
+      this.router.navigate([ `${returnState.mode}s/view/${returnState.teamId}` ]);
+      return;
+    }
     this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
 

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
-
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
-import { environment } from '../../../environments/environment';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import { UserService } from '../../shared/user.service';
 import { ResourcesService } from '../resources.service';
 import { debug } from '../../debug-operator';
@@ -20,19 +19,6 @@ import * as constants from '../resources-constants';
 })
 
 export class ResourcesViewComponent implements OnInit, OnDestroy {
-
-  constructor(
-    private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService,
-    private stateService: StateService,
-    private resourcesService: ResourcesService,
-    private planetMessageService: PlanetMessageService,
-    private dialogsLoadingService: DialogsLoadingService,
-    private deviceInfoService: DeviceInfoService
-  ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
 
   private dbName = 'resources';
   private onDestroy$ = new Subject<void>();
@@ -62,6 +48,19 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
   languageOptions = languages;
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private userService: UserService,
+    private stateService: StateService,
+    private resourcesService: ResourcesService,
+    private planetMessageService: PlanetMessageService,
+    private dialogsLoadingService: DialogsLoadingService,
+    private deviceInfoService: DeviceInfoService
+  ) {
+    this.deviceType = this.deviceInfoService.getDeviceType();
+  }
 
   @HostListener('window:resize') OnResize() {
     this.deviceType = this.deviceInfoService.getDeviceType();
@@ -122,9 +121,15 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * If returnState is set in history, it will navigate to that page.(teams/enterprises)
    * Returns routing to previous parent page
    */
   goBack() {
+    const returnState = history.state?.returnState;
+    if (returnState) {
+      this.router.navigate([ `${returnState.mode}s/view/${returnState.teamId}` ]);
+      return;
+    }
     this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
 }

--- a/src/app/shared/dialogs/dialogs-resources-viewer.component.ts
+++ b/src/app/shared/dialogs/dialogs-resources-viewer.component.ts
@@ -21,8 +21,10 @@ export class DialogsResourcesViewerComponent {
   ) {}
 
   viewResources() {
+    console.log('return', this.data);
     this.dialogRef.close();
-    this.router.navigate([ `/resources/view/${this.data.resourceId}` ], { relativeTo: this.route });
+    const navigationExtras = this.data.returnState ? { state: { returnState: this.data.returnState } } : { relativeTo: this.route };
+    this.router.navigate([ `/resources/view/${this.data.resourceId}` ], navigationExtras);
   }
 
 }

--- a/src/app/shared/dialogs/dialogs-resources-viewer.component.ts
+++ b/src/app/shared/dialogs/dialogs-resources-viewer.component.ts
@@ -21,7 +21,6 @@ export class DialogsResourcesViewerComponent {
   ) {}
 
   viewResources() {
-    console.log('return', this.data);
     this.dialogRef.close();
     const navigationExtras = this.data.returnState ? { state: { returnState: this.data.returnState } } : { relativeTo: this.route };
     this.router.navigate([ `/resources/view/${this.data.resourceId}` ], navigationExtras);

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -540,7 +540,9 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   openResource(resourceId) {
-    this.dialog.open(DialogsResourcesViewerComponent, { data: { resourceId, returnState: { teamId: this.teamId, mode: this.mode } }, autoFocus: false });
+    this.dialog.open(DialogsResourcesViewerComponent, {
+      data: { resourceId, returnState: { teamId: this.teamId, mode: this.mode }
+    }, autoFocus: false });
   }
 
   openMemberDialog(member) {

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -531,7 +531,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   openCourseView(courseId) {
     this.dialog.open(CoursesViewDetailDialogComponent, {
-      data: { courseId: courseId },
+      data: { courseId: courseId, returnState: { teamId: this.teamId, mode: this.mode } },
       minWidth: '600px',
       maxWidth: '90vw',
       maxHeight: '90vh',
@@ -540,7 +540,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   openResource(resourceId) {
-    this.dialog.open(DialogsResourcesViewerComponent, { data: { resourceId }, autoFocus: false });
+    this.dialog.open(DialogsResourcesViewerComponent, { data: { resourceId, returnState: { teamId: this.teamId, mode: this.mode } }, autoFocus: false });
   }
 
   openMemberDialog(member) {


### PR DESCRIPTION
Fixes #8860

In the teams and enterprises, allow redirection from courses/resources view  after viewing course/resource

![image](https://github.com/user-attachments/assets/5441c6d5-dd9c-4d5e-8003-6042c5471335)

Steps to test:
- Go to teams, click on resources tab
- Select resource, the dialog opens and click `View resource`
- Click the back button in the resources view, you should be back in the team

Similarly test the courses and then the enterprises(documents & courses).