### PR TITLE
Add theme toggling and dark mode support

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
 import { Router, NavigationStart, NavigationEnd } from '@angular/router';
 import { StateService } from './shared/state.service';
+import { ThemeService } from './services/theme.service';
 declare let gtag: Function;
 
 @Component({
@@ -14,7 +15,8 @@ export class AppComponent {
     iconRegistry: MatIconRegistry,
     sanitizer: DomSanitizer,
     public router: Router,
-    private stateService: StateService
+    private stateService: StateService,
+    private themeService: ThemeService
   ) {
     iconRegistry.addSvgIcon(
       'myLibrary',
@@ -88,5 +90,7 @@ export class AppComponent {
         gtag('config', 'UA-118745384-1', { 'page_path': event.urlAfterRedirects });
       }
     });
+
+    this.themeService.getActiveTheme();
   }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -56,6 +56,9 @@
       </ng-container>
       <planet-language i18n-title title="Language"></planet-language>
     </ng-container>
+    <button mat-icon-button [matMenuTriggerFor]="themeMenu" i18n-title title="Theme">
+      <mat-icon>{{ (activeTheme$ | async) === 'dark' ? 'dark_mode' : 'light_mode' }}</mat-icon>
+    </button>
     <ng-container *ngIf="isLoggedIn">
       <ng-container *planetAuthorizedRoles="'learner'">
         <button mat-icon-button *ngIf="notifications.length > 0" [matMenuTriggerFor]="notificationMenu" i18n-title title="Notifications">
@@ -77,8 +80,22 @@
       </ng-container>
       <button mat-menu-item i18n (click)="openLoginDialog()" *ngIf="!isLoggedIn">Login</button>
     </mat-menu>
-    <!--Notification dropdown menu-->
-    <mat-menu #notificationMenu="matMenu" [overlapTrigger]="false" class="notification-menu">
+    <mat-menu #themeMenu="matMenu" [overlapTrigger]="false">
+      <button mat-menu-item (click)="setThemePreference('light')" [disabled]="themePreference === 'light'">
+        <mat-icon>light_mode</mat-icon>
+        <span i18n>Light</span>
+      </button>
+      <button mat-menu-item (click)="setThemePreference('dark')" [disabled]="themePreference === 'dark'">
+        <mat-icon>dark_mode</mat-icon>
+        <span i18n>Dark</span>
+      </button>
+      <button mat-menu-item (click)="setThemePreference('system')" [disabled]="themePreference === 'system'">
+        <mat-icon>settings_suggest</mat-icon>
+        <span i18n>Use system setting</span>
+      </button>
+    </mat-menu>
+  <!--Notification dropdown menu-->
+  <mat-menu #notificationMenu="matMenu" [overlapTrigger]="false" class="notification-menu">
       <div class="notification-items">
         <a mat-menu-item (click)="readAllNotification()" i18n>Mark all as Read</a>
         <a [routerLink]="notification.type !== 'challenges' ? (!notification.link ? '/notifications' : notification.link !== '/' ? [notification.link, notification.linkParams || {}] : '/') : null"

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild, ElementRef, DoCheck, AfterViewChecked, Ho
 import { Router } from '@angular/router';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
-import { Subject, interval, of } from 'rxjs';
+import { Observable, Subject, interval, of } from 'rxjs';
 import { switchMap, takeUntil, tap, catchError } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { UserService } from '../shared/user.service';
@@ -15,6 +15,7 @@ import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { DialogsAnnouncementComponent, includedCodes, challengePeriod } from '../shared/dialogs/dialogs-announcement.component';
 import { LoginDialogComponent } from '../login/login-dialog.component';
+import { ThemeService, ThemePreference } from '../services/theme.service';
 import { PlanetLanguageComponent } from '../shared/planet-language.component';
 
 @Component({
@@ -61,6 +62,8 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   isMobile: boolean;
   showBanner = true;
   isLoggedIn = false;
+  themePreference: ThemePreference = 'system';
+  activeTheme$: Observable<'light' | 'dark'>;
 
   // Sets the margin for the main content to match the sidenav width
   animObs = interval(15).pipe(
@@ -84,8 +87,10 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
     private pouchAuthService: PouchAuthService,
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService,
-    private notificationsService: NotificationsService
+    private notificationsService: NotificationsService,
+    private themeService: ThemeService
   ) {
+    this.activeTheme$ = this.themeService.themeChanges$;
     this.userService.userChange$.pipe(takeUntil(this.onDestroy$))
       .subscribe(() => {
         this.onUserUpdate();
@@ -99,6 +104,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   }
 
   ngOnInit() {
+    this.themePreference = this.themeService.getPreference();
     this.getNotification();
     this.onUserUpdate();
     this.userService.notificationStateChange$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
@@ -147,6 +153,11 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
     }
     this.deviceType = this.deviceInfoService.getDeviceType();
     this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+  }
+
+  setThemePreference(preference: ThemePreference): void {
+    this.themePreference = preference;
+    this.themeService.setPreference(preference);
   }
 
   openLanguageSelector(): void {

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -43,7 +43,7 @@
 
   .header-nav::before {
     height: 3px;
-    background: linear-gradient(to bottom, $shadow, rgba($shadow, 0.2) 25%, rgba($shadow, 0.12) 75%, rgba($shadow, 0));
+    background: linear-gradient(to bottom, var(--color-shadow-strong, #{$shadow}), var(--color-shadow-soft, rgba(0, 0, 0, 0.2)) 25%, var(--color-shadow-faint, rgba(0, 0, 0, 0.12)) 75%, rgba(0, 0, 0, 0));
     width: 100%;
     left: 0;
     top: 100%;
@@ -62,8 +62,8 @@
     grid-area: center;
     justify-self: center;
     a.active {
-      color: $primary-text;
-      background-color: mat.get-color-from-palette($planet-app-primary, $dark-hue);
+      color: var(--color-primary-text, #{$primary-text});
+      background-color: var(--color-primary-dark, #{mat.get-color-from-palette($planet-app-primary, $dark-hue)});
     }
   }
 
@@ -87,7 +87,7 @@
 
   .main-sidenav::before {
     width: 3px;
-    background: linear-gradient(to right, $shadow, rgba($shadow, 0.2) 25%, rgba($shadow, 0.12) 75%, rgba($shadow, 0));
+    background: linear-gradient(to right, var(--color-shadow-strong, #{$shadow}), var(--color-shadow-soft, rgba(0, 0, 0, 0.2)) 25%, var(--color-shadow-faint, rgba(0, 0, 0, 0.12)) 75%, rgba(0, 0, 0, 0));
     height: 100%;
     left: 100%;
     top: 0;
@@ -147,8 +147,8 @@
 
       // takes the left sidenav and alters color of text, background and svg-fill on .active class
       a.active {
-        background-color: $primary-text;
-        color: $primary;
+        background-color: var(--color-primary-text, #{$primary-text});
+        color: var(--color-primary, #{$primary});
         transition: background-color 0.5s cubic-bezier(0, 0, 0.2, 1),
           color 0.5s cubic-bezier(0, 0, 0.2, 1); // Linear out, slow in;
         /*TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version.*/
@@ -158,7 +158,7 @@
         }
         // Fix SVG icons to use primary color when active
         mat-icon ::ng-deep svg {
-          fill: $primary;
+          fill: var(--color-primary, #{$primary});
         }
       }
 
@@ -181,7 +181,7 @@
     height: 36px;
     // align with top mat-icon-button
     padding: 0 24px;
-    color: $white;
+    color: var(--color-primary-text, #{$white});
 
     > * {
       vertical-align: middle;
@@ -220,7 +220,7 @@
 }
 
 .banner {
-  background-color: $primary;
+  background-color: var(--color-primary, #{$primary});
   color: white;
   padding: 10px;
   text-align: center;

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,112 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+type ActiveTheme = 'light' | 'dark';
+export type ThemePreference = ActiveTheme | 'system';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly storageKey = 'planet-theme-preference';
+  private readonly prefersDarkMediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : undefined;
+  private readonly themeSubject: BehaviorSubject<ActiveTheme>;
+  private preference: ThemePreference;
+
+  readonly themeChanges$: Observable<ActiveTheme>;
+
+  constructor(@Inject(DOCUMENT) private document: Document) {
+    const { activeTheme, preference } = this.resolveInitialState();
+    this.preference = preference;
+    this.themeSubject = new BehaviorSubject<ActiveTheme>(activeTheme);
+    this.themeChanges$ = this.themeSubject.asObservable();
+
+    this.applyTheme(activeTheme, preference);
+    this.startSystemListener();
+  }
+
+  setPreference(preference: ThemePreference): void {
+    this.preference = preference;
+    this.persistPreference(preference);
+
+    const nextTheme = this.determineActiveTheme(preference);
+    this.themeSubject.next(nextTheme);
+    this.applyTheme(nextTheme, preference);
+  }
+
+  getPreference(): ThemePreference {
+    return this.preference;
+  }
+
+  getActiveTheme(): ActiveTheme {
+    return this.themeSubject.getValue();
+  }
+
+  private resolveInitialState(): { activeTheme: ActiveTheme; preference: ThemePreference } {
+    const storedPreference = this.readPreference();
+    const preference = storedPreference ?? 'system';
+    const activeTheme = this.determineActiveTheme(preference);
+
+    return { activeTheme, preference };
+  }
+
+  private determineActiveTheme(preference: ThemePreference): ActiveTheme {
+    if (preference === 'system') {
+      return this.getSystemTheme();
+    }
+
+    return preference;
+  }
+
+  private applyTheme(theme: ActiveTheme, preference: ThemePreference): void {
+    const classList = this.document.body.classList;
+    classList.remove('theme-light', 'theme-dark');
+    classList.add(`theme-${theme}`);
+
+    this.document.body.dataset.themePreference = preference;
+  }
+
+  private readPreference(): ThemePreference | null {
+    try {
+      const storedPreference = localStorage.getItem(this.storageKey) as ThemePreference | null;
+      if (storedPreference === 'light' || storedPreference === 'dark' || storedPreference === 'system') {
+        return storedPreference;
+      }
+
+      return null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  private persistPreference(preference: ThemePreference): void {
+    try {
+      localStorage.setItem(this.storageKey, preference);
+    } catch (error) {
+      // Ignore write errors so the theme change can still occur.
+    }
+  }
+
+  private startSystemListener(): void {
+    if (!this.prefersDarkMediaQuery) {
+      return;
+    }
+
+    this.prefersDarkMediaQuery.addEventListener('change', event => {
+      if (this.preference !== 'system') {
+        return;
+      }
+
+      const theme = event.matches ? 'dark' : 'light';
+      this.themeSubject.next(theme);
+      this.applyTheme(theme, 'system');
+    });
+  }
+
+  private getSystemTheme(): ActiveTheme {
+    if (this.prefersDarkMediaQuery) {
+      return this.prefersDarkMediaQuery.matches ? 'dark' : 'light';
+    }
+
+    return 'light';
+  }
+}

--- a/src/planet-mat-theme.scss
+++ b/src/planet-mat-theme.scss
@@ -21,10 +21,24 @@
 @include mat.core();
 @import './app/_variables';
 
+$planet-app-dark-theme: mat.define-dark-theme((
+  color: (
+    primary: $planet-app-primary,
+    accent: $planet-app-accent,
+    warn: $planet-app-warn,
+  ),
+));
+
 /* TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
 @include mat.all-legacy-component-themes($planet-app-theme);
 
 @include mat.all-component-themes($planet-app-theme);
+
+.theme-dark {
+  /* TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
+  @include mat.all-legacy-component-themes($planet-app-dark-theme);
+  @include mat.all-component-themes($planet-app-dark-theme);
+}
 
 // Create sub-themes for the different sections which change the accent color.
 $accent-map: (

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,12 +1,62 @@
+@use '@angular/material' as mat;
 @import './app/variables';
 @import './planet-mat-theme.scss';
+
+:root {
+  color-scheme: light;
+  @include screen-sizes();
+  --color-primary: #{$primary};
+  --color-primary-text: #{$primary-text};
+  --color-primary-dark: #{$primary-dark};
+  --color-primary-light: #{$primary-light};
+  --color-primary-lighter: #{$primary-lighter};
+  --color-accent: #{$accent};
+  --color-accent-text: #{$accent-text};
+  --color-accent-lighter: #{$accent-lighter};
+  --color-warn: #{$warn};
+  --color-grey: #{$grey};
+  --color-grey-text: #{$grey-text};
+  --color-light-grey: #{$light-grey};
+  --color-surface: #fff;
+  --color-surface-alt: #f6f8fb;
+  --color-on-surface: #1c1c1c;
+  --color-shadow: #{$shadow};
+  --color-shadow-strong: rgba(0, 0, 0, 0.25);
+  --color-shadow-soft: rgba(0, 0, 0, 0.2);
+  --color-shadow-faint: rgba(0, 0, 0, 0.12);
+}
+
+.theme-dark {
+  color-scheme: dark;
+  --color-primary: #{$primary-dark};
+  --color-primary-text: #{$white};
+  --color-primary-dark: #{darken($primary-dark, 10%)};
+  --color-primary-light: #{lighten($primary-dark, 15%)};
+  --color-primary-lighter: #{lighten($primary-dark, 25%)};
+  --color-accent: #{mat.get-color-from-palette($planet-app-accent, 300)};
+  --color-accent-text: #000;
+  --color-accent-lighter: #{mat.get-color-from-palette($planet-app-accent, 200)};
+  --color-warn: #{lighten($warn, 20%)};
+  --color-grey: #{lighten($grey, 20%)};
+  --color-grey-text: #e0e0e0;
+  --color-light-grey: #1f1f1f;
+  --color-surface: #121212;
+  --color-surface-alt: #1e1e1e;
+  --color-on-surface: #e5e5e5;
+  --color-shadow: rgba(0, 0, 0, 0.6);
+  --color-shadow-strong: rgba(0, 0, 0, 0.6);
+  --color-shadow-soft: rgba(0, 0, 0, 0.4);
+  --color-shadow-faint: rgba(0, 0, 0, 0.25);
+}
 
 body {
   font-family: $font-family;
   margin: 0;
+  background-color: var(--color-surface, #fff);
+  color: var(--color-on-surface, #1c1c1c);
 
   .gradient-background {
-    background: linear-gradient(to bottom, #000000, $primary);
+    background: linear-gradient(to bottom, #000000, var(--color-primary, #{$primary}));
   }
 
   a,
@@ -16,37 +66,37 @@ body {
   }
 
   .primary-text-color {
-    color: $primary;
+    color: var(--color-primary, #{$primary});
   }
 
   .primary-color {
-    background-color: $primary;
-    color: $primary-text;
+    background-color: var(--color-primary, #{$primary});
+    color: var(--color-primary-text, #{$primary-text});
   }
 
   .accent-color {
-    background-color: $accent;
-    color: $accent-text;
+    background-color: var(--color-accent, #{$accent});
+    color: var(--color-accent-text, #{$accent-text});
   }
 
   .accent-text-color {
-    color: $accent;
+    color: var(--color-accent, #{$accent});
   }
 
   .warn-text-color {
-    color: $warn;
+    color: var(--color-warn, #{$warn});
   }
 
   .grey-text-color {
-    color: $grey-text;
+    color: var(--color-grey-text, #{$grey-text});
   }
 
   .bg-light-grey {
-    background-color: $light-grey;
+    background-color: var(--color-light-grey, #{$light-grey});
   }
 
   .bg-grey {
-    background-color: $grey;
+    background-color: var(--color-grey, #{$grey});
   }
 
   .display-flex {
@@ -217,7 +267,7 @@ body {
   $stars-width: calc(120px + (10 * #{$stars-margin}));
   .stars {
     display: inline-block;
-    color: $grey;
+    color: var(--color-grey, #{$grey});
     position: relative;
     // Each mat-icon star is 24x24.  Will need to change if star sizes change
     width: $stars-width;
@@ -227,7 +277,7 @@ body {
     }
 
     span {
-      color: $accent;
+      color: var(--color-accent, #{$accent});
       position: absolute;
       top: 0;
       left: 0;
@@ -323,11 +373,11 @@ body {
   .rating-bar {
     display: block;
     height: 10px;
-    border: 1px solid $accent;
+    border: 1px solid var(--color-accent, #{$accent});
     margin-top: 0.5em;
 
     div {
-      background-color: $accent;
+      background-color: var(--color-accent, #{$accent});
       height: 100%;
     }
   }
@@ -337,11 +387,11 @@ body {
   }
 
   mat-table .highlight, .primary-lighter-color {
-    background-color: $primary-lighter;
+    background-color: var(--color-primary-lighter, #{$primary-lighter});
   }
 
   mat-table, .primary-light-color {
-    background-color: $primary-light;
+    background-color: var(--color-primary-light, #{$primary-light});
   }
 
   // Fix for checkboxes changing vertical alignment in cells when clicked as of Dec 28, 2017
@@ -396,7 +446,7 @@ body {
   }
 
   .primary-link-hover a:hover {
-    color: $primary;
+    color: var(--color-primary, #{$primary});
   }
 
   .view-container {
@@ -664,7 +714,7 @@ body {
     text-align: left;
     padding: 8px;
     border-radius: 5px;
-    background-color: #{$primary};
+    background-color: var(--color-primary, #{$primary});
     color: white;
   }
 
@@ -707,7 +757,7 @@ body {
   }
 
   .copy-btn.copied {
-    color: $primary;
+    color: var(--color-primary, #{$primary});
   }
 
   .chat-link {
@@ -729,7 +779,7 @@ body {
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: $primary;
+    background-color: var(--color-primary, #{$primary});
     border-radius: 10px;
     border: 3px solid #f1f1f1;
   }


### PR DESCRIPTION
## Summary
- add a global theme service that reads system color scheme, persists user selection, and applies a theme class to the document
- add a toolbar menu to switch between light, dark, or system themes and wire it to the new service
- define CSS variable palettes for light/dark modes and scope an Angular Material dark theme alongside updated shared styles

## Testing
- Not run (not requested)
- Manual verification steps:
  - Toggle the theme from the header menu and confirm light/dark styling updates immediately.
  - Reload after changing the selection to confirm the stored preference persists.
  - Choose the system option, clear any stored preference, and ensure the theme follows the OS `prefers-color-scheme` setting.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6e995594832d9e01ea9d56906a81)