### PR TITLE
fix: disable 'Remove Description' button when no description exists (#9095)

### DIFF
--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -70,7 +70,7 @@
               <button class="toggle-button" (click)="openDescriptionDialog()" mat-stroked-button i18n>
                 { servicesDescriptionLabel, select, Edit {Edit} Add {Add}} { configuration.planetType, select, community {Community} nation {Nation} center {Earth}} Description
               </button>
-              <button (click)="confirmDeleteDescription()" mat-stroked-button>
+              <button (click)="confirmDeleteDescription()" mat-stroked-button [disabled]="!(team?.description?.trim()?.length)">
                 <span i18n>Remove Description</span>
               </button>
             </div>


### PR DESCRIPTION
Fix #9095.

- Disabled the "Remove Description" button in community.component.html when team.description is empty or whitespace.
- Ensures button only enabled when a description exists.
<img width="984" height="447" alt="image" src="https://github.com/user-attachments/assets/d022f620-7264-4962-a46d-cb4a284da8e1" />

Tested:
- Empty description → button disabled.
- Non-empty description → button enabled and works as expected.
