### PR TITLE
courses: smoother steps form handling (fixes #9397)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.20.99",
+  "version": "0.21.2",
   "myplanet": {
-    "latest": "v0.39.63",
+    "latest": "v0.40.23",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnDestroy, ViewEncapsulation, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { NonNullableFormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -8,6 +8,12 @@ import { CoursesService } from '../courses.service';
 import { DialogsAddResourcesComponent } from '../../shared/dialogs/dialogs-add-resources.component';
 import { DialogsLoadingService } from '../../shared/dialogs/dialogs-loading.service';
 import { PlanetStepListComponent } from '../../shared/forms/planet-step-list.component';
+
+interface CoursesStepForm {
+  id: FormControl<string>;
+  stepTitle: FormControl<string>;
+  description: FormControl<string>;
+}
 
 @Component({
   selector: 'planet-courses-step',
@@ -21,7 +27,7 @@ export class CoursesStepComponent implements OnDestroy {
   @Output() stepsChange = new EventEmitter<any>();
   @Output() addStepEvent = new EventEmitter<void>();
 
-  stepForm: FormGroup<{ id: FormControl<string>; stepTitle: FormControl<string>; description: FormControl<string> }>;
+  stepForm: FormGroup<CoursesStepForm>;
   dialogRef: MatDialogRef<DialogsAddResourcesComponent>;
   activeStep: any;
   activeStepIndex = -1;
@@ -38,12 +44,12 @@ export class CoursesStepComponent implements OnDestroy {
 
   constructor(
     private router: Router,
-    private fb: FormBuilder,
+    private fb: NonNullableFormBuilder,
     private dialog: MatDialog,
     private coursesService: CoursesService,
     private dialogsLoadingService: DialogsLoadingService
   ) {
-    this.stepForm = this.fb.nonNullable.group({
+    this.stepForm = this.fb.group({
       id: '',
       stepTitle: '',
       description: ''

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnDestroy, ViewEncapsulation, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -21,7 +21,7 @@ export class CoursesStepComponent implements OnDestroy {
   @Output() stepsChange = new EventEmitter<any>();
   @Output() addStepEvent = new EventEmitter<void>();
 
-  stepForm: UntypedFormGroup;
+  stepForm: FormGroup<{ id: FormControl<string>; stepTitle: FormControl<string>; description: FormControl<string> }>;
   dialogRef: MatDialogRef<DialogsAddResourcesComponent>;
   activeStep: any;
   activeStepIndex = -1;
@@ -38,12 +38,12 @@ export class CoursesStepComponent implements OnDestroy {
 
   constructor(
     private router: Router,
-    private fb: UntypedFormBuilder,
+    private fb: FormBuilder,
     private dialog: MatDialog,
     private coursesService: CoursesService,
     private dialogsLoadingService: DialogsLoadingService
   ) {
-    this.stepForm = this.fb.group({
+    this.stepForm = this.fb.nonNullable.group({
       id: '',
       stepTitle: '',
       description: ''


### PR DESCRIPTION
fixes #9397 Replace untyped course step form usage with typed non-nullable form controls for step fields.

<img width="1388" height="855" alt="image" src="https://github.com/user-attachments/assets/0063998f-dadc-460d-a58d-c7e70ed959ec" />


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332e59d46c832da39773c69e79a7b7)