### PR TITLE
chat: added padding to textarea (fixes #9111)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -295,6 +295,7 @@
   "cli": {
     "schematicCollections": [
       "@angular-eslint/schematics"
-    ]
+    ],
+    "analytics": false
   }
 }

--- a/src/app/chat/chat-window/chat-window.scss
+++ b/src/app/chat/chat-window/chat-window.scss
@@ -30,6 +30,7 @@
 .textarea-container textarea {
   resize: none;
   height: 100px;
+  padding: 15px;
 }
 
 .textarea-container button {


### PR DESCRIPTION
fixes #9111 

<img width="1662" height="227" alt="chatpadding" src="https://github.com/user-attachments/assets/acbd2aed-d741-4943-8aff-c98e7b72957e" />
