### PR TITLE
restore streaming flag handling in chat API

### DIFF
--- a/chatapi/jest.config.js
+++ b/chatapi/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/index.ts'],
+};

--- a/chatapi/package.json
+++ b/chatapi/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "dev": "nodemon --exec ts-node src/index.ts",
     "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint . --ext .ts --fix"
+    "lint-fix": "eslint . --ext .ts --fix",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -46,7 +47,10 @@
     "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
+    "@types/jest": "^29.5.5",
     "eslint": "^8.43.0",
-    "nodemon": "^2.0.22"
+    "jest": "^29.7.0",
+    "nodemon": "^2.0.22",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/chatapi/src/index.ts
+++ b/chatapi/src/index.ts
@@ -58,7 +58,11 @@ wss.on('connection', (ws) => {
 });
 
 app.post('/', async (req: any, res: any) => {
-  const { data, save } = req.body;
+  const { data, save, stream } = req.body;
+
+  const streamFlag = typeof stream === 'boolean'
+    ? stream
+    : (typeof data?.stream === 'boolean' ? data.stream : false);
 
   if (!isValidData(data)) {
     return res.status(400).json({ 'error': 'Bad Request', 'message': 'The "data" field must be a non-empty object' });
@@ -66,13 +70,19 @@ app.post('/', async (req: any, res: any) => {
 
   try {
     if (!save) {
-      const response = await chatNoSave(data.content, data.aiProvider, data.context, data.assistant, false);
+      const response = await chatNoSave(
+        data.content,
+        data.aiProvider,
+        data.assistant,
+        data.context,
+        streamFlag
+      );
       return res.status(200).json({
         'status': 'Success',
         'chat': response
       });
     } else {
-      const response = await chat(data, false);
+      const response = await chat(data, streamFlag);
       return res.status(201).json({
         'status': 'Success',
         'chat': response?.completionText,

--- a/chatapi/src/services/chat.service.spec.ts
+++ b/chatapi/src/services/chat.service.spec.ts
@@ -1,0 +1,43 @@
+import { chatNoSave } from './chat.service';
+import { aiChat } from '../utils/chat.utils';
+import { AIProvider } from '../models/chat.model';
+
+jest.mock('../utils/chat.utils', () => ({
+  aiChat: jest.fn().mockResolvedValue('mock-response')
+}));
+
+jest.mock('../config/nano.config', () => ({
+  chatDB: {
+    insert: jest.fn()
+  }
+}));
+
+jest.mock('../utils/db.utils', () => ({
+  retrieveChatHistory: jest.fn()
+}));
+
+const mockedAiChat = aiChat as jest.MockedFunction<typeof aiChat>;
+
+describe('chatNoSave', () => {
+  beforeEach(() => {
+    mockedAiChat.mockClear();
+  });
+
+  it('forwards stream flag and callback to aiChat when streaming', async () => {
+    const provider = { name: 'openai' } as AIProvider;
+    const callback = jest.fn();
+
+    await chatNoSave('Hello', provider, true, { topic: 'test' }, true, callback);
+
+    expect(mockedAiChat).toHaveBeenCalledTimes(1);
+
+    const [messagesArg, providerArg, assistantArg, contextArg, streamArg, callbackArg] = mockedAiChat.mock.calls[0];
+
+    expect(messagesArg[0]).toEqual({ role: 'user', content: 'Hello' });
+    expect(providerArg).toBe(provider);
+    expect(assistantArg).toBe(true);
+    expect(contextArg).toEqual({ topic: 'test' });
+    expect(streamArg).toBe(true);
+    expect(callbackArg).toBe(callback);
+  });
+});

--- a/chatapi/src/utils/chat.utils.spec.ts
+++ b/chatapi/src/utils/chat.utils.spec.ts
@@ -1,0 +1,31 @@
+import { aiChat } from './chat.utils';
+import { aiChatStream, aiChatNonStream } from './chat-helpers.utils';
+import { AIProvider, ChatMessage } from '../models/chat.model';
+
+jest.mock('./chat-helpers.utils', () => ({
+  aiChatStream: jest.fn().mockResolvedValue('stream-response'),
+  aiChatNonStream: jest.fn().mockResolvedValue('non-stream-response')
+}));
+
+const mockedStream = aiChatStream as jest.MockedFunction<typeof aiChatStream>;
+const mockedNonStream = aiChatNonStream as jest.MockedFunction<typeof aiChatNonStream>;
+
+describe('aiChat', () => {
+  const messages: ChatMessage[] = [{ role: 'user', content: 'Hello' }];
+  const provider = { name: 'openai' } as AIProvider;
+
+  beforeEach(() => {
+    mockedStream.mockClear();
+    mockedNonStream.mockClear();
+  });
+
+  it('uses streaming helper when stream flag is true', async () => {
+    const callback = jest.fn();
+
+    const response = await aiChat(messages, provider, false, { topic: 'test' }, true, callback);
+
+    expect(response).toBe('stream-response');
+    expect(mockedStream).toHaveBeenCalledWith(messages, provider, false, { topic: 'test' }, callback);
+    expect(mockedNonStream).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- propagate the HTTP stream flag through chatapi requests and maintain proper parameter order
- add Jest configuration for chatapi and new unit tests exercising streaming behaviour

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_6902710198b4832d85ffe46164ffe251