### PR TITLE
Improve chat window form typing

### DIFF
--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, ChangeDetectorRef, Input, AfterViewInit } from '@angular/core';
-import { FormBuilder, FormGroup, FormControl, AbstractControl } from '@angular/forms';
+import { FormBuilder, FormGroup, FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { CustomValidators } from '../../validators/custom-validators';
@@ -9,9 +9,8 @@ import { showFormErrors, trackByIdVal } from '../../shared/table-helpers';
 import { UserService } from '../../shared/user.service';
 import { StateService } from '../../shared/state.service';
 
-interface PromptForm {
+interface PromptFormControls {
   prompt: FormControl<string>;
-  [key: string]: AbstractControl<any, any>;
 }
 
 @Component({
@@ -33,7 +32,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   provider: AIProvider;
   fallbackConversation: any[] = [];
   selectedConversationId: any;
-  promptForm: FormGroup<PromptForm>;
+  promptForm: FormGroup<PromptFormControls>;
   data: ConversationForm = {
     _id: '',
     _rev: '',
@@ -131,8 +130,10 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   createForm() {
-    this.promptForm = this.formBuilder.nonNullable.group({
-      prompt: [ '', CustomValidators.required ],
+    this.promptForm = this.formBuilder.group<PromptFormControls>({
+      prompt: this.formBuilder.nonNullable.control('', {
+        validators: CustomValidators.required,
+      }),
     });
   }
 

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -207,8 +207,8 @@ export const trackByIdVal = (index, item: { id: string }) => item.id;
 
 export const trackByIndex = (index: number) => index;
 
-export const showFormErrors = (controls: { [key: string]: AbstractControl }) => {
-  Object.values(controls).forEach(control => {
+export const showFormErrors = <T extends { [K in keyof T]: AbstractControl<any, any> }>(controls: T) => {
+  Object.values(controls as { [key: string]: AbstractControl<any, any> }).forEach(control => {
     control.markAsTouched({ onlySelf: true });
   });
 };


### PR DESCRIPTION
## Summary
- define a typed prompt form interface for the chat window FormGroup
- initialize the prompt control with a non-nullable typed FormControl and required validator

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1e60183c832d85e7a76fa6ed2caf)