### PR TITLE
manager: smoother spanish translations (fixes #8960)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.80",
+  "version": "0.19.85",
   "myplanet": {
     "latest": "v0.27.66",
     "min": "v0.26.66"

--- a/src/i18n/messages.spa.xlf
+++ b/src/i18n/messages.spa.xlf
@@ -13270,7 +13270,7 @@
           <context context-type="sourcefile">src/app/manager-dashboard/manager-dashboard.component.html</context>
           <context context-type="linenumber">91</context>
         </context-group>
-        <target state="final">Registros de myPlanet</target>
+        <target state="final"><x id="START_BOLD_TEXT" ctype="x-b"/>Última actualización<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></target>
       </trans-unit>
       <trans-unit id="4541971088b5826c229cdd4a546515a4ea5ca759" datatype="html" approved="yes">
         <source><x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Last Sync<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>


### PR DESCRIPTION
fixes #8960

Fixed a mistranslation for the Last Upgrade header, which was also causing the boldness to go away.  

<img width="1569" height="201" alt="image" src="https://github.com/user-attachments/assets/c150bfa6-7e9f-4487-a6f2-1518032c42bb" />
