### PR TITLE
teams: smooth date time picker (fixes #9110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ planet.yml
 
 # Dev environment
 environment.dev.ts
-
-# Gemini CLI configuration
-gemini-extension.json

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ planet.yml
 
 # Dev environment
 environment.dev.ts
+
+# Gemini CLI configuration
+gemini-extension.json

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "material-icons": "^0.3.1",
     "mime": "4.0.0",
     "ngx-image-cropper": "^3.2.1",
+    "ngx-material-timepicker": "^13.1.1",
     "pdfmake": "^0.1.63",
     "pouchdb": "^7.1.1",
     "pouchdb-authentication": "^1.1.3",

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -68,15 +68,15 @@
 
       <!-- Date Select -->
       <mat-form-field *ngIf="field.type === 'date'" class="full-width" (click)="dp.open()">
-        <input matInput [matDatepicker]="dp" placeholder="{{field.placeholder}}" [formControl]="modalForm.controls[field.name]" required="{{field.required}}" [min]="field.min" [max]="field.max">
+        <input matInput [matDatepicker]="dp" class="date-picker-input" placeholder="{{field.placeholder}}" [formControl]="modalForm.controls[field.name]" required="{{field.required}}" [min]="field.min" [max]="field.max">
         <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
         <mat-datepicker #dp></mat-datepicker>
         <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
       </mat-form-field>
 
       <!-- Time Select -->
-      <mat-form-field *ngIf="field.type === 'time'" class="full-width" (click)="timeInput.click()">
-        <input #timeInput matInput type="time" [placeholder]="field.placeholder" [formControl]="modalForm.controls[field.name]" [required]="field.required">
+      <mat-form-field *ngIf="field.type === 'time'" class="full-width" (click)="openTimePicker(timeInput)">
+        <input #timeInput matInput type="time" class="time-picker-input" [placeholder]="field.placeholder" [formControl]="modalForm.controls[field.name]" [required]="field.required">
         <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
       </mat-form-field>
       

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -75,11 +75,11 @@
       </mat-form-field>
 
       <!-- Time Select -->
-      <mat-form-field *ngIf="field.type === 'time'" class="full-width" (click)="timeInput.focus()">
+      <mat-form-field *ngIf="field.type === 'time'" class="full-width" (click)="timeInput.click()">
         <input #timeInput matInput type="time" [placeholder]="field.placeholder" [formControl]="modalForm.controls[field.name]" [required]="field.required">
         <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
       </mat-form-field>
-
+      
       <!-- Slide Toggle -->
       <mat-slide-toggle *ngIf="field.type === 'toggle'" class="full-width" [formControl]="modalForm.controls[field.name]">{{field.label}}</mat-slide-toggle>
 

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -67,7 +67,7 @@
       </ng-container>
 
       <!-- Date Select -->
-      <mat-form-field *ngIf="field.type === 'date'" class="full-width">
+      <mat-form-field *ngIf="field.type === 'date'" class="full-width" (click)="dp.open()">
         <input matInput [matDatepicker]="dp" placeholder="{{field.placeholder}}" [formControl]="modalForm.controls[field.name]" required="{{field.required}}" [min]="field.min" [max]="field.max">
         <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
         <mat-datepicker #dp></mat-datepicker>

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -75,8 +75,8 @@
       </mat-form-field>
 
       <!-- Time Select -->
-      <mat-form-field *ngIf="field.type === 'time'" class="full-width">
-        <input matInput type="time" [placeholder]="field.placeholder" [formControl]="modalForm.controls[field.name]" [required]="field.required">
+      <mat-form-field *ngIf="field.type === 'time'" class="full-width" (click)="timeInput.focus()">
+        <input #timeInput matInput type="time" [placeholder]="field.placeholder" [formControl]="modalForm.controls[field.name]" [required]="field.required">
         <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
       </mat-form-field>
 

--- a/src/app/shared/dialogs/dialogs-form.component.scss
+++ b/src/app/shared/dialogs/dialogs-form.component.scss
@@ -17,5 +17,3 @@
     .time-picker-input {
     cursor: pointer;
     }
-
-

--- a/src/app/shared/dialogs/dialogs-form.component.scss
+++ b/src/app/shared/dialogs/dialogs-form.component.scss
@@ -1,0 +1,21 @@
+  .checkbox-wrapper:last-child {
+      margin: 0 0 20px 0;
+    }
+
+    .mat-radio-group.ng-touched.ng-invalid label {
+      border-bottom: 2px solid red;
+    }
+
+    .ng-touched.ng-valid {
+      border: none;
+    }
+
+    .date-picker-input{
+     cursor: pointer;
+    }
+
+    .time-picker-input {
+    cursor: pointer;
+    }
+
+

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -10,19 +10,7 @@ import { UserService } from '../user.service';
 
 @Component({
   templateUrl: './dialogs-form.component.html',
-  styles: [ `
-    .checkbox-wrapper:last-child {
-      margin: 0 0 20px 0;
-    }
-
-    .mat-radio-group.ng-touched.ng-invalid label {
-      border-bottom: 2px solid red;
-    }
-
-    .ng-touched.ng-valid {
-      border: none;
-    }
-  ` ]
+  styleUrls: [ './dialogs-form.component.scss' ]
 })
 export class DialogsFormComponent {
 
@@ -117,6 +105,19 @@ export class DialogsFormComponent {
 
   isDirty() {
     return this.modalForm.dirty;
+  }
+
+  openTimePicker(timeInput: HTMLInputElement) {
+    if (timeInput.showPicker) {
+      try {
+        timeInput.showPicker();
+      } catch (error) {
+        console.error(error);
+        timeInput.click(); // fallback for browsers that don't support showPicker but have it in the prototype chain
+      }
+    } else {
+      timeInput.click();
+    }
   }
 
 }

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -29,8 +29,9 @@ import { MatStepperModule } from '@angular/material/stepper';
 import { MatLegacyTableModule as MatTableModule } from '@angular/material/legacy-table';
 import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDatepickerModule } from '@angular/material/datepicker';
+import { NgxMaterialTimepickerModule } from 'ngx-material-timepicker';
 import { MatPaginatorIntl } from '@angular/material/paginator';
 import { CustomMatPaginatorIntl } from './custom-mat-paginator-intl.service';
 
@@ -76,6 +77,7 @@ export class CustomDateAdapter extends NativeDateAdapter {
     MatTabsModule,
     MatToolbarModule,
     MatTooltipModule,
+    NgxMaterialTimepickerModule,
   ],
   providers: [
     { provide: DateAdapter, useClass: CustomDateAdapter },


### PR DESCRIPTION
fixes #9110 

feat: Activate date and time pickers on row click

Makes the entire date and time picker rows clickable, not just the icons, improving usability.

<img width="1693" height="853" alt="datepicker" src="https://github.com/user-attachments/assets/792eb2db-5363-4a66-a573-ea3f8b1265e4" />
