### PR TITLE
Modularize Home dashboard dependencies – impact 85, feasibility 55

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -1,5 +1,4 @@
 @use '@angular/material' as mat;
-@import '@angular/material/theming';
 
 $primary-hue: 500;
 $accent-hue: 500;

--- a/src/app/community/community-home-routing.module.ts
+++ b/src/app/community/community-home-routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { CommunityComponent } from './community.component';
+
+const routes: Routes = [
+  { path: '', component: CommunityComponent },
+  { path: 'voices/:id', component: CommunityComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class CommunityHomeRoutingModule {}

--- a/src/app/community/community-home.module.ts
+++ b/src/app/community/community-home.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { CommunityHomeRoutingModule } from './community-home-routing.module';
+import { CommunitySharedModule } from './community-shared.module';
+
+@NgModule({
+  imports: [
+    CommunityHomeRoutingModule,
+    RouterModule,
+    CommunitySharedModule,
+  ],
+})
+export class CommunityHomeModule {}

--- a/src/app/community/community-shared.module.ts
+++ b/src/app/community/community-shared.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { CommunityComponent } from './community.component';
+import { CommunityLinkDialogComponent } from './community-link-dialog.component';
+import { MaterialModule } from '../shared/material.module';
+import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { NewsModule } from '../news/news.module';
+import { TeamsModule } from '../teams/teams.module';
+import { PlanetCalendarModule } from '../shared/calendar.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MaterialModule,
+    PlanetDialogsModule,
+    SharedComponentsModule,
+    NewsModule,
+    TeamsModule,
+    PlanetCalendarModule,
+    RouterModule,
+  ],
+  declarations: [
+    CommunityComponent,
+    CommunityLinkDialogComponent,
+  ],
+  exports: [
+    CommunityComponent,
+    CommunityLinkDialogComponent,
+  ]
+})
+export class CommunitySharedModule {}

--- a/src/app/community/community-viewer-routing.module.ts
+++ b/src/app/community/community-viewer-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { CommunityComponent } from './community.component';
+
+const routes: Routes = [
+  { path: ':code', component: CommunityComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class CommunityViewerRoutingModule {}

--- a/src/app/community/community-viewer.module.ts
+++ b/src/app/community/community-viewer.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { CommunityViewerRoutingModule } from './community-viewer-routing.module';
+import { CommunitySharedModule } from './community-shared.module';
+
+@NgModule({
+  imports: [
+    CommunityViewerRoutingModule,
+    RouterModule,
+    CommunitySharedModule,
+  ],
+})
+export class CommunityViewerModule {}

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { DashboardComponent } from './dashboard.component';
+
+const routes: Routes = [
+  { path: '', component: DashboardComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class DashboardRoutingModule {}

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { DashboardComponent } from './dashboard.component';
+import { DashboardTileComponent, DashboardTileTitleComponent } from './dashboard-tile.component';
+import { MaterialModule } from '../shared/material.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
+import { DashboardRoutingModule } from './dashboard-routing.module';
+import { CoursesViewDetailModule } from '../courses/view-courses/courses-view-detail.module';
+
+@NgModule({
+  imports: [
+    DashboardRoutingModule,
+    CommonModule,
+    RouterModule,
+    MaterialModule,
+    SharedComponentsModule,
+    PlanetDialogsModule,
+    CoursesViewDetailModule,
+  ],
+  declarations: [
+    DashboardComponent,
+    DashboardTileComponent,
+    DashboardTileTitleComponent,
+  ]
+})
+export class DashboardModule {}

--- a/src/app/health/health-list-routing.module.ts
+++ b/src/app/health/health-list-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { HealthListComponent } from './health-list.component';
+
+const routes: Routes = [
+  { path: '', component: HealthListComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class HealthListRoutingModule {}

--- a/src/app/health/health-list.module.ts
+++ b/src/app/health/health-list.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { HealthListComponent } from './health-list.component';
+import { MaterialModule } from '../shared/material.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { HealthListRoutingModule } from './health-list-routing.module';
+
+@NgModule({
+  imports: [
+    HealthListRoutingModule,
+    CommonModule,
+    RouterModule,
+    MaterialModule,
+    SharedComponentsModule,
+  ],
+  declarations: [ HealthListComponent ]
+})
+export class HealthListModule {}

--- a/src/app/health/health-list.module.ts
+++ b/src/app/health/health-list.module.ts
@@ -1,19 +1,23 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 
 import { HealthListComponent } from './health-list.component';
 import { MaterialModule } from '../shared/material.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { HealthListRoutingModule } from './health-list-routing.module';
+import { UsersTableModule } from '../users/users-table.module';
 
 @NgModule({
   imports: [
     HealthListRoutingModule,
     CommonModule,
     RouterModule,
+    FormsModule,
     MaterialModule,
     SharedComponentsModule,
+    UsersTableModule,
   ],
   declarations: [ HealthListComponent ]
 })

--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -1,25 +1,15 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { DashboardComponent } from '../dashboard/dashboard.component';
-import { NotificationsComponent } from '../notifications/notifications.component';
-import { UpgradeComponent } from '../upgrade/upgrade.component';
-import { UsersAchievementsComponent } from '../users/users-achievements/users-achievements.component';
-import { UsersAchievementsUpdateComponent } from '../users/users-achievements/users-achievements-update.component';
-import { TeamsViewComponent } from '../teams/teams-view.component';
-import { HealthListComponent } from '../health/health-list.component';
-import { CommunityComponent } from '../community/community.component';
 import { myDashboardRoute } from './router-constants';
 import { CoursesProgressLearnerComponent } from '../courses/progress-courses/courses-progress-learner.component';
-import { NewsListComponent } from '../news/news-list.component';
 import { AuthService } from '../shared/auth-guard.service';
-import { UnsavedChangesGuard } from '../shared/unsaved-changes.guard';
 
 export function dashboardPath(route): string {
   return `${myDashboardRoute}/${route}`;
 }
 
 const alwaysGuardedRoutes = [
-  { path: 'community/:code', component: CommunityComponent },
+  { path: 'community', loadChildren: () => import('../community/community-viewer.module').then(m => m.CommunityViewerModule) },
   { path: 'users', loadChildren: () => import('../users/users.module').then(m => m.UsersModule) },
   {
     path: 'manager',
@@ -31,18 +21,17 @@ const alwaysGuardedRoutes = [
   { path: 'resources', loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule) },
   { path: 'chat', loadChildren: () => import('../chat/chat.module').then(m => m.ChatModule) },
   { path: 'meetups', loadChildren: () => import('../meetups/meetups.module').then(m => m.MeetupsModule) },
-  { path: 'notifications', component: NotificationsComponent },
-  { path: 'upgrade', component: UpgradeComponent },
-  { path: 'upgrade/myplanet', component: UpgradeComponent, data: { myPlanet: true } },
+  { path: 'notifications', loadChildren: () => import('../notifications/notifications.module').then(m => m.NotificationsModule) },
+  { path: 'upgrade', loadChildren: () => import('../upgrade/upgrade.module').then(m => m.UpgradeModule) },
   { path: 'teams', loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule) },
   { path: 'enterprises', loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule), data: { mode: 'enterprise' } },
-  { path: 'health', component: HealthListComponent, data: { roles: [ '_admin', 'health' ] } },
+  { path: 'health', loadChildren: () => import('../health/health-list.module').then(m => m.HealthListModule), data: { roles: [ '_admin', 'health' ] } },
   {
     path: 'health/profile/:id',
     loadChildren: () => import('../health/health.module').then(m => m.HealthModule), data: { roles: [ '_admin', 'health' ] } },
-  { path: 'nation', component: TeamsViewComponent, data: { mode: 'services' } },
-  { path: 'earth', component: TeamsViewComponent, data: { mode: 'services' } },
-  { path: myDashboardRoute, component: DashboardComponent },
+  { path: 'nation', loadChildren: () => import('../teams/teams-services.module').then(m => m.TeamsServicesModule), data: { mode: 'services' } },
+  { path: 'earth', loadChildren: () => import('../teams/teams-services.module').then(m => m.TeamsServicesModule), data: { mode: 'services' } },
+  { path: myDashboardRoute, loadChildren: () => import('../dashboard/dashboard.module').then(m => m.DashboardModule) },
   {
     path: dashboardPath('mySurveys'),
     loadChildren: () => import('../submissions/submissions.module').then(m => m.SubmissionsModule), data: { mySurveys: true }
@@ -59,8 +48,8 @@ const alwaysGuardedRoutes = [
     path: dashboardPath('myTeams'),
     loadChildren: () => import('../teams/teams.module').then(m => m.TeamsModule), data: { myTeams: true }
   },
-  { path: dashboardPath('myAchievements'), component: UsersAchievementsComponent },
-  { path: dashboardPath('myAchievements/update'), component: UsersAchievementsUpdateComponent, canDeactivate: [UnsavedChangesGuard]  },
+  { path: dashboardPath('myAchievements'), loadChildren: () => import('../users/users-achievements/users-achievements.module').then(m => m.UsersAchievementsModule) },
+  { path: dashboardPath('myAchievements/update'), loadChildren: () => import('../users/users-achievements/users-achievements.module').then(m => m.UsersAchievementsModule) },
   { path: dashboardPath('myHealth'), loadChildren: () => import('../health/health.module').then(m => m.HealthModule) },
   {
     path: dashboardPath('myCourses'),
@@ -80,8 +69,7 @@ const alwaysGuardedRoutes = [
 const routes: Routes = [
   {
     path: '',
-    component: CommunityComponent,
-    children: [ { path: 'voices/:id', component: NewsListComponent } ]
+    loadChildren: () => import('../community/community-home.module').then(m => m.CommunityHomeModule)
   },
   {
     path: '',

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -10,6 +10,7 @@ import { PlanetFormsModule } from '../shared/forms/planet-forms.module';
 import { MaterialModule } from '../shared/material.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { PulsateIconDirective } from './pulsate-icon.directive';
+import { CommunitySharedModule } from '../community/community-shared.module';
 
 @NgModule({
   imports: [
@@ -20,6 +21,7 @@ import { PulsateIconDirective } from './pulsate-icon.directive';
     PlanetFormsModule,
     MaterialModule,
     SharedComponentsModule,
+    CommunitySharedModule,
     HttpClientModule,
     HttpClientJsonpModule,
   ],

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -1,33 +1,15 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
+import { HttpClientJsonpModule, HttpClientModule } from '@angular/common/http';
 
 import { HomeComponent } from './home.component';
-import { DashboardComponent } from '../dashboard/dashboard.component';
+import { PlanetComponent } from './planet.component';
 import { HomeRouterModule } from './home-router.module';
 import { PlanetFormsModule } from '../shared/forms/planet-forms.module';
-
 import { MaterialModule } from '../shared/material.module';
-import { DashboardTileComponent, DashboardTileTitleComponent } from '../dashboard/dashboard-tile.component';
-import { NotificationsComponent } from '../notifications/notifications.component';
-import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
-import { PulsateIconDirective } from './pulsate-icon.directive';
-import { UpgradeComponent } from '../upgrade/upgrade.component';
 import { SharedComponentsModule } from '../shared/shared-components.module';
-import { UsersAchievementsModule } from '../users/users-achievements/users-achievements.module';
-import { NewsModule } from '../news/news.module';
-import { LogsMyPlanetComponent } from '../manager-dashboard/reports/myplanet/logs-myplanet.component';
-import { TeamsModule } from '../teams/teams.module';
-import { CommunityComponent } from '../community/community.component';
-import { PlanetCalendarModule } from '../shared/calendar.module';
-import { CommunityLinkDialogComponent } from '../community/community-link-dialog.component';
-import { HealthListComponent } from '../health/health-list.component';
-import { UsersModule } from '../users/users.module';
-import { PlanetComponent } from './planet.component';
-import { CoursesViewDetailModule } from '../courses/view-courses/courses-view-detail.module';
-import { ChatModule } from '../chat/chat.module';
-import { SurveysModule } from '../surveys/surveys.module';
+import { PulsateIconDirective } from './pulsate-icon.directive';
 
 @NgModule({
   imports: [
@@ -37,32 +19,14 @@ import { SurveysModule } from '../surveys/surveys.module';
     ReactiveFormsModule,
     PlanetFormsModule,
     MaterialModule,
+    SharedComponentsModule,
     HttpClientModule,
     HttpClientJsonpModule,
-    PlanetDialogsModule,
-    SharedComponentsModule,
-    UsersAchievementsModule,
-    NewsModule,
-    TeamsModule,
-    PlanetCalendarModule,
-    UsersModule,
-    CoursesViewDetailModule,
-    ChatModule,
-    SurveysModule
   ],
   declarations: [
     HomeComponent,
-    DashboardComponent,
-    DashboardTileComponent,
-    DashboardTileTitleComponent,
-    NotificationsComponent,
-    PulsateIconDirective,
-    UpgradeComponent,
-    LogsMyPlanetComponent,
-    CommunityComponent,
-    CommunityLinkDialogComponent,
     PlanetComponent,
-    HealthListComponent,
+    PulsateIconDirective,
   ]
 })
 export class HomeModule {}

--- a/src/app/manager-dashboard/manager-dashboard.module.ts
+++ b/src/app/manager-dashboard/manager-dashboard.module.ts
@@ -20,6 +20,7 @@ import { ReportsDetailComponent } from './reports/reports-detail.component';
 import { ReportsPendingComponent } from './reports/reports-pending.component';
 import { PendingTableComponent } from './reports/pending-table.component';
 import { ReportsMyPlanetComponent } from './reports/myplanet/reports-myplanet.component';
+import { LogsMyPlanetComponent } from './reports/myplanet/logs-myplanet.component';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { ReportsDetailActivitiesComponent } from './reports/reports-detail-activities.component';
 import { ReportsHealthComponent } from './reports/reports-health.component';
@@ -52,6 +53,7 @@ import { ReportsHealthComponent } from './reports/reports-health.component';
     ReportsPendingComponent,
     PendingTableComponent,
     ReportsMyPlanetComponent,
+    LogsMyPlanetComponent,
     ReportsDetailActivitiesComponent,
     ReportsHealthComponent
   ]

--- a/src/app/notifications/notifications-routing.module.ts
+++ b/src/app/notifications/notifications-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { NotificationsComponent } from './notifications.component';
+
+const routes: Routes = [
+  { path: '', component: NotificationsComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class NotificationsRoutingModule {}

--- a/src/app/notifications/notifications.module.ts
+++ b/src/app/notifications/notifications.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { NotificationsComponent } from './notifications.component';
+import { MaterialModule } from '../shared/material.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { NotificationsRoutingModule } from './notifications-routing.module';
+import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
+
+@NgModule({
+  imports: [
+    NotificationsRoutingModule,
+    CommonModule,
+    RouterModule,
+    MaterialModule,
+    SharedComponentsModule,
+    PlanetDialogsModule,
+  ],
+  declarations: [ NotificationsComponent ]
+})
+export class NotificationsModule {}

--- a/src/app/teams/teams-services-routing.module.ts
+++ b/src/app/teams/teams-services-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { TeamsViewComponent } from './teams-view.component';
+
+const routes: Routes = [
+  { path: '', component: TeamsViewComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class TeamsServicesRoutingModule {}

--- a/src/app/teams/teams-services.module.ts
+++ b/src/app/teams/teams-services.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { TeamsModule } from './teams.module';
+
+import { TeamsServicesRoutingModule } from './teams-services-routing.module';
+
+@NgModule({
+  imports: [
+    TeamsServicesRoutingModule,
+    TeamsModule,
+  ]
+})
+export class TeamsServicesModule {}

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -10,7 +10,7 @@
     justify-content: center;
     max-width: 80px;
     padding-right: 1rem;
-    margin-right: 1rem
+    margin-right: 1rem;
   }
 
   mat-row {

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -1,4 +1,4 @@
-@import "../variables.scss";
+@use '../_variables.scss' as *;
 
 :host {
   .mat-column-doc-teamType {

--- a/src/app/upgrade/upgrade-routing.module.ts
+++ b/src/app/upgrade/upgrade-routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { UpgradeComponent } from './upgrade.component';
+
+const routes: Routes = [
+  { path: '', component: UpgradeComponent },
+  { path: 'myplanet', component: UpgradeComponent, data: { myPlanet: true } }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class UpgradeRoutingModule {}

--- a/src/app/upgrade/upgrade.module.ts
+++ b/src/app/upgrade/upgrade.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { UpgradeComponent } from './upgrade.component';
+import { MaterialModule } from '../shared/material.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { UpgradeRoutingModule } from './upgrade-routing.module';
+
+@NgModule({
+  imports: [
+    UpgradeRoutingModule,
+    CommonModule,
+    RouterModule,
+    MaterialModule,
+    SharedComponentsModule,
+  ],
+  declarations: [ UpgradeComponent ]
+})
+export class UpgradeModule {}

--- a/src/app/users/users-achievements/users-achievements.module.ts
+++ b/src/app/users/users-achievements/users-achievements.module.ts
@@ -1,21 +1,30 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { MaterialModule } from '../../shared/material.module';
 import { PlanetFormsModule } from '../../shared/forms/planet-forms.module';
 import { SharedComponentsModule } from '../../shared/shared-components.module';
 import { UsersAchievementsComponent } from './users-achievements.component';
 import { UsersAchievementsUpdateComponent } from './users-achievements-update.component';
+import { UnsavedChangesGuard } from '../../shared/unsaved-changes.guard';
+
+const routes: Routes = [
+  { path: '', component: UsersAchievementsComponent },
+  { path: 'update', component: UsersAchievementsUpdateComponent, canDeactivate: [ UnsavedChangesGuard ] }
+];
 
 @NgModule({
   imports: [
-    CommonModule, FormsModule, ReactiveFormsModule, RouterModule, MaterialModule, PlanetFormsModule, SharedComponentsModule, ClipboardModule
-  ],
-  exports: [
-    UsersAchievementsUpdateComponent,
-    UsersAchievementsComponent
+    RouterModule.forChild(routes),
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MaterialModule,
+    PlanetFormsModule,
+    SharedComponentsModule,
+    ClipboardModule
   ],
   declarations: [
     UsersAchievementsUpdateComponent,

--- a/src/app/users/users-table.module.ts
+++ b/src/app/users/users-table.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { MaterialModule } from '../shared/material.module';
+import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { UsersTableComponent } from './users-table.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MaterialModule,
+    SharedComponentsModule,
+    PlanetDialogsModule,
+    RouterModule,
+  ],
+  declarations: [ UsersTableComponent ],
+  exports: [ UsersTableComponent ]
+})
+export class UsersTableModule {}

--- a/src/app/users/users.module.ts
+++ b/src/app/users/users.module.ts
@@ -12,12 +12,13 @@ import { MaterialModule } from '../shared/material.module';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { UsersAchievementsModule } from './users-achievements/users-achievements.module';
-import { UsersTableComponent } from './users-table.component';
+import { UsersTableModule } from './users-table.module';
 import { UserProfileDialogComponent } from './users-profile/users-profile-dialog.component';
 
 @NgModule({
   exports: [
-    UsersTableComponent, UsersComponent
+    UsersComponent,
+    UsersTableModule
   ],
   imports: [
     UsersRouterModule,
@@ -29,14 +30,14 @@ import { UserProfileDialogComponent } from './users-profile/users-profile-dialog
     MaterialModule,
     SharedComponentsModule,
     UsersAchievementsModule,
-    ImageCropperModule
+    ImageCropperModule,
+    UsersTableModule
   ],
   declarations: [
     UsersComponent,
     UsersArchiveComponent,
     UsersProfileComponent,
     UsersUpdateComponent,
-    UsersTableComponent,
     UserProfileDialogComponent
   ]
 })


### PR DESCRIPTION
Refactor Home feature imports into lazy-loaded modules so the initial bundle no longer eagerly includes News/Chat/Surveys/Teams/etc.

## Summary
- split HomeModule so dashboard, community, notifications, upgrade, and health screens live in dedicated lazy modules instead of the root shell
- updated Home routing to lazy-load features and added a shared community bundle to avoid duplicate declarations while keeping guard data intact
- wired Teams services view and achievements routes through feature shells and registered missing MyPlanet logs component with the manager dashboard module

## Testing
- npm run build -- --configuration production --stats-json *(fails: missing @angular/cli because npm install repeatedly errors with ENOTEMPTY while deleting material-design-icons)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d2b56c10832b8cc257fa13532ff4