### PR TITLE
Remove unused deferred promise from Protractor onPrepare

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -26,7 +26,6 @@ exports.config = {
     print: function() {}
   },
   onPrepare() {
-    var defer = protractor.promise.defer();
     require('ts-node').register({
       project: './e2e/tsconfig.e2e.json'
     });
@@ -34,7 +33,7 @@ exports.config = {
     browser.params.user = user.get();
 
     return user.create().then(function(res) {
-      defer.fulfill();
+      return res;
     })
     .catch(function(err) {
       console.log(err);


### PR DESCRIPTION
### Motivation
- Remove unused `protractor.promise.defer()` and `defer.fulfill()` from `onPrepare` since the deferred value was never awaited and `onPrepare` can return the `user.create()` promise directly.

### Description
- Deleted the `var defer = protractor.promise.defer();` line and removed the `defer.fulfill();` call, and updated the `.then` handler to `return res;` so `onPrepare` returns the `user.create()` promise chain directly.

### Testing
- Ran `node --check protractor.conf.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9e19d7d8832d8b8ed61abcf06c42)