### PR TITLE
Import NodeSource GPG key in crosscompile script to allow Node.js install

### DIFF
--- a/docker/db-init/crosscompile_db-init.sh
+++ b/docker/db-init/crosscompile_db-init.sh
@@ -25,6 +25,7 @@ if [[ "${ACT}" == "install" ]]; then
   apt-get update -qq
   apt-get install -y curl gnupg
   curl -sL https://deb.nodesource.com/setup_10.x | bash -
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
   apt-get install -y nodejs build-essential ${PACKAGES}
   npm install "--arch=${TRIPLE}" -g add-cors-to-couchdb
 else


### PR DESCRIPTION
### Motivation
- The arm crosscompile step failed due to unauthenticated NodeSource packages which prevented `nodejs`/`npm` from being installed during the build. This change aims to ensure the NodeSource signing key is present so `apt-get install nodejs` succeeds.

### Description
- Add explicit NodeSource GPG key import by running `curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -` in `docker/db-init/crosscompile_db-init.sh` right after running the NodeSource setup script. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f9b489bac832bab35c6fef19cfbc9)