### PR TITLE
Fix workflows for branch names with slashes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,14 +35,15 @@ jobs:
 
       - name: deploy
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           if [[ "${{ github.event.inputs.hostname }}" == "" ]]; then
-            SERVER_HOST="planet.dev.ole.org"  
+            SERVER_HOST="planet.dev.ole.org"
           else
             SERVER_HOST="${{ github.event.inputs.hostname }}"
           fi
           PLANET_VERSION=$(jq '.version' package.json | sed -e 's/^"//' -e 's/"$//')
           if [[ "${{ github.event.inputs.buildname }}" == "" ]]; then
-            BUILD="$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
+            BUILD="$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
             # BUILD="0.13.4-deploy-d6b59441"
           else
             SERVER_HOST="${{ github.event.inputs.hostname }}"

--- a/.github/workflows/planet-chat.yml
+++ b/.github/workflows/planet-chat.yml
@@ -49,8 +49,9 @@ jobs:
 
       - name: Build image
         run: |
-          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker build -f './docker/chatapi/${{ matrix.arch }}-Dockerfile' -t $repo .
           docker images
@@ -71,17 +72,18 @@ jobs:
 
       - name: Multiarch Deploy
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
           sudo chmod +x /usr/local/bin/manifest_tool
           mkdir -p /tmp/MA_manifests
-          latesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e -n '.image = strenv(latesttag)' | \
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
+          latesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e -n '.image = strenv(latesttag)' | \
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
           yq e '.manifests[0].platform.architecture = "amd64"' - | \
           yq e '.manifests[0].platform.os = "linux"' - | \
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
           yq e '.manifests[1].platform.architecture = "arm"' - | \
           yq e '.manifests[1].platform.os = "linux"' - | \
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
           yq e '.manifests[2].platform.architecture = "arm64"' - | \
           yq e '.manifests[2].platform.os = "linux"' - | \
           tee /tmp/MA_manifests/MA_chatapi_latest.yaml
@@ -90,18 +92,19 @@ jobs:
       - name: Multiarch Deploy Versioned
         if: ${{ github.event_name == 'release' }}
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
           sudo chmod +x /usr/local/bin/manifest_tool
           mkdir -p /tmp/MA_manifests
           versiontag="$DOCKER_ORG/$DOCKER_REPO:chatapi-$PLANET_VERSION" yq e -n '.image = strenv(versiontag)' | \
           yq e '.tags |= . + ["chatapi"] ' - | \
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
           yq e '.manifests[0].platform.architecture = "amd64"' - | \
           yq e '.manifests[0].platform.os = "linux"' - | \
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
           yq e '.manifests[1].platform.architecture = "arm"' - | \
           yq e '.manifests[1].platform.os = "linux"' - | \
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
           yq e '.manifests[2].platform.architecture = "arm64"' - | \
           yq e '.manifests[2].platform.os = "linux"' - | \
           tee /tmp/MA_manifests/MA_chatapi_versioned.yaml

--- a/.github/workflows/planet-db.yml
+++ b/.github/workflows/planet-db.yml
@@ -49,8 +49,9 @@ jobs:
 
       - name: Build image
         run: |
-          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$GITHUB_REF_NAME"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker build -f './docker/db-init/${{ matrix.arch }}-Dockerfile' -t $repo .
           docker images
@@ -71,17 +72,18 @@ jobs:
 
       - name: Multiarch Deploy
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
           sudo chmod +x /usr/local/bin/manifest_tool
           mkdir -p /tmp/MA_manifests
-          latesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e -n '.image = strenv(latesttag)' | \
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
+          latesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e -n '.image = strenv(latesttag)' | \
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
           yq e '.manifests[0].platform.architecture = "amd64"' - | \
           yq e '.manifests[0].platform.os = "linux"' - | \
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
           yq e '.manifests[1].platform.architecture = "arm"' - | \
           yq e '.manifests[1].platform.os = "linux"' - | \
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
           yq e '.manifests[2].platform.architecture = "arm64"' - | \
           yq e '.manifests[2].platform.os = "linux"' - | \
           tee /tmp/MA_manifests/MA_db-init_latest.yaml
@@ -90,18 +92,19 @@ jobs:
       - name: Multiarch Deploy Versioned
         if: ${{ github.event_name == 'release' }}
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
           sudo chmod +x /usr/local/bin/manifest_tool
           mkdir -p /tmp/MA_manifests
           versiontag="$DOCKER_ORG/$DOCKER_REPO:db-init-$PLANET_VERSION" yq e -n '.image = strenv(versiontag)' | \
           yq e '.tags |= . + ["db-init"] ' - | \
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
           yq e '.manifests[0].platform.architecture = "amd64"' - | \
           yq e '.manifests[0].platform.os = "linux"' - | \
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
           yq e '.manifests[1].platform.architecture = "arm"' - | \
           yq e '.manifests[1].platform.os = "linux"' - | \
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
           yq e '.manifests[2].platform.architecture = "arm64"' - | \
           yq e '.manifests[2].platform.os = "linux"' - | \
           tee /tmp/MA_manifests/MA_db-init_versioned.yaml

--- a/.github/workflows/planet.yml
+++ b/.github/workflows/planet.yml
@@ -64,16 +64,18 @@ jobs:
       - name: Pre-Build Planet
         if: ${{ env.SHOULD_UPDATE_PACKAGES == 1 || github.event.inputs.buildtype == 'prebuild' }}
         run: |
-          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
           mkdir -p ./ng-app/dist
-          docker build -f './docker/planet/pre-builder-Dockerfile' -t $repo . 
+          docker build -f './docker/planet/pre-builder-Dockerfile' -t $repo .
           docker images
           docker push $repo
       
       - name: Push latest pre-build
         if: ${{ (github.ref == 'refs/heads/master' || env.IS_RELEASE == 'true') && (env.SHOULD_UPDATE_PACKAGES == 1 || github.event.inputs.buildtype == 'prebuild') }}
         run: |
-          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
           latestrepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker tag $repo $latestrepo
           docker push $latestrepo
@@ -100,18 +102,20 @@ jobs:
       - name: Tag prebuild as latest
         continue-on-error: true # If there are no package changes, the commit specific image will not be built so an error is expected here
         run: |
-          prerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          prerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
           latestprerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker pull $prerepo
           docker tag $prerepo $latestprerepo
 
       - name: Build single language build
         run: |
-          repo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$GITHUB_REF_NAME"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$BRANCH"
           export NODE_OPTIONS=--max_old_space_size=4096
           mkdir -p ./ng-app/dist
-          docker build -f './docker/planet/builder-Dockerfile' -t $repo . 
+          docker build -f './docker/planet/builder-Dockerfile' -t $repo .
           docker images
           docker push $repo
           docker tag $repo $branchrepo
@@ -138,12 +142,13 @@ jobs:
 
       - name: Build image
         run: |
-          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$GITHUB_REF_NAME"
+          BRANCH="${GITHUB_REF_NAME//\//-}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$BRANCH"
           LANGUAGES=( 'eng' 'ara' 'fra' 'spa' 'nep' 'som')
           mkdir -p ./ng-app/dist
           mkdir -p ./ng-app/langbuild
-          docker create --name langbuild "$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$GITHUB_REF_NAME"
+          docker create --name langbuild "$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$BRANCH"
           docker export langbuild > langbuild.tar
           tar -xf langbuild.tar -C ./ng-app/langbuild
           for LANGUAGE in "${LANGUAGES[@]}"; do
@@ -180,17 +185,18 @@ jobs:
 
       - name: Multiarch Deploy
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
           sudo chmod +x /usr/local/bin/manifest_tool
           mkdir -p /tmp/MA_manifests
-          latesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e -n '.image = strenv(latesttag)' | \
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
+          latesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e -n '.image = strenv(latesttag)' | \
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
           yq e '.manifests[0].platform.architecture = "amd64"' - | \
           yq e '.manifests[0].platform.os = "linux"' - | \
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
           yq e '.manifests[1].platform.architecture = "arm"' - | \
           yq e '.manifests[1].platform.os = "linux"' - | \
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
           yq e '.manifests[2].platform.architecture = "arm64"' - | \
           yq e '.manifests[2].platform.os = "linux"' - | \
           tee /tmp/MA_manifests/MA_planet_latest.yaml
@@ -199,18 +205,19 @@ jobs:
       - name: Multiarch Deploy Versioned
         if: ${{ github.event_name == 'release' }}
         run: |
+          BRANCH="${GITHUB_REF_NAME//\//-}"
           sudo wget -O /usr/local/bin/manifest_tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
           sudo chmod +x /usr/local/bin/manifest_tool
           mkdir -p /tmp/MA_manifests
           versiontag="$DOCKER_ORG/$DOCKER_REPO:$PLANET_VERSION" yq e -n '.image = strenv(versiontag)' | \
           yq e '.tags |= . + ["latest"] ' - | \
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[0].image = strenv(amd64tag)' - | \
           yq e '.manifests[0].platform.architecture = "amd64"' - | \
           yq e '.manifests[0].platform.os = "linux"' - | \
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[1].image = strenv(armtag)' - | \
           yq e '.manifests[1].platform.architecture = "arm"' - | \
           yq e '.manifests[1].platform.os = "linux"' - | \
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$GITHUB_REF_NAME-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}" yq e '.manifests[2].image = strenv(arm64tag)' - | \
           yq e '.manifests[2].platform.architecture = "arm64"' - | \
           yq e '.manifests[2].platform.os = "linux"' - | \
           tee /tmp/MA_manifests/MA_planet_versioned.yaml


### PR DESCRIPTION
## Summary
- escape branch names in Docker tags by replacing `/` with `-`
- update build and deploy workflow steps accordingly

## Testing
- `npm install --silent` *(fails: returned exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68769fdf4520832ba564851d9c8d81f0