### PR TITLE
chore(chatapi): mark unused GET handler request params

### DIFF
--- a/chatapi/src/index.ts
+++ b/chatapi/src/index.ts
@@ -17,7 +17,7 @@ app.use(cors());
 // Parse JSON bodies (as sent by API clients)
 app.use(express.json());
 
-app.get('/', (req: any, res: any) => {
+app.get('/', (_req: any, res: any) => {
   res.status(200).json({
     'status': 'Success',
     'message': 'OLE Chat API Service',
@@ -91,7 +91,7 @@ app.post('/', async (req: any, res: any) => {
   }
 });
 
-app.get('/checkproviders', async (req: any, res: any) => {
+app.get('/checkproviders', async (_req: any, res: any) => {
   res.status(200).json({
     'openai': keys.openai.apiKey ? true : false,
     'perplexity': keys.perplexity.apiKey ? true : false,


### PR DESCRIPTION
### Motivation
- Silence unused-parameter warnings from TypeScript/linters for two Express GET handlers in `chatapi/src/index.ts` without changing any route behavior.

### Description
- Renamed the `req` parameter to `_req` in the root handler (`app.get('/', ...)`) and the `/checkproviders` handler (`app.get('/checkproviders', ...)`) so the unused parameter is explicitly marked while leaving responses unchanged.

### Testing
- No automated tests were required for this rename-only change; behavior was validated by inspecting the modified file `chatapi/src/index.ts` and confirming responses remain the same.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc0766bd0832d9200900041ca37b4)