### PR TITLE
all: smoother planet build dockerfile (fixes #9188)

### DIFF
--- a/docker/planet/builder-Dockerfile
+++ b/docker/planet/builder-Dockerfile
@@ -1,9 +1,9 @@
-FROM treehouses/planet-base as builder
+FROM treehouses/planet-base AS builder
 
 ARG LANGUAGE=""
-ENV LANG ${LANGUAGE}
+ENV LANG=${LANGUAGE}
 ARG LANGUAGE2=""
-ENV LANG2 ${LANGUAGE2}
+ENV LANG2=${LANGUAGE2}
 
 COPY docker/planet/scripts/ ./
 COPY . .

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.20.38",
+  "version": "0.20.42",
   "myplanet": {
-    "latest": "v0.33.38",
-    "min": "v0.32.38"
+    "latest": "v0.33.66",
+    "min": "v0.32.66"
   },
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
## Summary
- capitalize the builder stage alias in the Dockerfile
- switch LANG environment variable declarations to use equals syntax

## Testing
- docker build -f docker/planet/builder-Dockerfile . *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc29c4ec832bbb0d93a892c5ae5d