### PR TITLE
Rename unused callback parameters to _err in design/create-design-docs.js

### DIFF
--- a/design/create-design-docs.js
+++ b/design/create-design-docs.js
@@ -2,10 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const basePath = __dirname;
 
-const readDirectories = (err, directories) => {
+const readDirectories = (_err, directories) => {
   directories.forEach((dir) => {
     const dirFullPath = path.join(basePath, dir);
-    fs.stat(dirFullPath, (err, stat) => {
+    fs.stat(dirFullPath, (_err, stat) => {
       if (stat.isDirectory()) {
         readDir(dir, readFiles(dir));
       }
@@ -13,10 +13,10 @@ const readDirectories = (err, directories) => {
   });
 };
 
-const readFiles = (dirPath) => (err, files) => {
+const readFiles = (dirPath) => (_err, files) => {
   files.forEach((file) => {
     const filePath = path.join(basePath, dirPath, file);
-    fs.stat(filePath, (err, stat) => {
+    fs.stat(filePath, (_err) => {
       if (path.extname(file) === '.js' && file !== 'create-design-docs.js') {
         const modulePath = './' + path.join(dirPath, file);
         writeDesignDoc(require(modulePath), filePath);


### PR DESCRIPTION
### Motivation
- Make intent explicit for unused callback arguments by renaming `err` to `_err` and removing an unused `stat` parameter to satisfy lint rules while preserving existing behavior.

### Description
- Updated `design/create-design-docs.js` to rename unused callback parameters in `readDirectories` and `readFiles` from `err` to `_err`, and removed the unused `stat` parameter in one `fs.stat` callback; no logic changes were made.

### Testing
- Attempted to run `npx eslint design/create-design-docs.js`, which failed in this environment due to ESLint v9 requiring an `eslint.config.*` file while the repository uses legacy config, so no lint pass was completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc0649b30832d8875e83679f9b01e)