### PR TITLE
Implement basic federated search

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -37,6 +37,7 @@
   <mat-form-field class="font-size-1 margin-lr-4">
     <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">
   </mat-form-field>
+  <mat-checkbox class="margin-lr-4" [(ngModel)]="federatedSearch" (change)="onFederatedToggle()">Federated</mat-checkbox>
   <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection._empty"><span i18n>Clear</span></button>
 </ng-template>
 
@@ -105,6 +106,7 @@
   </ng-template>
 
   <div [ngClass]="{ 'view-container view-full-height view-table': !isForm }">
+    <planet-federated-results [results]="federatedResults" *ngIf="federatedSearch"></planet-federated-results>
     <mat-table #table [dataSource]="courses" matSort [matSortDisableClear]="true" [trackBy]="trackById" multiTemplateDataRows>
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -34,6 +34,7 @@ import { SearchService } from '../shared/forms/search.service';
 import { CoursesViewDetailDialogComponent } from './view-courses/courses-view-detail.component';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import { CoursesSearchComponent } from './search-courses/courses-search.component';
+import { FederatedSearchService } from '../shared/federated-search.service';
 
 @Component({
   selector: 'planet-courses',
@@ -94,6 +95,9 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this._titleSearch = value;
     this.recordSearch();
     this.removeFilteredFromSelection();
+    if (this.federatedSearch) {
+      this.updateFederatedResults();
+    }
   }
   user = this.userService.get();
   userShelf: any = [];
@@ -103,6 +107,8 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   tagFilter = new FormControl([]);
   tagFilterValue = [];
   searchSelection: any = { _empty: true };
+  federatedSearch = false;
+  federatedResults = [];
   filterPredicate = composeFilterFunctions([
     filterAdvancedSearch(this.searchSelection),
     filterTags(this.tagFilter),
@@ -136,7 +142,8 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     private tagsService: TagsService,
     private searchService: SearchService,
     private deviceInfoService: DeviceInfoService,
-    private fuzzySearchService: FuzzySearchService
+    private fuzzySearchService: FuzzySearchService,
+    private federatedSearchService: FederatedSearchService
   ) {
     this.userService.shelfChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe((shelf: any) => {
@@ -491,6 +498,18 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
       return false;
     }
     return element.description.length > calculateMdAdjustedLimit(element.description, this.previewLimit) || element.images.length > 0;
+  }
+
+  onFederatedToggle() {
+    if (this.federatedSearch) {
+      this.updateFederatedResults();
+    } else {
+      this.federatedResults = [];
+    }
+  }
+
+  updateFederatedResults() {
+    this.federatedSearchService.search(this._titleSearch).subscribe(res => this.federatedResults = res);
   }
 
 }

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -37,6 +37,7 @@
   <mat-form-field class="font-size-1 margin-lr-4">
     <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">
   </mat-form-field>
+  <mat-checkbox class="margin-lr-4" [(ngModel)]="federatedSearch" (change)="onFederatedToggle()">Federated</mat-checkbox>
   <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="resources.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection._empty"><span i18n>Clear</span></button>
 </ng-template>
 
@@ -104,6 +105,7 @@
   </ng-template>
 
   <div class="view-container view-full-height view-table" [ngClass]="{'view-with-search':showFilters}">
+    <planet-federated-results [results]="federatedResults" *ngIf="federatedSearch"></planet-federated-results>
     <mat-table #table [dataSource]="resources" [matSortActive]="initialSort" matSortDirection="desc" matSort [matSortDisableClear]="true" [trackBy]="trackById" multiTemplateDataRows>
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -30,6 +30,7 @@ import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service
 import { ResourcesSearchComponent } from './search-resources/resources-search.component';
 import { SearchService } from '../shared/forms/search.service';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
+import { FederatedSearchService } from '../shared/federated-search.service';
 
 @Component({
   selector: 'planet-resources',
@@ -78,6 +79,9 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     this._titleSearch = value;
     this.recordSearch();
     this.removeFilteredFromSelection();
+    if (this.federatedSearch) {
+      this.updateFederatedResults();
+    }
   }
   myView = this.route.snapshot.data.view;
   selectedNotAdded = 0;
@@ -86,6 +90,8 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   isAuthorized = false;
   showFilters = false;
   searchSelection: any = { _empty: true };
+  federatedSearch = false;
+  federatedResults = [];
   filterPredicate = composeFilterFunctions(
     [
       filterAdvancedSearch(this.searchSelection),
@@ -120,7 +126,8 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     private dialogsLoadingService: DialogsLoadingService,
     private searchService: SearchService,
     private deviceInfoService: DeviceInfoService,
-    private fuzzySearchService: FuzzySearchService
+    private fuzzySearchService: FuzzySearchService,
+    private federatedSearchService: FederatedSearchService
   ) {
     this.dialogsLoadingService.start();
     this.deviceType = this.deviceInfoService.getDeviceType();
@@ -416,6 +423,18 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   showPreviewExpand(element: any): boolean {
     if (!element.description) { return false; }
     return element.description.length > calculateMdAdjustedLimit(element.description, this.previewLimit);
+  }
+
+  onFederatedToggle() {
+    if (this.federatedSearch) {
+      this.updateFederatedResults();
+    } else {
+      this.federatedResults = [];
+    }
+  }
+
+  updateFederatedResults() {
+    this.federatedSearchService.search(this._titleSearch).subscribe(res => this.federatedResults = res);
   }
 
 }

--- a/src/app/shared/federated-results.component.ts
+++ b/src/app/shared/federated-results.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'planet-federated-results',
+  template: `
+    <div *ngIf="results && results.length" class="federated-results">
+      <mat-list>
+        <mat-list-item *ngFor="let item of results">
+          <a [routerLink]="item.type === 'course' ? ['/courses/view', item._id] : ['/resources/view', item._id]">
+            {{ item.doc.courseTitle || item.doc.title }}
+            <span class="type-label">({{ item.type }})</span>
+          </a>
+        </mat-list-item>
+      </mat-list>
+    </div>
+  `,
+  styles: [
+    `.federated-results { margin-top: 10px; }`,
+    `.type-label { margin-left: 4px; font-size: 0.75em; }`
+  ]
+})
+export class FederatedResultsComponent {
+  @Input() results: any[] = [];
+}

--- a/src/app/shared/federated-search.service.ts
+++ b/src/app/shared/federated-search.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { combineLatest, map } from 'rxjs';
+import { CoursesService } from '../courses/courses.service';
+import { ResourcesService } from '../resources/resources.service';
+import { FuzzySearchService } from './fuzzy-search.service';
+
+@Injectable({ providedIn: 'root' })
+export class FederatedSearchService {
+  constructor(
+    private coursesService: CoursesService,
+    private resourcesService: ResourcesService,
+    private fuzzy: FuzzySearchService,
+  ) {}
+
+  search(term: string) {
+    const query = term ? term.trim() : '';
+    return combineLatest([
+      this.coursesService.coursesListener$(),
+      this.resourcesService.resourcesListener(false)
+    ]).pipe(
+      map(([courses, resources]) => {
+        if (!query) {
+          return [];
+        }
+        const match = (data: any) => {
+          const title = data.doc.courseTitle || data.doc.title || '';
+          return this.fuzzy.fuzzyWordMatch(query, title, { threshold: 0.6, maxDistance: 2 });
+        };
+        const courseResults = courses.filter(match).map(res => ({ ...res, type: 'course' }));
+        const resourceResults = resources.filter(match).map(res => ({ ...res, type: 'resource' }));
+        return [...courseResults, ...resourceResults];
+      })
+    );
+  }
+}

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -26,6 +26,7 @@ import { RestrictDiacriticsDirective } from './restrict-diacritics.directives';
 import { ChatOutputDirective } from './chat-output.directive';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 import { TimeAgoPipe } from '../shared/time-ago.pipe';
+import { FederatedResultsComponent } from './federated-results.component';
 
 @NgModule({
   imports: [
@@ -54,7 +55,8 @@ import { TimeAgoPipe } from '../shared/time-ago.pipe';
     ChatOutputDirective,
     OverlayModule,
     TruncateTextPipe,
-    TimeAgoPipe
+    TimeAgoPipe,
+    FederatedResultsComponent
   ],
   declarations: [
     PlanetLocalStatusComponent,
@@ -79,7 +81,8 @@ import { TimeAgoPipe } from '../shared/time-ago.pipe';
     RestrictDiacriticsDirective,
     ChatOutputDirective,
     TruncateTextPipe,
-    TimeAgoPipe
+    TimeAgoPipe,
+    FederatedResultsComponent
   ]
 })
 export class SharedComponentsModule {}


### PR DESCRIPTION
## Summary
- add FederatedSearchService to combine course and resource queries
- render list of federated results
- hook up federated search in courses and resources components
- export new component from shared module

## Testing
- `npm run lint`
- `npm test` *(fails: Could not find the '@angular-devkit/build-angular:karma' builder)*

------
https://chatgpt.com/codex/tasks/task_e_6877e705f8488330b81832822ca8d420