### PR TITLE
feat(chat): persist conversation message ids

### DIFF
--- a/chatapi/src/models/chat.model.ts
+++ b/chatapi/src/models/chat.model.ts
@@ -29,6 +29,7 @@ export interface ChatMessage {
 }
 
 export interface ChatItem {
+  id: string;
   query: string;
   response: string;
 }

--- a/chatapi/src/models/db-doc.model.ts
+++ b/chatapi/src/models/db-doc.model.ts
@@ -1,3 +1,5 @@
+import { ChatItem } from './chat.model';
+
 export interface DbDoc {
   _id: string;
   _rev: string;
@@ -5,7 +7,7 @@ export interface DbDoc {
   title: string;
   createdDate: number;
   aiProvider: string;
-  conversations: [];
+  conversations: ChatItem[];
 }
 
 export interface Attachment {

--- a/chatapi/src/services/chat.service.ts
+++ b/chatapi/src/services/chat.service.ts
@@ -41,7 +41,8 @@ export async function chat(data: any, stream?: boolean, callback?: (response: st
     dbData.aiProvider = aiProvider.name;
   }
 
-  dbData.conversations.push({ 'query': content, 'response': '' });
+  const messageId = Date.now().toString();
+  dbData.conversations.push({ 'id': messageId, 'query': content, 'response': '' });
   const res = await chatDB.insert(dbData);
 
   messages.push({ 'role': 'user', content });

--- a/src/app/chat/chat-window/chat-window.component.html
+++ b/src/app/chat/chat-window/chat-window.component.html
@@ -1,6 +1,6 @@
 <div class="full-container">
   <div class="chat-container" #chat>
-    <div *ngFor="let conversation of conversations">
+    <div *ngFor="let conversation of conversations; trackBy: trackByMessage">
       <p class="conversation-query" [planetChatOutput]="conversation.query"></p>
       <p [ngClass]="{'conversation-error': conversation.error, 'conversation-response': !conversation.error}" [planetChatOutput]="conversation.response"></p>
     </div>

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -183,9 +183,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   initializeErrorStream() {
     this.chatService.getErrorStream().subscribe((errorMessage) => {
-      const lastQuery = this.conversations[this.conversations.length - 1]?.query;
+      const lastConversation = this.conversations[this.conversations.length - 1];
       this.conversations[this.conversations.length - 1] = {
-        query: lastQuery,
+        ...lastConversation,
         response: 'Error: ' + errorMessage,
         error: true
       };
@@ -244,12 +244,12 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     if (this.streaming) {
-      this.conversations.push({ role: 'user', query: content, response: '' });
+      this.conversations.push({ id: Date.now().toString(), role: 'user', query: content, response: '' });
       this.chatService.sendUserInput(this.data);
     } else {
       this.chatService.getPrompt(this.data, true).subscribe(
         (completion: any) => {
-          this.conversations.push({ query: content, response: completion?.chat });
+          this.conversations.push({ id: Date.now().toString(), query: content, response: completion?.chat });
           this.selectedConversationId = {
             '_id': completion.couchDBResponse?.id,
             '_rev': completion.couchDBResponse?.rev
@@ -257,12 +257,16 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
           this.postSubmit();
         },
         (error: any) => {
-          this.conversations.push({ query: content, response: 'Error: ' + error.message, error: true });
+          this.conversations.push({ id: Date.now().toString(), query: content, response: 'Error: ' + error.message, error: true });
           this.spinnerOn = true;
           this.promptForm.controls['prompt'].setValue('');
         }
       );
     }
+  }
+
+  trackByMessage(index: number, msg: any) {
+    return msg.id;
   }
 
   focusInput() {

--- a/src/app/chat/chat.model.ts
+++ b/src/app/chat/chat.model.ts
@@ -20,6 +20,7 @@ export interface Conversation {
 }
 
 export interface Message {
+  id: string;
   query: string;
   response: string;
 }


### PR DESCRIPTION
## Summary
- assign a unique id to each chat message and include it in stored conversations
- rely on message id for rendering with Angular trackBy

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Module not found and ChromeHeadless binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_689203aa41c08329b753f81a81f89a11