### PR TITLE
src/app/shared/dialogs/dialogs-form.service.ts (fixes #9314)

### DIFF
--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -3,47 +3,62 @@ import { DialogsFormComponent } from './dialogs-form.component';
 import { MatLegacyDialogRef as MatDialogRef, MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { Injectable } from '@angular/core';
 import {
-  UntypedFormBuilder,
   UntypedFormGroup
 } from '@angular/forms';
+
+interface DialogsFormOptions {
+  autoFocus?: boolean;
+  closeOnSubmit?: boolean;
+  disableIfInvalid?: boolean;
+  onSubmit?: (...args: any[]) => void;
+  formOptions?: Record<string, unknown>;
+  [key: string]: any;
+}
+
+interface DialogsFormData {
+  title: string;
+  fields: any[];
+  formGroup: any;
+}
 
 @Injectable()
 export class DialogsFormService {
 
-  private dialogRef: MatDialogRef<DialogsFormComponent>;
+  private dialogRef?: MatDialogRef<DialogsFormComponent>;
 
-  constructor(private dialog: MatDialog, private fb: UntypedFormBuilder) { }
+  constructor(private dialog: MatDialog) { }
 
-  public confirm(title: string, fields: any, formGroup: any, autoFocus = false): Observable<boolean> {
-    let dialogRef: MatDialogRef<DialogsFormComponent>;
-    dialogRef = this.dialog.open(DialogsFormComponent, {
+  public confirm<T = any>(title: string, fields: any[], formGroup: any, autoFocus = false): Observable<T | undefined> {
+    const dialogRef = this.dialog.open<DialogsFormComponent, DialogsFormData, T>(DialogsFormComponent, {
       width: '600px',
-      autoFocus: autoFocus
+      autoFocus,
+      data: { title, fields, formGroup }
     });
-    if (formGroup instanceof UntypedFormGroup) {
-      dialogRef.componentInstance.modalForm = formGroup;
-    } else {
-      dialogRef.componentInstance.modalForm = this.fb.group(formGroup);
-    }
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.fields = fields;
+
     return dialogRef.afterClosed();
   }
 
-  openDialogsForm(title: string, fields: any[], formGroup: any, options: any) {
+  openDialogsForm(title: string, fields: any[], formGroup: any, options: DialogsFormOptions = {}) {
+    const mergedOptions: DialogsFormOptions = {
+      autoFocus: false,
+      ...options
+    };
+
     this.dialogRef = this.dialog.open(DialogsFormComponent, {
       width: '600px',
-      autoFocus: options.autoFocus,
-      data: { title, formGroup, fields, ...options }
+      autoFocus: mergedOptions.autoFocus,
+      data: { title, formGroup, fields, ...mergedOptions }
     });
   }
 
   closeDialogsForm() {
-    this.dialogRef.close();
+    this.dialogRef?.close();
   }
 
   showErrorMessage(errorMessage: string) {
-    this.dialogRef.componentInstance.errorMessage = errorMessage;
+    if (this.dialogRef?.componentInstance) {
+      this.dialogRef.componentInstance.errorMessage = errorMessage;
+    }
   }
 
 }


### PR DESCRIPTION
fixes #9314

- Harden dialogs form service by typing options and dialog data
- Use data-driven dialog creation with defaults to avoid undefined options
- Guard dialog closure and error message updates when no dialog is open

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260dbb71a0832daf5fd5e4accefd0d)