### PR TITLE
courses: smoother creation workflow (fixes #8952)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.76",
+  "version": "0.19.80",
   "myplanet": {
-    "latest": "v0.27.60",
-    "min": "v0.26.60"
+    "latest": "v0.27.66",
+    "min": "v0.26.66"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -46,7 +46,8 @@
     </div>
     <div class="actions-container">
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-      <button class="draft-btn margin-lr-2" type="button" mat-raised-button (click)="saveDraft()" i18n>Save Draft</button>
+      <button *ngIf="hasUnsavedChanges" class="draft-btn margin-lr-2" type="button" mat-raised-button (click)="saveDraft()" i18n>Save Draft</button>
+      <button *ngIf="draftExists" class="margin-lr-2" type="button" mat-raised-button (click)="deleteDraft()" i18n>Discard Draft</button>
       <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
       <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
     </div>

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -46,6 +46,7 @@
     </div>
     <div class="actions-container">
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
+      <button class="draft-btn margin-lr-2" type="button" mat-raised-button (click)="saveDraft()" i18n>Save Draft</button>
       <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
       <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
     </div>

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -232,6 +232,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
       showFormErrors(this.courseForm.controls);
       return;
     }
+    this.hasUnsavedChanges = false;
     this.updateCourse(this.courseForm.value, shouldNavigate);
   }
 
@@ -272,11 +273,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy, CanComponentDeact
 
   saveDraft() {
     const course = this.convertMarkdownImagesText({ ...this.courseForm.value, images: this.images }, this.steps);
-    this.pouchService.saveDocEditing(
-      { ...course, tags: this.tags.value, initialTags: this.coursesService.course.initialTags },
-      this.dbName,
-      this.courseId
-    );
+    this.pouchService.saveDocEditing({ ...course, tags: this.tags.value, initialTags: this.coursesService.course.initialTags }, this.dbName, this.courseId);
     this.hasUnsavedChanges = false;
     this.planetMessageService.showMessage($localize`Draft saved successfully`);
   }

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -27,6 +27,10 @@
     width: auto;
   }
 
+  .draft-btn {
+    background: $grey;
+  }
+
   @media (max-width: $screen-md) {
     .form-spacing {
       justify-content: center;

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnDestroy, ViewEncapsulation, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -7,6 +7,7 @@ import { takeUntil } from 'rxjs/operators';
 import { CoursesService } from '../courses.service';
 import { DialogsAddResourcesComponent } from '../../shared/dialogs/dialogs-add-resources.component';
 import { DialogsLoadingService } from '../../shared/dialogs/dialogs-loading.service';
+import { PlanetStepListComponent } from '../../shared/forms/planet-step-list.component';
 
 @Component({
   selector: 'planet-courses-step',
@@ -25,6 +26,7 @@ export class CoursesStepComponent implements OnDestroy {
   activeStep: any;
   activeStepIndex = -1;
   private onDestroy$ = new Subject<void>();
+  @ViewChild(PlanetStepListComponent) stepListComponent: PlanetStepListComponent;
 
   get examButtonLabel(): string {
     return this.activeStep?.exam ? $localize`Update Test` : $localize`Add Test`;
@@ -106,6 +108,12 @@ export class CoursesStepComponent implements OnDestroy {
 
   addStep() {
     this.addStepEvent.emit();
+  }
+
+  toList() {
+    if (this.stepListComponent) {
+      this.stepListComponent.toList();
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #8952

Improve the courses add/edit draft workflow. This is more intuitive for users & accomodates the unsaved changes dialog. Previously, changes were being auto saved.

<img width="3406" height="1852" alt="image" src="https://github.com/user-attachments/assets/d91b3bf9-0c39-4441-a790-df660a3051f4" />
