### PR TITLE
Make CouchDB attachment metadata optional in Attachment model

### DIFF
--- a/chatapi/src/models/db-doc.model.ts
+++ b/chatapi/src/models/db-doc.model.ts
@@ -12,8 +12,10 @@ export interface DbDoc {
 
 export interface Attachment {
   content_type: string;
-  revpos: number;
-  digest: string;
-  length: number;
-  stub: boolean;
+  // Optional CouchDB metadata fields are retained for compatibility with callers
+  // that may consume full attachment metadata in the future.
+  revpos?: number;
+  digest?: string;
+  length?: number;
+  stub?: boolean;
 }


### PR DESCRIPTION
### Motivation
- Reduce the `Attachment` interface to the fields currently used by the codebase while keeping `content_type` required so callers (notably chat helpers) can still detect PDF attachments; unused CouchDB metadata should be optional to lower typing friction.

### Description
- Updated `chatapi/src/models/db-doc.model.ts` to keep `content_type` required and mark `revpos`, `digest`, `length`, and `stub` as optional, with a short comment explaining the rationale.

### Testing
- Ran `npm install` and `npm run build` in `chatapi/`, and TypeScript compilation succeeded (`tsc` passed), confirming `chatapi/src/utils/chat-helpers.utils.ts` still type-checks and continues to use `content_type` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e7245ff4832d83eee172b74f8366)