### PR TITLE
community: smoother voices reply (fixes #8931)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.65",
+  "version": "0.19.69",
   "myplanet": {
     "latest": "v0.27.17",
     "min": "v0.26.17"

--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -3,7 +3,7 @@
     <div class="community-news">
       <mat-tab-group class="tabs-padding" (selectedTabChange)="tabChanged($event)">
         <mat-tab i18n-label label="Our Voices">
-          <mat-toolbar class="primary-color font-size-1 responsive-toolbar">
+          <mat-toolbar class="primary-color font-size-1 responsive-toolbar" *ngIf="!activeReplyId">
             <h1 i18n>{ configuration.planetType, select, community {Community} nation {Nation} center {Earth}} Board</h1>
             <div class="toolbar-row">
               <mat-form-field class="search-form-field">

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -60,6 +60,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   deviceType: DeviceType;
   deviceTypes = DeviceType;
   isLoading = true;
+  currentTab = 0;
   activeReplyId: string | null = null;
   lastReplyId: string | null = null;
   voiceSearch = '';
@@ -453,13 +454,17 @@ export class CommunityComponent implements OnInit, OnDestroy {
   }
 
   tabChanged({ index }: { index: number }) {
+    // stash reply only on voices tab change
+    if (this.currentTab === 0 && index !== 0) {
+      this.lastReplyId = this.activeReplyId;
+    }
     if (index === 0) {
       this.router.navigate([ this.lastReplyId ? `/voices/${this.lastReplyId}` : '' ]);
     } else {
-      this.lastReplyId = this.activeReplyId;
       this.router.navigate([ '' ]);
     }
-    this.resizeCalendar = index === 5;
+    this.resizeCalendar = (index === 5);
+    this.currentTab = index;
   }
 
   onLabelFilterChange(label: string): void {

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -61,6 +61,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   deviceTypes = DeviceType;
   isLoading = true;
   activeReplyId: string | null = null;
+  lastReplyId: string | null = null;
   voiceSearch = '';
   availableLabels: string[] = [];
   selectedLabel = '';
@@ -367,7 +368,7 @@ export class CommunityComponent implements OnInit, OnDestroy {
   }
 
   toggleShowButton(data) {
-    this.activeReplyId = data._id;
+    this.activeReplyId = data._id === 'root' ? null : data._id;
     this.showNewsButton = data._id === 'root';
   }
 
@@ -453,8 +454,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
 
   tabChanged({ index }: { index: number }) {
     if (index === 0) {
-      this.router.navigate([ this.activeReplyId ? `/voices/${this.activeReplyId}` : '' ]);
+      this.router.navigate([ this.lastReplyId ? `/voices/${this.lastReplyId}` : '' ]);
     } else {
+      this.lastReplyId = this.activeReplyId;
       this.router.navigate([ '' ]);
     }
     this.resizeCalendar = index === 5;


### PR DESCRIPTION
Fixes #8931

- Active voice reply persists even with switching between community tabs
- Hide the community board from display in the reply thread