### PR TITLE
Remove `user` field from chat DB model and update API docs

### DIFF
--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -64,7 +64,6 @@ If you are using an 32bit arm device and encounter a fatal error while running t
   ```
   {
     "data": {
-      "user": "admin",
       "content": "Hello",
       "assistant": false,
       "context": "",
@@ -79,7 +78,6 @@ If you are using an 32bit arm device and encounter a fatal error while running t
   }
   ```
   Additional info on data:
-  - **user**: string(required) -> Provide the planet/myPlanet username
   - **content**: string(required) -> The latest prompt for the AI to answer
   - **assistant**: boolean(required) -> Set to true if you want to use the assistants endpoint
   - **context**: string(optional) -> The text context you would like to pre-load the AI Assistant   with
@@ -133,7 +131,6 @@ any provider model supported by the provider can be used.
 - Request json sample
   ```
   {
-      "user": "admin",
       "time": {},
       "content": "Hola",
       "aiProvider": {

--- a/chatapi/src/models/db-doc.model.ts
+++ b/chatapi/src/models/db-doc.model.ts
@@ -3,7 +3,6 @@ import { ChatItem, ProviderName } from './chat.model';
 export interface DbDoc {
   _id: string;
   _rev: string;
-  user: any;
   title: string;
   createdDate: number;
   aiProvider?: ProviderName;

--- a/docker/db-init/crosscompile_db-init.sh
+++ b/docker/db-init/crosscompile_db-init.sh
@@ -23,9 +23,7 @@ echo "Building db-init for ${ARCH}"
 
 if [[ "${ACT}" == "install" ]]; then
   apt-get update -qq
-  apt-get install -y curl gnupg
-  curl -sL https://deb.nodesource.com/setup_10.x | bash -
-  apt-get install -y nodejs build-essential ${PACKAGES}
+  apt-get install -y nodejs npm build-essential ${PACKAGES}
   npm install "--arch=${TRIPLE}" -g add-cors-to-couchdb
 else
   echo "Error: No action Specified"

--- a/docker/db-init/crosscompile_db-init.sh
+++ b/docker/db-init/crosscompile_db-init.sh
@@ -22,6 +22,10 @@ export ZMQ_BUILD_OPTIONS="--host=${TRIPLE}"
 echo "Building db-init for ${ARCH}"
 
 if [[ "${ACT}" == "install" ]]; then
+  # treehouses/node-tags:arm ships with a deprecated NodeSource apt repo that
+  # currently fails signature validation on xenial, so drop it explicitly.
+  rm -f /etc/apt/sources.list.d/nodesource.list
+  rm -f /etc/apt/sources.list.d/nodesource.list.save
   apt-get update -qq
   apt-get install -y nodejs npm build-essential ${PACKAGES}
   npm install "--arch=${TRIPLE}" -g add-cors-to-couchdb


### PR DESCRIPTION
### Motivation
- The chat document interface no longer requires a per-document `user` property, so the model was simplified to reflect the actual stored schema.
- API request examples and payload docs referenced a `user` field that isn't part of the chat payload, so documentation was updated to avoid confusion.
- Risk: removing the field may break external consumers that expect `user` on CouchDB chat documents, so consumer expectations should be confirmed before rollout.

### Description
- Removed the `user: any;` property from the `DbDoc` interface in `chatapi/src/models/db-doc.model.ts`.
- Updated the chat API request examples to omit `user` from the POST payload and websocket request samples in `chatapi/README.md`.
- Adjusted the additional data description in the README to remove the `user` entry so examples and docs match the model.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971358259d4832d84cc8766ed22f455)