### PR TITLE
Remove hexToString helper from shared utils

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -85,8 +85,6 @@ export const toProperCase = (string: string) => `${string.slice(0, 1).toUpperCas
 
 export const stringToHex = (string: string) => string.split('').map(char => char.charCodeAt(0).toString(16)).join('');
 
-export const hexToString = (string: string) => string.match(/.{1,2}/g).map(hex => String.fromCharCode(parseInt(hex, 16))).join('');
-
 export const ageFromBirthDate = (currentTime: number, birthDate: string) => {
   const now = new Date(currentTime);
   const birth = new Date(birthDate);


### PR DESCRIPTION
## Summary
- remove the unused `hexToString` export from `src/app/shared/utils.ts`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7d3bd1c58832daea3b0177fc7ae6b