### PR TITLE
exams: add rating scale question type (fixes #9068)

### DIFF
--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -25,6 +25,7 @@
         <button mat-menu-item type="button" (click)="addQuestion('textarea')" i18n>Text - Long answer</button>
         <button mat-menu-item type="button" (click)="addQuestion('select')" i18n>Multiple Choice - single answer</button>
         <button mat-menu-item type="button" (click)="addQuestion('selectMultiple')" i18n>Multiple Choice - multiple answer</button>
+        <button *ngIf="examType !== 'exam'" mat-menu-item type="button" (click)="addQuestion('matrix')" i18n>Matrix - Number keypad</button>
       </mat-menu>
       <mat-accordion class="exam-inputs" *ngIf="!isCourseContent">
         <mat-expansion-panel [expanded]="!isQuestionsActive">

--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -25,7 +25,7 @@
         <button mat-menu-item type="button" (click)="addQuestion('textarea')" i18n>Text - Long answer</button>
         <button mat-menu-item type="button" (click)="addQuestion('select')" i18n>Multiple Choice - single answer</button>
         <button mat-menu-item type="button" (click)="addQuestion('selectMultiple')" i18n>Multiple Choice - multiple answer</button>
-        <button *ngIf="examType !== 'exam'" mat-menu-item type="button" (click)="addQuestion('matrix')" i18n>Matrix - Number keypad</button>
+        <button *ngIf="examType !== 'exam'" mat-menu-item type="button" (click)="addQuestion('ratingScale')" i18n>Rating Scale - 1 to 9</button>
       </mat-menu>
       <mat-accordion class="exam-inputs" *ngIf="!isCourseContent">
         <mat-expansion-panel [expanded]="!isQuestionsActive">

--- a/src/app/exams/exams-question.component.html
+++ b/src/app/exams/exams-question.component.html
@@ -6,7 +6,7 @@
         <mat-option value="textarea" i18n>Text - Long answer</mat-option>
         <mat-option value="select" i18n>Multiple Choice - single answer</mat-option>
         <mat-option value="selectMultiple" i18n>Multiple Choice - multiple answer</mat-option>
-        <mat-option *ngIf="examType !== 'exam'" value="matrix" i18n>Matrix - Number keypad</mat-option>
+        <mat-option *ngIf="examType !== 'exam'" value="ratingScale" i18n>Rating Scale - 1 to 9</mat-option>
       </mat-select>
     </mat-form-field>
   </div>
@@ -21,7 +21,7 @@
         You must add a choice
       </span>
     </div>
-    <div i18n class="mat-caption warn-text-color" *ngIf="!questionForm.controls.correctChoice.valid && questionForm.controls.correctChoice.touched && questionForm.controls.type.value !== 'matrix'">
+    <div i18n class="mat-caption warn-text-color" *ngIf="!questionForm.controls.correctChoice.valid && questionForm.controls.correctChoice.touched && questionForm.controls.type.value !== 'ratingScale'">
       You must select the correct {questionForm.controls.type.value, select, select {choice} selectMultiple {choices}}
     </div>
     <div *ngFor="let choice of choices.controls; index as i; trackBy: trackByFn">

--- a/src/app/exams/exams-question.component.html
+++ b/src/app/exams/exams-question.component.html
@@ -6,6 +6,7 @@
         <mat-option value="textarea" i18n>Text - Long answer</mat-option>
         <mat-option value="select" i18n>Multiple Choice - single answer</mat-option>
         <mat-option value="selectMultiple" i18n>Multiple Choice - multiple answer</mat-option>
+        <mat-option *ngIf="examType !== 'exam'" value="matrix" i18n>Matrix - Number keypad</mat-option>
       </mat-select>
     </mat-form-field>
   </div>
@@ -20,7 +21,7 @@
         You must add a choice
       </span>
     </div>
-    <div i18n class="mat-caption warn-text-color" *ngIf="!questionForm.controls.correctChoice.valid && questionForm.controls.correctChoice.touched">
+    <div i18n class="mat-caption warn-text-color" *ngIf="!questionForm.controls.correctChoice.valid && questionForm.controls.correctChoice.touched && questionForm.controls.type.value !== 'matrix'">
       You must select the correct {questionForm.controls.type.value, select, select {choice} selectMultiple {choices}}
     </div>
     <div *ngFor="let choice of choices.controls; index as i; trackBy: trackByFn">

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -77,6 +77,13 @@
                 </div>
               </ng-container>
             </div>
+            <div *ngSwitchCase="'matrix'" class="matrix-keypad">
+              <div class="matrix-grid">
+                <button type="button" mat-raised-button class="matrix-button" *ngFor="let num of [1,2,3,4,5,6,7,8,9]" [class.selected]="answer.value === num.toString()" (click)="setMatrixAnswer(num)">
+                  {{num}}
+                </button>
+              </div>
+            </div>
           </ng-container>
         </ng-container>
         <ng-container *ngSwitchCase="'grade'">

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -77,9 +77,9 @@
                 </div>
               </ng-container>
             </div>
-            <div *ngSwitchCase="'matrix'" class="matrix-keypad">
-              <div class="matrix-grid">
-                <button type="button" mat-raised-button class="matrix-button" *ngFor="let num of [1,2,3,4,5,6,7,8,9]" [class.selected]="answer.value === num.toString()" (click)="setMatrixAnswer(num)">
+            <div *ngSwitchCase="'ratingScale'" class="rating-scale-keypad">
+              <div class="rating-scale-grid">
+                <button type="button" mat-raised-button class="rating-scale-button" *ngFor="let num of [1,2,3,4,5,6,7,8,9]" [class.selected]="answer.value === num.toString()" (click)="setRatingScaleAnswer(num)">
                   {{num}}
                 </button>
               </div>

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -309,6 +309,11 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     this.checkboxState[option.id] = event.checked;
   }
 
+  setMatrixAnswer(number: number) {
+    this.answer.setValue(number.toString());
+    this.answer.updateValueAndValidity();
+  }
+
   calculateCorrect() {
     const value = this.answer.value;
     const answers = value instanceof Array ? value : [ value ];

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -309,7 +309,7 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     this.checkboxState[option.id] = event.checked;
   }
 
-  setMatrixAnswer(number: number) {
+  setRatingScaleAnswer(number: number) {
     this.answer.setValue(number.toString());
     this.answer.updateValueAndValidity();
   }

--- a/src/app/exams/exams-view.scss
+++ b/src/app/exams/exams-view.scss
@@ -1,3 +1,5 @@
+@import '../variables';
+
 :host {
 
   .view-container {
@@ -48,4 +50,40 @@
     outline: none;
     max-width: 50%;
   }
+
+  .matrix-keypad {
+    display: flex;
+    justify-content: flex-start;
+    margin: 20px 0;
+  }
+
+  .matrix-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+    max-width: 100px;
+    width: 100%;
+  }
+
+  .matrix-button {
+    height: 50px;
+    font-size: 24px;
+    font-weight: 500;
+    border: 2px solid #ddd;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: $primary;
+      box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    }
+
+    &.selected {
+      background-color: $primary;
+      color: white;
+      border-color: $primary;
+      box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+    }
+  }
+
 }

--- a/src/app/exams/exams-view.scss
+++ b/src/app/exams/exams-view.scss
@@ -51,13 +51,13 @@
     max-width: 50%;
   }
 
-  .matrix-keypad {
+  .rating-scale-keypad {
     display: flex;
     justify-content: flex-start;
     margin: 20px 0;
   }
 
-  .matrix-grid {
+  .rating-scale-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 6px;
@@ -65,7 +65,7 @@
     width: 100%;
   }
 
-  .matrix-button {
+  .rating-scale-button {
     height: 50px;
     font-size: 24px;
     font-weight: 500;

--- a/src/app/exams/exams.model.ts
+++ b/src/app/exams/exams.model.ts
@@ -13,7 +13,7 @@ export interface Exam {
 
 export interface ExamQuestion {
   body: string;
-  type: 'input' | 'textarea' | 'select' | 'selectMultiple';
+  type: 'input' | 'textarea' | 'select' | 'selectMultiple' | 'matrix';
   correctChoice: string[];
   marks: number;
   choices: { text: string, id: string }[];

--- a/src/app/exams/exams.model.ts
+++ b/src/app/exams/exams.model.ts
@@ -13,7 +13,7 @@ export interface Exam {
 
 export interface ExamQuestion {
   body: string;
-  type: 'input' | 'textarea' | 'select' | 'selectMultiple' | 'matrix';
+  type: 'input' | 'textarea' | 'select' | 'selectMultiple' | 'ratingScale';
   correctChoice: string[];
   marks: number;
   choices: { text: string, id: string }[];

--- a/src/app/exams/exams.service.ts
+++ b/src/app/exams/exams.service.ts
@@ -29,9 +29,8 @@ export class ExamsService {
   }
 
   choiceRequiredValidator(ac) {
-    return ac.get('type').value === 'select' || ac.get('type').value === 'selectMultiple' ?
-      Validators.required(ac.get('choices')) && { noChoices: true } :
-      null;
+    const questionType = ac.get('type').value;
+    return questionType === 'select' || questionType === 'selectMultiple' ? Validators.required(ac.get('choices')) && { noChoices: true } : null;
   }
 
   newQuestionChoice(newId, intialValue?) {

--- a/src/app/shared/ai-prompts.constants.ts
+++ b/src/app/shared/ai-prompts.constants.ts
@@ -4,7 +4,7 @@ export const surveyAnalysisPrompt = (examType, examName, examDescription, payloa
   Please generate a detailed AI Analysis for PDF export, organized into 4 sections:
 
   1. INDIVIDUAL QUESTION ANALYSIS
-    If the question is a **Closed-ended questions(type - select or selectMultiple):**
+    If the question is a **Closed-ended questions(type - select or selectMultiple or matrix[1-9 choices]):**
         - List the top three answer choices with absolute counts and percentages.
         - In addition to the top three, highlight any answer choice with fewer than 10% of responses and suggest why it might be under-selected
         - Create a hypothesis for the selections

--- a/src/app/shared/ai-prompts.constants.ts
+++ b/src/app/shared/ai-prompts.constants.ts
@@ -4,7 +4,7 @@ export const surveyAnalysisPrompt = (examType, examName, examDescription, payloa
   Please generate a detailed AI Analysis for PDF export, organized into 4 sections:
 
   1. INDIVIDUAL QUESTION ANALYSIS
-    If the question is a **Closed-ended questions(type - select or selectMultiple or matrix[1-9 choices]):**
+    If the question is a **Closed-ended questions(type - select or selectMultiple or rating scale [1-9 choices]):**
         - List the top three answer choices with absolute counts and percentages.
         - In addition to the top three, highlight any answer choice with fewer than 10% of responses and suggest why it might be under-selected
         - Create a hypothesis for the selections

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -384,7 +384,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   exportPdf(survey) {
-    const hasChartableData = survey.questions.some((question) => question.type === 'select' || question.type === 'selectMultiple' || question.type === 'matrix');
+    const hasChartableData = survey.questions.some((question) => question.type === 'select' || question.type === 'selectMultiple' || question.type === 'ratingScale');
     const chatDisabled = this.availableAIProviders.length === 0;
 
     this.dialogsFormService.openDialogsForm(

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -384,9 +384,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   exportPdf(survey) {
-    const hasChartableData = survey.questions.some(
-      (question) => question.type === 'select' || question.type === 'selectMultiple'
-    );
+    const hasChartableData = survey.questions.some((question) => question.type === 'select' || question.type === 'selectMultiple' || question.type === 'matrix');
     const chatDisabled = this.availableAIProviders.length === 0;
 
     this.dialogsFormService.openDialogsForm(


### PR DESCRIPTION
Fixes #9068

- Add default 1-9 rating scale question type to surveys.
- Add custom rating scale type representation in PDF export.

<img width="3406" height="1848" alt="image" src="https://github.com/user-attachments/assets/9147e8e2-67e2-4e0d-88e9-79bb1eac6d35" />

<img width="3406" height="1858" alt="image" src="https://github.com/user-attachments/assets/e2b8e0c5-a8c1-46fc-b9c1-a856c3f9e130" />


<img width="3402" height="1852" alt="image" src="https://github.com/user-attachments/assets/a145d076-05e8-4a70-b36b-368db00c1e0e" />


