### PR TITLE
all: less planet stacked bar component is more (fixes #9535)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.33",
+  "version": "0.21.34",
   "myplanet": {
-    "latest": "v0.44.60",
+    "latest": "v0.44.82",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -61,7 +61,6 @@ import { FileInputComponent } from './file-input.component';
     PlanetTagInputDialogComponent,
     PlanetTagInputToggleIconComponent,
     PlanetSelectorComponent,
-    PlanetStackedBarComponent,
     PlanetStepListComponent,
     FileInputComponent,
     PlanetStepListFormDirective,


### PR DESCRIPTION
Fixes a build issue where PlanetStackedBarComponent was declared twice in PlanetFormsModule's declarations array.

Test Plan:
- `npm run build` passes successfully.
- `npm run ng -- test --include src/app/shared/forms/form-error-messages.component.spec.ts --watch=false --browsers=ChromeHeadless` runs (fails due to unrelated existing errors, but proves the module compiles).

---
https://jules.google.com/session/9156472068702903108