### PR TITLE
chatapi: validate assistant mode and add integration tests

### DIFF
--- a/chatapi/package.json
+++ b/chatapi/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "dev": "nodemon --exec ts-node src/index.ts",
     "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint . --ext .ts --fix"
+    "lint-fix": "eslint . --ext .ts --fix",
+    "test:integration": "COUCHDB_HOST=http://localhost:5984 NODE_ENV=test tsx --test src/tests.chatapi.integration.test.ts"
   },
   "repository": {
     "type": "git",
@@ -47,6 +48,9 @@
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
     "eslint": "^8.43.0",
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "supertest": "^7.0.0",
+    "@types/supertest": "^6.0.3",
+    "tsx": "^4.19.2"
   }
 }

--- a/chatapi/src/tests.chatapi.integration.test.ts
+++ b/chatapi/src/tests.chatapi.integration.test.ts
@@ -1,0 +1,136 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+
+import { app } from './index';
+import { assistant, keys, models } from './config/ai-providers.config';
+
+async function waitForConfigurationInitialization() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+function setupStandardProviderResponse(responseText: string) {
+  models.openai = {
+    'defaultModel': 'gpt-test',
+    'ai': {
+      'chat': {
+        'completions': {
+          'create': async () => ({
+            'choices': [ { 'message': { 'content': responseText } } ]
+          })
+        }
+      }
+    }
+  };
+}
+
+test('assistant=false returns standard completion response', async () => {
+  await waitForConfigurationInitialization();
+  setupStandardProviderResponse('standard completion');
+  assistant.name = 'Test Assistant';
+  assistant.instructions = 'Provide helpful responses';
+
+  const response = await request(app)
+    .post('/')
+    .send({
+      'save': false,
+      'data': {
+        'content': 'Hello',
+        'aiProvider': { 'name': 'openai' },
+        'assistant': false,
+        'context': {}
+      }
+    });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.status, 'Success');
+  assert.equal(response.body.chat, 'standard completion');
+});
+
+test('assistant=true uses assistant thread/run flow', async () => {
+  await waitForConfigurationInitialization();
+
+  let createAssistantCalls = 0;
+  let createThreadCalls = 0;
+  let createRunCalls = 0;
+
+  setupStandardProviderResponse('unused');
+  assistant.name = 'Test Assistant';
+  assistant.instructions = 'Provide helpful responses';
+
+  keys.openai = {
+    'beta': {
+      'assistants': {
+        'create': async () => {
+          createAssistantCalls += 1;
+          return { 'id': 'asst_123' };
+        }
+      },
+      'threads': {
+        'create': async () => {
+          createThreadCalls += 1;
+          return { 'id': 'thread_123' };
+        },
+        'messages': {
+          'create': async () => ({ 'id': 'msg_123' }),
+          'list': async () => ({
+            'data': [
+              {
+                'role': 'assistant',
+                'content': [ { 'text': { 'value': 'assistant flow response' } } ]
+              }
+            ]
+          })
+        },
+        'runs': {
+          'create': async () => {
+            createRunCalls += 1;
+            return { 'id': 'run_123' };
+          },
+          'retrieve': async () => ({ 'status': 'completed' })
+        }
+      }
+    }
+  };
+
+  const response = await request(app)
+    .post('/')
+    .send({
+      'save': false,
+      'data': {
+        'content': 'Hello assistant',
+        'aiProvider': { 'name': 'openai' },
+        'assistant': true,
+        'context': { 'data': 'Additional context' }
+      }
+    });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.chat, 'assistant flow response');
+  assert.equal(createAssistantCalls, 1);
+  assert.equal(createThreadCalls, 1);
+  assert.equal(createRunCalls, 1);
+});
+
+test('assistant=true returns clear error when assistant config is missing', async () => {
+  await waitForConfigurationInitialization();
+  setupStandardProviderResponse('unused');
+  assistant.name = '';
+  assistant.instructions = '';
+
+  const response = await request(app)
+    .post('/')
+    .send({
+      'save': false,
+      'data': {
+        'content': 'Hello assistant',
+        'aiProvider': { 'name': 'openai' },
+        'assistant': true,
+        'context': { 'data': 'Additional context' }
+      }
+    });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'Bad Request');
+  assert.equal(response.body.message, 'Assistant mode requires assistant configuration with both "name" and "instructions"');
+});


### PR DESCRIPTION
### Motivation
- Formalize assistant vs standard completion branches by validating the `assistant` flag, provider support, and required assistant configuration before entering assistant flows.
- Improve API behavior by returning clear client errors when assistant configuration is missing or invalid instead of surfacing generic internal errors.

### Description
- Added `validateAssistantMode` and imported `assistant` config in `chatapi/src/utils/chat-helpers.utils.ts`, and invoked it from both streaming (`aiChatStream`) and non-stream (`aiChatNonStream`) paths to gate assistant logic.
- Added error classification in `chatapi/src/index.ts` via `isClientConfigError` to map assistant validation failures to HTTP `400 Bad Request` for both REST and WebSocket flows and exported the Express `app` while skipping `server.listen` under `NODE_ENV=test` to enable integration testing.
- Added integration tests in `chatapi/src/tests.chatapi.integration.test.ts` covering `assistant=false` standard completion, `assistant=true` assistant thread/run flow, and the clear `400` error when assistant configuration is missing, plus a `test:integration` script and test dependencies (`tsx`, `supertest`, `@types/supertest`).

### Testing
- Ran `npm run test:integration` in `chatapi` which executed the three integration cases and all passed.
- Built the TypeScript project with `npm run build` in `chatapi` which completed successfully.
- Ran lint with `npm run lint` in `chatapi` and fixed formatting issues so lint now succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699381e6d7d0832db3af1e34c0d514e0)