### PR TITLE
manager: smoother reports charting (fixes #9529)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.44",
+  "version": "0.21.46",
   "myplanet": {
     "latest": "v0.45.74",
     "min": "v0.37.60"

--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -104,10 +104,10 @@
 <ng-template #chartWithActions let-chartId="chartId">
   <div class="chart-wrapper">
     <div class="chart-actions">
-      <button mat-icon-button (click)="downloadChart(chartId)" [disabled]="!hasChartData(chartId)" matTooltip="Download as image" i18n-matTooltip>
+      <button mat-icon-button (click)="downloadChart(chartId)" [disabled]="!hasNonZeroChartData(chartId)" matTooltip="Download as image" i18n-matTooltip>
         <mat-icon>get_app</mat-icon>
       </button>
-      <button mat-icon-button (click)="copyChartToClipboard(chartId)" [disabled]="!hasChartData(chartId)" matTooltip="Copy to clipboard" i18n-matTooltip>
+      <button mat-icon-button (click)="copyChartToClipboard(chartId)" [disabled]="!hasNonZeroChartData(chartId)" matTooltip="Copy to clipboard" i18n-matTooltip>
         <mat-icon>content_copy</mat-icon>
       </button>
     </div>

--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -104,10 +104,10 @@
 <ng-template #chartWithActions let-chartId="chartId">
   <div class="chart-wrapper">
     <div class="chart-actions">
-      <button mat-icon-button (click)="downloadChart(chartId)" [disabled]="charts.length === 0" matTooltip="Download as image" i18n-matTooltip>
+      <button mat-icon-button (click)="downloadChart(chartId)" [disabled]="!hasChartData(chartId)" matTooltip="Download as image" i18n-matTooltip>
         <mat-icon>get_app</mat-icon>
       </button>
-      <button mat-icon-button (click)="copyChartToClipboard(chartId)" [disabled]="charts.length === 0" matTooltip="Copy to clipboard" i18n-matTooltip>
+      <button mat-icon-button (click)="copyChartToClipboard(chartId)" [disabled]="!hasChartData(chartId)" matTooltip="Copy to clipboard" i18n-matTooltip>
         <mat-icon>content_copy</mat-icon>
       </button>
     </div>

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -1023,18 +1023,26 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     link.click();
   }
 
-  hasChartData(chartId: string): boolean {
+  hasNonZeroChartData(chartId: string): boolean {
     const chart = this.charts.find(c => c.canvas.id === chartId);
     if (!chart) { return false; }
     const datasets: any[] = (chart.data && (chart.data as any).datasets) || [];
     if (!datasets.length) { return false; }
-    for (const ds of datasets) {
+    return datasets.some(ds => {
       const dataArr = Array.isArray(ds.data) ? ds.data : [];
-      if (dataArr.some(v => (typeof v === 'number' && v > 0) || (v && typeof v === 'object' && (v.y > 0 || v.v > 0)))) {
-        return true;
-      }
+      return dataArr.some(v => {
+        const val = this.getChartPointValue(v);
+        return val !== undefined && val !== 0;
+      });
+    });
+  }
+
+  private getChartPointValue(value: any): number | undefined {
+    if (value && typeof value === 'object') {
+      const val = value.y ?? value.v;
+      return typeof val === 'number' ? val : undefined;
     }
-    return false;
+    return typeof value === 'number' ? value : undefined;
   }
 
   async copyChartToClipboard(chartId: string) {

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -1015,6 +1015,20 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     link.click();
   }
 
+  hasChartData(chartId: string): boolean {
+    const chart = this.charts.find(c => c.canvas.id === chartId);
+    if (!chart) { return false; }
+    const datasets: any[] = (chart.data && (chart.data as any).datasets) || [];
+    if (!datasets.length) { return false; }
+    for (const ds of datasets) {
+      const dataArr = Array.isArray(ds.data) ? ds.data : [];
+      if (dataArr.some(v => (typeof v === 'number' && v > 0) || (v && typeof v === 'object' && (v.y > 0 || v.v > 0)))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   async copyChartToClipboard(chartId: string) {
     const canvas = this.getChartAsCanvas(chartId);
     const blob = await new Promise<Blob>((resolve) => {


### PR DESCRIPTION
Thie PR addresses Issue #9529 where the action buttons such as 'copy to clipboard' and 'download' remain disabled if the chart is empty. This prevent users from downloading or copying empty charts (avoids exporting blank images).

Changes implemented:
- In reports-detail.component.ts, Added: hasChartData() helper: checks a chart's datasets for meaningful (>0) values
- In report-detail.component.html Updated: Chart action buttons now use the guard and are disabled when the chart has no data

Screenshots:
Before:
<img width="1904" height="768" alt="image" src="https://github.com/user-attachments/assets/189740ff-e4b7-4419-9d92-cde6f72b55d1" />

After:
<img width="1886" height="692" alt="image" src="https://github.com/user-attachments/assets/20dc3130-2f34-4cea-babd-016fddcad173" />
