### PR TITLE
news based pagination limits (fixes #9205)

### DIFF
--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -39,11 +39,11 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   shareDialog: MatDialogRef<CommunityListDialogComponent>;
   isLoadingMore = false;
   hasMoreNews = false;
-  pageSize = 10;
+  pageSize = 25;
   nextStartIndex = 0;
   totalReplies = 0;
   // Key value store for max number of posts viewed per conversation
-  pageEnd = { root: 10 };
+  pageEnd = { root: 25 };
   // store the last opened thread’s root post id
   lastRootPostId: string;
   trackById = trackById;


### PR DESCRIPTION
fixes #9205

## Summary
- increase the default news feed pagination window to 25 items so more posts appear on initial load
- retain the per-thread page end tracking to keep already viewed pages respected when returning to a conversation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e956590248832d8207b0ab76856c45