### PR TITLE
Remove unused protractor.defer in onPrepare

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -26,17 +26,13 @@ exports.config = {
     print: function() {}
   },
   onPrepare() {
-    var defer = protractor.promise.defer();
     require('ts-node').register({
       project: './e2e/tsconfig.e2e.json'
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
     browser.params.user = user.get();
 
-    return user.create().then(function(res) {
-      defer.fulfill();
-    })
-    .catch(function(err) {
+    return user.create().catch(function(err) {
       console.log(err);
     });
   },


### PR DESCRIPTION
### Motivation
- Remove an unused manual `protractor.promise.defer()` and `defer.fulfill()` to simplify `onPrepare()` while preserving the `user.create()` async flow.

### Description
- Deleted the `var defer = protractor.promise.defer();` declaration and removed the `defer.fulfill()` usage so `onPrepare()` now returns the `user.create()` promise directly and still logs errors via `.catch()`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bc4b9fc0832da5e2e5eb2196281c)