### PR TITLE
Make dialogs announcement examId internal-only

### DIFF
--- a/src/app/shared/dialogs/dialogs-announcement.component.ts
+++ b/src/app/shared/dialogs/dialogs-announcement.component.ts
@@ -16,7 +16,7 @@ import { planetAndParentId } from '../../manager-dashboard/reports/reports.utils
 
 export const includedCodes = [ 'guatemala', 'san.pablo', 'xela', 'okuro', 'uriur', 'mutugi', 'vi' ];
 export const challengeCourseId = '4e6b78800b6ad18b4e8b0e1e38a98cac';
-export const examId = '4e6b78800b6ad18b4e8b0e1e38b382ab';
+const examId = '4e6b78800b6ad18b4e8b0e1e38b382ab';
 export const challengePeriod = (new Date() > new Date(2024, 10, 31)) && (new Date() < new Date(2025, 0, 16));
 
 @Component({


### PR DESCRIPTION
### Motivation
- Reduce exported surface by making `examId` internal to `dialogs-announcement.component.ts` because its usage is internal only and no cross-file references are required.

### Description
- Replaced `export const examId = ...` with `const examId = ...` in `src/app/shared/dialogs/dialogs-announcement.component.ts` so the constant is module-private and runtime behavior is unchanged.

### Testing
- Ran an import search and diff checks with `rg` and `git diff` to confirm there are no cross-file imports of `examId` and that the only change is the export removal, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc062aeb8832da25b92b1eb8b80d5)