### PR TITLE
Refactor Angular Material theming configuration

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -16,7 +16,17 @@ $planet-app-primary: mat.define-palette($planet-primary, $primary-hue);
 $planet-app-accent: mat.define-palette($planet-accent, $accent-hue);
 $planet-app-warn: mat.define-palette($planet-warn, $warn-hue);
 
-$planet-app-theme: mat.define-light-theme($planet-app-primary, $planet-app-accent, $planet-app-warn);
+$planet-app-theme-config: (
+  color: (
+    primary: $planet-app-primary,
+    accent: $planet-app-accent,
+    warn: $planet-app-warn,
+  ),
+  typography: mat.define-legacy-typography-config(),
+  density: 0,
+);
+
+$planet-app-theme: mat.define-light-theme($planet-app-theme-config);
 
 $primary: mat.get-color-from-palette($planet-app-primary, $primary-hue);
 $accent: mat.get-color-from-palette($planet-app-accent, $accent-hue);

--- a/src/planet-mat-theme.scss
+++ b/src/planet-mat-theme.scss
@@ -29,7 +29,18 @@ $accent-map: (
 
 @each $section in library, courses, meetups, teams {
   $accent-palette: map-get($accent-map, #{$section});
-  $theme: mat.define-light-theme($planet-app-primary, $accent-palette, $planet-app-warn);
+  $section-color-config: map-merge(
+    map-get($planet-app-theme-config, color),
+    (
+      accent: $accent-palette,
+    )
+  );
+  $section-theme-config: (
+    color: $section-color-config,
+    typography: null,
+    density: null,
+  );
+  $theme: mat.define-light-theme($section-theme-config);
   .planet-#{$section}-theme {
     @include mat.all-legacy-component-themes($theme);
 


### PR DESCRIPTION
## Summary
- wrap the Angular Material palettes in a theme configuration map that includes color, typography, and density details
- consume the shared theme map when generating section-specific themes and avoid re-emitting typography and density styles

## Testing
- `CI=1 NG_CLI_ANALYTICS=false npm run build -- --progress=false`


------
https://chatgpt.com/codex/tasks/task_e_68dbdbe350cc832b9116cf6ea6655783