### PR TITLE
Add beta guard to beta-only routes

### DIFF
--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -12,6 +12,7 @@ import { myDashboardRoute } from './router-constants';
 import { CoursesProgressLearnerComponent } from '../courses/progress-courses/courses-progress-learner.component';
 import { NewsListComponent } from '../news/news-list.component';
 import { AuthService } from '../shared/auth-guard.service';
+import { BetaThenAuthService } from '../shared/beta-then-auth-guard-service';
 import { UnsavedChangesGuard } from '../shared/unsaved-changes.guard';
 
 export function dashboardPath(route): string {
@@ -41,7 +42,12 @@ const alwaysGuardedRoutes = [
     path: 'health/profile/:id',
     loadChildren: () => import('../health/health.module').then(m => m.HealthModule), data: { roles: [ '_admin', 'health' ] } },
   { path: 'nation', component: TeamsViewComponent, data: { mode: 'services' } },
-  { path: 'earth', component: TeamsViewComponent, data: { mode: 'services' } },
+  {
+    path: 'earth',
+    component: TeamsViewComponent,
+    data: { mode: 'services' },
+    canActivate: [ BetaThenAuthService ]
+  },
   { path: myDashboardRoute, component: DashboardComponent },
   {
     path: dashboardPath('mySurveys'),

--- a/src/app/manager-dashboard/manager-dashboard-router.module.ts
+++ b/src/app/manager-dashboard/manager-dashboard-router.module.ts
@@ -12,12 +12,17 @@ import { ReportsDetailComponent } from './reports/reports-detail.component';
 import { ReportsPendingComponent } from './reports/reports-pending.component';
 import { ReportsMyPlanetComponent } from './reports/myplanet/reports-myplanet.component';
 import { LogsMyPlanetComponent } from './reports/myplanet/logs-myplanet.component';
+import { BetaThenAuthService } from '../shared/beta-then-auth-guard-service';
 
 const routes: Routes = [
   { path: '', component: ManagerDashboardComponent },
   { path: 'aiservices', component: ManagerAIServicesComponent },
   { path: 'currency', component: ManagerCurrencyComponent },
-  { path: 'certifications', loadChildren: () => import('./certifications/certifications.module').then(m => m.CertificationsModule) },
+  {
+    path: 'certifications',
+    loadChildren: () => import('./certifications/certifications.module').then(m => m.CertificationsModule),
+    canActivate: [ BetaThenAuthService ]
+  },
   { path: 'sync', component: ManagerSyncComponent },
   { path: 'fetch', component: ManagerFetchComponent },
   { path: 'meetups', loadChildren: () => import('../meetups/meetups.module').then(m => m.MeetupsModule), data: { parent: true } },


### PR DESCRIPTION
## Summary
- add BetaThenAuthService as a canActivate guard for Earth navigation
- gate manager certifications route behind beta-aware guard

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694998ca3624832daef0c4517d3aca8e)