### PR TITLE
add other gender option (fixes #9201)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -47,6 +47,9 @@ export class AppComponent {
       'female',
       sanitizer.bypassSecurityTrustResourceUrl('assets/icons/female.svg'));
     iconRegistry.addSvgIcon(
+      'other',
+      sanitizer.bypassSecurityTrustResourceUrl('assets/icons/other.svg'));
+    iconRegistry.addSvgIcon(
       'home',
       sanitizer.bypassSecurityTrustResourceUrl('assets/icons/home.svg'));
     iconRegistry.addSvgIcon(

--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -151,6 +151,11 @@
               <mat-grid-tile>{{reports?.usersByGender?.female || 0}}</mat-grid-tile>
               <mat-grid-tile class="label">
                 <mat-icon>subdirectory_arrow_right</mat-icon>
+                <span i18n>Other</span>
+              </mat-grid-tile>
+              <mat-grid-tile>{{reports?.usersByGender?.other || 0}}</mat-grid-tile>
+              <mat-grid-tile class="label">
+                <mat-icon>subdirectory_arrow_right</mat-icon>
                 <span i18n>Did not specify</span>
               </mat-grid-tile>
               <mat-grid-tile>{{reports?.usersByGender?.didNotSpecify || 0}}</mat-grid-tile>

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -441,7 +441,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     });
     const labels = months.map(month => monthDataLabels(month));
 
-    const genderFilter = (gender: string) =>
+    const genderFilter = (gender: string | undefined) =>
       months.map((month) => data.find((datum: any) => datum.gender === gender && datum.date === month) || { date: month, unique: [] });
     const monthlyObj = (month) => {
       const monthlyData = data.filter((datum: any) => datum.date === month);
@@ -456,6 +456,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
         datasets: [
           datasetObject($localize`Male`, xyChartData(genderFilter('male'), unique), styleVariables.primaryLighter),
           datasetObject($localize`Female`, xyChartData(genderFilter('female'), unique), styleVariables.accentLighter),
+          datasetObject($localize`Other`, xyChartData(genderFilter('other'), unique), styleVariables.warnLighter),
           datasetObject($localize`Did not specify`, xyChartData(genderFilter(undefined), unique), styleVariables.grey),
           datasetObject($localize`Total`, xyChartData(totals(), unique), styleVariables.primary)
         ]

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -115,9 +115,16 @@ export class ReportsService {
     return ({
       count: users.length,
       byGender: users.reduce((usersByGender: any, user: any) => {
-        usersByGender[(user.doc || user).gender || 'didNotSpecify'] += 1;
+        const userRecord = user.doc || user;
+        const rawGender = userRecord?.gender;
+        const normalizedGender = typeof rawGender === 'string' ? rawGender.toLowerCase() : '';
+        const hasGender = rawGender !== undefined && rawGender !== null && rawGender !== '';
+        const gender = normalizedGender === 'male' || normalizedGender === 'female' || normalizedGender === 'other'
+          ? normalizedGender
+          : hasGender ? 'other' : 'didNotSpecify';
+        usersByGender[gender] += 1;
         return usersByGender;
-      }, { 'male': 0, 'female': 0, 'didNotSpecify': 0 }),
+      }, { 'male': 0, 'female': 0, 'other': 0, 'didNotSpecify': 0 }),
       byMonth: this.groupByMonth(users, 'joinDate')
     });
   }
@@ -199,9 +206,14 @@ export class ReportsService {
   appendGender(array) {
     return array.map((item: any) => {
       const user = this.users.find((u: any) => u.name === item.user) || {};
+      const rawGender = user.gender;
+      const normalizedGender = typeof rawGender === 'string' ? rawGender.toLowerCase() : '';
+      const gender = normalizedGender === 'male' || normalizedGender === 'female' || normalizedGender === 'other'
+        ? normalizedGender
+        : rawGender ? 'other' : undefined;
       return ({
         ...item,
-        gender: user.gender
+        gender
       });
     });
   }

--- a/src/app/shared/csv.service.ts
+++ b/src/app/shared/csv.service.ts
@@ -103,21 +103,23 @@ export class CsvService {
   private processSection(
     formattedData: any[], title: string, groupedData: any[], countUnique: boolean, sortedMonths: string[], monthLabels: string[]
   ): void {
-    const pushRow = (section, month, all, male, female, unspecified) => {
+    const pushRow = (section, month, all, male, female, other, unspecified) => {
       formattedData.push({
         [$localize`Section`]: section,
         [$localize`Month`]: month,
         [$localize`All`]: all,
         [$localize`Male`]: male,
         [$localize`Female`]: female,
+        [$localize`Other`]: other,
         [$localize`Unspecified`]: unspecified
       });
     };
 
-    pushRow(title, '', '', '', '', '');
+    pushRow(title, '', '', '', '', '', '');
     let totalAll = 0;
     let totalMale = 0;
     let totalFemale = 0;
+    let totalOther = 0;
     let totalUnspecified = 0;
 
     sortedMonths.forEach((month, i) => {
@@ -125,16 +127,18 @@ export class CsvService {
       const all = this.getMonthlyData(month, groupedData, countUnique);
       const male = this.getMonthlyData(month, groupedData.filter(item => item.gender === 'male'), countUnique);
       const female = this.getMonthlyData(month, groupedData.filter(item => item.gender === 'female'), countUnique);
+      const other = this.getMonthlyData(month, groupedData.filter(item => item.gender === 'other'), countUnique);
       const unspecified = this.getMonthlyData(month, groupedData.filter(item => item.gender === undefined), countUnique);
 
       totalAll += all;
       totalMale += male;
       totalFemale += female;
+      totalOther += other;
       totalUnspecified += unspecified;
-      pushRow('', monthLabel, all, male, female, unspecified);
+      pushRow('', monthLabel, all, male, female, other, unspecified);
     });
 
-    pushRow('', $localize`Total`, totalAll, totalMale, totalFemale, totalUnspecified);
+    pushRow('', $localize`Total`, totalAll, totalMale, totalFemale, totalOther, totalUnspecified);
   }
 
   formatValue(key: string, value: any) {

--- a/src/app/shared/forms/planet-rating.component.html
+++ b/src/app/shared/forms/planet-rating.component.html
@@ -1,6 +1,7 @@
 <div class="list-item-rating">
   <div class="stats-ratio" [ngClass]="{'invisible':rating.totalRating===0}">
     <mat-icon svgIcon="male" class="male-icon primary-text-color"></mat-icon>
+    <mat-icon svgIcon="other" class="other-icon warn-text-color"></mat-icon>
     <mat-icon svgIcon="female" class="female-icon accent-text-color"></mat-icon>
     <planet-stacked-bar [data]="stackedBarData"></planet-stacked-bar>
   </div>

--- a/src/app/shared/forms/planet-rating.component.ts
+++ b/src/app/shared/forms/planet-rating.component.ts
@@ -70,14 +70,21 @@ export class PlanetRatingComponent implements OnChanges {
 
   ngOnChanges() {
     // After any changes to ratings ensures all properties are set
-    this.rating = Object.assign({ rateSum: 0, totalRating: 0, maleRating: 0, femaleRating: 0, userRating: {} }, this.rating);
+    this.rating = Object.assign({
+      rateSum: 0,
+      totalRating: 0,
+      maleRating: 0,
+      femaleRating: 0,
+      otherRating: 0,
+      userRating: {}
+    }, this.rating);
+    const unspecifiedAmount = this.rating.totalRating === 0
+      ? 1
+      : Math.max(this.rating.totalRating - this.rating.maleRating - this.rating.femaleRating - this.rating.otherRating, 0);
     this.stackedBarData = [
       { class: 'primary-color', amount: this.rating.maleRating },
-      { class: 'primary-light-color',
-        amount: this.rating.totalRating === 0 ? 1
-          : this.rating.totalRating - this.rating.maleRating - this.rating.femaleRating,
-        noLabel: true
-      },
+      { class: 'warn-color', amount: this.rating.otherRating },
+      { class: 'primary-light-color', amount: unspecifiedAmount, noLabel: true },
       { class: 'accent-color', amount: this.rating.femaleRating, align: 'right' }
     ];
     this.rateForm.setValue(this.rateFormField);

--- a/src/app/shared/forms/rating.service.ts
+++ b/src/app/shared/forms/rating.service.ts
@@ -6,7 +6,15 @@ import { of, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { StateService } from '../state.service';
 
-const startingRating = { rateSum: 0, totalRating: 0, maleRating: 0, femaleRating: 0, userRating: {}, allRatings: [] };
+const startingRating = {
+  rateSum: 0,
+  totalRating: 0,
+  maleRating: 0,
+  femaleRating: 0,
+  otherRating: 0,
+  userRating: {},
+  allRatings: []
+};
 
 @Injectable({
   providedIn: 'root'
@@ -67,13 +75,23 @@ export class RatingService {
     // If totalRating is undefined, will start count at 1
     ratingInfo.totalRating = ratingInfo.totalRating + 1;
     ratingInfo.rateSum = ratingInfo.rateSum + rating.rate;
-    switch (rating.user.gender) {
+    const gender = typeof rating.user.gender === 'string'
+      ? rating.user.gender.toLowerCase()
+      : rating.user.gender;
+    switch (gender) {
       case 'male':
         ratingInfo.maleRating = ratingInfo.maleRating + 1;
         break;
       case 'female':
         ratingInfo.femaleRating = ratingInfo.femaleRating + 1;
         break;
+      case 'other':
+        ratingInfo.otherRating = ratingInfo.otherRating + 1;
+        break;
+      default:
+        if (gender) {
+          ratingInfo.otherRating = ratingInfo.otherRating + 1;
+        }
     }
     ratingInfo.userRating = rating.user.name === this.userService.get().name ? rating : ratingInfo.userRating;
     ratingInfo.allRatings = [ ...ratingInfo.allRatings, rating ];

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -42,6 +42,8 @@ export const styleVariables: any = {
   accent: '#ffc107',
   accentLighter: '#ffecb3',
   accentText: 'rgba(0, 0, 0, 0.87)',
+  warn: '#ed9121',
+  warnLighter: '#ffe1c6',
   grey: '#bdbdbd',
   greyText: 'rgba(0, 0, 0, 0.54)',
   lightGrey: 'whitesmoke'

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -286,7 +286,7 @@ export class SubmissionsService {
         const data = updatedSubmissions.map(submission => {
           const answerIndexes = this.answerIndexes(questionTexts, submission);
           return {
-            [$localize`Gender`]: submission.user.gender || 'N/A',
+            [$localize`Gender`]: submission.user.gender ? toProperCase(submission.user.gender.toString().toLowerCase()) : 'N/A',
             [$localize`Age (years)`]: submission.user.birthDate ?
               ageFromBirthDate(time, submission.user.birthDate) :
               submission.user.age || 'N/A',
@@ -522,7 +522,9 @@ export class SubmissionsService {
       const userAge = submission.user.birthDate ?
        ageFromBirthDate(submission.lastUpdateTime, submission.user.birthDate) :
        submission.user.age;
-      const userGender = submission.user.gender;
+      const userGender = submission.user.gender
+        ? toProperCase(submission.user.gender.toString().toLowerCase())
+        : '';
       const communityOrNation = submission.planetName;
       const teamType = submission.teamInfo?.type ? toProperCase(submission.teamInfo.type) : '';
       const teamName = submission.teamInfo?.name || '';

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -1,7 +1,12 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1">
     <span>{{userDetail.name}}</span>
-    <mat-icon class="margin-lr-5" *ngIf="userDetail.gender" svgIcon="{{userDetail.gender.toLowerCase()}}"></mat-icon>
+    <ng-container *ngIf="genderIcon(userDetail.gender) as genderIconName">
+      <mat-icon
+        class="margin-lr-5"
+        [svgIcon]="genderIconName"
+        [ngClass]="['gender-icon', genderColorClass(genderIconName)]"></mat-icon>
+    </ng-container>
     <span class="toolbar-fill"></span>
     <button mat-icon-button [matMenuTriggerFor]="menu" *ngIf="isMobile; else actionButtons">
       <mat-icon>more_vert</mat-icon>

--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -155,4 +155,28 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
       this.enterprises = teams.filter((team: any) => team.doc.type === 'enterprise');
     });
   }
+
+  genderIcon(gender: any): 'male' | 'female' | 'other' | null {
+    if (!gender) {
+      return null;
+    }
+    const normalizedGender = gender.toString().toLowerCase();
+    if (normalizedGender === 'male' || normalizedGender === 'female') {
+      return normalizedGender;
+    }
+    return 'other';
+  }
+
+  genderColorClass(icon: string | null): string {
+    switch (icon) {
+      case 'male':
+        return 'gender-icon-male';
+      case 'female':
+        return 'gender-icon-female';
+      case 'other':
+        return 'gender-icon-other';
+      default:
+        return 'gender-icon-other';
+    }
+  }
 }

--- a/src/app/users/users-profile/users-profile.scss
+++ b/src/app/users/users-profile/users-profile.scss
@@ -31,6 +31,23 @@
     }
   }
 
+  .gender-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .gender-icon-male {
+    color: $primary;
+  }
+
+  .gender-icon-female {
+    color: $accent;
+  }
+
+  .gender-icon-other {
+    color: $warn;
+  }
+
   @media (max-width: $screen-sm) {
     .profile-image-section {
       grid-area: icon;

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -81,7 +81,7 @@
             </mat-form-field>
           </div>
         </ng-container>
-        <mat-radio-group class="radio-group" formControlName="gender" [required]="!submissionMode" class="full-width">
+        <mat-radio-group class="radio-group full-width" formControlName="gender" [required]="!submissionMode">
           <label i18n>Gender</label>
           <mat-radio-button class="planet-radio-button" value="male">
             <div class="radio-icon-label">
@@ -93,6 +93,11 @@
             <div class="radio-icon-label">
               <mat-icon svgIcon="female" class="female-icon accent-text-color margin-lr-3"></mat-icon><span
                 i18n>Female</span>
+            </div>
+          </mat-radio-button>
+          <mat-radio-button class="planet-radio-button" value="other">
+            <div class="radio-icon-label">
+              <mat-icon svgIcon="other" class="margin-lr-3 warn-text-color"></mat-icon><span i18n>Other</span>
             </div>
           </mat-radio-button>
           <mat-error i18n *ngIf="editForm.controls.gender.invalid && editForm.controls.gender.touched">

--- a/src/assets/icons/other.svg
+++ b/src/assets/icons/other.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 4a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 12a7.5 7.5 0 0 1-6-3c.3-2.34 2.58-4 6-4s5.7 1.66 6 4a7.5 7.5 0 0 1-6 3Z"/>
+</svg>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -29,6 +29,11 @@ body {
     color: $accent-text;
   }
 
+  .warn-color {
+    background-color: $warn;
+    color: $white;
+  }
+
   .accent-text-color {
     color: $accent;
   }
@@ -240,14 +245,18 @@ body {
     .stats-ratio {
       grid-area: ratio;
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr;
       grid-template-rows: 1.75rem 0.75rem;
-      grid-template-areas: 'm-icon f-icon' 'bar bar';
+      grid-template-areas: 'm-icon o-icon f-icon' 'bar bar bar';
       mat-icon {
         align-self: start;
       }
       .male-icon {
         grid-area: m-icon;
+      }
+      .other-icon {
+        grid-area: o-icon;
+        justify-self: center;
       }
       .female-icon {
         grid-area: f-icon;


### PR DESCRIPTION
fixes #9201

## Summary
- add an "Other" gender option to the user update form and profile icon display, backed by a new SVG
- update reporting, rating, and CSV aggregation logic to count the new gender bucket alongside existing categories
- ensure exports and visualizations treat unspecified entries as "Other" when provided and style stacked bars/icons for the added option

------
https://chatgpt.com/codex/tasks/task_e_68f2832362ec832dadb66c61e7f6fa8f