### PR TITLE
community: smoother dialog padding (fixes #9672)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.21.79",
+  "version": "0.21.80",
   "myplanet": {
-    "latest": "v0.48.13",
+    "latest": "v0.48.84",
     "min": "v0.47.40"
   },
   "scripts": {

--- a/src/app/community/community-link-dialog.component.html
+++ b/src/app/community/community-link-dialog.component.html
@@ -1,60 +1,62 @@
-<div mat-dialog-title>
-  <mat-form-field class="full-width">
+<mat-dialog-content>
+  <mat-form-field class="full-width link-type-field">
     <mat-label i18n>Type of Link</mat-label>
     <mat-select [(ngModel)]="selectedLink">
       <mat-option *ngFor="let link of links" [value]="link">{{link.title}}</mat-option>
     </mat-select>
   </mat-form-field>
-</div>
-<mat-dialog-content *ngIf="selectedLink?.db === 'teams'">
-  <form [formGroup]="linkForm">
-    <mat-horizontal-stepper #linkStepper linear (selectionChange)="linkStepperChange($event)">
-      <mat-step i18n-label completed="false" label="Select">
-        <planet-teams [mode]="selectedLink?.selector?.type" [excludeIds]="data.excludeIds" [isDialog]="true" (rowClick)="teamSelect($event)"></planet-teams>
-      </mat-step>
-      <mat-step i18n-label label="Title" [stepControl]="linkTitleForm">
-        <mat-form-field class="full-width">
-          <mat-label i18n>Title</mat-label>
-          <input matInput formControlName="title" required>
-          <mat-error><planet-form-error-messages [control]="linkForm.controls.title"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-      </mat-step>
-    </mat-horizontal-stepper>
-  </form>
-</mat-dialog-content>
-<mat-dialog-content *ngIf="selectedLink?.db === 'social'">
-  <form [formGroup]="linkForm">
-    <mat-form-field class="full-width">
-      <mat-label i18n>Platform</mat-label>
-      <mat-select formControlName="platform" (selectionChange)="onPlatformSelect($event.value)" required>
-        <mat-select-trigger>
-          <ng-container [ngSwitch]="linkForm.value.platform">
-            <mat-icon *ngSwitchCase="'website'" class="margin-r-5">public</mat-icon>
-            <mat-icon *ngSwitchDefault [svgIcon]="linkForm.value.platform" class="margin-r-5"></mat-icon>
-          </ng-container>
-          {{getPlatformLabel(linkForm.value.platform)}}
-        </mat-select-trigger>
-        <mat-option *ngFor="let p of socialPlatforms" [value]="p.value">
-          <ng-container [ngSwitch]="p.value">
-            <mat-icon *ngSwitchCase="'website'" class="margin-r-5">public</mat-icon>
-            <mat-icon *ngSwitchDefault [svgIcon]="p.value" class="margin-r-5"></mat-icon>
-          </ng-container>
-          {{ p.label }}
-        </mat-option>
-      </mat-select>
-      <mat-error *ngIf="linkForm.controls.platform.invalid && linkForm.controls.platform.touched" i18n>Platform is required.</mat-error>
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label i18n>Title</mat-label>
-      <input matInput formControlName="title" required>
-      <mat-error><planet-form-error-messages [control]="linkForm.controls.title"></planet-form-error-messages></mat-error>
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label i18n>Link URL</mat-label>
-      <input matInput formControlName="route" placeholder="https://..." required>
-      <mat-error><planet-form-error-messages [control]="linkForm.controls.route"></planet-form-error-messages></mat-error>
-    </mat-form-field>
-  </form>
+
+  <ng-container *ngIf="selectedLink?.db === 'teams'">
+    <form [formGroup]="linkForm">
+      <mat-horizontal-stepper #linkStepper linear (selectionChange)="linkStepperChange($event)">
+        <mat-step i18n-label completed="false" label="Select">
+          <planet-teams [mode]="selectedLink?.selector?.type" [excludeIds]="data.excludeIds" [isDialog]="true" (rowClick)="teamSelect($event)"></planet-teams>
+        </mat-step>
+        <mat-step i18n-label label="Title" [stepControl]="linkTitleForm">
+          <mat-form-field class="full-width">
+            <mat-label i18n>Title</mat-label>
+            <input matInput formControlName="title" required>
+            <mat-error><planet-form-error-messages [control]="linkForm.controls.title"></planet-form-error-messages></mat-error>
+          </mat-form-field>
+        </mat-step>
+      </mat-horizontal-stepper>
+    </form>
+  </ng-container>
+
+  <ng-container *ngIf="selectedLink?.db === 'social'">
+    <form [formGroup]="linkForm">
+      <mat-form-field class="full-width">
+        <mat-label i18n>Platform</mat-label>
+        <mat-select formControlName="platform" (selectionChange)="onPlatformSelect($event.value)" required>
+          <mat-select-trigger>
+            <ng-container [ngSwitch]="linkForm.value.platform">
+              <mat-icon *ngSwitchCase="'website'" class="margin-r-5">public</mat-icon>
+              <mat-icon *ngSwitchDefault [svgIcon]="linkForm.value.platform" class="margin-r-5"></mat-icon>
+            </ng-container>
+            {{getPlatformLabel(linkForm.value.platform)}}
+          </mat-select-trigger>
+          <mat-option *ngFor="let p of socialPlatforms" [value]="p.value">
+            <ng-container [ngSwitch]="p.value">
+              <mat-icon *ngSwitchCase="'website'" class="margin-r-5">public</mat-icon>
+              <mat-icon *ngSwitchDefault [svgIcon]="p.value" class="margin-r-5"></mat-icon>
+            </ng-container>
+            {{ p.label }}
+          </mat-option>
+        </mat-select>
+        <mat-error *ngIf="linkForm.controls.platform.invalid && linkForm.controls.platform.touched" i18n>Platform is required.</mat-error>
+      </mat-form-field>
+      <mat-form-field class="full-width">
+        <mat-label i18n>Title</mat-label>
+        <input matInput formControlName="title" required>
+        <mat-error><planet-form-error-messages [control]="linkForm.controls.title"></planet-form-error-messages></mat-error>
+      </mat-form-field>
+      <mat-form-field class="full-width">
+        <mat-label i18n>Link URL</mat-label>
+        <input matInput formControlName="route" placeholder="https://..." required>
+        <mat-error><planet-form-error-messages [control]="linkForm.controls.route"></planet-form-error-messages></mat-error>
+      </mat-form-field>
+    </form>
+  </ng-container>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button type="button" mat-raised-button (click)="cancelForm()" i18n>Cancel</button>

--- a/src/app/community/community-link-dialog.component.html
+++ b/src/app/community/community-link-dialog.component.html
@@ -1,5 +1,6 @@
+<h2 mat-dialog-title i18n>Add Link</h2>
 <mat-dialog-content>
-  <mat-form-field class="full-width link-type-field">
+  <mat-form-field class="full-width">
     <mat-label i18n>Type of Link</mat-label>
     <mat-select [(ngModel)]="selectedLink">
       <mat-option *ngFor="let link of links" [value]="link">{{link.title}}</mat-option>

--- a/src/app/shared/dialogs/dialogs-ratings.component.html
+++ b/src/app/shared/dialogs/dialogs-ratings.component.html
@@ -1,17 +1,17 @@
-<div mat-dialog-title class="display-flex">
-  <h3><ng-container i18n>Ratings for</ng-container><i> {{title}}</i></h3>
-  <span class="toolbar-fill"></span>
-  <mat-form-field class="font-size-1 margin-lr-5">
-    <mat-label i18n>Sort by</mat-label>
-    <mat-select (selectionChange)="onSortChange($event.value)">
-      <mat-option i18n value="time,1">Most Recent</mat-option>
-      <mat-option i18n value="time,-1">Oldest</mat-option>
-      <mat-option i18n value="rate,1">Best Rating</mat-option>
-      <mat-option i18n value="rate,-1">Worst Rating</mat-option>
-    </mat-select>
-  </mat-form-field>
-</div>
+<h2 mat-dialog-title><ng-container i18n>Ratings for</ng-container><i> {{title}}</i></h2>
 <mat-dialog-content>
+  <div class="display-flex">
+    <span class="toolbar-fill"></span>
+    <mat-form-field class="font-size-1 margin-lr-5">
+      <mat-label i18n>Sort by</mat-label>
+      <mat-select (selectionChange)="onSortChange($event.value)">
+        <mat-option i18n value="time,1">Most Recent</mat-option>
+        <mat-option i18n value="time,-1">Oldest</mat-option>
+        <mat-option i18n value="rate,1">Best Rating</mat-option>
+        <mat-option i18n value="rate,-1">Worst Rating</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
   <mat-card *ngFor="let rating of ratings" class="margin-tb">
     <mat-card-header>
       <mat-card-title>


### PR DESCRIPTION
Fixes #9672

- Move form fields to the `mat-dialog-content` to improve padding allowance
- Additionally, fix the `View Ratings` dialog

<img width="1210" height="436" alt="image" src="https://github.com/user-attachments/assets/66a84e96-723a-4c80-83fe-bfe756557307" />


<img width="894" height="484" alt="image" src="https://github.com/user-attachments/assets/7ede3b24-3ac8-4d6c-a341-a0539e16be0c" />


