### PR TITLE
refactor: add unsaved changes guard (fixes: #9415)

### DIFF
--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -17,12 +17,13 @@ import { StateService } from '../shared/state.service';
 import { markdownToPlainText } from '../shared/utils';
 import { SubmissionsService } from './../submissions/submissions.service';
 import { findDocuments } from '../shared/mangoQueries';
+import { CanComponentDeactivate } from '../shared/unsaved-changes.guard';
 
 @Component({
   templateUrl: 'exams-add.component.html',
   styleUrls: [ 'exams-add.scss' ]
 })
-export class ExamsAddComponent implements OnInit {
+export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
   readonly dbName = 'exams';
   examForm: FormGroup;
   documentInfo: any = {};
@@ -150,6 +151,7 @@ export class ExamsAddComponent implements OnInit {
       examInfo.name = examInfo.name || this.newExamName(exams, namePrefix);
       return this.examsService.createExamDocument(examInfo);
     })).subscribe((res) => {
+      this.examForm.markAsPristine();
       this.documentInfo = { _id: res.id, _rev: res.rev };
       if (this.examType === 'exam' || this.isCourseContent) {
         this.appendToCourse(examInfo, this.examType);
@@ -162,6 +164,10 @@ export class ExamsAddComponent implements OnInit {
       // Connect to an error display component to show user that an error has occurred
       console.log(err);
     });
+  }
+
+  canDeactivate() {
+    return this.examForm.pristine;
   }
 
   appendToCourse(info, type: 'exam' | 'survey') {

--- a/src/app/surveys/surveys-router.module.ts
+++ b/src/app/surveys/surveys-router.module.ts
@@ -4,11 +4,12 @@ import { Routes, RouterModule } from '@angular/router';
 import { SurveysComponent } from './surveys.component';
 import { ExamsAddComponent } from '../exams/exams-add.component';
 import { ExamsViewComponent } from '../exams/exams-view.component';
+import { UnsavedChangesGuard } from '../shared/unsaved-changes.guard';
 
 const routes: Routes = [
   { path: '', component: SurveysComponent },
-  { path: 'add', component: ExamsAddComponent },
-  { path: 'update/:id', component: ExamsAddComponent },
+  { path: 'add', component: ExamsAddComponent, canDeactivate: [UnsavedChangesGuard] },
+  { path: 'update/:id', component: ExamsAddComponent, canDeactivate: [UnsavedChangesGuard] },
   { path: 'dispense', component: ExamsViewComponent, data: { newUser: true } }
 ];
 


### PR DESCRIPTION
fixes: #9415

Implements an unsaved changes guard for the survey creation and editing pages. This prevents users from accidentally losing their work by navigating away from the page without saving.

- Implemented the `CanComponentDeactivate` interface in `ExamsAddComponent`.
- Added a `canDeactivate` method to check for unsaved changes in the form.
- Marked the form as pristine after submission.
- Updated `surveys-router.module.ts` to use the `UnsavedChangesGuard`.

Note: Frontend verification was not possible due to persistent issues with starting the local development server.

Jules Link: https://jules.google.com/session/11438802049581444556/code/src/app/exams/exams-add.component.ts