### PR TITLE
dashboard: myteams search filter not working (fixes #9147)

### DIFF
--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -48,8 +48,21 @@ export const filterSpecificFields = (filterFields: string[]): any => {
 
 export const filterSpecificFieldsByWord = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
+    const trimmedFilter = filter.trim();
+    if (!trimmedFilter) {
+      return true;
+    }
+
     // Normalize each word
-    const words = filter.split(' ').map(value => value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, ''));
+    const words = trimmedFilter
+      .split(' ')
+      .map(value => value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, ''))
+      .filter(Boolean);
+
+    if (!words.length) {
+      return true;
+    }
+
     return words.every(word => {
       return filterFields.some(field => {
         const fieldValue = getProperty(data, field);

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -321,7 +321,12 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   }
 
   applyFilter(filterValue: string) {
-    this.teams.filter = filterValue || (this.myTeamsFilter ? ' ' : '');
+    const normalizedFilter = filterValue ? filterValue.trim().toLowerCase() : '';
+    this.teams.filter = normalizedFilter || (this.myTeamsFilter ? ' ' : '');
+
+    if (this.teams.paginator) {
+      this.teams.paginator.firstPage();
+    }
   }
 
   sortbyUserTeams() {


### PR DESCRIPTION
fixes #9147
Normalize and reapply the MatTable filter in MyTeams so typed searches filter the table.

------
https://chatgpt.com/codex/tasks/task_e_68d5b988831c832d9c636ef1421578a0