### PR TITLE
courses: smoother open grade levelling (fixes #9427)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.7",
+  "version": "0.21.13",
   "myplanet": {
-    "latest": "v0.40.48",
+    "latest": "v0.40.99",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/courses/constants.ts
+++ b/src/app/courses/constants.ts
@@ -1,5 +1,5 @@
 export const gradeLevels = [
-  { 'label': $localize`Open`, 'value': 'Open' },
+  { 'label': $localize`Open`, 'value': 'Pre-Kindergarten' },
   { 'label': $localize`Kindergarten`, 'value': 'Kindergarten' },
   { 'label': $localize`1`, 'value': '1' },
   { 'label': $localize`2`, 'value': '2' },


### PR DESCRIPTION
Fixes #9427 

revert the 'open' grade level value to 'pre-kindergarten'

<img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/70be5372-ae34-40fd-88f1-57aa5c6acf43" />
