### PR TITLE
chore: remove undocumented legacy npm scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,7 @@
     "lint": "ng lint planet-app",
     "lint-all": "npm run sass-lint && ng lint planet-app --type-check && npm run htmlhint",
     "e2e": "ng e2e --webdriver-update=false",
-    "install-hooks": "cp -a git-hooks/. .git/hooks/",
-    "webdriver-set-version": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",
-    "generate-yml": "cd $(git rev-parse --show-toplevel)/docker;./generate_yml.sh",
-    "starthub-true": "echo \"true\" > /srv/starthub",
-    "starthub-false": "echo \"false\" > /srv/starthub"
+    "install-hooks": "cp -a git-hooks/. .git/hooks/"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Remove legacy, undocumented npm scripts to reduce maintenance surface and avoid accidental use of obsolete helpers.
- Clean up `package.json` to ensure scripts list reflects only actively used developer workflows.
- Minimize operational confusion while noting there is medium risk if external automation references these names.

### Description
- Deleted the root `package.json` scripts: `webdriver-set-version`, `starthub-true`, and `starthub-false`. 
- Also removed the optional undocumented `generate-yml` script from `package.json` after confirming it is not referenced in docs or CI.
- Left the remaining scripts intact and preserved valid JSON structure in `package.json`.

### Testing
- Parsed `package.json` with Node using `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` which succeeded. 
- Searched for references to the removed scripts with ripgrep using `rg -n "webdriver-set-version|starthub-true|starthub-false|generate-yml" .github/workflows README.md docker/README.md package.json` and found no matches in checked CI/workflow and release docs.
- Confirmed no other matches across the repository with a broader ripgrep scan, indicating no in-repo invocations of the removed script names.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e721d29c832da7526ac3baf118c5)