### PR TITLE
Add BetaThenAuth guard to earth route and unit tests for BetaThenAuthService

### DIFF
--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -12,6 +12,7 @@ import { myDashboardRoute } from './router-constants';
 import { CoursesProgressLearnerComponent } from '../courses/progress-courses/courses-progress-learner.component';
 import { NewsListComponent } from '../news/news-list.component';
 import { AuthService } from '../shared/auth-guard.service';
+import { BetaThenAuthService } from '../shared/beta-then-auth-guard-service';
 import { UnsavedChangesGuard } from '../shared/unsaved-changes.guard';
 
 export function dashboardPath(route): string {
@@ -41,7 +42,7 @@ const alwaysGuardedRoutes = [
     path: 'health/profile/:id',
     loadChildren: () => import('../health/health.module').then(m => m.HealthModule), data: { roles: [ '_admin', 'health' ] } },
   { path: 'nation', component: TeamsViewComponent, data: { mode: 'services' } },
-  { path: 'earth', component: TeamsViewComponent, data: { mode: 'services' } },
+  { path: 'earth', component: TeamsViewComponent, data: { mode: 'services' }, canActivate: [ BetaThenAuthService ] },
   { path: myDashboardRoute, component: DashboardComponent },
   {
     path: dashboardPath('mySurveys'),

--- a/src/app/shared/router/beta-then-auth-guard-service.spec.ts
+++ b/src/app/shared/router/beta-then-auth-guard-service.spec.ts
@@ -1,0 +1,73 @@
+import { Subject, of } from 'rxjs';
+
+import { AuthService } from '../auth-guard.service';
+import { BetaThenAuthService } from '../beta-then-auth-guard-service';
+import { StateService } from '../state.service';
+import { UserService } from '../user.service';
+
+describe('BetaThenAuthService', () => {
+  let authService: jasmine.SpyObj<AuthService>;
+  let userService: jasmine.SpyObj<UserService>;
+  let stateService: jasmine.SpyObj<StateService> & { configuration: any };
+  let guardService: BetaThenAuthService;
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj<AuthService>('AuthService', [ 'canActivateChild' ]);
+    userService = jasmine.createSpyObj<UserService>('UserService', [ 'isBetaEnabled' ]);
+    stateService = jasmine.createSpyObj<StateService>('StateService', [ 'couchStateListener' ]) as jasmine.SpyObj<StateService> & { configuration: any };
+    stateService.configuration = { _id: 'config-id' };
+
+    guardService = new BetaThenAuthService(authService, userService, stateService);
+  });
+
+  it('waits for config load before evaluating authentication', () => {
+    const route = {} as any;
+    const state = { url: '/earth' } as any;
+    const configLoaded$ = new Subject<any>();
+    stateService.configuration = {};
+    stateService.couchStateListener.and.returnValue(configLoaded$);
+    userService.isBetaEnabled.and.returnValue(false);
+    authService.canActivateChild.and.returnValue(of(true));
+
+    let activationResult: boolean | undefined;
+    guardService.canActivate(route, state).subscribe((result) => {
+      activationResult = result;
+    });
+
+    expect(stateService.couchStateListener).toHaveBeenCalledWith('configurations');
+    expect(authService.canActivateChild).not.toHaveBeenCalled();
+    expect(activationResult).toBeUndefined();
+
+    configLoaded$.next({ newData: {}, db: 'configurations', planetField: null, inProgress: false });
+
+    expect(authService.canActivateChild).toHaveBeenCalledWith(route, state);
+    expect(activationResult).toBe(true);
+  });
+
+  it('allows beta-enabled users without auth guard checks', () => {
+    userService.isBetaEnabled.and.returnValue(true);
+
+    let activationResult: boolean | undefined;
+    guardService.canActivate({} as any, {} as any).subscribe((result) => {
+      activationResult = result;
+    });
+
+    expect(activationResult).toBe(true);
+    expect(authService.canActivateChild).not.toHaveBeenCalled();
+  });
+
+  it('defers to auth guard for authenticated non-beta users', () => {
+    const route = {} as any;
+    const state = { url: '/earth' } as any;
+    userService.isBetaEnabled.and.returnValue(false);
+    authService.canActivateChild.and.returnValue(of(true));
+
+    let activationResult: boolean | undefined;
+    guardService.canActivate(route, state).subscribe((result) => {
+      activationResult = result;
+    });
+
+    expect(authService.canActivateChild).toHaveBeenCalledWith(route, state);
+    expect(activationResult).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Gate direct navigation to the `earth` route behind the beta-flow so the route is not reachable solely by UI visibility.
- Ensure `BetaThenAuthService.canActivate(...)` behaves correctly when configuration is not loaded, when a user is beta-enabled, and when a user is authenticated but not beta-enabled.

### Description
- Import and apply `BetaThenAuthService` in `src/app/home/home-router.module.ts` and add `canActivate: [ BetaThenAuthService ]` to the `earth` route.
- Add unit tests in `src/app/shared/router/beta-then-auth-guard-service.spec.ts` that cover: waiting for config load before evaluating auth, allowing beta-enabled users immediately, and deferring to `AuthService.canActivateChild(...)` for non-beta authenticated users.
- Use a `Subject<any>` to simulate `stateService.couchStateListener('configurations')` events in the config-not-yet-loaded test.

### Testing
- Attempted to run the focused spec with `node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/shared/router/beta-then-auth-guard-service.spec.ts`, but the test run was blocked by numerous pre-existing unrelated spec compile errors in the repo (legacy imports and stale specs).
- Per-file TypeScript transpile check for the new spec (`typescript.transpileModule` on `src/app/shared/router/beta-then-auth-guard-service.spec.ts`) completed successfully. 
- The new spec was run through a local transpile check and validated to compile, but a full `ng test` could not be completed due to unrelated suite failures in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699381de79f8832d828cc5d13866d63a)