### PR TITLE
Add checked-in Angular dev environment file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ planet.yml
 
 # Dev environment
 environment.dev.ts
+
+!src/environments/environment.dev.ts

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,0 +1,11 @@
+export const environment = {
+  production: false,
+  test: false,
+  chatAddress: window.location.protocol + '//' + window.location.hostname + ':5000',
+  couchAddress: window.location.protocol + '//' + window.location.hostname + ':2200',
+  centerAddress: 'planet.earth.ole.org/db',
+  centerProtocol: 'https',
+  parentProtocol: 'https',
+  upgradeAddress: window.location.origin + '/upgrade',
+  syncAddress: window.location.protocol + '//localhost:5984'
+};


### PR DESCRIPTION
### Motivation
- Provide a concrete, committed dev environment file so local `dev` builds have defined endpoints/flags and the app does not rely on a templating step at runtime. 
- Ensure the dev environment uses the same key shape as other environments to avoid runtime type/shape drift.

### Description
- Added `src/environments/environment.dev.ts` with the required keys (`production`, `test`, `chatAddress`, `couchAddress`, `centerAddress`, `centerProtocol`, `parentProtocol`, `upgradeAddress`, `syncAddress`) and sensible local defaults for chat/couch endpoints. 
- Updated `.gitignore` to keep the generic `environment.dev.ts` ignore rule while explicitly allowing `src/environments/environment.dev.ts` to be tracked. 
- Verified that `angular.json` `build.configurations.dev.fileReplacements` remains unchanged and still maps `src/environments/environment.ts` to `src/environments/environment.dev.ts`. 

### Testing
- Ran a key-shape check with `python - <<'PY' ...` to extract environment object keys from each environment file and confirmed `environment.dev.ts` matches the expected key set, which succeeded. 
- Confirmed the dev file replacement is present by running `rg -n "\"dev\"|environment.dev.ts|fileReplacements" angular.json` and inspecting the `dev` configuration, which returned the mapping to `src/environments/environment.dev.ts`. 
- Inspected the new file with `nl -ba src/environments/environment.dev.ts` to verify contents and confirmed success; noted that `src/environments/environment.test.ts` currently does not include `chatAddress` (left unchanged by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9e2c50d0832d9da31537c882ebaa)