### PR TITLE
Resolve nation APK version metadata before writing apkversion

### DIFF
--- a/docker/planet/nginx/upgrade_planetapk_fromnation.sh
+++ b/docker/planet/nginx/upgrade_planetapk_fromnation.sh
@@ -11,6 +11,39 @@ sha256File="$apkName.sha256"
 nationUrl="$(curl -s http://couchdb:5984/configurations/$(curl http://couchdb:5984/configurations/_all_docs -s | jq .rows[0].id -r) | jq .parentDomain -r | sed -e 's|^[^/]*//||' -e 's|/.*$||')"
 downloadUrl="$nationUrl/fs/$apkName"
 
+resolve_apk_version() {
+  metadataVersion="$(curl -fsSL "$nationUrl/fs/apkversion" 2>/dev/null | tr -d '\r' | head -n 1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if [ -n "$metadataVersion" ] && [ "$metadataVersion" != "null" ]; then
+    echo "$metadataVersion"
+    return 0
+  fi
+
+  headerVersion="$(curl -fsSI "$downloadUrl" 2>/dev/null | awk '
+    BEGIN{IGNORECASE=1}
+    /^x-apk-version:/ {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      gsub(/\r/, "")
+      print
+      exit
+    }
+  ')"
+
+  if [ -n "$headerVersion" ]; then
+    echo "$headerVersion"
+  fi
+}
+
+write_apk_version() {
+  resolvedVersion="$(resolve_apk_version)"
+
+  if [ -n "$resolvedVersion" ]; then
+    echo "$resolvedVersion" > /usr/share/nginx/html/fs/apkversion
+    echo "Resolved version: $resolvedVersion"
+  else
+    echo "Unable to resolve apk version metadata; keeping existing /usr/share/nginx/html/fs/apkversion"
+  fi
+}
+
 download_apk(){
   echo "Downloading new version"
   echo "$(curl -# "$downloadUrl" -o "$apkName" -L)"
@@ -29,7 +62,7 @@ if [ -f "$apkName" ] && [ -f "$sha256File" ]; then
     if sha256sum "$apkName" | sha256sum -c "$sha256File" 2>&1 | grep OK; then
       echo "Download successful"
       rm -f "$apkName.tmp"
-      echo $tag > /usr/share/nginx/html/fs/apkversion
+      write_apk_version
     else
       echo "Download error"
       mv "$apkName.tmp" "$apkName"
@@ -41,7 +74,7 @@ else
   if sha256sum "$apkName" | sha256sum -c "$sha256File" 2>&1 | grep OK; then
     echo "Download successful"
     rm -f "$apkName.tmp"
-    echo $tag > /usr/share/nginx/html/fs/apkversion
+    write_apk_version
   else
     echo "Download error"
   fi


### PR DESCRIPTION
### Motivation
- The script previously attempted to write an undefined `$tag` to `/usr/share/nginx/html/fs/apkversion`, so the version needs to be resolved from nation-hosted metadata instead of relying on an undefined variable.
- Prefer authoritative nation metadata (a nation-hosted `/fs/apkversion`) and fall back to HTTP response headers so the server-side published version is captured when available.
- Avoid clobbering an existing `/usr/share/nginx/html/fs/apkversion` when metadata fetch or parsing fails.

### Description
- Add `resolve_apk_version()` which first fetches `"$nationUrl/fs/apkversion"` and then falls back to parsing an `x-apk-version` header from a `HEAD`/`GET` response to `"$downloadUrl"`. 
- Add `write_apk_version()` which calls `resolve_apk_version()` and only writes the resolved non-empty value to `/usr/share/nginx/html/fs/apkversion`, leaving the existing file unchanged on failure. 
- Replace the previous `echo $tag > /usr/share/nginx/html/fs/apkversion` occurrences with `write_apk_version` in both successful download/verify paths. 
- Preserve existing download and SHA verification logic and only change how the APK version is determined and recorded.

### Testing
- Ran a shell syntax check with `sh -n docker/planet/nginx/upgrade_planetapk_fromnation.sh`, which completed without errors.
- Verified the script changes in a diff and committed the updated file to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc075d64c832d9621dde568fea448)