### PR TITLE
Document legacy helper scripts and add CI/deploy invocation points

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,10 +55,16 @@ jobs:
           echo "planet.dev.ole.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFqXBJPFe+pH3L57o1ildAxHssG4lpkloTcw3Wbs64c7bL8M6hR0rre4ufpCKboVLn4trJqbKOPWtFgBJHsgqXA=" > ~/.ssh/known_hosts
           # echo "planet.earth.ole.org ...."
           ssh root@$SERVER_HOST <<EOF
+          if [ ! -w /srv ] && [ ! -w /srv/starthub ] && [ ! -e /srv/starthub ]; then
+            echo "Error: /srv/starthub is not writable on deployment target"
+            exit 1
+          fi
+          echo "true" > /srv/starthub
           docker pull $PLANET_REPO
           docker pull $DBINIT_REPO
           docker tag $PLANET_REPO "$DOCKER_ORG/$DOCKER_REPO:local"
           docker tag $DBINIT_REPO "$DOCKER_ORG/$DOCKER_REPO:db-init-local"
           docker images
           treehouses services planet restart
+          echo "false" > /srv/starthub
           EOF

--- a/.github/workflows/planet.yml
+++ b/.github/workflows/planet.yml
@@ -22,6 +22,27 @@ env:
 
 jobs:
 
+  legacy-e2e-webdriver-setup:
+    name: Legacy e2e webdriver setup
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies for legacy e2e webdriver pin
+        run: npm ci
+
+      - name: Pin legacy chromedriver for Protractor e2e
+        run: npm run webdriver-set-version
+
+
   build-prepare:
     name: Preparing
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ To run planet in development with a different locale, you can set the configurat
 ```
 *You can use the short-hand `-c` in place of `--configuration`*
 
+### Script Maintenance & Operational Helpers
+
+The following npm scripts are intentionally kept for legacy automation and deployment toggles:
+
+* `npm run starthub-true` / `npm run starthub-false`
+  * **Purpose:** Toggle the `/srv/starthub` marker used by hub deployments to signal start-state transitions.
+  * **Environment prerequisite:** The deployment target must provide a writable `/srv/starthub` path (for GitHub Actions deploys, this is the remote host accessed over SSH, not the CI runner).
+  * **Deployment invocation:** `.github/workflows/deploy.yml` writes `true` before restart and resets to `false` after restart to mirror these scripts.
+
+* `npm run webdriver-set-version`
+  * **Purpose:** Pin the Protractor/WebDriverManager ChromeDriver version for **legacy Angular e2e** flows (`npm run e2e`).
+  * **Scope:** Legacy Protractor-based e2e only; it is not required for unit tests, linting, docker builds, or chatapi workflows.
+  * **Compatibility expectation:** Uses ChromeDriver `2.37`, expected to match legacy Chrome `64-66` era environments used by this e2e stack.
+  * **CI invocation:** `.github/workflows/planet.yml` includes a `legacy-e2e-webdriver-setup` job that runs `npm run webdriver-set-version` on manual dispatch.
+
 ## Unit & End-to-End Tests
 
 You can run tests directly from the host or within the development container.


### PR DESCRIPTION
### Motivation

- Preserve and document legacy operational scripts that are still referenced by deployment and e2e flows so operators understand their purpose and prerequisites.
- Ensure deployments explicitly toggle the `/srv/starthub` marker on the remote host to match existing `starthub-*` behavior and fail early if the target cannot support it.
- Provide an explicit CI invocation for pinning the legacy ChromeDriver used by Protractor-based e2e so manual runs are repeatable and scoped.

### Description

- Added a new `Script Maintenance & Operational Helpers` section to `README.md` that documents the purpose and prerequisites for `starthub-true`/`starthub-false` and `webdriver-set-version`, including the writable `/srv/starthub` requirement and ChromeDriver `2.37` compatibility expectations for legacy Protractor e2e.
- Updated `.github/workflows/deploy.yml` to verify `/srv/starthub` writability on the remote host, to write `true` before restarting services, and to write `false` after restart, and to exit with an error if the path is not writable.
- Added a `legacy-e2e-webdriver-setup` manual-dispatch job to `.github/workflows/planet.yml` that checks out code, sets up Node, runs `npm ci`, and executes `npm run webdriver-set-version` to pin the legacy ChromeDriver for Protractor e2e runs.

### Testing

- Validated the modified workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); YAML.load_file('.github/workflows/planet.yml')"`, which completed successfully.
- Attempted to validate YAML with Python using `yaml.safe_load` but the `PyYAML` module was not available in the environment, so that check was not executed.
- Performed local file diffs and basic syntax inspection of `README.md`, `.github/workflows/deploy.yml`, and `.github/workflows/planet.yml` to confirm the intended insertions were applied without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699381e9ddd0832d9199f91776dd5418)