### PR TITLE
Add hex decode consumer and tests for shared hex utils

### DIFF
--- a/src/app/health/health.component.ts
+++ b/src/app/health/health.component.ts
@@ -11,6 +11,7 @@ import { Subject, of } from 'rxjs';
 import { CouchService } from '../shared/couchdb.service';
 import { conditionAndTreatmentFields } from './health.constants';
 import { findDocuments } from '../shared/mangoQueries';
+import { hexToString } from '../shared/utils';
 
 @Component({
   templateUrl: './health.component.html',
@@ -44,9 +45,12 @@ export class HealthComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   ngOnInit() {
     this.route.paramMap.pipe(takeUntil(this.onDestroy$)).pipe(switchMap((params: ParamMap) => {
-      const id = `org.couchdb.user:${params.get('id')}`;
-      this.isOwnUser = params.get('id') === null || params.get('id') === this.userService.get().name;
-      return params.get('id') ? this.couchService.get(`_users/${id}`) : of(this.userService.get());
+      const routeId = params.get('id');
+      const decodedId = hexToString(routeId || '');
+      const userName = decodedId || routeId;
+      const id = userName ? `org.couchdb.user:${userName}` : '';
+      this.isOwnUser = userName === null || userName === this.userService.get().name;
+      return userName ? this.couchService.get(`_users/${id}`) : of(this.userService.get());
     })).subscribe((user) => {
       this.userDetail = user;
       this.initData();

--- a/src/app/shared/utils.spec.ts
+++ b/src/app/shared/utils.spec.ts
@@ -1,0 +1,17 @@
+import { stringToHex, hexToString } from './utils';
+
+describe('shared utils', () => {
+  describe('stringToHex / hexToString', () => {
+    it('should round-trip encoded text back to the original string', () => {
+      const value = 'org.couchdb.user:alice@planet';
+      const encoded = stringToHex(value);
+
+      expect(hexToString(encoded)).toBe(value);
+    });
+
+    it('should return an empty string for malformed hex input', () => {
+      expect(hexToString('abc')).toBe('');
+      expect(hexToString('zz')).toBe('');
+    });
+  });
+});

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -83,7 +83,12 @@ export const toProperCase = (string: string) => `${string.slice(0, 1).toUpperCas
 
 export const stringToHex = (string: string) => string.split('').map(char => char.charCodeAt(0).toString(16)).join('');
 
-export const hexToString = (string: string) => string.match(/.{1,2}/g).map(hex => String.fromCharCode(parseInt(hex, 16))).join('');
+export const hexToString = (string: string) => {
+  if (!string || string.length % 2 !== 0 || /[^0-9a-f]/i.test(string)) {
+    return '';
+  }
+  return string.match(/.{1,2}/g).map(hex => String.fromCharCode(parseInt(hex, 16))).join('');
+};
 
 export const ageFromBirthDate = (currentTime: number, birthDate: string) => {
   const now = new Date(currentTime);


### PR DESCRIPTION
### Motivation
- Support decoding optionally hex-encoded CouchDB/user identifiers in the health flow and make the hex utility safer for malformed input.
- Provide a focused unit test to verify `stringToHex`/`hexToString` round-trip and malformed-input handling.

### Description
- Hardened `hexToString` in `src/app/shared/utils.ts` to return `''` for empty, odd-length, or non-hex inputs while preserving normal decode behavior.
- Added a concrete consumer in `src/app/health/health.component.ts` which attempts to decode the route `id` via `hexToString` and falls back to the raw route value when decoding fails before loading `_users/org.couchdb.user:*` records.
- Added a focused unit test file `src/app/shared/utils.spec.ts` that verifies round-trip encoding/decoding and malformed hex handling.
- Left `stringToHex` behavior unchanged so encoding remains consistent with existing callers.

### Testing
- Attempted to run `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/shared/utils.spec.ts`, which initially failed because the Angular CLI binary was not present (`ng: not found`).
- Installed dependencies with `npm install --ignore-scripts` and re-ran the test command; the test run failed during test-suite compilation with pre-existing TypeScript/spec errors from unrelated legacy tests across the repository, not due to these changes.
- The new focused spec (`src/app/shared/utils.spec.ts`) was included in the test run and is expected to pass in a healthy test environment where the broader legacy spec issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc071efa8832d9d242503e2c92062)