### PR TITLE
Document and harden starthub toggle workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,36 @@ Lint: `ng lint`
 This will fix any lint errors that TSLint can automatically fix:
 `Fix Lint: ng lint --fix`
 
+### Starthub toggle (`/srv/starthub`)
+
+If your deployment workflow still relies on `/srv/starthub`, use the package scripts below instead of writing the file manually:
+
+```bash
+npm run starthub-true
+npm run starthub-false
+npm run starthub-status
+```
+
+#### Host/container path semantics
+
+* Default path is `/srv/starthub`.
+* The path is resolved in the environment where the command runs:
+  * Running on the host writes to the host filesystem.
+  * Running inside a container writes to the container filesystem unless `/srv` is bind-mounted.
+* To target a different location, set `STARTHUB_FILE` when calling `docker/starthub.sh`.
+
+#### When to run each script
+
+* `npm run starthub-true`: before operations that should explicitly enable hub startup behavior.
+* `npm run starthub-false`: before operations that should explicitly disable hub startup behavior.
+* `npm run starthub-status`: verification step before/after deployment and troubleshooting.
+
+#### Safety constraints and rollback
+
+* `docker/starthub.sh` validates that the parent directory exists and the target path is writable before writing.
+* The script only accepts `true`, `false`, or `status` to avoid accidental file corruption from arbitrary values.
+* Rollback is immediate: run the opposite command (`starthub-false` or `starthub-true`) and confirm with `starthub-status`.
+
 
 To serve the app in a different language, use the LNG variable:
 `

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,6 +29,18 @@ This docker compose can be use for your development environment and very handy, 
 ## How to use
 I will divide this how to use into two sections, for development and for production. It is interesting to run our development environment on top of isolated docker container.
 
+## Starthub control file
+
+If your environment still uses `/srv/starthub` as an external toggle, use `docker/starthub.sh`:
+
+```bash
+bash ./docker/starthub.sh true
+bash ./docker/starthub.sh false
+bash ./docker/starthub.sh status
+```
+
+The script checks path existence and write permissions before writing to reduce deployment mistakes.
+
 ### For Production
 
 1. Move to `srv/planet` folder

--- a/docker/starthub.sh
+++ b/docker/starthub.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_FILE="${STARTHUB_FILE:-/srv/starthub}"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <true|false|status>
+
+Writes an explicit start-hub toggle value to 
+  ${TARGET_FILE}
+
+Environment:
+  STARTHUB_FILE  Optional path override (default: /srv/starthub)
+USAGE
+}
+
+require_parent_dir() {
+  local parent
+  parent="$(dirname "$TARGET_FILE")"
+  if [[ ! -d "$parent" ]]; then
+    echo "Error: expected parent directory '$parent' to exist." >&2
+    echo "Create it first or set STARTHUB_FILE to a valid location." >&2
+    exit 1
+  fi
+}
+
+require_writable_target() {
+  if [[ -e "$TARGET_FILE" && ! -w "$TARGET_FILE" ]]; then
+    echo "Error: '$TARGET_FILE' exists but is not writable by user $(id -un)." >&2
+    exit 1
+  fi
+
+  local parent
+  parent="$(dirname "$TARGET_FILE")"
+  if [[ ! -e "$TARGET_FILE" && ! -w "$parent" ]]; then
+    echo "Error: cannot create '$TARGET_FILE' because '$parent' is not writable by user $(id -un)." >&2
+    exit 1
+  fi
+}
+
+print_status() {
+  if [[ -f "$TARGET_FILE" ]]; then
+    echo "starthub=$(<"$TARGET_FILE")"
+  else
+    echo "starthub=<unset> (file does not exist at $TARGET_FILE)"
+  fi
+}
+
+main() {
+  local action="${1:-}"
+  case "$action" in
+    true|false)
+      require_parent_dir
+      require_writable_target
+      printf '%s\n' "$action" > "$TARGET_FILE"
+      echo "Wrote '$action' to $TARGET_FILE"
+      ;;
+    status)
+      print_status
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      echo "Error: unsupported value '$action'. Expected true, false, or status." >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "install-hooks": "cp -a git-hooks/. .git/hooks/",
     "webdriver-set-version": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",
     "generate-yml": "cd $(git rev-parse --show-toplevel)/docker;./generate_yml.sh",
-    "starthub-true": "echo \"true\" > /srv/starthub",
-    "starthub-false": "echo \"false\" > /srv/starthub"
+    "starthub-true": "bash ./docker/starthub.sh true",
+    "starthub-false": "bash ./docker/starthub.sh false",
+    "starthub-status": "bash ./docker/starthub.sh status"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
### Motivation

- Make existing `/srv/starthub` usage explicit and safer by centralizing writes behind a small wrapper and documenting expected host/container semantics.
- Prevent accidental corruption or writes from package scripts by validating paths and limiting allowed actions to explicit values.

### Description

- Add `docker/starthub.sh`, a wrapper that accepts only `true`, `false`, or `status`, validates parent directory existence and write permissions, supports `STARTHUB_FILE` overrides, and prints clear status/usage messages.
- Replace direct redirections in `package.json` with calls to the wrapper (`starthub-true`, `starthub-false`) and add `starthub-status` to verify state.
- Document the workflow, host vs container path semantics, when to run each command, and safety/rollback guidance in `README.md` and add a short note to `docker/README.md` pointing to the wrapper.

### Testing

- Ran `bash ./docker/starthub.sh help` and it printed usage information successfully.
- Exercised the full flow using a temporary file (`STARTHUB_FILE=/tmp/starthub-test`) with `true`, `status`, `false`, and `status`, and all operations completed and reported expected output.
- No automated unit tests were added; validation was performed via the manual script invocation sequence above and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699381c53c2c832da414fbab1b074fb5)