### PR TITLE
Refactor hardcoded colors to use Material theme system

### DIFF
--- a/src/app/manager-dashboard/manager-fetch.component.ts
+++ b/src/app/manager-dashboard/manager-fetch.component.ts
@@ -23,7 +23,7 @@ import { PlanetMessageService } from '../shared/planet-message.service';
       max-width: 150px;
     }
     .fetch-icon {
-      color: #666;
+      color: var(--grey-text-color, #666);
     }
   ` ]
 })

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -9,7 +9,7 @@ import type { Chart as ChartJs, ChartConfiguration } from 'chart.js';
 import { loadChart } from '../../shared/chart-utils';
 import { ReportsService } from './reports.service';
 import { StateService } from '../../shared/state.service';
-import { styleVariables, formatDate } from '../../shared/utils';
+import { styleVariables, formatDate, getThemeColor } from '../../shared/utils';
 import { DialogsLoadingService } from '../../shared/dialogs/dialogs-loading.service';
 import { CsvService } from '../../shared/csv.service';
 import { DialogsFormService } from '../../shared/dialogs/dialogs-form.service';
@@ -998,7 +998,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     tempCanvas.height = canvas.height;
     const ctx = tempCanvas.getContext('2d');
 
-    ctx.fillStyle = '#ffffff';
+    ctx.fillStyle = getThemeColor('--white-color') || '#ffffff';
     ctx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
     ctx.drawImage(canvas, 0, 0);
 

--- a/src/app/resources/view-resources/resources-viewer.component.html
+++ b/src/app/resources/view-resources/resources-viewer.component.html
@@ -8,7 +8,7 @@
   </audio>
   <div *ngSwitchCase="'pdf'" style="position: relative;">
     <div class="pdf-toolbar">
-      <button mat-icon-button style="color: white" (click)="openFullscreen()">
+      <button mat-icon-button class="text-white" (click)="openFullscreen()">
         <mat-icon>fullscreen</mat-icon>
       </button>
     </div>

--- a/src/app/shared/chart-utils.ts
+++ b/src/app/shared/chart-utils.ts
@@ -1,3 +1,5 @@
+import { getThemeColor } from './utils';
+
 type ChartJsModule = typeof import('chart.js');
 type RegisterableKey = 'ArcElement' | 'BarController' | 'BarElement' | 'CategoryScale' | 'DoughnutController'
   | 'Legend' | 'LinearScale' | 'Title' | 'Tooltip' | 'LineController' | 'PointElement' | 'LineElement';
@@ -46,7 +48,7 @@ export function createChartCanvas(width = 300, height = 400): { canvas: HTMLCanv
 }
 
 export function renderNoDataPlaceholder(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, message = 'No data available'): string {
-  ctx.fillStyle = '#666666';
+  ctx.fillStyle = getThemeColor('--grey-color') || '#666666';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.font = '16px sans-serif';
@@ -54,7 +56,19 @@ export function renderNoDataPlaceholder(ctx: CanvasRenderingContext2D, canvas: H
   return canvas.toDataURL('image/png');
 }
 
-export const CHART_COLORS = [
-  '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF',
-  '#FF9F40', '#C9CBCF', '#8DD4F2', '#A8E6CF', '#DCE775'
-];
+export function getChartColors(): string[] {
+  return [
+    getThemeColor('--chart-color-1') || '#FF6384',
+    getThemeColor('--chart-color-2') || '#36A2EB',
+    getThemeColor('--chart-color-3') || '#FFCE56',
+    getThemeColor('--chart-color-4') || '#4BC0C0',
+    getThemeColor('--chart-color-5') || '#9966FF',
+    getThemeColor('--chart-color-6') || '#FF9F40',
+    getThemeColor('--chart-color-7') || '#C9CBCF',
+    getThemeColor('--chart-color-8') || '#8DD4F2',
+    getThemeColor('--chart-color-9') || '#A8E6CF',
+    getThemeColor('--chart-color-10') || '#DCE775'
+  ];
+}
+
+export const CHART_COLORS = getChartColors();

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -35,17 +35,24 @@ export const findByIdInArray = (array = [], id: string) => array.find(item => it
  * See https://github.com/angular/angular-cli/issues/23273
  */
 
+export const getThemeColor = (variableName: string): string => {
+  if (typeof getComputedStyle === 'undefined') {
+    return '';
+  }
+  return getComputedStyle(document.documentElement).getPropertyValue(variableName).trim();
+};
+
 export const styleVariables: any = {
-  primary: '#2196f3',
-  primaryLighter: '#bbdefb',
-  primaryText: 'white',
-  accent: '#ffc107',
-  accentLighter: '#ffecb3',
-  accentText: 'rgba(0, 0, 0, 0.87)',
-  grey: '#bdbdbd',
-  greyText: 'rgba(0, 0, 0, 0.54)',
-  lightGrey: 'whitesmoke'
-};;
+  get primary() { return getThemeColor('--primary-color') || '#2196f3'; },
+  get primaryLighter() { return getThemeColor('--primary-lighter-color') || '#bbdefb'; },
+  get primaryText() { return getThemeColor('--primary-text-color') || 'white'; },
+  get accent() { return getThemeColor('--accent-color') || '#ffc107'; },
+  get accentLighter() { return getThemeColor('--accent-lighter-color') || '#ffecb3'; },
+  get accentText() { return getThemeColor('--accent-text-color') || 'rgba(0, 0, 0, 0.87)'; },
+  get grey() { return getThemeColor('--grey-color') || '#bdbdbd'; },
+  get greyText() { return getThemeColor('--grey-text-color') || 'rgba(0, 0, 0, 0.54)'; },
+  get lightGrey() { return getThemeColor('--light-grey-color') || 'whitesmoke'; }
+};
 
 export const filterById = (array = [], id: string) => array.filter(item => item._id !== id);
 

--- a/src/planet-mat-theme.scss
+++ b/src/planet-mat-theme.scss
@@ -67,3 +67,27 @@ $accent-map: (
 .mat-mdc-raised-button[color="primary"][disabled] {
   pointer-events: none;
 }
+
+:root {
+  --primary-color: #{$primary};
+  --primary-lighter-color: #{$primary-lighter};
+  --primary-text-color: #{$primary-text};
+  --accent-color: #{$accent};
+  --accent-lighter-color: #{$accent-lighter};
+  --accent-text-color: #{$accent-text};
+  --warn-color: #{$warn};
+  --grey-color: #{$grey};
+  --grey-text-color: #{$grey-text};
+  --light-grey-color: #{$light-grey};
+  --white-color: #{$white};
+  --chart-color-1: #FF6384;
+  --chart-color-2: #36A2EB;
+  --chart-color-3: #FFCE56;
+  --chart-color-4: #4BC0C0;
+  --chart-color-5: #9966FF;
+  --chart-color-6: #FF9F40;
+  --chart-color-7: #C9CBCF;
+  --chart-color-8: #8DD4F2;
+  --chart-color-9: #A8E6CF;
+  --chart-color-10: #DCE775;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -739,3 +739,7 @@ body {
   }
 
 }
+
+.text-white {
+  color: white !important;
+}


### PR DESCRIPTION
- Defined CSS custom properties for theme colors in `src/planet-mat-theme.scss`.
- Refactored `src/app/shared/utils.ts` to use `getThemeColor` for `styleVariables`.
- Updated `src/app/shared/chart-utils.ts` to use theme variables for chart colors and no-data placeholder.
- Replaced inline style in `src/app/resources/view-resources/resources-viewer.component.html` with `.text-white` class.
- Replaced hardcoded colors in `src/app/manager-dashboard/reports/reports-detail.component.ts` and `src/app/manager-dashboard/manager-fetch.component.ts` with theme variables.
- Verified changes with linting and manual code inspection.

---
https://jules.google.com/session/9304652404821053992