### PR TITLE
Teams: chat/voices initially shows community content before switching to team content (fixes #9124)

### DIFF
--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -135,9 +135,15 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   initTeam(teamId: string) {
     this.newsService.newsUpdated$.pipe(takeUntil(this.onDestroy$))
-      .subscribe(news => this.news = news.map(post => ({
-        ...post, public: ((post.doc.viewIn || []).find(view => view._id === teamId) || {}).public
-      })));
+      .subscribe(news => {
+        if (this.newsService.currentOptions.viewId !== teamId) {
+          return;
+        }
+        this.news = news.map(post => ({
+          ...post,
+          public: ((post.doc.viewIn || []).find(view => view._id === teamId) || {}).public
+        }));
+      });
     if (this.mode === 'services') {
       this.initServices(teamId);
       return;
@@ -160,6 +166,8 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
         this.visits[visit.user] = { count: visit.count, recentTime: visit.max && visit.max.time };
       });
       this.setStatus(teamId, this.leader, this.userService.get());
+      this.news = [];
+      this.isRoot = true;
       this.requestTeamNews(teamId);
     });
   }


### PR DESCRIPTION
## Summary
- clear existing team news and reset the compose state before loading the selected team feed
- guard the news subscription so only updates for the active team are displayed

fixes #9124

------
https://chatgpt.com/codex/tasks/task_e_68e8115f7508832d863e9c8dd51e8595