### PR TITLE
Fix deferred promise handling in onPrepare

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -27,18 +27,21 @@ exports.config = {
   },
   onPrepare() {
     var defer = protractor.promise.defer();
+    // Protractor may require an explicit deferred promise to keep onPrepare waiting.
     require('ts-node').register({
       project: './e2e/tsconfig.e2e.json'
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
     browser.params.user = user.get();
 
-    return user.create().then(function(res) {
+    user.create().then(function(res) {
       defer.fulfill();
     })
     .catch(function(err) {
       console.log(err);
+      defer.reject(err);
     });
+    return defer.promise;
   },
   onComplete() {
     return user.delete().then(function(res) {


### PR DESCRIPTION
### Motivation
- Ensure Protractor's `onPrepare()` waits correctly by using an explicit deferred promise and avoid mixing deferred and returned promises which can hang test runs.

### Description
- Return the manual deferred promise from `onPrepare`, add a short comment explaining why the deferred is needed, and wire `defer.fulfill()`/`defer.reject()` to the `user.create()` success/failure paths instead of returning `user.create()` directly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bc4bfc28832d9db7dd7872b00b3f)