### PR TITLE
Fix ARM64 Docker build by upgrading to Ubuntu 20.04 and Node 18 (fixes #9502)

### DIFF
--- a/docker/db-init/arm-Dockerfile
+++ b/docker/db-init/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial as builder
+FROM ubuntu:20.04 as builder
 LABEL maintainer="dogi@ole.org,mutugiii@ole.org"
 
 COPY ./docker/db-init/crosscompile_db-init.sh .

--- a/docker/db-init/arm64-Dockerfile
+++ b/docker/db-init/arm64-Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial as builder
+FROM ubuntu:20.04 as builder
 LABEL maintainer="dogi@ole.org,mutugiii@ole.org"
 
 COPY ./docker/db-init/crosscompile_db-init.sh .

--- a/docker/db-init/crosscompile_db-init.sh
+++ b/docker/db-init/crosscompile_db-init.sh
@@ -5,10 +5,10 @@ ACT=$2
 
 if [[ "${ARCH}" == "armv7" ]]; then
   TRIPLE="arm-linux-gnueabihf"
-  GCC="4.8"
+  GCC="9"
 elif [[ "${ARCH}" == "armv8" ]]; then
   TRIPLE="aarch64-linux-gnu"
-  GCC="4.8"
+  GCC="9"
 else
   exit 1
 fi
@@ -24,7 +24,7 @@ echo "Building db-init for ${ARCH}"
 if [[ "${ACT}" == "install" ]]; then
   apt-get update -qq
   apt-get install -y curl gnupg
-  curl -sL https://deb.nodesource.com/setup_10.x | bash -
+  curl -sL https://deb.nodesource.com/setup_18.x | bash -
   apt-get install -y nodejs build-essential ${PACKAGES}
   npm install "--arch=${TRIPLE}" -g add-cors-to-couchdb
 else


### PR DESCRIPTION
 #9502
---
The previous build used Ubuntu Xenial (16.04) and Node.js 10.x, both of which are End-of-Life. This caused GPG key errors during the build process because the NodeSource repository for Node 10 on Xenial is no longer properly signed or the keys are missing.

This commit updates the builder image to Ubuntu 20.04 and the Node.js version to 18.x. It also updates the GCC version to 9 to match the default compiler available in Ubuntu 20.04.

Changes:
- Update `docker/db-init/arm-Dockerfile` and `docker/db-init/arm64-Dockerfile` to use `ubuntu:20.04` as the builder image.
- Update `docker/db-init/crosscompile_db-init.sh` to install Node.js 18.x and use GCC 9.