### PR TITLE
all: smoother active svg icon colors (fixes #8849)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.46",
+  "version": "0.19.47",
   "myplanet": {
-    "latest": "v0.26.71",
-    "min": "v0.25.71"
+    "latest": "v0.26.74",
+    "min": "v0.25.74"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -193,7 +193,7 @@
       <!--Bottom part-->
       <ul class="bottom-nav">
         <li>
-          <a mat-button routerLink="/chat" i18n-title title="Chat">
+          <a mat-button routerLink="/chat" routerLinkActive="active" i18n-title title="Chat">
             <mat-icon>question_answer</mat-icon>
             <label i18n>{{ 'Chat' | truncateText:12 }}</label>
           </a>
@@ -205,7 +205,7 @@
           </a>
         </li>
         <li>
-          <a mat-button routerLink="/feedback" i18n-title title="Messages">
+          <a mat-button routerLink="/feedback" routerLinkActive="active" i18n-title title="Messages">
             <mat-icon svgIcon="feedbacklist"></mat-icon>
             <label i18n>{{ 'Messages' | truncateText:12 }}</label>
           </a>
@@ -213,7 +213,7 @@
         <ng-container *ngIf="isLoggedIn">
           <ng-container *planetAuthorizedRoles="'manager'">
             <li>
-              <a mat-button routerLink="/manager" i18n-title title="Manager Settings">
+              <a mat-button routerLink="/manager" routerLinkActive="active" i18n-title title="Manager Settings">
                 <mat-icon svgIcon="usersettings"></mat-icon>
                 <label i18n>{{ 'Manager Settings' | truncateText:12 }}</label>
               </a>

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -156,6 +156,10 @@
           background-color: rgba(0, 0, 0, 0.06);
           transition: background-color 1s ease-in;
         }
+        // Fix SVG icons to use primary color when active
+        mat-icon ::ng-deep svg {
+          fill: $primary;
+        }
       }
 
       // Animates pulsating icon when navbar link clicked
@@ -197,7 +201,7 @@
 }
 
 .banner {
-  background-color: #2196f3;
+  background-color: $primary;
   color: white;
   padding: 10px;
   text-align: center;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -690,7 +690,7 @@ body {
   }
 
   .copy-btn.copied {
-    color: #2196f3;
+    color: $primary;
   }
 
   .chat-link {


### PR DESCRIPTION
Fixes #8849

- Fix svg icon active color
- Add active state to bottom sidenav icons

![image](https://github.com/user-attachments/assets/8011f3e4-849e-4599-8cae-cf78ab196b3c)
