### PR TITLE
Extract large inline templates to separate HTML files

### DIFF
--- a/src/app/shared/dialogs/dialogs-announcement-success.component.html
+++ b/src/app/shared/dialogs/dialogs-announcement-success.component.html
@@ -1,0 +1,8 @@
+<div class="announcement-container">
+  <img
+    src="assets/challenge/dec challenge.jpeg"
+    alt="Issues Challenge"
+    class="announcement-banner"
+  />
+  <p class="success-msg">¡Felicidades reto completado!</p>
+</div>

--- a/src/app/shared/dialogs/dialogs-announcement.component.ts
+++ b/src/app/shared/dialogs/dialogs-announcement.component.ts
@@ -20,16 +20,7 @@ export const examId = '4e6b78800b6ad18b4e8b0e1e38b382ab';
 export const challengePeriod = (new Date() > new Date(2024, 10, 31)) && (new Date() < new Date(2025, 0, 16));
 
 @Component({
-  template: `
-    <div class="announcement-container">
-      <img
-        src="assets/challenge/dec challenge.jpeg"
-        alt="Issues Challenge"
-        class="announcement-banner"
-      />
-      <p class="success-msg">¡Felicidades reto completado!</p>
-    </div>
-  `,
+  templateUrl: './dialogs-announcement-success.component.html',
   styleUrls: [ './dialogs-announcement.component.scss' ]
 })
 export class DialogsAnnouncementSuccessComponent { }

--- a/src/app/shared/dialogs/dialogs-submissions.component.html
+++ b/src/app/shared/dialogs/dialogs-submissions.component.html
@@ -1,0 +1,13 @@
+<h3 mat-dialog-title i18n class="mat-subtitle-1">Review Previous Test Attempts</h3>
+<mat-dialog-content>
+  <planet-submissions *ngIf="view==='list'" [isDialog]="true" [parentId]="data.parentId"
+    [displayedColumns]="[ 'lastUpdateTime', 'gradeTime', 'grade', 'status' ]" (submissionClick)="showSubmission($event)">
+  </planet-submissions>
+  <ng-container *ngIf="view==='submission'">
+    <planet-exams-view [isDialog]="true" [submission]="submission" [questionNum]="1" mode="view"></planet-exams-view>
+  </ng-container>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button *ngIf="view==='submission'" mat-stroked-button (click)="showList()" i18n>Back to submission list</button>
+  <button mat-dialog-close mat-raised-button color="primary" i18n>OK</button>
+</mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-submissions.component.ts
+++ b/src/app/shared/dialogs/dialogs-submissions.component.ts
@@ -2,21 +2,7 @@ import { Component, Inject } from '@angular/core';
 import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
 
 @Component({
-  template: `
-    <h3 mat-dialog-title i18n class="mat-subtitle-1">Review Previous Test Attempts</h3>
-    <mat-dialog-content>
-      <planet-submissions *ngIf="view==='list'" [isDialog]="true" [parentId]="data.parentId"
-        [displayedColumns]="[ 'lastUpdateTime', 'gradeTime', 'grade', 'status' ]" (submissionClick)="showSubmission($event)">
-      </planet-submissions>
-      <ng-container *ngIf="view==='submission'">
-        <planet-exams-view [isDialog]="true" [submission]="submission" [questionNum]="1" mode="view"></planet-exams-view>
-      </ng-container>
-    </mat-dialog-content>
-    <mat-dialog-actions>
-      <button *ngIf="view==='submission'" mat-stroked-button (click)="showList()" i18n>Back to submission list</button>
-      <button mat-dialog-close mat-raised-button color="primary" i18n>OK</button>
-    </mat-dialog-actions>
-  `,
+  templateUrl: './dialogs-submissions.component.html',
   styles: [ `
     h3.mat-dialog-title {
       margin: 0


### PR DESCRIPTION
Extracted inline templates for `DialogsAnnouncementSuccessComponent` and `DialogsSubmissionsComponent` into separate `.component.html` files to improve maintainability and readability. Updated component decorators to use `templateUrl`. Verified via linting and build.

---
https://jules.google.com/session/18337613516194667468