### PR TITLE
dashboard: mycourses: Add helper text when no collection is selected (fixes #9144)

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -6,6 +6,7 @@
       <mat-form-field class="font-size-1 margin-lr-4 mat-form-field-type-no-underline mat-form-field-dynamic-width collections-search">
         <planet-tag-input [formControl]="tagFilter" [db]="dbName" [parent]="parent" [filteredData]="courses.filteredData" [helperText]="false" [largeFont]="true" [selectMany]="false" mode="filter" [updateRouteParam]="!isDialog"></planet-tag-input>
       </mat-form-field>
+      <span class="font-size-1 margin-lr-4 select-collection-helper" *ngIf="showSelectCollectionHelper">{{ selectCollectionHelperText }}</span>
       <span class="toolbar-fill"></span>
       <ng-container *ngTemplateOutlet="filterOptions"></ng-container>
     </mat-toolbar-row>
@@ -18,6 +19,7 @@
       <mat-form-field class="font-size-1 margin-lr-4 mat-form-field-type-no-underline mat-form-field-dynamic-width collections-search">
         <planet-tag-input [formControl]="tagFilter" [db]="dbName" [parent]="parent" [filteredData]="courses.filteredData" [helperText]="false" [largeFont]="true" [selectMany]="false" mode="filter" [updateRouteParam]="!isDialog"></planet-tag-input>
       </mat-form-field>
+      <span class="font-size-1 margin-lr-4 select-collection-helper" *ngIf="showSelectCollectionHelper">{{ selectCollectionHelperText }}</span>
       <span class="toolbar-fill"></span>
       <button mat-icon-button (click)="this.showFiltersRow = !this.showFiltersRow" ><mat-icon>filter_list</mat-icon></button>
     </mat-toolbar-row>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -117,6 +117,12 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   showFiltersRow = false;
   expandedElement: any = null;
   previewLimit = 450;
+  readonly selectCollectionHelperText = $localize`:@@courses.selectCollectionHelperText:Select a collection to view your courses.`;
+
+  get showSelectCollectionHelper(): boolean {
+    const tags = this.tagFilter.value;
+    return this.myCoursesFilter.value === 'on' && Array.isArray(tags) && tags.length === 0;
+  }
 
   @ViewChild(PlanetTagInputComponent)
   private tagInputComponent: PlanetTagInputComponent;

--- a/src/i18n/messages.afr.xlf
+++ b/src/i18n/messages.afr.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.ara.xlf
+++ b/src/i18n/messages.ara.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.deu.xlf
+++ b/src/i18n/messages.deu.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.eng.xlf
+++ b/src/i18n/messages.eng.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="final">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html" approved="yes">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.fra.xlf
+++ b/src/i18n/messages.fra.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.hin.xlf
+++ b/src/i18n/messages.hin.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.ind.xlf
+++ b/src/i18n/messages.ind.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.ita.xlf
+++ b/src/i18n/messages.ita.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.mlg.xlf
+++ b/src/i18n/messages.mlg.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.nep.xlf
+++ b/src/i18n/messages.nep.xlf
@@ -8648,6 +8648,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.por.xlf
+++ b/src/i18n/messages.por.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.rus.xlf
+++ b/src/i18n/messages.rus.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.som.xlf
+++ b/src/i18n/messages.som.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.spa.xlf
+++ b/src/i18n/messages.spa.xlf
@@ -2568,6 +2568,14 @@
         </context-group>
         <target state="translated"> No se encontró ningún curso </target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="2270713094750834385" datatype="html" approved="yes">
         <source>Course deleted: <x id="PH" equiv-text="course.courseTitle"/></source>
         <context-group purpose="location">

--- a/src/i18n/messages.swa.xlf
+++ b/src/i18n/messages.swa.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.tam.xlf
+++ b/src/i18n/messages.tam.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.tur.xlf
+++ b/src/i18n/messages.tur.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.ukr.xlf
+++ b/src/i18n/messages.ukr.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.vie.xlf
+++ b/src/i18n/messages.vie.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -2351,6 +2351,13 @@
           <context context-type="linenumber">259,261</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2270713094750834385" datatype="html">
         <source>Course deleted: <x id="PH" equiv-text="course.courseTitle"/></source>
         <context-group purpose="location">

--- a/src/i18n/messages.zho.xlf
+++ b/src/i18n/messages.zho.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/i18n/messages.zul.xlf
+++ b/src/i18n/messages.zul.xlf
@@ -8646,6 +8646,14 @@
         </context-group>
         <target state="needs-translation">No Course Found</target>
       </trans-unit>
+      <trans-unit id="courses.selectCollectionHelperText" datatype="html" approved="yes">
+        <source>Select a collection to view your courses.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/courses/courses.component.ts</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <target state="final">Select a collection to view your courses.</target>
+      </trans-unit>
       <trans-unit id="4368235916055792182" datatype="html">
         <source>Add title</source>
         <context-group purpose="location">

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -8,3 +8,5 @@ declare module '*.scss' {
   const content: string;
   export = content;
 }
+
+declare const $localize: any;


### PR DESCRIPTION
## Summary
- show a toolbar helper prompt in the myCourses view when no collection is selected so users know to pick one
- add the localized translation key for the helper message across language bundles and expose the global $localize declaration

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e8117f7c98832db8abbc42a3bcad12