### PR TITLE
survey: improve pdf export markdown (fixes #9071)

### DIFF
--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -544,8 +544,7 @@ export class SubmissionsService {
   questionOutput(submission, answerIndexes, includeQuestions, includeAnswers) {
     const exportText = (text, index, label: 'Question' | 'Response') => {
       const alignment = label === 'Response' ? 'right' : 'left';
-      const processedText = label === 'Question' ? converter.makeHtml(text) : text;
-      return `<div style="text-align: ${alignment};"><strong>${label} ${index + 1}:</strong><br>${processedText}</div>`;
+      return `<div style="text-align: ${alignment};"><strong>${label} ${index + 1}:</strong><br>${converter.makeHtml(text)}</div>`;
     };
     return (question, questionIndex) =>
       (includeQuestions ? exportText(question, questionIndex, 'Question') : '') +

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -544,7 +544,8 @@ export class SubmissionsService {
   questionOutput(submission, answerIndexes, includeQuestions, includeAnswers) {
     const exportText = (text, index, label: 'Question' | 'Response') => {
       const alignment = label === 'Response' ? 'right' : 'left';
-      return `<div style="text-align: ${alignment};"><strong>${label} ${index + 1}:</strong><br>${text}</div>`;
+      const processedText = label === 'Question' ? converter.makeHtml(text) : text;
+      return `<div style="text-align: ${alignment};"><strong>${label} ${index + 1}:</strong><br>${processedText}</div>`;
     };
     return (question, questionIndex) =>
       (includeQuestions ? exportText(question, questionIndex, 'Question') : '') +

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -343,7 +343,7 @@ export class SubmissionsService {
       const question = exam.questions[i];
       if (question.type !== 'select' && question.type !== 'selectMultiple' && question.type !== 'ratingScale') { continue; }
       question.index = i;
-      docContent.push({ text: `Q${i + 1}: ${question.body}` });
+      docContent.push({ stack: htmlToPdfmake(`<strong>Q${i + 1}:</strong> ${converter.makeHtml(question.body)}`) });
       if (question.type === 'selectMultiple') {
         const barAgg = this.aggregateQuestionResponses(question, updatedSubmissions, 'percent', 'users');
         const barImg = await this.generateChartImage(barAgg);


### PR DESCRIPTION
Fixes #9071

Add full markdown support for survey pdf exports

<img width="3398" height="1846" alt="image" src="https://github.com/user-attachments/assets/0f5bd437-014f-461e-88eb-b9dca98400cb" />
