### PR TITLE
Simplify dead branching in planet build scripts

### DIFF
--- a/docker/planet/scripts/build_planet.sh
+++ b/docker/planet/scripts/build_planet.sh
@@ -2,10 +2,6 @@
 
 build_single(){
   LANG=$1
-  LANG2=$2
-  if [ -z "${LANG}" ]; then
-    npm run ng-high-memory -- build --configuration production --aot --localize=true
-  else
-    npm run ng-high-memory -- build --configuration production --aot --localize=true
-  fi
+
+  npm run ng-high-memory -- build --configuration production --aot --localize=true
 }

--- a/docker/planet/scripts/compile_planet.sh
+++ b/docker/planet/scripts/compile_planet.sh
@@ -3,5 +3,4 @@
 . ./build_planet.sh
 
 echo "Build the angular app in production mode stage"
-build_single $LANG $LANG2
-
+build_single $LANG


### PR DESCRIPTION
### Motivation
- Remove dead `if/else` branching and an unused parameter to simplify the Angular build flow and align the function invocation between the build helper and its caller.

### Description
- Replaced the redundant conditional in `docker/planet/scripts/build_planet.sh` with a single unconditional `npm run ng-high-memory -- build --configuration production --aot --localize=true` inside `build_single`, removed the unused `LANG2` assignment, and updated `docker/planet/scripts/compile_planet.sh` to call `build_single $LANG` to match the streamlined function.

### Testing
- Ran syntax checks with `bash -n docker/planet/scripts/build_planet.sh` and `bash -n docker/planet/scripts/compile_planet.sh`, both completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699381d5d700832d8135f343fafce0e3)