### PR TITLE
deadcode: remove future date validator usage

### DIFF
--- a/src/app/health/health-update.component.ts
+++ b/src/app/health/health-update.component.ts
@@ -4,7 +4,6 @@ import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms
 import { interval, of, race, forkJoin } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 import { CustomValidators } from '../validators/custom-validators';
-import { ValidatorService } from '../validators/validator.service';
 import { UserService } from '../shared/user.service';
 import { HealthService } from './health.service';
 import { showFormErrors } from '../shared/table-helpers';
@@ -28,7 +27,6 @@ export class HealthUpdateComponent implements OnInit, CanComponentDeactivate {
 
   constructor(
     private fb: UntypedFormBuilder,
-    private validatorService: ValidatorService,
     private userService: UserService,
     private healthService: HealthService,
     private router: Router,
@@ -92,8 +90,7 @@ export class HealthUpdateComponent implements OnInit, CanComponentDeactivate {
       phoneNumber: [ '', CustomValidators.required ],
       birthDate: [
         '',
-        CustomValidators.dateValidRequired,
-        ac => this.validatorService.notDateInFuture$(ac)
+        CustomValidators.dateValidRequired
       ],
       birthplace: ''
     });

--- a/src/app/users/users-achievements/users-achievements-update.component.ts
+++ b/src/app/users/users-achievements/users-achievements-update.component.ts
@@ -10,7 +10,6 @@ import { UsersAchievementsService } from './users-achievements.service';
 import { DialogsFormService } from '../../shared/dialogs/dialogs-form.service';
 import { StateService } from '../../shared/state.service';
 import { CustomValidators } from '../../validators/custom-validators';
-import { ValidatorService } from '../../validators/validator.service';
 import { PlanetStepListService } from '../../shared/forms/planet-step-list.component';
 import { showFormErrors } from '../../shared/table-helpers';
 import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
@@ -53,7 +52,6 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
     private usersAchievementsService: UsersAchievementsService,
     private dialogsFormService: DialogsFormService,
     private stateService: StateService,
-    private validatorService: ValidatorService,
     private planetStepListService: PlanetStepListService
   ) {
     this.createForm();
@@ -164,8 +162,7 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
       lastName: [ '', CustomValidators.required ],
       birthDate: [
         '',
-        [ CustomValidators.dateValidRequired ],
-        ac => this.validatorService.notDateInFuture$(ac)
+        [ CustomValidators.dateValidRequired ]
       ],
       birthplace: ''
     });
@@ -188,7 +185,7 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
         title: [ achievement.title, CustomValidators.required ],
         description: [ achievement.description ],
         link: [ achievement.link, [], CustomValidators.validLink ],
-        date: [ achievement.date, null, ac => this.validatorService.notDateInFuture$(ac) ]
+        date: [ achievement.date ]
       }),
       { onSubmit: (formValue, formGroup) => {
         const achievedAt = formGroup.controls.date.value instanceof Date ? formGroup.controls.date.value.toISOString() :

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -8,7 +8,6 @@ import { environment } from '../../../environments/environment';
 import { languages } from '../../shared/languages';
 import { CustomValidators } from '../../validators/custom-validators';
 import { StateService } from '../../shared/state.service';
-import { ValidatorService } from '../../validators/validator.service';
 import { showFormErrors } from '../../shared/table-helpers';
 import { educationLevel } from '../user-constants';
 import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
@@ -58,7 +57,6 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
     private router: Router,
     private userService: UserService,
     private stateService: StateService,
-    private validatorService: ValidatorService,
     private dialog: MatDialog
   ) {
     this.userData();
@@ -108,8 +106,7 @@ export class UsersUpdateComponent implements OnInit, CanComponentDeactivate {
       phoneNumber: [ '', this.conditionalValidator(CustomValidators.required).bind(this) ],
       birthDate: [
         '',
-        this.conditionalValidator(CustomValidators.dateValidRequired).bind(this),
-        ac => this.validatorService.notDateInFuture$(ac)
+        this.conditionalValidator(CustomValidators.dateValidRequired).bind(this)
       ],
       birthYear: [ '', [
         Validators.min(1900),

--- a/src/app/validators/validator.service.ts
+++ b/src/app/validators/validator.service.ts
@@ -91,10 +91,6 @@ export class ValidatorService {
     return new Date(timestamp).setHours(0, 0, 0, 0);
   }
 
-  public notDateInFuture$(ac: AbstractControl): Observable<ValidationErrors | null> {
-    return this.couchService.currentTime().pipe(map(date => ac.value > date ? ({ invalidFutureDate: true }) : null));
-  }
-
   public notDateInPast$(ac: AbstractControl): Observable<ValidationErrors | null> {
     return (this.couchService.currentTime() as Observable<number>).pipe(
       map(date => ac.value < this.roundTimestamp(date) ? ({ dateInPast: true }) : null)


### PR DESCRIPTION
## Summary
- remove the notDateInFuture async validator from the shared validator service
- drop future-date async validators from user profile and achievements forms and related injection usage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6996062c832d97ab1f1108b98373)