### PR TITLE
Remove deprecated assistant-mode payload handling

### DIFF
--- a/chatapi/README.md
+++ b/chatapi/README.md
@@ -66,7 +66,6 @@ If you are using an 32bit arm device and encounter a fatal error while running t
     "data": {
       "user": "admin",
       "content": "Hello",
-      "assistant": false,
       "context": "",
       "aiProvider": {
         "name": "openai",
@@ -81,7 +80,7 @@ If you are using an 32bit arm device and encounter a fatal error while running t
   Additional info on data:
   - **user**: string(required) -> Provide the planet/myPlanet username
   - **content**: string(required) -> The latest prompt for the AI to answer
-  - **assistant**: boolean(required) -> Set to true if you want to use the assistants endpoint
+  - **assistant**: deprecated/unsupported -> requests that include this flag are rejected with `400 Bad Request`
   - **context**: string(optional) -> The text context you would like to pre-load the AI Assistant   with
   - **aiProvider**: Object(required)
     - **name**: string(required) -> Name of the API provider to choose from i.e openai, perplexity, deepseek or gemini.

--- a/chatapi/src/services/chat.service.ts
+++ b/chatapi/src/services/chat.service.ts
@@ -47,7 +47,7 @@ export async function chat(data: any, stream?: boolean, callback?: (response: st
   messages.push({ 'role': 'user', content });
 
   try {
-    const completionText = await aiChat(messages, aiProvider, dbData.assistant, dbData.context, stream, callback);
+    const completionText = await aiChat(messages, aiProvider, dbData.context, stream, callback);
 
     dbData.conversations[dbData.conversations.length - 1].response = completionText;
 
@@ -68,7 +68,6 @@ export async function chat(data: any, stream?: boolean, callback?: (response: st
 export async function chatNoSave(
   content: any,
   aiProvider: AIProvider,
-  assistant: boolean,
   context?: any
 ): Promise<string | undefined> {
   const messages: ChatMessage[] = [];
@@ -76,7 +75,7 @@ export async function chatNoSave(
   messages.push({ 'role': 'user', content });
 
   try {
-    const completionText = await aiChat(messages, aiProvider, assistant, context);
+    const completionText = await aiChat(messages, aiProvider, context);
     return completionText;
   } catch (error: any) {
     handleChatError(error);

--- a/chatapi/src/utils/chat.utils.ts
+++ b/chatapi/src/utils/chat.utils.ts
@@ -4,14 +4,13 @@ import { AIProvider, ChatMessage } from '../models/chat.model';
 export async function aiChat(
   messages: ChatMessage[],
   aiProvider: AIProvider,
-  assistant: boolean,
   context?: any,
   stream?: boolean,
   callback?: (response: string) => void
 ): Promise<string> {
   if (stream) {
-    return await aiChatStream(messages, aiProvider, assistant, context, callback);
+    return await aiChatStream(messages, aiProvider, context, callback);
   } else {
-    return await aiChatNonStream(messages, aiProvider, assistant, context);
+    return await aiChatNonStream(messages, aiProvider, context);
   }
 }

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -37,7 +37,6 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     user: this.userService.get().name,
     content: '',
     aiProvider: { name: 'openai' },
-    assistant: true,
     context: '',
   };
   providers: AIProvider[] = [];
@@ -241,7 +240,6 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     this.setSelectedConversation();
 
     if (this.context) {
-      // this.data.assistant = true;
       this.data.context = this.context;
     }
 

--- a/src/app/chat/chat.model.ts
+++ b/src/app/chat/chat.model.ts
@@ -4,7 +4,6 @@ export interface ConversationForm {
   user: string;
   content: string;
   aiProvider: AIProvider;
-  assistant: boolean;
   context: string;
 }
 

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -795,8 +795,7 @@ export class SubmissionsService {
       response = await this.chatService.getPrompt(
         {
           content: surveyAnalysisPrompt(exam.type, exam.name, exam.description, payloadString),
-          aiProvider: { name: 'openai' },
-          assistant: false
+          aiProvider: { name: 'openai' }
         },
         false
       ).toPromise();


### PR DESCRIPTION
### Motivation
- Remove legacy "assistant mode" code paths and the `assistant` request flag to simplify chat handling and consolidate on standard chat completions flows. 
- Protect the API from accidental assistant-mode usage by making the request contract explicit: any payload including `assistant` should be rejected. 

### Description
- Deleted assistant-only branches and removed imports relying on the assistants API from `chatapi/src/utils/chat-helpers.utils.ts`, so streaming/non-streaming now always use regular chat completions. 
- Simplified the internal API surface by removing the `assistant` parameter from `aiChat` (`chatapi/src/utils/chat.utils.ts`) and from callers in `chatapi/src/services/chat.service.ts`. 
- Updated HTTP and WebSocket entrypoints in `chatapi/src/index.ts` to explicitly reject requests containing `data.assistant` with `400 Bad Request`. 
- Updated frontend types and callers to stop emitting the flag by removing `assistant` from `src/app/chat/chat.model.ts`, `src/app/chat/chat-window/chat-window.component.ts`, and from the AI analysis call in `src/app/submissions/submissions.service.ts`. 
- Updated `chatapi/README.md` to remove `assistant` from examples and mark it as deprecated/unsupported in the API contract. 

### Testing
- Attempted a TypeScript build for the chat API with `npm --prefix chatapi run build`, which could not complete in this environment because project dependencies/type declarations are not installed locally and the build failed with missing modules/type errors (examples: `openai`, `nano`, `express`, and Node type declarations).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699381e61bf0832d8370d0b38b8e8cb8)