### PR TITLE
Show active filters in Library view

### DIFF
--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -34,6 +34,14 @@
 <ng-template #filterRow>
   <span class="font-size-1 margin-lr-4" i18n>Search by:</span>
   <button mat-stroked-button i18n (click)="this.showFilters = !this.showFilters" *ngIf="myView !== 'myPersonals'">Filter</button>
+  <div class="active-filter-chips" *ngIf="activeTagFilters.length">
+    <mat-chip-list aria-label="Active collection filters">
+      <mat-chip *ngFor="let tag of activeTagFilters" color="primary" selected removable (removed)="removeTagFilter(tag.id)">
+        {{ tag.name }}
+        <mat-icon matChipRemove>cancel</mat-icon>
+      </mat-chip>
+    </mat-chip-list>
+  </div>
   <mat-form-field class="font-size-1 margin-lr-4">
     <input matInput i18n-placeholder placeholder="Title" [(ngModel)]="titleSearch">
   </mat-form-field>

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -39,6 +39,17 @@ $label-height: 1rem;
     min-width: auto;
   }
 
+  .active-filter-chips {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 0 8px;
+
+    .mat-chip {
+      margin: 2px 4px;
+    }
+  }
+
   .column {
     display: flex;
     flex-direction: column;

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -22,8 +22,8 @@ export class PlanetTagInputDialogComponent {
 
   deleteDialog: any;
   tags: any[] = [];
-  selected: Map<string, boolean> = new Map(this.data.tags.map(value => [ value, false ] as [ string, boolean ]));
-  indeterminate: Map<string, boolean> = new Map(this.data.tags.map((value: any) => [ value._id, false ] as [ string, boolean ]));
+  selected: Map<string, boolean> = new Map();
+  indeterminate: Map<string, boolean> = new Map();
   filterValue = '';
   mode = 'filter';
   _selectMany = true;
@@ -83,6 +83,17 @@ export class PlanetTagInputDialogComponent {
   dataInit() {
     this.tags = this.filterTags(this.filterValue);
     this.mode = this.data.mode;
+    this.initializeSelectionMaps();
+    if (Array.isArray(this.data.startingTags)) {
+      this.data.startingTags
+        .filter((tag: any) => tag)
+        .forEach((tag: any) => {
+          const tagId = tag.tagId || tag;
+          const isIndeterminate = !!tag.indeterminate;
+          this.selected.set(tagId, true);
+          this.indeterminate.set(tagId, isIndeterminate);
+        });
+    }
     if (this.newTagInfo && this.newTagInfo.id !== undefined && this.mode === 'add') {
       const { parentId, id } = this.newTagInfo;
       const parentTag = parentId.length > 0 ? this.data.tags.find(tag => tag._id === parentId) : undefined;
@@ -91,9 +102,29 @@ export class PlanetTagInputDialogComponent {
     this.newTagInfo = undefined;
   }
 
+  private initializeSelectionMaps() {
+    const selected = new Map<string, boolean>();
+    const indeterminate = new Map<string, boolean>();
+    if (Array.isArray(this.data.tags)) {
+      this.data.tags.forEach((tag: any) => {
+        const tagId = tag._id || tag.name;
+        selected.set(tagId, false);
+        indeterminate.set(tagId, false);
+        (tag.subTags || []).forEach((subTag: any) => {
+          const subTagId = subTag._id || subTag.name;
+          selected.set(subTagId, false);
+          indeterminate.set(subTagId, false);
+        });
+      });
+    }
+    this.selected = selected;
+    this.indeterminate = indeterminate;
+  }
+
   resetSelection() {
     this.data.tagUpdate('', false, true);
     this.selected.clear();
+    this.indeterminate.clear();
     this.data.reset(this._selectMany);
   }
 


### PR DESCRIPTION
## Summary
- Persist selected and indeterminate collection tags across dialog sessions in the tag input component
- Reinitialize dialog selection state from starting tags so previously chosen collections remain checked when reopening
- Surface active collection filters as removable chips in the Library toolbar with responsive styling

## Testing
- npm run lint *(fails: ng command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e01021d0c8832d9d0ba19b174337d8