### PR TITLE
all: smoother slide toggle radio material handling (connects #9166)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.47",
+  "version": "0.21.48",
   "myplanet": {
     "latest": "v0.46.0",
     "min": "v0.37.60"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.35",
+  "version": "0.21.47",
   "myplanet": {
-    "latest": "v0.44.82",
+    "latest": "v0.46.0",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -16,7 +16,7 @@ import { DialogField, DialogsFormData } from './dialogs-form.service';
       margin: 0 0 20px 0;
     }
 
-    .mat-radio-group.ng-touched.ng-invalid label {
+    .mat-mdc-radio-group.ng-touched.ng-invalid label {
       border-bottom: 2px solid red;
     }
 

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -22,7 +22,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatStepperModule } from '@angular/material/stepper';

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -19,7 +19,7 @@ import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-m
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
+import { MatRadioModule } from '@angular/material/radio';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';


### PR DESCRIPTION
Connects #9166

Migrate the `slide toggle` component to mdc spec

<img width="484" height="240" alt="image" src="https://github.com/user-attachments/assets/7608b4e3-3ecb-4502-be96-9c25d9adac36" />


Additionally, migrate the `radio` component

<img width="1356" height="817" alt="image" src="https://github.com/user-attachments/assets/0f7ebc08-fd5c-46d7-bfdf-e4517a258035" />

