### PR TITLE
Fix unsaved changes dialog Cancel behavior on Add Resource page(fixes #9665)

### DIFF
--- a/src/app/shared/unsaved-changes.guard.ts
+++ b/src/app/shared/unsaved-changes.guard.ts
@@ -29,10 +29,12 @@ export class UnsavedChangesGuard  {
         const dialogResult = UnsavedChangesPromptComponent.open(this.dialog);
         return dialogResult.pipe(
           switchMap(confirmed => {
-            if (confirmed && component.onLeaveConfirmed) {
+            const leaveConfirmed = confirmed === true;
+
+            if (leaveConfirmed && component.onLeaveConfirmed) {
               component.onLeaveConfirmed();
             }
-            return of(confirmed);
+            return of(leaveConfirmed);
           })
         );
       }


### PR DESCRIPTION
Ensure Cancel in the unsaved-changes prompt keeps users on the form and only navigates away when OK is explicitly confirmed.

Fixes #9665 

<img width="1911" height="933" alt="image" src="https://github.com/user-attachments/assets/a4464763-1538-4dfd-b0ea-4a22d68acaf1" />
