### PR TITLE
login: takes over 10 seconds to load after version 0.20.49 → 0.20.54 update (fixes #9234)

### DIFF
--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -22,6 +22,10 @@ export class LoginComponent implements OnInit {
   ngOnInit() {
     this.getPlanetVersion();
     this.configurationCheckService.checkConfiguration().subscribe(isOnline => {
+      if (!isOnline) {
+        this.online = 'off';
+        return;
+      }
       this.online = isOnline;
     });
   }


### PR DESCRIPTION
fixes #9234 - reduce login configuration delay by short-circuiting admin lookups and timing out unreachable parent requests.

## Summary
- limit the admin lookup to a single `_users` document and map success responses to `true`
- timeout the parent domain configuration fetch at three seconds and surface failures as offline
- keep the login screen in the offline state whenever configuration checks return falsy responses

------
https://chatgpt.com/codex/tasks/task_e_68f29c27a30c832dabb8b0e934e0c1a0