### PR TITLE
Fix chart action buttons enabled state logic

### DIFF
--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -104,10 +104,10 @@
 <ng-template #chartWithActions let-chartId="chartId">
   <div class="chart-wrapper">
     <div class="chart-actions">
-      <button mat-icon-button (click)="downloadChart(chartId)" [disabled]="charts.length === 0" matTooltip="Download as image" i18n-matTooltip>
+      <button mat-icon-button (click)="downloadChart(chartId)" [disabled]="!isChartReady(chartId)" matTooltip="Download as image" i18n-matTooltip>
         <mat-icon>get_app</mat-icon>
       </button>
-      <button mat-icon-button (click)="copyChartToClipboard(chartId)" [disabled]="charts.length === 0" matTooltip="Copy to clipboard" i18n-matTooltip>
+      <button mat-icon-button (click)="copyChartToClipboard(chartId)" [disabled]="!isChartReady(chartId)" matTooltip="Copy to clipboard" i18n-matTooltip>
         <mat-icon>content_copy</mat-icon>
       </button>
     </div>

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -985,6 +985,10 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     });
   }
 
+  isChartReady(chartId: string): boolean {
+    return !!this.charts.find(chart => chart.canvas.id === chartId);
+  }
+
   private getChartAsCanvas(chartId: string): HTMLCanvasElement {
     const chart = this.charts.find(c => c.canvas.id === chartId);
     if (!chart) {


### PR DESCRIPTION
Fixes a bug where chart action buttons are clickable when the data is not yet ready. The fix involves checking for the existence of the specific chart by ID instead of checking if any chart exists.

---
*PR created automatically by Jules for task [14921036252108764922](https://jules.google.com/task/14921036252108764922) started by @uj-sxn*