### PR TITLE
community: add "Date Modified" column with sort to Finances table (fixes #9096)

### DIFF
--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -22,10 +22,14 @@
   <div class="warning-container"><mat-icon color="accent">warning</mat-icon><span i18n>The current balance is negative!</span></div>
 </mat-card>
 <ng-container *ngIf="!isLoading; else loadingTpl">
-<mat-table [dataSource]="table" *ngIf="!emptyTable; else emptyMessage">
+<mat-table [dataSource]="table" matSort *ngIf="!emptyTable; else emptyMessage">
   <ng-container matColumnDef="date">
     <mat-header-cell *matHeaderCellDef class="narrow-column" i18n>Date</mat-header-cell>
     <mat-cell *matCellDef="let element" class="narrow-column narrow-column-date">{{ element.date === 'Total' ? element.date : (element.date | date) }}</mat-cell>
+  </ng-container>
+  <ng-container matColumnDef="updatedDate">
+    <mat-header-cell *matHeaderCellDef class="narrow-column" mat-sort-header i18n>Date Modified</mat-header-cell>
+    <mat-cell *matCellDef="let element" class="narrow-column narrow-column-date">{{ element.date === 'Total' ? '' : (element.updatedDate | date:'medium') }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="description">
     <mat-header-cell *matHeaderCellDef i18n>Note</mat-header-cell>


### PR DESCRIPTION
fixes #9096

- add a Date Modified column to the finances table with a friendly timestamp display
- ensure each transaction exposes an updatedDate field and enable sorting while keeping the total row fixed

------
https://chatgpt.com/codex/tasks/task_e_68dcb6ed763c832d94ac03b8a41dbbc4