### PR TITLE
Remove notDateInPast validator from validator service

### DIFF
--- a/src/app/validators/validator.service.ts
+++ b/src/app/validators/validator.service.ts
@@ -87,18 +87,8 @@ export class ValidatorService {
       }));
   }
 
-  private roundTimestamp(timestamp: number) {
-    return new Date(timestamp).setHours(0, 0, 0, 0);
-  }
-
   public notDateInFuture$(ac: AbstractControl): Observable<ValidationErrors | null> {
     return this.couchService.currentTime().pipe(map(date => ac.value > date ? ({ invalidFutureDate: true }) : null));
-  }
-
-  public notDateInPast$(ac: AbstractControl): Observable<ValidationErrors | null> {
-    return (this.couchService.currentTime() as Observable<number>).pipe(
-      map(date => ac.value < this.roundTimestamp(date) ? ({ dateInPast: true }) : null)
-    );
   }
 
 }


### PR DESCRIPTION
## Summary
- remove the notDateInPast validator from validator.service.ts
- keep remaining date validation and support methods intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c69982ed0832dbdc9b7ded8abdba0)