### PR TITLE
e2e: convert userHandler to ES module export

### DIFF
--- a/e2e/userHandler.ts
+++ b/e2e/userHandler.ts
@@ -1,6 +1,6 @@
-const rp = require('request-promise');
+import * as rp from 'request-promise';
 
-module.exports = function(timeStamp) {
+export default function userHandler(timeStamp: string) {
   const user = 'e2e_' + timeStamp;
 
   return {
@@ -28,4 +28,4 @@ module.exports = function(timeStamp) {
       });
     }
   };
-};
+}


### PR DESCRIPTION
### Motivation
- Migrate the e2e user helper from CommonJS to ES module syntax to align with TypeScript imports/exports and modern module usage.

### Description
- Replace `const rp = require('request-promise')` with `import * as rp from 'request-promise'` and change `module.exports = function(...)` to `export default function userHandler(timeStamp: string)` while preserving the existing helper functionality.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69792c620cbc832dbe8ef5fe85f5f4b6)