### PR TITLE
Remove unused itemsShown helper from shared utils

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -50,9 +50,6 @@ export const styleVariables: any = {
 export const filterById = (array = [], id: string) => array.filter(item => item._id !== id);
 
 export const arraySubField = (array: any[], field: string) => array.map(item => item[field]);
-
-export const itemsShown = (paginator: any) => Math.min(paginator.length - (paginator.pageIndex * paginator.pageSize), paginator.pageSize);
-
 export const isInMap = (tag: string, map: Map<string, boolean>) => map.get(tag);
 
 export const mapToArray = (map: Map<string, boolean>, equalValue?) => {


### PR DESCRIPTION
## Summary
- remove the unused `itemsShown` helper from the shared utilities module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7d44a6620832da227adfbc0a8a5d6