### PR TITLE
teams: smoother finances transacting (fixes #9531)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.35",
+  "version": "0.21.36",
   "myplanet": {
-    "latest": "v0.44.82",
+    "latest": "v0.45.0",
     "min": "v0.37.60"
   },
   "scripts": {

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -1,8 +1,8 @@
 <div class="action-buttons">
   <div class="transaction-buttons">
     <button mat-raised-button color="primary" i18n (click)="openEditTransactionDialog()" *ngIf="editable">Add Transaction</button>
-    <button mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
-    <button mat-raised-button color="accent"  i18n (click)="exportTableData()" *ngIf="!emptyTable">Export Transactions</button>
+    <button *ngIf="startDate && endDate" mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
+    <button *ngIf="startDate && endDate && !emptyTable" mat-raised-button color="accent" i18n (click)="exportTableData()">Export Transactions</button>
   </div>
   <div class="transaction-date-fields">
     <mat-form-field>

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -1,7 +1,7 @@
 <div class="action-buttons">
   <div class="transaction-buttons">
     <button mat-raised-button color="primary" i18n (click)="openEditTransactionDialog()" *ngIf="editable">Add Transaction</button>
-    <button *ngIf="startDate && endDate" mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
+    <button *ngIf="startDate || endDate" mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
     <button mat-raised-button color="accent" i18n (click)="exportTableData()" *ngIf="!emptyTable">Export Transactions</button>
   </div>
   <div class="transaction-date-fields">

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -2,7 +2,7 @@
   <div class="transaction-buttons">
     <button mat-raised-button color="primary" i18n (click)="openEditTransactionDialog()" *ngIf="editable">Add Transaction</button>
     <button *ngIf="startDate && endDate" mat-raised-button color="primary" i18n (click)="resetDateFilter()" [disabled]="table.filter === ''">View All Transactions</button>
-    <button *ngIf="startDate && endDate && !emptyTable" mat-raised-button color="accent" i18n (click)="exportTableData()">Export Transactions</button>
+    <button mat-raised-button color="accent" i18n (click)="exportTableData()" *ngIf="!emptyTable">Export Transactions</button>
   </div>
   <div class="transaction-date-fields">
     <mat-form-field>


### PR DESCRIPTION
### Description
This PR addresses issue #9531 by conditionally hiding the "View All Transactions" button on the Finances dashboard until a valid date range is selected.

### Changes
- **Conditional Visibility**: Added `*ngIf="startDate && endDate"` to the "View All Transactions" button in `teams-view-finances.component.html`.


### Verification
- [x] "View All Transactions" button is hidden on initial page load.
- [x] "View All Transactions" button appears only when both "Pick Start Date" and "Pick End Date" are populated.

### Screenshots
After fix, button hidden on initial page:
<img width="1307" height="665" alt="view all button hidden" src="https://github.com/user-attachments/assets/2c20148e-6810-40cf-8737-5c22fe85ccd3" />


Button enabled when date range is selected:
<img width="1265" height="667" alt="view all button enabled when selecting dates" src="https://github.com/user-attachments/assets/afabac34-53cd-4037-b674-dbe6890ce452" />
