### PR TITLE
Remove unused hexToString utility

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -83,8 +83,6 @@ export const toProperCase = (string: string) => `${string.slice(0, 1).toUpperCas
 
 export const stringToHex = (string: string) => string.split('').map(char => char.charCodeAt(0).toString(16)).join('');
 
-export const hexToString = (string: string) => string.match(/.{1,2}/g).map(hex => String.fromCharCode(parseInt(hex, 16))).join('');
-
 export const ageFromBirthDate = (currentTime: number, birthDate: string) => {
   const now = new Date(currentTime);
   const birth = new Date(birthDate);


### PR DESCRIPTION
## Summary
- remove unused hexToString helper from shared utils since it is unused
- verified no references to hexToString remain

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459fc0c44c832db7fe4b5493be2b54)