### PR TITLE
dashboard: myteams cannot edit team type in edit options (fixes #9146)

### DIFF
--- a/src/app/shared/forms/form-error-messages.component.ts
+++ b/src/app/shared/forms/form-error-messages.component.ts
@@ -44,6 +44,7 @@ import { AbstractControl, AbstractControlDirective } from '@angular/forms';
       bp {Blood Pressure should be systolic/diastolic}
       notFileMatch {File not found in list}
       invalidLink {Invalid link. Must be a valid URL e.g https://ole.org/}
+      invalidTeamTypeTransition {Team type can only be changed for teams created on this planet}
     }</span>{{number === undefined ? '' : ' ' + number}}
     <ng-container *ngIf="error === 'matDatepickerMin' || error === 'matDatepickerMax'">
       {{date === undefined ? '' : ' ' + (date | date)}}


### PR DESCRIPTION
fixes #9146

## Summary
* allow team editors to change the team type for existing teams while guarding against invalid planet transitions and surfacing a clear validation error.
* ensure team type updates propagate through membership and legacy shelf documents so downstream data stays consistent.

## Testing
* npm run lint *(fails: ng CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e811496058832da1d5851fb888be1c