### PR TITLE
refactor: add typed forms for courses

### DIFF
--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnDestroy, ViewEncapsulation, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -15,13 +15,19 @@ import { PlanetStepListComponent } from '../../shared/forms/planet-step-list.com
   styleUrls: [ 'courses-step.scss' ],
   encapsulation: ViewEncapsulation.None
 })
+interface StepFormModel {
+  id: string;
+  stepTitle: string;
+  description: string;
+}
+
 export class CoursesStepComponent implements OnDestroy {
 
   @Input() steps: any[];
   @Output() stepsChange = new EventEmitter<any>();
   @Output() addStepEvent = new EventEmitter<void>();
 
-  stepForm: UntypedFormGroup;
+  stepForm: FormGroup<StepFormModel>;
   dialogRef: MatDialogRef<DialogsAddResourcesComponent>;
   activeStep: any;
   activeStepIndex = -1;
@@ -38,15 +44,15 @@ export class CoursesStepComponent implements OnDestroy {
 
   constructor(
     private router: Router,
-    private fb: UntypedFormBuilder,
+    private fb: FormBuilder,
     private dialog: MatDialog,
     private coursesService: CoursesService,
     private dialogsLoadingService: DialogsLoadingService
   ) {
-    this.stepForm = this.fb.group({
-      id: '',
-      stepTitle: '',
-      description: ''
+    this.stepForm = this.fb.group<StepFormModel>({
+      id: this.fb.control(''),
+      stepTitle: this.fb.control(''),
+      description: this.fb.control('')
     });
     this.stepForm.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe(value => {
       this.steps[this.activeStepIndex] = { ...this.activeStep, ...value };

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -6,7 +6,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { SelectionModel } from '@angular/cdk/collections';
 import { Router, ActivatedRoute, } from '@angular/router';
-import { UntypedFormBuilder, UntypedFormGroup, UntypedFormControl, } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { Subject, of } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import { FuzzySearchService } from '../shared/fuzzy-search.service';
@@ -27,6 +27,7 @@ import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.compone
 import { CoursesService } from './courses.service';
 import { dedupeShelfReduce, findByIdInArray, calculateMdAdjustedLimit } from '../shared/utils';
 import { StateService } from '../shared/state.service';
+import { CourseFormModel } from './courses.model';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { TagsService } from '../shared/forms/tags.service';
 import { PlanetTagInputComponent } from '../shared/forms/planet-tag-input.component';
@@ -70,8 +71,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   dialogRef: MatDialogRef<DialogsListComponent>;
   message = '';
   deleteDialog: any;
-  fb: UntypedFormBuilder;
-  courseForm: UntypedFormGroup;
+  courseForm!: FormGroup<CourseFormModel>;
   readonly dbName = 'courses';
   parent = this.route.snapshot.data.parent;
   planetConfiguration = this.stateService.configuration;
@@ -100,7 +100,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   private onDestroy$ = new Subject<void>();
   planetType = this.planetConfiguration.planetType;
   isAuthorized = false;
-  tagFilter = new UntypedFormControl([]);
+  tagFilter = new FormControl<string[]>([]);
   tagFilterValue = [];
   searchSelection: any = { _empty: true };
   filterPredicate = composeFilterFunctions([

--- a/src/app/courses/courses.model.ts
+++ b/src/app/courses/courses.model.ts
@@ -1,0 +1,13 @@
+export interface CourseFormModel {
+  courseTitle: string;
+  description: string;
+  languageOfInstruction: string;
+  gradeLevel: string;
+  subjectLevel: string;
+  createdDate: unknown;
+  creator: string;
+  sourcePlanet: string;
+  resideOn: string;
+  updatedDate: unknown;
+  images?: any[];
+}

--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -11,19 +11,27 @@ import { TagsService } from '../shared/forms/tags.service';
 import { dedupeObjectArray } from '../shared/utils';
 import { MarkdownService } from '../shared/markdown.service';
 import { UsersService } from '../users/users.service';
+import { CourseFormModel } from './courses.model';
 
 // Service for updating and storing active course for single course views.
 @Injectable({
   providedIn: 'root'
 })
+interface CourseDraft {
+  form?: CourseFormModel;
+  steps?: any[];
+  tags?: any[];
+  initialTags?: any[];
+}
+
 export class CoursesService {
   private dbName = 'courses';
   private progressDb = 'courses_progress';
-  private _course: any = {};
-  get course() {
+  private _course: CourseDraft = {};
+  get course(): CourseDraft {
     return this._course;
   }
-  set course(newCourse: any) {
+  set course(newCourse: CourseDraft) {
     this._course = { ...this._course, ...newCourse };
   }
   progress: any;


### PR DESCRIPTION
## Summary
- add CourseFormModel for course fields
- use typed FormGroup controls in course add, step, and list components
- update CoursesService to track typed course drafts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a305624ec88329809039983a107a03