### PR TITLE
chore(login): drop full mat theme import

### DIFF
--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -1,5 +1,4 @@
 @import "../variables.scss";
-@import "../../planet-mat-theme.scss";
 @import "../mixins.scss";
 
 :host {


### PR DESCRIPTION
## Summary
- remove the global Angular Material theme import from the login stylesheet so it only consumes shared variables and mixins

## Testing
- `npm run ng -- build --configuration production` *(fails: ng: not found)*
- `npx ng build --configuration production` *(fails: npm error could not determine executable to run)*
- `npm install --no-progress` *(fails: ENOTEMPTY while cleaning node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc088568832bbf37a2e10a50e118