### PR TITLE
teams: smoother member cards (fixes #8913)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.19.80",
+  "version": "0.19.84",
   "myplanet": {
     "latest": "v0.27.66",
     "min": "v0.26.66"

--- a/src/app/teams/teams-member.component.html
+++ b/src/app/teams/teams-member.component.html
@@ -1,5 +1,5 @@
 <mat-card-header>
-  <img mat-card-avatar [src]="member?.avatar" class="cursor-pointer" (click)="openMemberDialog(member)">
+  <img mat-card-avatar [src]="member?.avatar" class="cursor-pointer avatar-spacing" (click)="openMemberDialog(member)">
   <a mat-card-title class="cursor-pointer member-name" (click)="openMemberDialog(member)">{{member?.userDoc?.fullName || member?.userDoc?.firstName || member?.name | truncateText:70}}</a>
   <mat-card-subtitle>
     <p class="primary-text-color" *ngIf="member?.userPlanetCode !== planetCode"><ng-container i18n>Member of Planet</ng-container> {{member?.userPlanetCode}}</p>
@@ -7,7 +7,7 @@
     <span i18n *ngIf="member?.userId === teamLeader?.userId && member?.userPlanetCode === teamLeader?.userPlanetCode">(Team Leader)</span>{{' '}}<span *ngIf="visits">({{ visits?.count || 0 }} <ng-container i18n>visits</ng-container>)</span>
     <p *ngIf="visits && (userStatus === 'member' || user.isUserAdmin)"><ng-container i18n>Last visit:</ng-container> {{ visits?.recentTime | date }}</p>
     <p class="primary-text-color" *ngIf="member?.doc?.leadershipTitle">
-      {{member?.doc?.leadershipTitle | truncateText:40}}
+      {{member?.doc?.leadershipTitle | truncateText:38}}
     </p>
     <p class="primary-text-color role-text" *ngIf="member?.role">{{member?.role | truncateText:70}}</p>
   </mat-card-subtitle>

--- a/src/app/teams/teams-member.component.ts
+++ b/src/app/teams/teams-member.component.ts
@@ -30,6 +30,9 @@ import { UserProfileDialogComponent } from '../users/users-profile/users-profile
       overflow: hidden;
       word-break: break-word;
     }
+    .avatar-spacing {
+      margin-right: 5px;
+    }
   ` ]
 })
 export class TeamsMemberComponent implements OnInit, OnChanges {


### PR DESCRIPTION
fixes #8913

Added a bit of space between the avatar and the user name. Affects how it's displayed in Teams and Community Leaders. Had to truncate after 2 fewer characters to make room. 

<img width="303" height="163" alt="image" src="https://github.com/user-attachments/assets/00eadc6f-f60f-4202-ae22-da6bcc28493c" />
