### PR TITLE
Simplify Protractor promise handlers in protractor.conf.js

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -26,22 +26,20 @@ exports.config = {
     print: function() {}
   },
   onPrepare() {
-    var defer = protractor.promise.defer();
     require('ts-node').register({
       project: './e2e/tsconfig.e2e.json'
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
     browser.params.user = user.get();
 
-    return user.create().then(function(res) {
-      defer.fulfill();
+    return user.create().then(function() {
     })
     .catch(function(err) {
       console.log(err);
     });
   },
   onComplete() {
-    return user.delete().then(function(res) {
+    return user.delete().then(function() {
       console.log('Completed tests and removed new user: ' + user.get());
     })
     .catch(function(err) {


### PR DESCRIPTION
### Motivation
- Simplify the async setup/teardown flow in `protractor.conf.js` by removing unused promise machinery and unused callback parameters.

### Description
- Removed the unused `var defer = protractor.promise.defer();` declaration and the `defer.fulfill()` call, and removed unused `res` arguments from the `.then(...)` callbacks in both `onPrepare()` and `onComplete()` while keeping the returned `user.create()`/`user.delete()` promise chains intact.

### Testing
- Ran `node -c protractor.conf.js` to verify the file parses correctly, and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9e371a18832dbe1ae76b2249fe7b)