### PR TITLE
dashboard: smoother spanish translation (fixes #8911)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -202,7 +202,7 @@
               "browserTarget": "planet-app:build:spa"
             }
           },
-          "defaultConfiguration": ""
+          "defaultConfiguration": "dev"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/angular.json
+++ b/angular.json
@@ -202,7 +202,7 @@
               "browserTarget": "planet-app:build:spa"
             }
           },
-          "defaultConfiguration": "dev"
+          "defaultConfiguration": ""
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.62",
+  "version": "0.19.64",
   "myplanet": {
     "latest": "v0.27.8",
     "min": "v0.26.8"

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -116,7 +116,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       { baseFirstLine: $localize`my`, title: $localize`Submissions`, link: 'submissions', authorization: 'leader,manager',
         badge: this.examsCount },
       { baseFirstLine: $localize` my `, title: $localize`Chat`, link: 'chat' },
-      { baseFirstLine: $localize`my`, title: $localize`Progress`, link: 'myProgress' },
+      { baseFirstLine: $localize` my `, title: $localize`Progress`, link: 'myProgress' },
       { baseFirstLine: $localize`my`, title: $localize`Personals`, link: 'myPersonals' },
       { baseFirstLine: $localize`my`, title: $localize`Achievements`, link: 'myAchievements' },
       { baseFirstLine: $localize`my`, title: $localize`Surveys`, link: 'mySurveys', badge: this.surveysCount },


### PR DESCRIPTION
fixes #8911

Adding the space around "my" grabs the singular version, which is what we want for myProgress.

<img width="208" height="391" alt="image" src="https://github.com/user-attachments/assets/876f9db5-bb37-4e3a-81a6-4201454e1291" />
