### PR TITLE
add Dark Mode toggle with persisted theme preference (fixes #9471)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,17 @@ For chatapi development instructions, refer to the [chatapi README](chatapi/READ
 
 To run planet in development with a different locale, you can set the configuration to one of the supported language tags. For example, to run in Spanish, use:
 ```
-  npm run dev -- --configuration spa 
+  npm run dev -- --configuration spa
 
   or 
 
   ng serve --configuration spa
 ```
 *You can use the short-hand `-c` in place of `--configuration`*
+
+## Theme preferences
+
+Planet now supports light and dark themes across the application. By default the UI mirrors the browser or operating system `prefers-color-scheme` setting, and any explicit selection is saved to the browser so it persists between visits. Use the moon/sun toggle in the main navigation bar to switch themes at any time; the change is applied immediately to the full UI, including dialogs and menus.
 
 ## Unit & End-to-End Tests
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
 import { Router, NavigationStart, NavigationEnd } from '@angular/router';
 import { StateService } from './shared/state.service';
+import { ThemeService } from './shared/theme.service';
 declare let gtag: Function;
 
 @Component({
@@ -14,7 +15,8 @@ export class AppComponent {
     iconRegistry: MatIconRegistry,
     sanitizer: DomSanitizer,
     public router: Router,
-    private stateService: StateService
+    private stateService: StateService,
+    private themeService: ThemeService
   ) {
     iconRegistry.addSvgIcon(
       'myLibrary',

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -51,10 +51,17 @@
       <ng-container *ngIf="isLoggedIn">
         <ng-container *planetAuthorizedRoles="''">
           <button mat-icon-button planetSync i18n-title title="Sync" *ngIf="onlineStatus === 'accepted'"><mat-icon svgIcon="sync"></mat-icon></button>
-        </ng-container>
-        <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
+      </ng-container>
+      <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings" *planetAuthorizedRoles="'manager'"><mat-icon>settings</mat-icon></button>
       </ng-container>
       <planet-language i18n-title title="Language"></planet-language>
+    </ng-container>
+    <ng-container *ngIf="activeTheme$ | async as activeTheme">
+      <button mat-icon-button class="theme-toggle" (click)="toggleTheme()"
+        [matTooltip]="activeTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'"
+        i18n-matTooltip>
+        <mat-icon>{{ activeTheme === 'dark' ? 'light_mode' : 'dark_mode' }}</mat-icon>
+      </button>
     </ng-container>
     <ng-container *ngIf="isLoggedIn">
       <ng-container *planetAuthorizedRoles="'learner'">

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -7,24 +7,35 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HomeComponent } from './home.component';
 import { CouchService } from '../shared/couchdb.service';
 import { UserService } from '../shared/user.service';
-import { of } from 'rxjs/observable/of';
+import { of } from 'rxjs';
+import { ThemeService } from '../shared/theme.service';
 
 describe('Home', () => {
 
   const setup = () => {
+    const themeService = jasmine.createSpyObj('ThemeService', ['toggleTheme'], {
+      activeTheme$: of('light'),
+      themePreference$: of('system')
+    });
     TestBed.configureTestingModule({
       imports: [ RouterTestingModule, BrowserAnimationsModule, CommonModule, HttpClientModule, MaterialModule ],
       declarations: [ HomeComponent ],
-      providers: [ CouchService, UserService ]
+      providers: [ CouchService, UserService, { provide: ThemeService, useValue: themeService } ]
     });
     const fixture = TestBed.createComponent(HomeComponent),
       comp = fixture.componentInstance;
-    return { fixture, comp };
+    return { fixture, comp, themeService };
   };
 
   it('Should be a HomeComponent', () => {
     const { comp } = setup();
     expect(comp instanceof HomeComponent).toBe(true, 'Should create HomeComponent');
+  });
+
+  it('delegates theme toggling to the theme service', () => {
+    const { comp, themeService } = setup();
+    comp.toggleTheme();
+    expect(themeService.toggleTheme).toHaveBeenCalled();
   });
 
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -16,6 +16,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { DialogsAnnouncementComponent, includedCodes, challengePeriod } from '../shared/dialogs/dialogs-announcement.component';
 import { LoginDialogComponent } from '../login/login-dialog.component';
 import { PlanetLanguageComponent } from '../shared/planet-language.component';
+import { ThemeService } from '../shared/theme.service';
 
 @Component({
   templateUrl: './home.component.html',
@@ -61,6 +62,8 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   isMobile: boolean;
   showBanner = true;
   isLoggedIn = false;
+  activeTheme$ = this.themeService.activeTheme$;
+  themePreference$ = this.themeService.themePreference$;
 
   // Sets the margin for the main content to match the sidenav width
   animObs = interval(15).pipe(
@@ -84,7 +87,8 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
     private pouchAuthService: PouchAuthService,
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService,
-    private notificationsService: NotificationsService
+    private notificationsService: NotificationsService,
+    private themeService: ThemeService
   ) {
     this.userService.userChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe(() => {
@@ -271,5 +275,9 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
         maxHeight: '100vh'
       });
     }
+  }
+
+  toggleTheme() {
+    this.themeService.toggleTheme();
   }
 }

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -73,6 +73,10 @@
     align-self: center;
     display: flex;
     align-items: center;
+
+    .theme-toggle {
+      margin-left: 6px;
+    }
   }
 
   .nav-shadow::before {

--- a/src/app/shared/theme.service.spec.ts
+++ b/src/app/shared/theme.service.spec.ts
@@ -1,0 +1,77 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { DOCUMENT } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { ThemeService } from './theme.service';
+
+type MatchMediaMock = MediaQueryList & { trigger: (matches: boolean) => void };
+
+describe('ThemeService', () => {
+  let overlayContainerElement: HTMLDivElement;
+  let matchMediaMock: MatchMediaMock;
+
+  const createMatchMedia = (matches: boolean): MatchMediaMock => {
+    let listener: ((event: MediaQueryListEvent) => void) | null = null;
+    const matcher: MatchMediaMock = {
+      matches,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: (_: string, callback: (event: MediaQueryListEvent) => void) => { listener = callback; },
+      removeEventListener: () => { listener = null; },
+      addListener: (_: any) => {},
+      removeListener: (_: any) => {},
+      dispatchEvent: () => false,
+      trigger: (value: boolean) => {
+        matcher.matches = value;
+        listener?.({ matches: value } as MediaQueryListEvent);
+      }
+    };
+    return matcher;
+  };
+
+  beforeEach(() => {
+    overlayContainerElement = document.createElement('div');
+    matchMediaMock = createMatchMedia(true);
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => matchMediaMock
+    });
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        ThemeService,
+        { provide: OverlayContainer, useValue: { getContainerElement: () => overlayContainerElement } },
+        { provide: DOCUMENT, useValue: document }
+      ]
+    });
+  });
+
+  it('defaults to system preference when no user choice exists', () => {
+    const service = TestBed.inject(ThemeService);
+    expect(service.activeTheme).toBe('dark');
+    expect(document.body.classList.contains('planet-theme-dark')).toBeTrue();
+  });
+
+  it('persists explicit user preferences and toggles theme', () => {
+    const service = TestBed.inject(ThemeService);
+
+    service.setPreference('light');
+    expect(service.activeTheme).toBe('light');
+    expect(localStorage.getItem('planet-theme-preference')).toBe('light');
+
+    service.toggleTheme();
+    expect(service.activeTheme).toBe('dark');
+    expect(localStorage.getItem('planet-theme-preference')).toBe('dark');
+    expect(overlayContainerElement.classList.contains('planet-theme-dark')).toBeTrue();
+  });
+
+  it('reacts to system preference changes when using system setting', () => {
+    const service = TestBed.inject(ThemeService);
+
+    service.setPreference('system');
+    matchMediaMock.trigger(false);
+    expect(service.activeTheme).toBe('light');
+
+    matchMediaMock.trigger(true);
+    expect(service.activeTheme).toBe('dark');
+  });
+});

--- a/src/app/shared/theme.service.ts
+++ b/src/app/shared/theme.service.ts
@@ -1,0 +1,102 @@
+import { DOCUMENT } from '@angular/common';
+import { Injectable, Inject, OnDestroy } from '@angular/core';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { BehaviorSubject } from 'rxjs';
+
+type ThemePreference = 'light' | 'dark' | 'system';
+type ActiveTheme = 'light' | 'dark';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService implements OnDestroy {
+  private static readonly STORAGE_KEY = 'planet-theme-preference';
+  private readonly darkModeQuery: MediaQueryList = typeof window !== 'undefined' && window.matchMedia ?
+    window.matchMedia('(prefers-color-scheme: dark)') :
+    {
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false
+    } as MediaQueryList;
+  private readonly preference$ = new BehaviorSubject<ThemePreference>('system');
+  private readonly activeThemeSubject$ = new BehaviorSubject<ActiveTheme>('light');
+  private readonly mediaListener = (event: MediaQueryListEvent) => {
+    if (this.preference$.value === 'system') {
+      this.applyResolvedTheme(event.matches ? 'dark' : 'light');
+    }
+  };
+
+  readonly activeTheme$ = this.activeThemeSubject$.asObservable();
+  readonly themePreference$ = this.preference$.asObservable();
+
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private overlayContainer: OverlayContainer
+  ) {
+    const storedPreference = this.readStoredPreference();
+    if (storedPreference) {
+      this.preference$.next(storedPreference);
+    }
+    this.applyResolvedTheme(this.resolveTheme(this.preference$.value));
+    this.darkModeQuery.addEventListener('change', this.mediaListener);
+  }
+
+  ngOnDestroy(): void {
+    this.darkModeQuery.removeEventListener('change', this.mediaListener);
+  }
+
+  get activeTheme(): ActiveTheme {
+    return this.activeThemeSubject$.value;
+  }
+
+  toggleTheme(): ActiveTheme {
+    const nextTheme: ThemePreference = this.activeThemeSubject$.value === 'dark' ? 'light' : 'dark';
+    this.setPreference(nextTheme);
+    return this.activeThemeSubject$.value;
+  }
+
+  setPreference(preference: ThemePreference): void {
+    this.preference$.next(preference);
+    this.persistPreference(preference);
+    this.applyResolvedTheme(this.resolveTheme(preference));
+  }
+
+  private resolveTheme(preference: ThemePreference): ActiveTheme {
+    if (preference === 'light' || preference === 'dark') {
+      return preference;
+    }
+    return this.darkModeQuery.matches ? 'dark' : 'light';
+  }
+
+  private applyResolvedTheme(theme: ActiveTheme): void {
+    this.activeThemeSubject$.next(theme);
+    const themeClass = `planet-theme-${theme}`;
+    this.updateClassList(this.document.body.classList, themeClass);
+    this.updateClassList(this.overlayContainer.getContainerElement().classList, themeClass);
+  }
+
+  private updateClassList(classList: DOMTokenList, themeClass: string): void {
+    classList.remove('planet-theme-light', 'planet-theme-dark');
+    classList.add(themeClass);
+  }
+
+  private readStoredPreference(): ThemePreference | null {
+    try {
+      const storedValue = localStorage.getItem(ThemeService.STORAGE_KEY) as ThemePreference | null;
+      return storedValue === 'light' || storedValue === 'dark' || storedValue === 'system' ? storedValue : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private persistPreference(preference: ThemePreference): void {
+    try {
+      localStorage.setItem(ThemeService.STORAGE_KEY, preference);
+    } catch {
+      // Ignore persistence errors (e.g. storage disabled)
+    }
+  }
+}

--- a/src/planet-mat-theme.scss
+++ b/src/planet-mat-theme.scss
@@ -26,6 +26,20 @@
 
 @include mat.all-component-themes($planet-app-theme);
 
+$planet-app-dark-theme: mat.define-dark-theme($planet-app-primary, $planet-app-accent, $planet-app-warn);
+
+.planet-theme-light {
+  /* TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
+  @include mat.all-legacy-component-themes($planet-app-theme);
+  @include mat.all-component-themes($planet-app-theme);
+}
+
+.planet-theme-dark {
+  /* TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
+  @include mat.all-legacy-component-themes($planet-app-dark-theme);
+  @include mat.all-component-themes($planet-app-dark-theme);
+}
+
 // Create sub-themes for the different sections which change the accent color.
 $accent-map: (
   library: mat.define-palette(mat.$pink-palette, $accent-hue),

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,12 +1,62 @@
 @import './app/variables';
 @import './planet-mat-theme.scss';
 
+:root {
+  --planet-surface: #ffffff;
+  --planet-background: #f7f9fc;
+  --planet-text: #0f172a;
+  --planet-subdued-text: #475569;
+  --planet-border: rgba(0, 0, 0, 0.08);
+}
+
+.planet-theme-dark {
+  --planet-surface: #1f2937;
+  --planet-background: #0f172a;
+  --planet-text: #e5e7eb;
+  --planet-subdued-text: #cbd5e1;
+  --planet-border: rgba(255, 255, 255, 0.12);
+
+  color: var(--planet-text);
+  background-color: var(--planet-background);
+
+  a,
+  a:hover {
+    color: var(--planet-text);
+  }
+
+  .mat-divider,
+  mat-divider {
+    border-color: var(--planet-border);
+  }
+
+  .mat-card,
+  .mat-expansion-panel,
+  .mat-table,
+  .mat-select-panel,
+  .mat-menu-panel,
+  .mat-list-base .mat-list-item,
+  .mat-list-base .mat-list-option {
+    background-color: var(--planet-surface);
+    color: var(--planet-text);
+  }
+}
+
 body {
   font-family: $font-family;
   margin: 0;
+  background-color: var(--planet-background);
+  color: var(--planet-text);
 
   .gradient-background {
     background: linear-gradient(to bottom, #000000, $primary);
+  }
+
+  .mat-sidenav,
+  .mat-sidenav-content,
+  .mat-drawer-content,
+  .main-content {
+    background-color: var(--planet-background);
+    color: var(--planet-text);
   }
 
   a,
@@ -38,11 +88,11 @@ body {
   }
 
   .grey-text-color {
-    color: $grey-text;
+    color: var(--planet-subdued-text);
   }
 
   .bg-light-grey {
-    background-color: $light-grey;
+    background-color: var(--planet-surface);
   }
 
   .bg-grey {


### PR DESCRIPTION
fixes #9471

## Summary
- add a theme preference service that defaults to the system scheme and persists user selections
- wire a dark/light toggle into the global navigation and extend styling support for both themes
- cover theme selection logic with unit tests and document the new toggle

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless --include src/app/shared/theme.service.spec.ts,src/app/home/home.component.spec.ts *(fails: ng command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6e8f4108832d995802eed9d4caed)