### PR TITLE
refactor: ensure cancel prevents navigation (fixes: #9414)

### DIFF
--- a/src/app/shared/dialogs/dialogs-prompt.component.ts
+++ b/src/app/shared/dialogs/dialogs-prompt.component.ts
@@ -63,7 +63,7 @@ export class DialogsPromptComponent {
   }
 
   close() {
-    this.dialogRef.close();
+    this.dialogRef.close(false);
   }
 
   setDefault(value, dfault) {


### PR DESCRIPTION
fixes: #9414

The unsaved changes guard was not correctly preventing navigation when the user clicked "Cancel" on the confirmation dialog. This was because the dialog's `close` method did not return a value, which the guard interpreted as a confirmation to proceed with navigation.

This commit modifies the `DialogsPromptComponent` to return `false` when the dialog is closed, ensuring that the `UnsavedChangesGuard` correctly interprets a cancellation and prevents navigation.

Jules link: https://jules.google.com/session/8181152220759963602/code/src/app/shared/dialogs/dialogs-prompt.component.ts