### PR TITLE
Re-enable beta authentication guard

### DIFF
--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -6,13 +6,15 @@ import { AuthService } from './shared/auth-guard.service';
 import { HomeComponent } from './home/home.component';
 import { UserGuard } from './shared/user-guard.service';
 import { UnsavedChangesGuard } from './shared/unsaved-changes.guard';
+import { BetaThenAuthService } from './shared/beta-then-auth-guard-service';
 
 const routes: Routes = [
   {
     path: '',
     component: HomeComponent,
     loadChildren: () => import('./home/home.module').then(m => m.HomeModule),
-    canActivateChild: [ UserGuard ],
+    canActivate: [ BetaThenAuthService ],
+    canActivateChild: [ BetaThenAuthService, UserGuard ],
     canDeactivate: [ UnsavedChangesGuard ]
   },
   { path: 'login', loadChildren: () => import('./login/login.module').then(m => m.LoginModule), canActivate: [ AuthService ] },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { PageNotFoundComponent } from './page-not-found/page-not-found.component
 import { MaterialModule } from './shared/material.module';
 import { environment } from '../environments/environment';
 import { PlanetDialogsModule } from './shared/dialogs/planet-dialogs.module';
+import { BetaThenAuthService } from './shared/beta-then-auth-guard-service';
 
 import { FullCalendarModule } from '@fullcalendar/angular';
 
@@ -31,6 +32,7 @@ import { FullCalendarModule } from '@fullcalendar/angular';
   declarations: [
     AppComponent, PageNotFoundComponent
   ],
+  providers: [ BetaThenAuthService ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {}

--- a/src/app/shared/beta-then-auth-guard-service.ts
+++ b/src/app/shared/beta-then-auth-guard-service.ts
@@ -7,6 +7,12 @@ import { AuthService } from './auth-guard.service';
 import { UserService } from './user.service';
 import { StateService } from './state.service';
 
+/**
+ * Guard that allows beta-enabled users to skip authentication while forcing
+ * everyone else through the standard {@link AuthService} checks. To keep this
+ * guard active, ensure `betaEnabled` is set to either `off` or `user` in the
+ * configuration; setting it to `on` bypasses the auth flow entirely.
+ */
 @Injectable({
   providedIn: 'root'
 })
@@ -29,6 +35,10 @@ export class BetaThenAuthService {
       }
       return this.authService.canActivateChild(route, state);
     }));
+  }
+
+  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    return this.canActivate(route, state);
   }
 
 }


### PR DESCRIPTION
## Summary
- add BetaThenAuthService to root routes so activation and child routes honor beta gating
- register the guard in the app module and document how beta toggles affect auth fallback
- ensure the guard supports child activation paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ce7a9700832d92391f719983029c)