### PR TITLE
courses: smoother survey quesitions title aligning (fixes #9444)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.15",
+  "version": "0.21.19",
   "myplanet": {
     "latest": "v0.41.2",
     "min": "v0.37.60"

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -6,8 +6,8 @@
 
 <div [ngClass]="{ 'space-container': !isDialog }">
   <mat-toolbar class="primary-color font-size-1">
-    <span class="ellipsis-title" *ngIf="!isLoading">{{title ? title + ': ' : ''}}</span>
     <span *ngIf="!isLoading">
+      <span class="ellipsis-title">{{title ? title + ': ' : ''}}</span>
       <ng-container i18n>Question</ng-container>{{' ' + questionNum + ' '}}<ng-container i18n>of</ng-container>{{' ' + maxQuestions }}
       <span *ngIf="previewMode" i18n>(Preview)</span>
       <button *ngIf="mode !== 'take'" mat-icon-button [matMenuTriggerFor]="infoMenu">

--- a/src/app/exams/exams-view.scss
+++ b/src/app/exams/exams-view.scss
@@ -2,6 +2,11 @@
 
 :host {
 
+  mat-toolbar.primary-color > span {
+    display: inline-flex;
+    align-items: center;
+  }
+
   .view-container {
     display: grid;
     grid-template-rows: min-content minmax(auto, min-content) max-content min-content;


### PR DESCRIPTION
fixes #9444 
Fixed misaligned title row label under - Surveys -> Submissions -> Select any survey.

<img width="646" height="382" alt="image" src="https://github.com/user-attachments/assets/eb2219bc-6f6b-4619-8cb4-1d10ed92f3f4" />