### PR TITLE
teams: smoother survey submissions (fixes #8959)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.80",
+  "version": "0.19.83",
   "myplanet": {
-    "latest": "v0.27.66",
-    "min": "v0.26.66"
+    "latest": "v0.27.83",
+    "min": "v0.26.83"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -48,7 +48,6 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
   isFormInitialized = false;
   imageChangedEvent: Event | null = null;
   showImagePreview = true;
-  isNavigating = false;
   @ViewChild('imageEditDialog') imageEditDialog: TemplateRef<any>;
 
   constructor(
@@ -149,7 +148,6 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
         this.editForm.markAsPristine();
         this.initialFormValues = { ...this.editForm.value };
         this.hasUnsavedChanges = false;
-        this.isNavigating = true;
         this.goBack();
       }, (err) => {
         // Connect to an error display component to show user that an error has occurred
@@ -178,7 +176,6 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
   }
 
   goBack() {
-    this.isNavigating = true;
     this.router.navigate([ this.redirectUrl ], { relativeTo: this.route });
   }
 
@@ -244,16 +241,14 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
     this.couchService.get('submissions/' + submissionId).pipe(switchMap((submission) => {
       return this.couchService.put('submissions/' + submissionId, { ...submission, user });
     })).subscribe(() => {
+      this.avatarChanged = false;
+      this.initialFormValues = { ...this.editForm.value };
       this.hasUnsavedChanges = false;
-      this.isNavigating = true;
       this.goBack();
     });
   }
 
   canDeactivate(): boolean {
-    if (this.isNavigating) {
-      return true;
-    }
     return !this.getHasUnsavedChanges();
   }
 

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -48,6 +48,7 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
   isFormInitialized = false;
   imageChangedEvent: Event | null = null;
   showImagePreview = true;
+  isNavigating = false;
   @ViewChild('imageEditDialog') imageEditDialog: TemplateRef<any>;
 
   constructor(
@@ -148,6 +149,7 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
         this.editForm.markAsPristine();
         this.initialFormValues = { ...this.editForm.value };
         this.hasUnsavedChanges = false;
+        this.isNavigating = true;
         this.goBack();
       }, (err) => {
         // Connect to an error display component to show user that an error has occurred
@@ -176,6 +178,7 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
   }
 
   goBack() {
+    this.isNavigating = true;
     this.router.navigate([ this.redirectUrl ], { relativeTo: this.route });
   }
 
@@ -241,11 +244,16 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
     this.couchService.get('submissions/' + submissionId).pipe(switchMap((submission) => {
       return this.couchService.put('submissions/' + submissionId, { ...submission, user });
     })).subscribe(() => {
+      this.hasUnsavedChanges = false;
+      this.isNavigating = true;
       this.goBack();
     });
   }
 
   canDeactivate(): boolean {
+    if (this.isNavigating) {
+      return true;
+    }
     return !this.getHasUnsavedChanges();
   }
 


### PR DESCRIPTION
fixes #8959

Unsaved changes guard no longer fires when submitting the user profile info