### PR TITLE
Add dedicated Angular test build targets and document QA environment toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ To run planet in development with a different locale, you can set the configurat
 ```
 *You can use the short-hand `-c` in place of `--configuration`*
 
+## Environment Configuration
+
+Planet environment files live in `src/environments/`, and the Angular `test` build profile maps to `src/environments/environment.test.ts`.
+
+For QA/integration testing, keep these toggles aligned with current infrastructure defaults:
+- `test: true`
+- `couchAddress: 'http://127.0.0.1:5984'`
+- `syncAddress: 'http://localhost:5984'`
+
+Use the dedicated test-profile targets when validating this setup:
+```
+npm run serve:test
+npm run build:test
+```
+
 ## Unit & End-to-End Tests
 
 You can run tests directly from the host or within the development container.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "start": "ng serve",
     "dev": "bash dev-env.sh && ng serve --configuration dev",
     "build": "npm run ng-high-memory -- build --configuration production",
+    "build:test": "npm run ng-high-memory -- build --configuration test",
+    "serve:test": "ng serve --configuration test",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",
     "sass-lint": "./node_modules/sass-lint/bin/sass-lint.js -c ./sass-lint.yml -v -q",

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -6,5 +6,5 @@ export const environment = {
   centerProtocol: 'https',
   parentProtocol: 'https',
   upgradeAddress: window.location.origin + '/upgrade',
-  syncAddress: window.location.protocol + '//localhost:5984'
+  syncAddress: 'http://localhost:5984'
 };


### PR DESCRIPTION
### Motivation

- Provide an explicit npm script and build target for the Angular `test` configuration so QA/integration runs use a dedicated, reproducible target. 
- Ensure critical environment toggles used by integration tests (`test`, `couchAddress`, `syncAddress`) match QA infrastructure and avoid protocol-derived misrouting.

### Description

- Added `build:test` and `serve:test` npm scripts to `package.json` to expose `planet-app:build:test` and `serve:test` workflows via `npm`. 
- Made `syncAddress` in `src/environments/environment.test.ts` an explicit `http://localhost:5984` to prevent protocol-dependent misrouting during tests. 
- Added an "Environment Configuration" note to `README.md` documenting that `src/environments/environment.test.ts` is the Angular `test` target and listing expected QA toggles and the new `npm` commands.

### Testing

- Ran `npm run build:test`, which invoked the new build script and failed in this environment because local dependencies are not installed (`node_modules/@angular/cli/bin/ng` not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc0681890832da07757ed25f3da88)