### PR TITLE
resources: prompt for custom title on add (#9097)

### DIFF
--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -183,6 +183,15 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   }
 
   onSubmit() {
+    // If no title typed yet, ask for one (default to "Financial Report")
+    if (!this.resourceForm.value.title || !this.resourceForm.value.title.trim()) {
+      const proposed = window.prompt('Name this report', 'Financial Report');
+      if (proposed === null) {
+        return; // user canceled -> stay on form
+      }
+      const name = (proposed || '').trim() || 'Financial Report';
+      this.resourceForm.patchValue({ title: name });
+    }
     if (this.attachmentMarkedForDeletion) {
       delete this.existingResource.doc._attachments;
     }


### PR DESCRIPTION
Fix: 9097

## What
Adds a prompt on Add Resource to name financial reports and saves it to `doc.title`.

## Why
All reports were titled "Financial Report", making them hard to distinguish. This lets users set a custom name.

## Changes
- src/app/resources/resources-add.component.ts: If Title is empty on submit, prompt user; patch `title` before save.

## Testing
1. Go to Resources → Add
2. Leave Title empty; fill required fields (Subject, Level, Description)
3. Click Save → prompt appears → enter custom name
   - List shows the custom Title
   - Detail/preview shows the same Title
   - Leaving Title filled skips the prompt

## Backward compatibility
- Existing items without `title` still display as "Financial Report" (UI fallback remains).
