### PR TITLE
community: add custom naming for financial reports (fixes #9097)

### DIFF
--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -11,8 +11,15 @@
   <mat-grid-tile *ngFor="let report of reports" (click)="openReportDialog(report)">
     <mat-card>
       <mat-card-header>
-        <mat-card-title i18n>Financial Report</mat-card-title>
-        <mat-card-subtitle>{{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date : 'mediumDate' : '+0000' }}</mat-card-subtitle>
+        <ng-template #dateRange>
+          {{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date : 'mediumDate' : '+0000' }}
+        </ng-template>
+        <mat-card-title>
+          <ng-container *ngIf="report.name; else dateRange">{{ report.name }}</ng-container>
+        </mat-card-title>
+        <mat-card-subtitle *ngIf="report.name">
+          <ng-container *ngTemplateOutlet="dateRange"></ng-container>
+        </mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
         <planet-teams-reports-detail [report]="report"></planet-teams-reports-detail>

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -64,6 +64,7 @@ export class TeamsReportsComponent implements DoCheck {
       this.dialogsFormService.openDialogsForm(
         dialogTitle,
         [
+          { name: 'name', placeholder: $localize`:@@financial-report-name:Report Name`, type: 'textbox', required: true },
           { name: 'startDate', placeholder: $localize`Start Date`, type: 'date', required: true },
           { name: 'endDate', placeholder: $localize`End Date`, type: 'date', required: true },
           { name: 'description', placeholder: $localize`Summary`, type: 'markdown', required: true },
@@ -87,12 +88,15 @@ export class TeamsReportsComponent implements DoCheck {
   }
 
   openDeleteReportDialog(report) {
+    const start = new Date(report.startDate).toLocaleDateString('en-US', { timeZone: 'UTC' });
+    const end = new Date(report.endDate).toLocaleDateString('en-US', { timeZone: 'UTC' });
+    const rangeLabel = `${$localize`Report from`} ${start} ${$localize`to`} ${end}`;
+    const displayName = report.name ? `${report.name} (${rangeLabel})` : rangeLabel;
     const deleteDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
         changeType: 'delete',
         type: 'report',
-        displayName: `${$localize`Report from`} ${new Date(report.startDate).toLocaleDateString('en-US', { timeZone: 'UTC' })}
-          ${$localize`to`} ${new Date(report.endDate).toLocaleDateString('en-US', { timeZone: 'UTC' })}`,
+        displayName,
         okClick: {
           request: this.updateReport(report),
           onNext: () => {
@@ -112,6 +116,7 @@ export class TeamsReportsComponent implements DoCheck {
 
   addFormInitialValues(oldReport, { startDate, endDate }) {
     const initialValues = {
+      name: '',
       description: '',
       beginningBalance: 0,
       sales: 0,
@@ -167,6 +172,7 @@ export class TeamsReportsComponent implements DoCheck {
 
   exportReports() {
     const exportData = this.reports.map(report => ({
+      'Name': report.name || '',
       'Start Date': report.startDate,
       'End Date': report.endDate,
       'Created Date': report.createdDate,

--- a/src/i18n/messages.afr.xlf
+++ b/src/i18n/messages.afr.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.ara.xlf
+++ b/src/i18n/messages.ara.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.deu.xlf
+++ b/src/i18n/messages.deu.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.eng.xlf
+++ b/src/i18n/messages.eng.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="final">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html" approved="yes">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="final">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.fra.xlf
+++ b/src/i18n/messages.fra.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.hin.xlf
+++ b/src/i18n/messages.hin.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.ind.xlf
+++ b/src/i18n/messages.ind.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.ita.xlf
+++ b/src/i18n/messages.ita.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.mlg.xlf
+++ b/src/i18n/messages.mlg.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.nep.xlf
+++ b/src/i18n/messages.nep.xlf
@@ -11926,6 +11926,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.por.xlf
+++ b/src/i18n/messages.por.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.rus.xlf
+++ b/src/i18n/messages.rus.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.som.xlf
+++ b/src/i18n/messages.som.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.spa.xlf
+++ b/src/i18n/messages.spa.xlf
@@ -15678,6 +15678,14 @@
       } many {seleccionado <x id="INTERPOLATION"/> {VAR_SELECT_1, select, community {comunidades} nation {centros} course {cursos} resource {recursos} meetup {encuentros} event {eventos} survey {encuestas}}?
       }}</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.swa.xlf
+++ b/src/i18n/messages.swa.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.tam.xlf
+++ b/src/i18n/messages.tam.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.tur.xlf
+++ b/src/i18n/messages.tur.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.ukr.xlf
+++ b/src/i18n/messages.ukr.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.vie.xlf
+++ b/src/i18n/messages.vie.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -13806,6 +13806,13 @@
           <context context-type="linenumber">[line number]</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.zho.xlf
+++ b/src/i18n/messages.zho.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/i18n/messages.zul.xlf
+++ b/src/i18n/messages.zul.xlf
@@ -11924,6 +11924,14 @@
         </context-group>
         <target state="needs-translation">No Survey Found</target>
       </trans-unit>
+      <trans-unit id="financial-report-name" datatype="html">
+        <source>Report Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teams/teams-reports.component.ts</context>
+          <context context-type="linenumber">[line number]</context>
+        </context-group>
+        <target state="needs-translation">Report Name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
fixes #9097

## Summary
- add a required report name control to the financial report dialog and store it with each document
- surface custom names in the report list, deletion prompt, and CSV export
- localize the new report name label across bundled translation catalogs

------
https://chatgpt.com/codex/tasks/task_e_68dcb6ef76dc832da84131cdc2450205