### PR TITLE
all: fix defaulting to dev conf (fixes #8901)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -202,7 +202,7 @@
               "browserTarget": "planet-app:build:spa"
             }
           },
-          "defaultConfiguration": "dev"
+          "defaultConfiguration": ""
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",


### PR DESCRIPTION
Fixes #8901

stop `ng s` and `npm run start` from defaulting to the 'dev' configuration which checks for the `environment.dev.ts`

Steps to test
- Delete the `environment.dev.ts`
- Run `ng s` or `npm run start`

The app should run appropriately