### PR TITLE
src/app/shared/forms/planet-step-list.component.ts (fixes #9296)

### DIFF
--- a/src/app/shared/forms/planet-step-list.component.ts
+++ b/src/app/shared/forms/planet-step-list.component.ts
@@ -15,8 +15,11 @@ import {
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { UntypedFormArray } from '@angular/forms';
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
 import { uniqueId } from '../utils';
+
+type PlanetStepListFormGroup = FormGroup<Record<string, AbstractControl<unknown>>>;
+type PlanetStepListFormArray = FormArray<PlanetStepListFormGroup | AbstractControl<unknown>>;
 
 @Injectable({
   providedIn: 'root'
@@ -71,7 +74,7 @@ export class PlanetStepListItemComponent {
 })
 export class PlanetStepListComponent implements AfterContentChecked, OnDestroy {
 
-  @Input() steps: any[] | UntypedFormArray;
+  @Input() steps: any[] | PlanetStepListFormArray;
   @Input() nameProp: string;
   @Input() defaultName = 'Step';
   @Input() ignoreClick = false;
@@ -122,9 +125,9 @@ export class PlanetStepListComponent implements AfterContentChecked, OnDestroy {
     if (listId !== this.listId) {
       return;
     }
-    if (this.steps instanceof Array) {
+    if (Array.isArray(this.steps)) {
       this.moveArrayStep(index, direction, this.steps);
-    } else if (this.steps instanceof UntypedFormArray) {
+    } else if (this.steps instanceof FormArray) {
       this.moveFormArrayStep(index, direction, this.steps);
     }
     if (Array.isArray(this.steps)) {
@@ -139,7 +142,7 @@ export class PlanetStepListComponent implements AfterContentChecked, OnDestroy {
     }
   }
 
-  moveFormArrayStep(index, direction, steps: UntypedFormArray) {
+  moveFormArrayStep(index, direction, steps: PlanetStepListFormArray) {
     const step = steps.at(index);
     steps.removeAt(index);
     if (direction !== 0) {


### PR DESCRIPTION
fixes #9296

## Summary
- replace the remaining untyped form array usage in the step list component with typed aliases
- update moveStep guards to prefer Array.isArray and typed FormArray handling while continuing to emit plain arrays
- refactor the FormArray step mover to rely on typed accessors without falling back to any

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_690506a5e51c832db5f8bc01f88ab3ad