### PR TITLE
community: clean up css class (fixes #9478)

### DIFF
--- a/src/app/community/community.component.html
+++ b/src/app/community/community.component.html
@@ -68,7 +68,7 @@
             <ng-template #noTeamDesc><p i18n>No description available.</p></ng-template>
           </ng-container>
           <ng-container *planetAuthorizedRoles="''">
-            <div *ngIf="!planetCode" class="action-buttons sticky-button">
+            <div *ngIf="!planetCode" class="action-buttons flex-row-gap">
               <button class="toggle-button" (click)="openDescriptionDialog()" mat-stroked-button i18n>
                 { servicesDescriptionLabel, select, Edit {Edit} Add {Add}} { configuration.planetType, select, community {Community} nation {Nation} center {Earth}} Description
               </button>

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -8,7 +8,7 @@
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-template-areas: "news calendar";
-  gap: .5rem; // sass-lint:disable-line no-misspelled-properties
+  gap: .5rem; 
 
   @media only screen and (max-width: #{$screen-md}) {
     grid-template-columns: 1fr;
@@ -70,9 +70,9 @@ mat-tab-group, mat-tab {
   height: 100%;
 }
 
-.flex-row-gap {
+.community-flex-row-gap {
   display: flex;
-  gap: .5rem; // sass-lint:disable-line no-misspelled-properties
+  gap: .5rem; 
 }
 
 .sticky-button {

--- a/src/app/community/community.scss
+++ b/src/app/community/community.scss
@@ -8,7 +8,7 @@
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-template-areas: "news calendar";
-  gap: 0.5rem;
+  gap: .5rem; // sass-lint:disable-line no-misspelled-properties
 
   @media only screen and (max-width: #{$screen-md}) {
     grid-template-columns: 1fr;
@@ -70,12 +70,15 @@ mat-tab-group, mat-tab {
   height: 100%;
 }
 
+.flex-row-gap {
+  display: flex;
+  gap: .5rem; // sass-lint:disable-line no-misspelled-properties
+}
+
 .sticky-button {
   position: sticky;
   top: 0;
   z-index: 10;
-  display: flex;
-  gap: 0.5rem;
 }
 
 .toggle-button {


### PR DESCRIPTION
Refactor the sticky-button class in community.component by decoupling layout properties (flex and gap) into a new generic class .flex-row-gap. This fixes an alignment issue where the sticky-button class was being misused for layout on a specific div. Also addresses sass-lint warnings for the gap property.

Addresses issue #9478 

