### PR TITLE
Remove itemsShown utility export

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -51,8 +51,6 @@ export const filterById = (array = [], id: string) => array.filter(item => item.
 
 export const arraySubField = (array: any[], field: string) => array.map(item => item[field]);
 
-export const itemsShown = (paginator: any) => Math.min(paginator.length - (paginator.pageIndex * paginator.pageSize), paginator.pageSize);
-
 export const isInMap = (tag: string, map: Map<string, boolean>) => map.get(tag);
 
 export const mapToArray = (map: Map<string, boolean>, equalValue?) => {


### PR DESCRIPTION
## Summary
- remove the unused `itemsShown` helper from the shared utilities module

## Testing
- ng lint planet-app *(fails: Angular CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690270fe8aa4832d9ac4985158cd0003