### PR TITLE
manager: smoother survey exports (fixes #9042)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.20.3",
+  "version": "0.20.9",
   "myplanet": {
     "latest": "v0.29.23",
     "min": "v0.28.23"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "license": "AGPL-3.0",
   "version": "0.20.3",
   "myplanet": {
-    "latest": "v0.28.45",
-    "min": "v0.27.45"
+    "latest": "v0.29.23",
+    "min": "v0.28.23"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { UntypedFormGroup } from '@angular/forms';
+import { FormGroup, FormControl } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
@@ -24,6 +24,13 @@ import { UserService } from '../shared/user.service';
 import { findDocuments } from '../shared/mangoQueries';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { DialogsAddTableComponent } from '../shared/dialogs/dialogs-add-table.component';
+
+interface SurveyFilterForm {
+  includeQuestions: FormControl<boolean | null>;
+  includeAnswers: FormControl<boolean | null>;
+  includeCharts: FormControl<boolean | null>;
+  includeAnalysis: FormControl<boolean | null>;
+}
 
 @Component({
   selector: 'planet-surveys',
@@ -408,7 +415,8 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
           this.submissionsService.exportSubmissionsPdf(survey, 'survey', options, this.teamId || this.routeTeamId || '');
         },
         formOptions: {
-          validator: (ac: UntypedFormGroup) => Object.values(ac.controls).some(({ value }) => value) ? null : { required: true }
+          validator: (ac: FormGroup<SurveyFilterForm>) =>
+            Object.values(ac.controls).some(control => control.value) ? null : { required: true }
         }
       }
     );

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -5,18 +5,16 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
+import { SelectionModel } from '@angular/cdk/collections';
 import { forkJoin, Observable, Subject, throwError, of } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
 import { CouchService } from '../shared/couchdb.service';
 import { ChatService } from '../shared/chat.service';
-import {
-  filterSpecificFields, sortNumberOrString, createDeleteArray, selectedOutOfFilter
-} from '../shared/table-helpers';
+import { filterSpecificFields, sortNumberOrString, createDeleteArray, selectedOutOfFilter } from '../shared/table-helpers';
 import { SubmissionsService } from '../submissions/submissions.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
-import { SelectionModel } from '@angular/cdk/collections';
 import { findByIdInArray, filterById } from '../shared/utils';
 import { debug } from '../debug-operator';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
@@ -415,8 +413,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
           this.submissionsService.exportSubmissionsPdf(survey, 'survey', options, this.teamId || this.routeTeamId || '');
         },
         formOptions: {
-          validator: (ac: FormGroup<SurveyFilterForm>) =>
-            Object.values(ac.controls).some(control => control.value) ? null : { required: true }
+          validator: (ac: FormGroup<SurveyFilterForm>) => Object.values(ac.controls).some(control => control.value) ? null : { required: true }
         }
       }
     );


### PR DESCRIPTION
## Summary
- add SurveyFilterForm interface for export options
- use FormGroup<SurveyFilterForm> instead of UntypedFormGroup
- type the export options validator

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c6b3073488329afb2247f3d67c20f