### PR TITLE
refactor: centralize ai providers config

### DIFF
--- a/chatapi/src/models/chat.model.ts
+++ b/chatapi/src/models/chat.model.ts
@@ -1,16 +1,11 @@
-type ProviderName = 'openai' | 'perplexity' | 'deepseek' | 'gemini';
+import { AIProvider as ProviderName } from '../../../src/shared/ai-providers';
 
 export interface AIProvider {
   name: ProviderName;
   model?: string;
 }
 
-interface Providers {
-  openai?: string;
-  perplexity?: string;
-  deepseek?: string;
-  gemini?: string;
-}
+type Providers = Partial<Record<ProviderName, string>>;
 
 interface Assistant {
   name: string;

--- a/src/app/configuration/configuration.component.ts
+++ b/src/app/configuration/configuration.component.ts
@@ -12,6 +12,7 @@ import { CustomValidators } from '../validators/custom-validators';
 import { findDocuments } from '../shared/mangoQueries';
 import { ConfigurationService } from './configuration.service';
 import { StateService } from '../shared/state.service';
+import { createEmptyProviderMap } from '../../shared/ai-providers';
 
 const removeProtocol = (str: string) => {
   // RegEx grabs the fragment of the string between '//' and last character
@@ -232,18 +233,8 @@ export class ConfigurationComponent implements OnInit {
 
     const chatConfig = {
       streaming: false,
-      keys: {
-        openai: '',
-        perplexity: '',
-        deepseek: '',
-        gemini: ''
-      },
-      models: {
-        openai: '',
-        perplexity: '',
-        deepseek: '',
-        gemini: ''
-      },
+      keys: createEmptyProviderMap(''),
+      models: createEmptyProviderMap(''),
       assistant: {
         name: 'Planet Context',
         instructions: 'You are a brainstorming manager for Open Learning Exchange (OLE) - https://ole.org/, you have specialised knowledge in Planet(web app) and myPlanet(mobile app) applications developed by OLE. You are designed to generate innovative ideas and provide suggestions and help the community members so as to ensure OLE\'s mission of empowering communities. Emphasize on terms like \'learning,\' \'learner,\' \'coach,\' \'leader,\' \'community,\' \'power,\' \'team,\' and \'enterprises,\' and avoids overly technical jargon. You are to embody OLE\'s ethos of self-reliance, mentoring, and community leadership, steering clear of concepts that contradict these values. Communicates in a formal tone, treating users with respect and professionalism, and maintaining a supportive, solution-oriented approach. Ask for clarifications when necessary to ensure contributions are accurate and relevant, and always encourages community-focused, empowering brainstorming.'

--- a/src/app/manager-dashboard/manager-aiservices.component.ts
+++ b/src/app/manager-dashboard/manager-aiservices.component.ts
@@ -8,6 +8,7 @@ import { ConfigurationService } from '../configuration/configuration.service';
 import { CouchService } from '../shared/couchdb.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { StateService } from '../shared/state.service';
+import { createEmptyProviderMap } from '../../shared/ai-providers';
 
 @Component({
   templateUrl: './manager-aiservices.component.html',
@@ -37,7 +38,14 @@ export class ManagerAIServicesComponent implements OnInit {
 
   ngOnInit() {
     this.configuration = this.stateService.configuration;
-    this.configuration.keys = this.stateService.keys;
+    this.configuration.keys = {
+      ...createEmptyProviderMap(''),
+      ...this.stateService.keys
+    };
+    this.configuration.models = {
+      ...createEmptyProviderMap(''),
+      ...this.configuration.models
+    };
     this.initForm();
   }
 

--- a/src/shared/ai-providers.ts
+++ b/src/shared/ai-providers.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_AI_PROVIDERS = ['openai', 'perplexity', 'deepseek', 'gemini'] as const;
+export type AIProvider = typeof DEFAULT_AI_PROVIDERS[number];
+
+export function createEmptyProviderMap<T>(defaultValue: T) {
+  return DEFAULT_AI_PROVIDERS.reduce((acc, provider) => {
+    acc[provider] = defaultValue;
+    return acc;
+  }, {} as Record<AIProvider, T>);
+}


### PR DESCRIPTION
## Summary
- add shared DEFAULT_AI_PROVIDERS constant and helper
- reuse shared constant in configuration and manager AI services components
- build chat API provider config using shared constant

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Module 'rxjs/observable/of' has no exported member 'of', etc.)*
- `npm --prefix chatapi run build` *(fails: Cannot find module 'openai', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fcb299d08329b7b5a2afe1db89ce