### PR TITLE
community/finances: italicize notes for finances (fixes #9113)

### DIFF
--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -24,11 +24,11 @@
 <mat-table [dataSource]="table" *ngIf="!emptyTable; else emptyMessage">
   <ng-container matColumnDef="date">
     <mat-header-cell *matHeaderCellDef class="narrow-column" i18n>Date</mat-header-cell>
-    <mat-cell *matCellDef="let element" class="narrow-column">{{ element.date === 'Total' ? element.date : (element.date | date) }}</mat-cell>
+    <mat-cell *matCellDef="let element" class="narrow-column date">{{ element.date === 'Total' ? element.date : (element.date | date) }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="description">
     <mat-header-cell *matHeaderCellDef i18n>Note</mat-header-cell>
-    <mat-cell *matCellDef="let element">{{ element.description }}</mat-cell>
+    <mat-cell *matCellDef="let element"><i>{{ element.description }}</i></mat-cell>
   </ng-container>
   <ng-container matColumnDef="credit">
     <mat-header-cell *matHeaderCellDef class="narrow-column" i18n>Credits</mat-header-cell>

--- a/src/app/teams/teams-view-finances.scss
+++ b/src/app/teams/teams-view-finances.scss
@@ -2,6 +2,10 @@
   max-width: 100px;
 }
 
+.date{
+  font-size: 0.8em;
+}
+
 .action-buttons {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
fixes #9113 

I formatted the text under ‘Note’ in italics and reduced the date’s size to create better visual correspondence.

<img width="1230" height="357" alt="noteItalics" src="https://github.com/user-attachments/assets/f1a2ae59-ab8f-417d-8f07-46eaad55e026" />
