### PR TITLE
add global chat context (fixes #9203)

### DIFF
--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -158,7 +158,19 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
       .subscribe(
         (conversations: any) => {
           this.conversations = conversations
-            .filter((conversation) => !conversation?.context)
+            .filter((conversation) => {
+              const context = conversation?.context;
+
+              if (!context) {
+                return true;
+              }
+
+              if (typeof context === 'object' && context?.type === 'global') {
+                return true;
+              }
+
+              return false;
+            })
             .sort((a, b) => {
               const dateA = a.updatedDate || a.createdDate;
               const dateB = b.updatedDate || b.createdDate;

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -58,6 +58,13 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     if (this.conversations === null) {
       this.conversations = this.fallbackConversation;
     }
+    if (this.context == null) {
+      const globalContext = this.getGlobalContext();
+      this.context = globalContext;
+      if (globalContext) {
+        this.data.assistant = true;
+      }
+    }
     this.createForm();
     this.subscribeToNewChatSelected();
     this.subscribeToSelectedConversation();
@@ -157,6 +164,19 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
       top: target,
       behavior: 'smooth',
     });
+  }
+
+  private getGlobalContext(): { type: 'global'; data: any } | undefined {
+    const instructions = this.stateService.configuration?.assistant?.instructions;
+
+    if (!instructions) {
+      return undefined;
+    }
+
+    return {
+      type: 'global',
+      data: instructions,
+    };
   }
 
   setSelectedConversation(): void {


### PR DESCRIPTION
fixes #9203

## Summary
- default chat window context to global assistant instructions when available and ensure assistant mode is enabled for new chats
- expose a helper on the chat window component to pull global instructions from configuration
- keep globally scoped conversations visible in the sidebar while continuing to hide other context-specific entries

------
https://chatgpt.com/codex/tasks/task_e_68e956553c30832db6ca20ba83e7088e