### PR TITLE
manager: smoother send on accept buttons aligning (fixes #9628)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.67",
+  "version": "0.21.72",
   "myplanet": {
     "latest": "v0.47.40",
     "min": "v0.37.60"

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -15,7 +15,6 @@ import { CoursesService } from '../courses/courses.service';
 import { ConfigurationService } from '../configuration/configuration.service';
 import { ManagerService } from './manager.service';
 import { StateService } from '../shared/state.service';
-import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 
 @Component({
   templateUrl: './manager-dashboard.component.html',
@@ -56,8 +55,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private configurationService: ConfigurationService,
     private stateService: StateService,
-    private managerService: ManagerService,
-    private deviceInfoService: DeviceInfoService
+    private managerService: ManagerService
   ) {}
 
   ngOnInit() {

--- a/src/app/manager-dashboard/manager-dashboard.scss
+++ b/src/app/manager-dashboard/manager-dashboard.scss
@@ -1,10 +1,10 @@
 @import "../variables";
 
-.view-container > * {
+.list-view > * {
   margin-bottom: 0.5rem;
 }
 
-.view-container > *:last-child {
+.list-view > *:last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Fixes #9628

Fix the `send on accept` buttons alignment. Additionally, clean up on unused deviceInfoService

<img width="1904" height="419" alt="image" src="https://github.com/user-attachments/assets/a92c749c-3ea9-4851-bcae-31ebd5f6550e" />
