### PR TITLE
all: fix npm dev script (fixes #9055)

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -5,9 +5,15 @@ set -euo pipefail
 [ -f .env ] && source .env
 
 CHAT_PORT="${CHAT_PORT:-5000}"
+COUCH_PORT="${COUCH_PORT:-2200}"
+PARENT_PROTOCOL="${PARENT_PROTOCOL:-https}"
 
 sed \
   -e "s/{{CHAT_PORT}}/${CHAT_PORT}/g" \
+  -e "s/{{COUCH_PORT}}/${COUCH_PORT}/g" \
+  -e "s/{{PARENT_PROTOCOL}}/${PARENT_PROTOCOL}/g" \
   src/environments/environment.template > src/environments/environment.dev.ts
 
 echo "chatapi running on port: ${CHAT_PORT}"
+echo "couchdb running on port: ${COUCH_PORT}"
+echo "parent protocol: ${PARENT_PROTOCOL}"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ng": "ng",
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "ng serve",
-    "dev": "bash dev-env.sh && ng serve",
+    "dev": "bash dev-env.sh && ng serve --configuration=dev",
     "build": "npm run ng-high-memory -- build --configuration production",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -2,10 +2,10 @@ export const environment = {
   production: false,
   test: false,
   chatAddress: window.location.protocol + '//' + window.location.hostname + ':{{CHAT_PORT}}',
-  couchAddress: window.location.protocol + '//' + window.location.hostname + ':2200',
+  couchAddress: window.location.protocol + '//' + window.location.hostname + ':{{COUCH_PORT}}',
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
-  parentProtocol: 'https',
+  parentProtocol: '{{PARENT_PROTOCOL}}',
   upgradeAddress: window.location.origin + '/upgrade',
   syncAddress: window.location.protocol + '//localhost:5984'
 };


### PR DESCRIPTION
Fixes #9055 

- `npm run dev` correctly uses the `environment.dev.ts` config
- Update the `environment.dev.ts` custom configurations to include the `couch port` & `parentProtocol`