### PR TITLE
Fix unsaved changes Cancel behavior in Achievements form navigation(fixes #9667)

### DIFF
--- a/src/app/shared/unsaved-changes.guard.ts
+++ b/src/app/shared/unsaved-changes.guard.ts
@@ -29,10 +29,12 @@ export class UnsavedChangesGuard  {
         const dialogResult = UnsavedChangesPromptComponent.open(this.dialog);
         return dialogResult.pipe(
           switchMap(confirmed => {
-            if (confirmed && component.onLeaveConfirmed) {
+            const leaveConfirmed = confirmed === true;
+
+            if (leaveConfirmed && component.onLeaveConfirmed) {
               component.onLeaveConfirmed();
             }
-            return of(confirmed);
+            return of(leaveConfirmed);
           })
         );
       }


### PR DESCRIPTION
Updated the [canDeactivate] guard to allow leaving only on explicit OK, so clicking Cancel keeps users on the current Achievements page.

Fixes #9667 

<img width="1918" height="937" alt="image" src="https://github.com/user-attachments/assets/44be44c5-4912-4a76-b942-022409c3b1a7" />
