### PR TITLE
resources: smoother icon downloading  (fixes #9307)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.15",
+  "version": "0.21.20",
   "myplanet": {
-    "latest": "v0.41.2",
+    "latest": "v0.42.56",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -109,7 +109,7 @@
           </div>
         </div>
         <div class="inner-gaps full-width">
-          <mat-checkbox [disabled]="disableDownload || resourceForm?.errors?.fileTooBig" formControlName="isDownloadable" i18n>File downloadable</mat-checkbox>
+          <mat-checkbox *ngIf="showDownloadCheckbox" [disabled]="disableDownload || resourceForm?.errors?.fileTooBig" formControlName="isDownloadable" i18n>File downloadable</mat-checkbox>
           <mat-checkbox *ngIf="privateFor" formControlName="private" i18n-matTooltip matTooltip="If checked, resource will only be viewable by this team" i18n>Private Resource</mat-checkbox>
         </div>
       </form>

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -109,7 +109,7 @@
           </div>
         </div>
         <div class="inner-gaps full-width">
-          <mat-checkbox *ngIf="showDownloadCheckbox" [disabled]="disableDownload || resourceForm?.errors?.fileTooBig" formControlName="isDownloadable" i18n>File downloadable</mat-checkbox>
+          <mat-checkbox *ngIf="showDownloadCheckbox" [disabled]="resourceForm?.errors?.fileTooBig" formControlName="isDownloadable" i18n>File downloadable</mat-checkbox>
           <mat-checkbox *ngIf="privateFor" formControlName="private" i18n-matTooltip matTooltip="If checked, resource will only be viewable by this team" i18n>Private Resource</mat-checkbox>
         </div>
       </form>

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -46,6 +46,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   pageType: string | null = null;
   disableDownload = true;
   disableDelete = true;
+  showDownloadCheckbox = false;
   resourceFilename = '';
   languages = languages;
   tags = this.fb.control([]);
@@ -155,6 +156,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     // If the resource does not have an attachment, disable file downloadable toggle
     this.disableDownload = !resource.doc._attachments;
     this.disableDelete = !resource.doc._attachments;
+    this.showDownloadCheckbox = !!resource.doc._attachments;
     this.resourceFilename = resource.doc._attachments
       ? Object.keys(resource.doc._attachments).join(', ')
       : '';
@@ -255,6 +257,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     this.deleteAttachment = event.checked;
     // Also disable downloadable toggle if user is removing file
     this.disableDownload = event.checked;
+    this.showDownloadCheckbox = !event.checked;
     this.resourceForm.patchValue({ isDownloadable: false });
   }
 
@@ -263,6 +266,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     this.resourceFilename = '';
     this.disableDelete = true;
     this.disableDownload = true;
+    this.showDownloadCheckbox = false;
     this.resourceForm.patchValue({ isDownloadable: false });
     this.hasUnsavedChanges = true;
   }
@@ -333,7 +337,8 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   removeNewFile() {
     this.file = null;
     this.fileInput.clearFile();
-    this.disableDownload = false;
+    this.disableDownload = true;
+    this.showDownloadCheckbox = false;
     this.resourceForm.patchValue({ isDownloadable: false });
     this.resourceForm.updateValueAndValidity();
     this.hasUnsavedChanges = true;
@@ -352,6 +357,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     }
     this.file = input.files[0];
     this.disableDownload = false;
+    this.showDownloadCheckbox = true;
     this.resourceForm.updateValueAndValidity();
 
     if (this.resourcesService.simpleMediaType(this.file.type) !== 'zip') {

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -44,7 +44,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   readonly dbName = 'resources'; // make database name a constant
   currentUsername = '';
   pageType: string | null = null;
-  disableDownload = true;
   disableDelete = true;
   showDownloadCheckbox = false;
   resourceFilename = '';
@@ -154,7 +153,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   setFormValues(resource) {
     this.privateFor = resource.doc.privateFor;
     // If the resource does not have an attachment, disable file downloadable toggle
-    this.disableDownload = !resource.doc._attachments;
     this.disableDelete = !resource.doc._attachments;
     this.showDownloadCheckbox = !!resource.doc._attachments;
     this.resourceFilename = resource.doc._attachments
@@ -257,7 +255,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   deleteAttachmentToggle(event) {
     this.deleteAttachment = event.checked;
     // Also disable downloadable toggle if user is removing file
-    this.disableDownload = event.checked;
     this.showDownloadCheckbox = !event.checked;
     this.resourceForm.patchValue({ isDownloadable: false });
   }
@@ -266,7 +263,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     this.attachmentMarkedForDeletion = true;
     this.resourceFilename = '';
     this.disableDelete = true;
-    this.disableDownload = true;
     this.showDownloadCheckbox = false;
     this.resourceForm.patchValue({ isDownloadable: false });
     this.hasUnsavedChanges = true;
@@ -338,8 +334,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   removeNewFile() {
     this.file = null;
     this.fileInput.clearFile();
-    this.disableDownload = true;
-    this.showDownloadCheckbox = false;
+    this.showDownloadCheckbox = !!this.existingResource.doc?._attachments && !this.attachmentMarkedForDeletion;
     this.resourceForm.patchValue({ isDownloadable: false });
     this.resourceForm.updateValueAndValidity();
     this.hasUnsavedChanges = true;
@@ -357,7 +352,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
       return;
     }
     this.file = input.files[0];
-    this.disableDownload = false;
     this.showDownloadCheckbox = true;
     this.resourceForm.updateValueAndValidity();
 

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -44,8 +44,8 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   readonly dbName = 'resources'; // make database name a constant
   currentUsername = '';
   pageType: string | null = null;
-  disableDelete = true;
   showDownloadCheckbox = false;
+  disableDelete = true;
   resourceFilename = '';
   languages = languages;
   tags = this.fb.control([]);
@@ -153,8 +153,8 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   setFormValues(resource) {
     this.privateFor = resource.doc.privateFor;
     // If the resource does not have an attachment, disable file downloadable toggle
-    this.disableDelete = !resource.doc._attachments;
     this.showDownloadCheckbox = !!resource.doc._attachments;
+    this.disableDelete = !resource.doc._attachments;
     this.resourceFilename = resource.doc._attachments
       ? Object.keys(resource.doc._attachments).join(', ')
       : '';
@@ -335,7 +335,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     this.file = null;
     this.fileInput.clearFile();
     this.showDownloadCheckbox = !!this.existingResource.doc?._attachments && !this.attachmentMarkedForDeletion;
-    this.resourceForm.patchValue({ isDownloadable: false });
     this.resourceForm.updateValueAndValidity();
     this.hasUnsavedChanges = true;
   }

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -214,12 +214,13 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   }
 
   createFileObs() {
-    // If file doesn't exist, mediaType will be undefined
+    // If file doesn't exist, mediaType will be undefined or null
     const mediaType = this.file && this.resourcesService.simpleMediaType(this.file.type);
+    if (!mediaType) {
+      // Creates an observable that immediately returns an empty object
+      return of({ resource: {} });
+    }
     switch (mediaType) {
-      case undefined:
-        // Creates an observable that immediately returns an empty object
-        return of({ resource: {} });
       case 'zip':
         return this.zipObs(this.file);
       default:

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -333,7 +333,8 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   removeNewFile() {
     this.file = null;
     this.fileInput.clearFile();
-    this.disableDownload = !this.existingResource.doc?._attachments || this.attachmentMarkedForDeletion;
+    this.disableDownload = false;
+    this.resourceForm.patchValue({ isDownloadable: false });
     this.resourceForm.updateValueAndValidity();
     this.hasUnsavedChanges = true;
   }


### PR DESCRIPTION
Fixes #9307 

Fixed the checkbox enabled problem when file is deleted after selecting from local files. Checkbox automatically gets refreshed if file is deleted and not uploaded.

<img width="840" height="840" alt="image" src="https://github.com/user-attachments/assets/7c7d24ca-5bf6-4901-a6df-03d9809cab9d" />

### After Deleting File

<img width="838" height="490" alt="image" src="https://github.com/user-attachments/assets/620e9a8c-57a7-4778-8524-f5a9c4f3462e" />
