### PR TITLE
manager: smoother voices summary export (fixes #9049)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.20.9",
+  "version": "0.20.15",
   "myplanet": {
-    "latest": "v0.29.23",
-    "min": "v0.28.23"
+    "latest": "v0.30.39",
+    "min": "v0.29.39"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -732,6 +732,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     const courseData = filterByMember(filterByDate(this.courseActivities?.total?.data, 'time', dateRange), members);
     const progressData = filterByMember(filterByDate(this.progress?.steps?.data, 'time', dateRange), members);
     const chatData = filterByMember(filterByDate(this.chatActivities?.data, 'createdDate', dateRange), members);
+    const voicesData = filterByMember(filterByDate(this.voicesActivities?.data, 'time', dateRange), members);
 
     if (sortBy) {
       const order = sortBy.endsWith('Asc') ? 1 : -1;
@@ -748,6 +749,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       courseData.sort(sortFunction);
       progressData.sort(sortFunction);
       chatData.sort(sortFunction);
+      voicesData.sort(sortFunction);
     }
 
     this.csvService.exportSummaryCSV(
@@ -756,6 +758,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       courseData,
       progressData,
       chatData,
+      voicesData,
       this.planetName,
       dateRange.startDate,
       dateRange.endDate

--- a/src/app/shared/csv.service.ts
+++ b/src/app/shared/csv.service.ts
@@ -41,7 +41,7 @@ export class CsvService {
     this.generate(formattedData, options);
   }
 
-  exportSummaryCSV(logins: any[], resourceViews: any[], courseViews: any[], stepCompletions: any[], chatActivities: any[], planetName: string, startDate: Date, endDate: Date) {
+  exportSummaryCSV(logins: any[], resourceViews: any[], courseViews: any[], stepCompletions: any[], chatActivities: any[], voicesActivities: any[], planetName: string, startDate: Date, endDate: Date) {
     const options = {
       title: $localize`Summary report for ${planetName}\n${formatDate(startDate)} - ${formatDate(endDate)}`,
       filename: $localize`Report of ${planetName} on ${new Date().toDateString()}`,
@@ -53,15 +53,16 @@ export class CsvService {
     const groupedResourceViews = this.reportsService.groupDocVisits(resourceViews, 'resourceId').byMonth;
     const groupedCourseViews = this.reportsService.groupDocVisits(courseViews, 'courseId').byMonth;
     const groupedStepCompletions = this.reportsService.groupStepCompletion(stepCompletions).byMonth;
-    const groupedChatData = chatActivities.length > 0 && this.reportsService.groupChatUsage ?
-      this.reportsService.groupChatUsage(chatActivities).byMonth : [];
+    const groupedChatData = this.reportsService.groupChatUsage(chatActivities).byMonth;
+    const groupedVoicesData = this.reportsService.groupVoicesCreated(voicesActivities).byMonth;
     const formattedData = this.buildSummaryTable([
       { title: $localize`Unique Member Visits`, data: groupedLogins, countUnique: true },
       { title: $localize`Total Member Visits`, data: groupedLogins, countUnique: false },
       { title: $localize`Resource Views`, data: groupedResourceViews, countUnique: false },
       { title: $localize`Course Views`, data: groupedCourseViews, countUnique: false },
       { title: $localize`Steps Completed`, data: groupedStepCompletions, countUnique: false },
-      { title: $localize`Chats Created`, data: groupedChatData, countUnique: false }
+      { title: $localize`Chats Created`, data: groupedChatData, countUnique: false },
+      { title: $localize`Voices Created`, data: groupedVoicesData, countUnique: false }
     ]);
     this.generate(formattedData, options);
   }


### PR DESCRIPTION
Fixes #9049


Add the `Voices Created` to the CSV summary export

<img width="3406" height="2058" alt="image" src="https://github.com/user-attachments/assets/165c2fd0-25bf-4423-b6c6-074d841f5524" />
