### PR TITLE
Implement lazy loading for major feature modules

### DIFF
--- a/LAZY_LOADING.md
+++ b/LAZY_LOADING.md
@@ -1,0 +1,55 @@
+# Lazy Loading Guide
+
+This guide describes the lazy loading pattern used in the application to optimize bundle size and load times.
+
+## 1. Creating a Lazy Loaded Module
+
+To create a lazy loaded module, follow these steps:
+
+1.  **Create the Module**: Create a new module (e.g., `FeatureModule`) that defines the feature.
+2.  **Create Routing Module**: Create a routing module (e.g., `FeatureRouterModule`) with `RouterModule.forChild(routes)`.
+3.  **Lazy Load in Parent**: In the parent routing module (e.g., `HomeRouterModule`), use `loadChildren` to import the module.
+
+```typescript
+// parent-router.module.ts
+{
+  path: 'feature',
+  loadChildren: () => import('./feature/feature.module').then(m => m.FeatureModule)
+}
+```
+
+## 2. Handling Shared Components (Crucial)
+
+To ensure the module is truly lazy loaded and not bundled into the main or parent chunk, you must avoid eager imports.
+
+-   **Problem**: If `FeatureModule` imports a module that is also imported by the parent (e.g., `HomeModule`), and that shared module imports `FeatureModule` (directly or indirectly), you get a circular dependency or eager loading.
+-   **Solution**: If other modules need components from your `FeatureModule`, create a **Shared Module** (e.g., `FeatureSharedModule`).
+    -   Move shared components/pipes/directives to `FeatureSharedModule`.
+    -   Import `FeatureSharedModule` in `FeatureModule`.
+    -   Import `FeatureSharedModule` in other modules that need these components (e.g., Dialogs, other features).
+    -   **Do NOT** import `FeatureModule` (the one with routing) in any other module. Only `loadChildren` should refer to it.
+
+### Example: Resources Module Refactoring
+
+We split `ResourcesModule` into `ResourcesModule` (Lazy) and `ResourcesSharedModule` (Shared).
+
+-   `ResourcesSharedModule`: Exports `ResourcesViewerComponent`, `ResourcesAddComponent`, etc.
+-   `ResourcesModule`: Imports `ResourcesSharedModule`, defines routes.
+-   `DialogsAddResourcesModule`: Imports `ResourcesSharedModule` (instead of `ResourcesModule`).
+
+## 3. Preloading Strategy
+
+For commonly accessed features, we use a custom preloading strategy `SelectedPreloadingStrategy`.
+
+To enable preloading for a lazy route, add `data: { preload: true }`.
+
+```typescript
+// home-router.module.ts
+{
+  path: 'courses',
+  loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule),
+  data: { preload: true }
+}
+```
+
+This ensures that the module is downloaded in the background after the main app loads, improving navigation speed without blocking initial load.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "webdriver-set-version": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",
     "generate-yml": "cd $(git rev-parse --show-toplevel)/docker;./generate_yml.sh",
     "starthub-true": "echo \"true\" > /srv/starthub",
-    "starthub-false": "echo \"false\" > /srv/starthub"
+    "starthub-false": "echo \"false\" > /srv/starthub",
+    "analyze": "ng build --stats-json && webpack-bundle-analyzer dist/stats.json -m static -r report.html"
   },
   "private": true,
   "dependencies": {
@@ -98,6 +99,7 @@
     "request-promise": "^4.2.5",
     "sass-lint": "^1.13.1",
     "ts-node": "~8.5.4",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "webpack-bundle-analyzer": "^5.2.0"
   }
 }

--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -6,6 +6,7 @@ import { AuthService } from './shared/auth-guard.service';
 import { HomeComponent } from './home/home.component';
 import { UserGuard } from './shared/user-guard.service';
 import { UnsavedChangesGuard } from './shared/unsaved-changes.guard';
+import { SelectedPreloadingStrategy } from './shared/selected-preloading-strategy';
 
 const routes: Routes = [
   {
@@ -20,7 +21,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [ RouterModule.forRoot(routes, {}) ],
+  imports: [ RouterModule.forRoot(routes, { preloadingStrategy: SelectedPreloadingStrategy }) ],
   exports: [ RouterModule ]
 })
 export class AppRoutingModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { AppRoutingModule } from './app-router.module';
+import { SelectedPreloadingStrategy } from './shared/selected-preloading-strategy';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ImageCropperModule } from 'ngx-image-cropper';
@@ -31,6 +32,7 @@ import { FullCalendarModule } from '@fullcalendar/angular';
   declarations: [
     AppComponent, PageNotFoundComponent
   ],
+  providers: [ SelectedPreloadingStrategy ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {}

--- a/src/app/courses/courses.module.ts
+++ b/src/app/courses/courses.module.ts
@@ -11,7 +11,7 @@ import { MaterialModule } from '../shared/material.module';
 import { CoursesViewComponent } from './view-courses/courses-view.component';
 import { CoursesStepComponent } from './add-courses/courses-step.component';
 import { CoursesStepViewComponent } from './step-view-courses/courses-step-view.component';
-import { ResourcesModule } from '../resources/resources.module';
+import { ResourcesSharedModule } from '../resources/resources-shared.module';
 import { ExamsModule } from '../exams/exams.module';
 import { CoursesProgressLeaderComponent } from './progress-courses/courses-progress-leader.component';
 import { CoursesProgressBarComponent } from './progress-courses/courses-progress-bar.component';
@@ -36,7 +36,7 @@ import { ChatModule } from '../chat/chat.module';
     PlanetFormsModule,
     PlanetDialogsModule,
     MaterialModule,
-    ResourcesModule,
+    ResourcesSharedModule,
     ExamsModule,
     SharedComponentsModule,
     DialogsAddResourcesModule,

--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -24,11 +24,11 @@ const alwaysGuardedRoutes = [
   {
     path: 'manager',
     loadChildren: () => import('../manager-dashboard/manager-dashboard.module').then(m => m.ManagerDashboardModule),
-    data: { roles: [ '_admin' ] }
+    data: { roles: [ '_admin' ], preload: true }
   },
-  { path: 'courses', loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule) },
+  { path: 'courses', loadChildren: () => import('../courses/courses.module').then(m => m.CoursesModule), data: { preload: true } },
   { path: 'feedback', loadChildren: () => import('../feedback/feedback.module').then(m => m.FeedbackModule) },
-  { path: 'resources', loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule) },
+  { path: 'resources', loadChildren: () => import('../resources/resources.module').then(m => m.ResourcesModule), data: { preload: true } },
   { path: 'chat', loadChildren: () => import('../chat/chat.module').then(m => m.ChatModule) },
   { path: 'meetups', loadChildren: () => import('../meetups/meetups.module').then(m => m.MeetupsModule) },
   { path: 'notifications', component: NotificationsComponent },

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -43,7 +43,6 @@ import { SurveysModule } from '../surveys/surveys.module';
     TeamsModule,
     PlanetCalendarModule,
     UsersModule,
-    CoursesViewDetailModule,
     ChatModule,
     SurveysModule
   ],

--- a/src/app/resources/resources-shared.module.ts
+++ b/src/app/resources/resources-shared.module.ts
@@ -2,14 +2,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PlanetFormsModule } from '../shared/forms/planet-forms.module';
-import { ResourcesComponent } from './resources.component';
-import { ResourcesViewComponent } from './view-resources/resources-view.component';
-import { ResourcesRouterModule } from './resources-router.module';
 import { MaterialModule } from '../shared/material.module';
 import { HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
-import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
-import { ResourcesSharedModule } from './resources-shared.module';
+
+import { ResourcesViewerComponent } from './view-resources/resources-viewer.component';
+import { ResourcesAddComponent } from './resources-add.component';
+import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search-resources/resources-search.component';
 
 @NgModule({
   imports: [
@@ -17,18 +16,22 @@ import { ResourcesSharedModule } from './resources-shared.module';
     FormsModule,
     ReactiveFormsModule,
     PlanetFormsModule,
-    ResourcesRouterModule,
     MaterialModule,
     HttpClientModule,
     HttpClientJsonpModule,
-    PlanetDialogsModule,
-    SharedComponentsModule,
-    ResourcesSharedModule
+    SharedComponentsModule
   ],
   declarations: [
-    ResourcesComponent,
-    ResourcesViewComponent
+    ResourcesViewerComponent,
+    ResourcesAddComponent,
+    ResourcesSearchComponent,
+    ResourcesSearchListComponent
   ],
-  exports: [ ResourcesComponent ]
+  exports: [
+    ResourcesViewerComponent,
+    ResourcesAddComponent,
+    ResourcesSearchComponent,
+    ResourcesSearchListComponent
+  ]
 })
-export class ResourcesModule {}
+export class ResourcesSharedModule {}

--- a/src/app/shared/dialogs/dialogs-add-resources.module.ts
+++ b/src/app/shared/dialogs/dialogs-add-resources.module.ts
@@ -1,7 +1,7 @@
 import { MaterialModule } from '../material.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ResourcesModule } from '../../resources/resources.module';
+import { ResourcesSharedModule } from '../../resources/resources-shared.module';
 import { DialogsAddResourcesComponent } from './dialogs-add-resources.component';
 
 
@@ -9,7 +9,7 @@ import { DialogsAddResourcesComponent } from './dialogs-add-resources.component'
   imports: [
     CommonModule,
     MaterialModule,
-    ResourcesModule
+    ResourcesSharedModule
   ],
   exports: [
     DialogsAddResourcesComponent

--- a/src/app/shared/dialogs/dialogs-resources-viewer.module.ts
+++ b/src/app/shared/dialogs/dialogs-resources-viewer.module.ts
@@ -1,7 +1,7 @@
 import { MaterialModule } from '../material.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ResourcesModule } from '../../resources/resources.module';
+import { ResourcesSharedModule } from '../../resources/resources-shared.module';
 import { DialogsResourcesViewerComponent } from './dialogs-resources-viewer.component';
 
 
@@ -9,7 +9,7 @@ import { DialogsResourcesViewerComponent } from './dialogs-resources-viewer.comp
   imports: [
     CommonModule,
     MaterialModule,
-    ResourcesModule
+    ResourcesSharedModule
   ],
   exports: [
     DialogsResourcesViewerComponent

--- a/src/app/shared/selected-preloading-strategy.ts
+++ b/src/app/shared/selected-preloading-strategy.ts
@@ -1,0 +1,14 @@
+import { PreloadingStrategy, Route } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class SelectedPreloadingStrategy implements PreloadingStrategy {
+  preload(route: Route, load: () => Observable<any>): Observable<any> {
+    if (route.data && route.data['preload']) {
+      return load();
+    } else {
+      return of(null);
+    }
+  }
+}


### PR DESCRIPTION
- Configure lazy loading for `courses`, `resources`, and `manager-dashboard` modules in `HomeRouterModule` with `preload: true`.
- Implement `SelectedPreloadingStrategy` to support selective preloading of lazy routes.
- Refactor `ResourcesModule` to extract `ResourcesSharedModule` (containing `ResourcesViewerComponent`, `ResourcesAddComponent`, etc.) to resolve circular dependencies and prevent eager loading when imported by other modules (e.g., `CoursesModule`).
- Update `CoursesModule` and `DialogsAddResourcesModule` to import `ResourcesSharedModule` instead of `ResourcesModule`.
- Remove unused `CoursesViewDetailModule` from `HomeModule` imports.
- Add `LAZY_LOADING.md` documentation.
- Add `analyze` script to `package.json` for bundle analysis.

---
https://jules.google.com/session/10797508676261830925