### PR TITLE
surveys: improved error handling (fixes #9194)

### DIFF
--- a/src/app/submissions/submissions.component.html
+++ b/src/app/submissions/submissions.component.html
@@ -71,7 +71,8 @@
       <ng-container matColumnDef="teamInfo">
         <mat-header-cell *matHeaderCellDef mat-sort-header="teamInfo" i18n>Team/Enterprise</mat-header-cell>
         <mat-cell *matCellDef="let element" style="cursor: pointer">
-          <ng-container *ngIf="element.teamInfo">{{element.teamInfo?.name}} ({{getTeamTypeLabel(element.teamInfo?.type)}})</ng-container>
+          <ng-container *ngIf="element.teamInfo && !element.teamInfo.missing">{{element.teamInfo?.name}} ({{getTeamTypeLabel(element.teamInfo?.type)}})</ng-container>
+          <ng-container *ngIf="element.teamInfo?.missing"><i i18n>(missing)</i></ng-container>
         </mat-cell>
       </ng-container>
       <ng-container matColumnDef="status">

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -330,7 +330,7 @@ export class SubmissionsService {
   }
 
   getAnswerText(answers: any[], index, answerIndexes: number[]) {
-    const answer = answerIndexes[index] > -1 ? answers[index].value : undefined;
+    const answer = answerIndexes[index] > -1 && answers[index] ? answers[index].value : undefined;
     return answer && (
       Array.isArray(answer) ? answer.reduce((ans, v) => ans + v.text + ',', '').slice(0, -1) : answer.text || answer
     );

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { of, empty, forkJoin, Observable } from 'rxjs';
-import { switchMap, map, take } from 'rxjs/operators';
+import { switchMap, map, take, catchError } from 'rxjs/operators';
 import { CouchService } from '../shared/couchdb.service';
 import { UserService } from '../shared/user.service';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
@@ -388,6 +388,7 @@ export class TeamsService {
         }
         return { id: teamId };
       }),
+      catchError(() => of({ id: teamId, missing: true }))
     );
   }
 


### PR DESCRIPTION
Fixes #9194

Improved error handling for deleted/missing teams data related to survey submissions:
- Fix submissions list
- Fix pdf/csv exports
