### PR TITLE
manager: smoother submissions counting (fixes #9448)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.12",
+  "version": "0.21.16",
   "myplanet": {
-    "latest": "v0.40.90",
+    "latest": "v0.41.22",
     "min": "v0.37.60"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #9448

In the manager surveys, avoid deduping submissions to standardize count across exports & submissions