### PR TITLE
chore: remove unused arraySubField helper

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -49,8 +49,6 @@ export const styleVariables: any = {
 
 export const filterById = (array = [], id: string) => array.filter(item => item._id !== id);
 
-export const arraySubField = (array: any[], field: string) => array.map(item => item[field]);
-
 export const itemsShown = (paginator: any) => Math.min(paginator.length - (paginator.pageIndex * paginator.pageSize), paginator.pageSize);
 
 export const isInMap = (tag: string, map: Map<string, boolean>) => map.get(tag);


### PR DESCRIPTION
## Summary
- remove the unused arraySubField helper from shared utils and tidy whitespace

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7d4485acc832d83c5740dfd065443