### PR TITLE
remove redundant directory creation from docker entrypoint

### DIFF
--- a/docker/planet/scripts/docker-entrypoint.sh
+++ b/docker/planet/scripts/docker-entrypoint.sh
@@ -41,5 +41,3 @@ envsubst '$DEFAULT_LANGUAGE' < /etc/nginx/templates/default.conf.template > /etc
 spawn-fcgi -s /run/fcgi.sock -U nginx -G nginx /usr/bin/fcgiwrap
 
 nginx -g "daemon off;"
-
-mkdir -p /usr/share/nginx/html/fs


### PR DESCRIPTION
## Summary
- remove the unused directory creation command from the docker entrypoint script

## Testing
- docker build -f docker/planet/amd64-Dockerfile . *(fails: docker not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690271028f18832da0c8108eb421b4c0