### PR TITLE
Remove unused itemsShown helper from shared utils

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -51,8 +51,6 @@ export const filterById = (array = [], id: string) => array.filter(item => item.
 
 export const arraySubField = (array: any[], field: string) => array.map(item => item[field]);
 
-export const itemsShown = (paginator: any) => Math.min(paginator.length - (paginator.pageIndex * paginator.pageSize), paginator.pageSize);
-
 export const isInMap = (tag: string, map: Map<string, boolean>) => map.get(tag);
 
 export const mapToArray = (map: Map<string, boolean>, equalValue?) => {


### PR DESCRIPTION
## Summary
- remove the unused `itemsShown` export from `src/app/shared/utils.ts` after inlining its logic elsewhere

## Testing
- npm run lint
- CI=true npx ng test planet-app --watch=false --browsers=ChromeHeadless --include src/app/courses/courses.component.spec.ts *(fails: multiple existing spec files reference removed RxJS compatibility modules and outdated component APIs)*

------
https://chatgpt.com/codex/tasks/task_e_6902710bc5f8832db4196cd2a40b273c