### PR TITLE
manager: smoother myplanet logs filtering (fixes #9346)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.20.84",
+  "version": "0.20.88",
   "myplanet": {
-    "latest": "v0.38.34",
+    "latest": "v0.38.86",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/manager-dashboard/reports/myplanet/filter.base.ts
+++ b/src/app/manager-dashboard/reports/myplanet/filter.base.ts
@@ -35,12 +35,11 @@ export abstract class MyPlanetFiltersBase {
     this.defaultTimeFilter = defaultTimeFilter;
     this.selectedTimeFilter = defaultTimeFilter;
 
-    this.filtersForm = this.fb.group({
-      startDate: this.fb.control(this.minDate),
-      endDate: this.fb.control(this.today)
-    }, {
-      validators: (ac) => {
-        const { startDate, endDate } = ac.value;
+    this.filtersForm = this.fb.group({ startDate: this.minDate, endDate: this.today }, {
+      validators: (group) => {
+        const fg = group as FormGroup<MyPlanetFiltersForm>;
+        const startDate = fg.controls.startDate.value;
+        const endDate = fg.controls.endDate.value;
         return startDate > endDate ? { invalidDates: true } : null;
       }
     });

--- a/src/app/manager-dashboard/reports/myplanet/filter.base.ts
+++ b/src/app/manager-dashboard/reports/myplanet/filter.base.ts
@@ -1,5 +1,10 @@
-import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup, NonNullableFormBuilder, Validators } from '@angular/forms';
 import { ReportsService } from '../reports.service';
+
+export interface MyPlanetFiltersForm {
+  startDate: FormControl<Date>;
+  endDate: FormControl<Date>;
+}
 
 export abstract class MyPlanetFiltersBase {
 
@@ -17,13 +22,13 @@ export abstract class MyPlanetFiltersBase {
   today: Date = new Date();
   startDate: Date = this.minDate;
   endDate: Date = this.today;
-  filtersForm: FormGroup<{ startDate: FormControl<Date>; endDate: FormControl<Date>; }>;
+  filtersForm: FormGroup<MyPlanetFiltersForm>;
   get isDefaultTimeFilter(): boolean {
     return this.selectedTimeFilter === this.defaultTimeFilter;
   }
 
   protected constructor(
-    protected fb: FormBuilder,
+    protected fb: NonNullableFormBuilder,
     protected activityService: ReportsService,
     defaultTimeFilter: string
   ) {
@@ -31,8 +36,8 @@ export abstract class MyPlanetFiltersBase {
     this.selectedTimeFilter = defaultTimeFilter;
 
     this.filtersForm = this.fb.group({
-      startDate: this.fb.control(this.minDate, { nonNullable: true }),
-      endDate: this.fb.control(this.today, { nonNullable: true })
+      startDate: this.fb.control(this.minDate),
+      endDate: this.fb.control(this.today)
     }, {
       validators: (ac) => {
         const { startDate, endDate } = ac.value;
@@ -91,10 +96,12 @@ export abstract class MyPlanetFiltersBase {
   }
 
   private updateFormValidators() {
-    this.filtersForm.get('startDate')?.setValidators(
+    const { startDate, endDate } = this.filtersForm.controls;
+
+    startDate.setValidators(
       [ Validators.required, Validators.min(this.minDate.getTime()), Validators.max(this.today.getTime()) ]
     );
-    this.filtersForm.get('endDate')?.setValidators(
+    endDate.setValidators(
       [ Validators.required, Validators.min(this.minDate.getTime()), Validators.max(this.today.getTime()) ]
     );
     this.filtersForm.updateValueAndValidity();

--- a/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { NonNullableFormBuilder } from '@angular/forms';
 import { forkJoin } from 'rxjs';
 import { CouchService } from '../../../shared/couchdb.service';
 import { StateService } from '../../../shared/state.service';
@@ -35,7 +35,7 @@ export class LogsMyPlanetComponent extends MyPlanetFiltersBase implements OnInit
     private stateService: StateService,
     private planetMessageService: PlanetMessageService,
     private managerService: ManagerService,
-    fb: FormBuilder,
+    fb: NonNullableFormBuilder,
     activityService: ReportsService,
   ) {
     super(fb, activityService, '24h');

--- a/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
-import { FormGroup, FormControl } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import { DeviceInfoService, DeviceType } from '../../../shared/device-info.service';
+import { MyPlanetFiltersForm } from './filter.base';
 
 @Component({
   selector: 'planet-myplanet-toolbar',
@@ -17,7 +18,7 @@ export class MyPlanetToolbarComponent {
   @Input() showTypeFilter = false;
   @Input() timeFilterOptions: { label: string; value: string }[] = [];
   @Input() selectedTimeFilter = '';
-  @Input() formGroup!: FormGroup<{ startDate: FormControl<Date>; endDate: FormControl<Date>; }>;
+  @Input() formGroup!: FormGroup<MyPlanetFiltersForm>;
   @Input() showCustomDateFields = false;
   @Input() minDate!: Date;
   @Input() today!: Date;

--- a/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { NonNullableFormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { forkJoin, of } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
@@ -42,7 +42,7 @@ export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnI
     private reportsService: ReportsService,
     private route: ActivatedRoute,
     private timePipe: TimePipe,
-    fb: FormBuilder,
+    fb: NonNullableFormBuilder,
     activityService: ReportsService,
   ) {
     super(fb, activityService, 'all');


### PR DESCRIPTION
fixes #9346

## Summary
- introduce a shared typed filter form shape for myPlanet reports and logs
- switch myPlanet report components to NonNullableFormBuilder for typed control creation
- update the toolbar to accept the typed form group used by the filters

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7ba20a28832db110b5cec5c6608e)