### PR TITLE
teams: add public/private badges to resources

### DIFF
--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -196,14 +196,15 @@
                   </span>
                   <span
                     *ngIf="resource.resource !== undefined"
+                  <!-- Non-interactive visibility badge; click handler only stops propagation to prevent mat-card activation -->
+                  <div
+                    *ngIf="resource.resource !== undefined"
                     class="visibility-badge"
                     [ngClass]="resource.resource?.private === true ? 'is-private' : 'is-public'"
-                    (click)="$event.stopPropagation()"
-                    aria-label="{ resource.resource?.private, select, true {Private resource visibility} other {Public resource visibility} }"
-                    i18n-aria-label="Accessibility label describing whether the resource visibility is private or public.">
+                    (click)="$event.stopPropagation()">
                     <ng-container *ngIf="resource.resource?.private === true" i18n>Private</ng-container>
                     <ng-container *ngIf="resource.resource?.private !== true" i18n>Public</ng-container>
-                  </span>
+                  </div>
                 </div>
                 <mat-card-content>
                   <planet-markdown [content]="resource.resource.description | truncateText:120"></planet-markdown>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -194,6 +194,14 @@
                     matTooltip="Resource unavailable. Contact your administrator to add resource to this Planet.">
                     {{resource.linkDoc.title | truncateText:75}}
                   </span>
+                  <span
+                    *ngIf="resource.resource !== undefined"
+                    class="visibility-badge"
+                    [ngClass]="resource.resource?.private === true ? 'is-private' : 'is-public'"
+                    (click)="$event.stopPropagation()">
+                    <ng-container *ngIf="resource.resource?.private === true" i18n>Private</ng-container>
+                    <ng-container *ngIf="resource.resource?.private !== true" i18n>Public</ng-container>
+                  </span>
                 </div>
                 <mat-card-content>
                   <planet-markdown [content]="resource.resource.description | truncateText:120"></planet-markdown>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -194,15 +194,14 @@
                     matTooltip="Resource unavailable. Contact your administrator to add resource to this Planet.">
                     {{resource.linkDoc.title | truncateText:75}}
                   </span>
-                  <span
+                  <div
                     *ngIf="resource.resource !== undefined"
                     class="visibility-badge"
                     [ngClass]="resource.resource?.private === true ? 'is-private' : 'is-public'"
                     (click)="$event.stopPropagation()">
                     <ng-container *ngIf="resource.resource?.private === true" i18n>Private</ng-container>
                     <ng-container *ngIf="resource.resource?.private !== true" i18n>Public</ng-container>
-                  </span>
-                </div>
+                  </div>
                 <mat-card-content>
                   <planet-markdown [content]="resource.resource.description | truncateText:120"></planet-markdown>
                 </mat-card-content>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -198,7 +198,9 @@
                     *ngIf="resource.resource !== undefined"
                     class="visibility-badge"
                     [ngClass]="resource.resource?.private === true ? 'is-private' : 'is-public'"
-                    (click)="$event.stopPropagation()">
+                    (click)="$event.stopPropagation()"
+                    aria-label="{ resource.resource?.private, select, true {Private resource visibility} other {Public resource visibility} }"
+                    i18n-aria-label="Accessibility label describing whether the resource visibility is private or public.">
                     <ng-container *ngIf="resource.resource?.private === true" i18n>Private</ng-container>
                     <ng-container *ngIf="resource.resource?.private !== true" i18n>Public</ng-container>
                   </span>

--- a/src/app/teams/teams-view.scss
+++ b/src/app/teams/teams-view.scss
@@ -22,12 +22,44 @@
     }
 
     mat-card {
+      position: relative;
+
       mat-card-actions {
         margin-top: auto;
         display: flex;
         justify-content: center;
         gap: 1rem;
       }
+    }
+
+    .visibility-badge {
+      position: absolute;
+      bottom: 10px;
+      right: 12px;
+
+      display: inline-block;
+      padding: 2px 8px;
+      font-size: 12px;
+      line-height: 18px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      white-space: nowrap;
+      user-select: none;
+
+      // helps it stay readable over content
+      background-clip: padding-box;
+    }
+
+    .visibility-badge.is-public {
+      color: #1b5e20;
+      background: #e8f5e9;
+      border-color: #c8e6c9;
+    }
+
+    .visibility-badge.is-private {
+      color: #7f0000;
+      background: #ffebee;
+      border-color: #ffcdd2;
     }
   }
 


### PR DESCRIPTION
This PR addresses issue #9626 

Changes made:
- show a Public/Private badge on team resource cards
- add styles to position and color the badge by visibility

Screenshot:
<img width="1896" height="666" alt="after" src="https://github.com/user-attachments/assets/d8bec149-5851-4c31-948b-35fb8a8fb078" />

