### PR TITLE
Migrate CoursesViewComponent to standard MatMenu

### DIFF
--- a/src/app/courses/courses-shared.module.ts
+++ b/src/app/courses/courses-shared.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { CoursesIconComponent } from './courses-icon.component';
+import { CoursesProgressBarComponent } from './progress-courses/courses-progress-bar.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatIconModule,
+    MatTooltipModule
+  ],
+  declarations: [
+    CoursesIconComponent,
+    CoursesProgressBarComponent
+  ],
+  exports: [
+    CoursesIconComponent,
+    CoursesProgressBarComponent
+  ]
+})
+export class CoursesSharedModule {}

--- a/src/app/courses/courses.module.ts
+++ b/src/app/courses/courses.module.ts
@@ -8,24 +8,23 @@ import { CoursesRouterModule } from './courses-router.module';
 import { PlanetFormsModule } from '../shared/forms/planet-forms.module';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { MaterialModule } from '../shared/material.module';
-import { CoursesViewComponent } from './view-courses/courses-view.component';
 import { CoursesStepComponent } from './add-courses/courses-step.component';
 import { CoursesStepViewComponent } from './step-view-courses/courses-step-view.component';
 import { ResourcesModule } from '../resources/resources.module';
 import { ExamsModule } from '../exams/exams.module';
 import { CoursesProgressLeaderComponent } from './progress-courses/courses-progress-leader.component';
-import { CoursesProgressBarComponent } from './progress-courses/courses-progress-bar.component';
 import { CoursesProgressChartComponent } from './progress-courses/courses-progress-chart.component';
 import { CoursesProgressLearnerComponent } from './progress-courses/courses-progress-learner.component';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { DialogsAddResourcesModule } from '../shared/dialogs/dialogs-add-resources.module';
 import { CoursesEnrollComponent } from './enroll-courses/courses-enroll.component';
 import { UsersModule } from '../users/users.module';
-import { CoursesIconComponent } from './courses-icon.component';
 import { DialogsSubmissionsModule } from '../shared/dialogs/dialogs-submissions.module';
 import { CoursesViewDetailModule } from './view-courses/courses-view-detail.module';
 import { CoursesSearchComponent, CoursesSearchListComponent } from './search-courses/courses-search.component';
 import { ChatModule } from '../chat/chat.module';
+import { CoursesSharedModule } from './courses-shared.module';
+import { CoursesViewModule } from './view-courses/courses-view.module';
 
 @NgModule({
   imports: [
@@ -43,22 +42,21 @@ import { ChatModule } from '../chat/chat.module';
     DialogsSubmissionsModule,
     UsersModule,
     CoursesViewDetailModule,
-    ChatModule
+    ChatModule,
+    CoursesSharedModule,
+    CoursesViewModule
   ],
   declarations: [
     CoursesComponent,
     CoursesAddComponent,
-    CoursesViewComponent,
     CoursesStepComponent,
     CoursesStepViewComponent,
     CoursesSearchComponent,
     CoursesSearchListComponent,
     CoursesProgressLeaderComponent,
     CoursesProgressLearnerComponent,
-    CoursesProgressBarComponent,
     CoursesProgressChartComponent,
-    CoursesEnrollComponent,
-    CoursesIconComponent
+    CoursesEnrollComponent
   ],
   exports: [ CoursesComponent ]
 })

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, ViewChild, HostListener } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
-import { MatLegacyMenuTrigger as MatMenuTrigger } from '@angular/material/legacy-menu';
+import { MatMenuTrigger } from '@angular/material/menu';
 import { Subject } from 'rxjs';
 import { takeUntil, switchMap, take, filter, map } from 'rxjs/operators';
 import { UserService } from '../../shared/user.service';

--- a/src/app/courses/view-courses/courses-view.module.ts
+++ b/src/app/courses/view-courses/courses-view.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { MatMenuModule } from '@angular/material/menu';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
+
+import { CoursesSharedModule } from '../courses-shared.module';
+import { CoursesViewDetailModule } from './courses-view-detail.module';
+import { SharedComponentsModule } from '../../shared/shared-components.module';
+
+import { CoursesViewComponent } from './courses-view.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatMenuModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatExpansionModule,
+    MatIconModule,
+    CoursesSharedModule,
+    CoursesViewDetailModule,
+    SharedComponentsModule
+  ],
+  declarations: [
+    CoursesViewComponent
+  ],
+  exports: [
+    CoursesViewComponent
+  ]
+})
+export class CoursesViewModule {}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -650,7 +650,8 @@ body {
   }
 
   // Course/Resources Details ellipsis menu
-  .actions-menu .mat-menu-content {
+  .actions-menu .mat-menu-content,
+  .actions-menu .mat-mdc-menu-content {
     display: flex;
     flex-flow: column;
     gap: 1rem;


### PR DESCRIPTION
- Created `CoursesViewModule` to isolate `CoursesViewComponent` and import standard `MatMenuModule`.
- Created `CoursesSharedModule` to share `CoursesIconComponent` and `CoursesProgressBarComponent` between `CoursesModule` and `CoursesViewModule`.
- Updated `CoursesModule` to use `CoursesSharedModule` and `CoursesViewModule`.
- Updated `CoursesViewComponent` to import `MatMenuTrigger` from `@angular/material/menu`.
- Updated global styles to support `.mat-mdc-menu-content` for standard menu styling.

---
https://jules.google.com/session/5340815750476427717