### PR TITLE
chat: smoother angular forms handling (fixes #9429)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.14",
+  "version": "0.21.15",
   "myplanet": {
-    "latest": "v0.40.99",
+    "latest": "v0.41.2",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, ChangeDetectorRef, Input, AfterViewInit } from '@angular/core';
-import { FormBuilder, FormGroup, FormControl, AbstractControl } from '@angular/forms';
+import { FormBuilder, FormGroup, FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { CustomValidators } from '../../validators/custom-validators';
@@ -9,10 +9,7 @@ import { showFormErrors, trackByIdVal } from '../../shared/table-helpers';
 import { UserService } from '../../shared/user.service';
 import { StateService } from '../../shared/state.service';
 
-interface PromptForm {
-  prompt: FormControl<string>;
-  [key: string]: AbstractControl<any, any>;
-}
+type PromptFormGroup = FormGroup<{ prompt: FormControl<string> }>;
 
 @Component({
   selector: 'planet-chat-window',
@@ -33,7 +30,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   provider: AIProvider;
   fallbackConversation: any[] = [];
   selectedConversationId: any;
-  promptForm: FormGroup<PromptForm>;
+  promptForm: PromptFormGroup;
   data: ConversationForm = {
     _id: '',
     _rev: '',
@@ -132,7 +129,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   createForm() {
     this.promptForm = this.formBuilder.nonNullable.group({
-      prompt: [ '', CustomValidators.required ],
+      prompt: this.formBuilder.nonNullable.control('', { validators: [ CustomValidators.required ] }),
     });
   }
 

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, ChangeDetectorRef, Input, AfterViewInit } from '@angular/core';
-import { FormBuilder, FormGroup, FormControl } from '@angular/forms';
+import { NonNullableFormBuilder, FormGroup, FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { CustomValidators } from '../../validators/custom-validators';
@@ -46,7 +46,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
     private chatService: ChatService,
-    private formBuilder: FormBuilder,
+    private fb: NonNullableFormBuilder,
     private stateService: StateService,
     private userService: UserService
   ) {}
@@ -128,8 +128,8 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   createForm() {
-    this.promptForm = this.formBuilder.nonNullable.group({
-      prompt: this.formBuilder.nonNullable.control('', { validators: [ CustomValidators.required ] }),
+    this.promptForm = this.fb.group({
+      prompt: this.fb.control('', { validators: [ CustomValidators.required ] }),
     });
   }
 


### PR DESCRIPTION
fixes #9429

- migrate the chat prompt form to use Angular typed form controls with explicit string typing for the message field

<img width="1919" height="936" alt="image" src="https://github.com/user-attachments/assets/e2f2d08e-4339-44d2-8d5d-1890d3552d8d" />

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c76c72c58832d82964b8448ce856c)