### PR TITLE
chat: smoother siderbar (fixes #8932)

### DIFF
--- a/src/app/chat/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.html
@@ -15,11 +15,15 @@
       <button mat-icon-button color="primary" (click)="resetFilter()" [disabled]="!titleSearch && !searchType" matTooltip="Clear search" i18n-matTooltip [matTooltipDisabled]="!titleSearch && !searchType">
         <mat-icon>delete</mat-icon>
       </button><br>
-      <mat-checkbox [checked]="fullTextSearch" (change)="toggleSearchType()"></mat-checkbox>
-      <span style="font-size: small; font-style: italic;" i18n>Full Conversation Search </span>
-      <button style="text-align: end;" mat-icon-button (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
-        <mat-icon>help_outline</mat-icon>
-      </button>
+      <div class="full-conversation-row">
+        <div class="full-conversation-label-row">
+          <mat-checkbox [checked]="fullTextSearch" (change)="toggleSearchType()"></mat-checkbox>
+          <span class="full-conversation-label" i18n>Full Conversation Search </span>
+        </div>
+        <button mat-icon-button (mouseenter)="toggleOverlay()" (mouseleave)="toggleOverlay()" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
+          <mat-icon>help_outline</mat-icon>
+        </button>
+      </div>
       <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="overlayOpen">
         <span class="overlay-text" i18n>Search through the entire conversation, not just the title</span>
       </ng-template>

--- a/src/app/chat/chat-sidebar/chat-sidebar.scss
+++ b/src/app/chat/chat-sidebar/chat-sidebar.scss
@@ -85,6 +85,26 @@ li:hover {
   margin-right: 4px;
 }
 
+.full-conversation-label {
+  font-size: small;
+  font-style: italic;
+  word-break: break-word;
+  width: 180px;
+  white-space: normal;
+}
+
+.full-conversation-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.full-conversation-label-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
 @media only screen and (max-width: $screen-md) {
   .expand-button {
     top: 10px;


### PR DESCRIPTION
fixes #8932

Longer translated versions of the `Full Conversations Search` text no longer make the sidebar get wider. 

Also moved inline stylings to the css file.

<img width="803" height="1037" alt="image" src="https://github.com/user-attachments/assets/27c82ed4-cf3c-4d27-9536-177361ca12e5" />

Should be the same in English

<img width="976" height="1046" alt="image" src="https://github.com/user-attachments/assets/a401931e-24c7-475d-af04-49d4d4e4253c" />
