### PR TITLE
src/app/manager-dashboard/reports/reports-detail.component.ts (fixes #9504)

### DIFF
--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -867,8 +867,9 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     this.showCustomDateFields = showCustomDateFields;
 
     if (timeFilter === 'custom') {
-      const currentStartDate = new Date();
-      currentStartDate.setMonth(currentStartDate.getMonth() - 12);
+      // Preserve the user's existing custom range (including deep-linked query params)
+      // instead of resetting to a default 12-month window every time "Custom" is selected.
+      const currentStartDate = this.filter.startDate || this.minDate || new Date(new Date().setMonth(new Date().getMonth() - 12));
       const currentEndDate = this.filter.endDate || this.today;
       this.dateFilterForm.patchValue({
         startDate: currentStartDate,


### PR DESCRIPTION
### Motivation
- fixes #9504: avoid wiping out user-selected or deep-linked custom date ranges when switching the reports time filter to `custom`, so the UI preserves the intended date range instead of resetting to a default window.

### Description
- Updated `onTimeFilterChange` in `src/app/manager-dashboard/reports/reports-detail.component.ts` to preserve existing `this.filter.startDate` / `this.filter.endDate` (or fall back to `minDate` / a 12-month default) when `timeFilter === 'custom'`, and added an explanatory comment.

### Testing
- No automated tests were executed for this change (per instructions not to run `./gradlew test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971385939cc832d949f44216587dae6)