### PR TITLE
Add assertion to verify test build maps environment.ts → environment.test.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,17 +12,18 @@
     "start": "ng serve",
     "dev": "bash dev-env.sh && ng serve --configuration dev",
     "build": "npm run ng-high-memory -- build --configuration production",
-    "test": "ng test",
+    "test": "npm run assert:test-environment-mapping && ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",
     "sass-lint": "./node_modules/sass-lint/bin/sass-lint.js -c ./sass-lint.yml -v -q",
     "lint": "ng lint planet-app",
-    "lint-all": "npm run sass-lint && ng lint planet-app --type-check && npm run htmlhint",
+    "lint-all": "npm run assert:test-environment-mapping && npm run sass-lint && ng lint planet-app --type-check && npm run htmlhint",
     "e2e": "ng e2e --webdriver-update=false",
     "install-hooks": "cp -a git-hooks/. .git/hooks/",
     "webdriver-set-version": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",
     "generate-yml": "cd $(git rev-parse --show-toplevel)/docker;./generate_yml.sh",
     "starthub-true": "echo \"true\" > /srv/starthub",
-    "starthub-false": "echo \"false\" > /srv/starthub"
+    "starthub-false": "echo \"false\" > /srv/starthub",
+    "assert:test-environment-mapping": "node scripts/assert-test-environment-mapping.js"
   },
   "private": true,
   "dependencies": {

--- a/scripts/assert-test-environment-mapping.js
+++ b/scripts/assert-test-environment-mapping.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const angularJsonPath = path.resolve(__dirname, '..', 'angular.json');
+const angularConfig = JSON.parse(fs.readFileSync(angularJsonPath, 'utf8'));
+
+const expectedFileReplacementBlock = [
+  {
+    replace: 'src/environments/environment.ts',
+    with: 'src/environments/environment.test.ts'
+  }
+];
+
+const testBuildConfig =
+  angularConfig.projects?.['planet-app']?.architect?.build?.configurations?.test;
+
+if (!testBuildConfig) {
+  throw new Error(
+    'Missing angular.json block: projects["planet-app"].architect.build.configurations.test'
+  );
+}
+
+const actualFileReplacements = testBuildConfig.fileReplacements;
+
+if (
+  JSON.stringify(actualFileReplacements) !==
+  JSON.stringify(expectedFileReplacementBlock)
+) {
+  throw new Error(
+    [
+      'Unexpected test environment file replacement config in angular.json.',
+      'Expected exact block at projects["planet-app"].architect.build.configurations.test.fileReplacements:',
+      JSON.stringify(expectedFileReplacementBlock, null, 2),
+      'Received:',
+      JSON.stringify(actualFileReplacements, null, 2)
+    ].join('\n')
+  );
+}
+
+console.log(
+  'Verified angular.json projects["planet-app"].architect.build.configurations.test.fileReplacements maps environment.ts to environment.test.ts.'
+);


### PR DESCRIPTION
### Motivation
- Make the role of the test environment file explicit and prevent false dead-code assumptions by failing CI when the mapping drifts. 
- Detect future tooling/`angular.json` changes by referencing the exact block `projects["planet-app"].architect.build.configurations.test.fileReplacements` so drift is obvious.

### Description
- Add `scripts/assert-test-environment-mapping.js`, a small Node script that reads `angular.json` and asserts the exact file replacement block maps `src/environments/environment.ts` to `src/environments/environment.test.ts` (throws on mismatch). 
- Wire the assertion into `package.json` by adding `assert:test-environment-mapping` and prepending it to the `test` and `lint-all` scripts so CI and local test runs enforce the check. 

### Testing
- Ran `node scripts/assert-test-environment-mapping.js`, which printed a verification message and exited successfully. 
- Ran `npm run assert:test-environment-mapping`, which also succeeded and printed the same verification message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc0578fb4832dab37127a92cb1562)