### PR TITLE
Refactor diacritic normalization into utility function

### DIFF
--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -1,5 +1,6 @@
 import { FormControl, AbstractControl } from '../../../node_modules/@angular/forms';
 import { FuzzySearchService } from './fuzzy-search.service';
+import { normalizeDiacritics } from './utils';
 
 const dropdownString = (fieldValue: any, value: string) => {
   if (fieldValue === undefined || value === undefined) {
@@ -34,11 +35,11 @@ const checkFilterItems = (data: any) => ((includeItem: boolean, [ field, val ]) 
 // Multi level field filter by spliting each field by '.'
 export const filterSpecificFields = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
-    const normalizedFilter = filter.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const normalizedFilter = normalizeDiacritics(filter.trim().toLowerCase());
     for (let i = 0; i < filterFields.length; i++) {
       const fieldValue = getProperty(data, filterFields[i]);
       if (typeof fieldValue === 'string' &&
-          fieldValue.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').indexOf(normalizedFilter) > -1) {
+          normalizeDiacritics(fieldValue.toLowerCase()).indexOf(normalizedFilter) > -1) {
         return true;
       }
     }
@@ -49,12 +50,12 @@ export const filterSpecificFields = (filterFields: string[]): any => {
 export const filterSpecificFieldsByWord = (filterFields: string[]): any => {
   return (data: any, filter: string) => {
     // Normalize each word
-    const words = filter.split(' ').map(value => value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, ''));
+    const words = filter.split(' ').map(value => normalizeDiacritics(value.toLowerCase()));
     return words.every(word => {
       return filterFields.some(field => {
         const fieldValue = getProperty(data, field);
         return typeof fieldValue === 'string' &&
-               fieldValue.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').includes(word);
+               normalizeDiacritics(fieldValue.toLowerCase()).includes(word);
       });
     });
   };
@@ -63,7 +64,7 @@ export const filterSpecificFieldsByWord = (filterFields: string[]): any => {
 // Enhanced version that combines exact and fuzzy search
 export const filterSpecificFieldsHybrid = (filterFields: string[], fuzzySearchService?: FuzzySearchService): any => {
   return (data: any, filter: string) => {
-    const normalizedFilter = filter.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const normalizedFilter = normalizeDiacritics(filter.trim().toLowerCase());
     if (!normalizedFilter) { return true; }
 
     return filterFields.some(field => {
@@ -71,7 +72,7 @@ export const filterSpecificFieldsHybrid = (filterFields: string[], fuzzySearchSe
       if (typeof fieldValue !== 'string') { return false; }
 
       // Try exact match first, then fuzzy if available
-      const normalizedFieldValue = fieldValue.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      const normalizedFieldValue = normalizeDiacritics(fieldValue.toLowerCase());
       return normalizedFieldValue.includes(normalizedFilter) ||
              (fuzzySearchService?.fuzzyWordMatch(filter, fieldValue, { threshold: 0.6, maxDistance: 2 }) ?? false);
     });

--- a/src/app/shared/utils.spec.ts
+++ b/src/app/shared/utils.spec.ts
@@ -1,0 +1,20 @@
+import { normalizeDiacritics } from './utils';
+
+describe('normalizeDiacritics', () => {
+  it('should remove accents', () => {
+    expect(normalizeDiacritics('Crème Brûlée')).toBe('Creme Brulee');
+  });
+
+  it('should handle empty string', () => {
+    expect(normalizeDiacritics('')).toBe('');
+  });
+
+  it('should handle strings without accents', () => {
+    expect(normalizeDiacritics('Hello World')).toBe('Hello World');
+  });
+
+  it('should handle other diacritics', () => {
+    expect(normalizeDiacritics('Ångström')).toBe('Angstrom');
+    expect(normalizeDiacritics('ñ')).toBe('n');
+  });
+});

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -142,3 +142,7 @@ export const calculateMdAdjustedLimit = (content, limit) => {
   const scaleFactor = hasLists && !hasRegularText ? 0.2 : hasTables && !hasRegularText ? 0.55 : hasMdStyles ? 0.8 : 1;
   return Math.floor(limit * scaleFactor);
 };
+
+export const normalizeDiacritics = (text: string): string => {
+  return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+};


### PR DESCRIPTION
Extracted diacritic normalization logic into `normalizeDiacritics` function in `src/app/shared/utils.ts`. Updated `src/app/shared/table-helpers.ts` to use this utility function in `filterSpecificFields`, `filterSpecificFieldsByWord`, and `filterSpecificFieldsHybrid` to remove code duplication. Added unit tests for the new utility in `src/app/shared/utils.spec.ts`.

---
https://jules.google.com/session/12393276100888116578