### PR TITLE
Automate WebDriver version alignment for e2e

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,5 +26,14 @@ For those comfortable with GitHub and with the above languages please jump right
 * [Treehouse Project](https://github.com/treehouses/) - A image builder for planet learning deployment in raspberry pi
 * [Pirateship](https://github.com/ole-vi/pirateship) - Our homebrew system CLI tool
 
+
+## Legacy e2e WebDriver script ownership
+
+The `webdriver-set-version` script is still required for our Protractor-based end-to-end tests. It is actively owned through the maintained npm meta-script chain:
+
+- `npm run e2e` -> `npm run e2e:prepare` -> `npm run webdriver-set-version`
+
+Run `npm run webdriver-set-version` whenever your local Chrome/Chromium version changes, or before debugging e2e failures related to browser startup. The script automatically detects the browser version and requests a compatible ChromeDriver release.
+
 # Asking for help // OLE support communities
 OLE maintains a community of developers who actively maintain the Planet Learning system. You can discuss issue and ask for help in via our Gitter channel [here](https://gitter.im/open-learning-exchange/chat).

--- a/README.md
+++ b/README.md
@@ -116,7 +116,15 @@ Open `localhost:9876` once this is done compiling
 ```
 npm run e2e
 ```
-Results will appear in the console
+Results will appear in the console.
+
+The e2e command now runs `npm run e2e:prepare` first, which executes `scripts/webdriver-set-version.sh` to pin WebDriver to a Chrome-compatible version before Protractor starts.
+
+If Chrome or Chromium is upgraded, run the prep script directly once to refresh the local WebDriver binary:
+```
+npm run webdriver-set-version
+```
+The script reads your installed browser version, resolves the matching ChromeDriver milestone from Chrome for Testing metadata, and updates `webdriver-manager` with that exact version.
 
 ## Additional Commands
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "sass-lint": "./node_modules/sass-lint/bin/sass-lint.js -c ./sass-lint.yml -v -q",
     "lint": "ng lint planet-app",
     "lint-all": "npm run sass-lint && ng lint planet-app --type-check && npm run htmlhint",
-    "e2e": "ng e2e --webdriver-update=false",
+    "e2e": "npm run e2e:prepare && ng e2e --webdriver-update=false",
+    "e2e:prepare": "npm run webdriver-set-version",
     "install-hooks": "cp -a git-hooks/. .git/hooks/",
-    "webdriver-set-version": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",
+    "webdriver-set-version": "bash ./scripts/webdriver-set-version.sh",
     "generate-yml": "cd $(git rev-parse --show-toplevel)/docker;./generate_yml.sh",
     "starthub-true": "echo \"true\" > /srv/starthub",
     "starthub-false": "echo \"false\" > /srv/starthub"

--- a/scripts/webdriver-set-version.sh
+++ b/scripts/webdriver-set-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chrome_cmd=""
+for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    chrome_cmd="$candidate"
+    break
+  fi
+done
+
+if [ -z "$chrome_cmd" ]; then
+  echo "Could not find a Chrome/Chromium binary on PATH." >&2
+  echo "Install Chrome/Chromium, then re-run npm run webdriver-set-version." >&2
+  exit 1
+fi
+
+chrome_version="$($chrome_cmd --version | sed -E 's/.* ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+chrome_major="${chrome_version%%.*}"
+
+driver_version="$(curl -fsSL "https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json" \
+  | node -e "const fs=require('fs'); const milestone=process.argv[1]; const data=JSON.parse(fs.readFileSync(0,'utf8')); const match=data.milestones?.[milestone]?.version; if(!match){process.exit(1);} process.stdout.write(match);" "$chrome_major")"
+
+if [ -z "$driver_version" ]; then
+  echo "Could not resolve chromedriver version for Chrome milestone $chrome_major." >&2
+  exit 1
+fi
+
+echo "Detected $chrome_cmd version: $chrome_version"
+echo "Using chromedriver version: $driver_version"
+
+webdriver-manager update --standalone false --gecko false --versions.chrome "$driver_version"


### PR DESCRIPTION
### Motivation
- Prevent brittle e2e runs caused by hard-coded WebDriver versions that can drift from locally installed Chrome/Chromium versions. 
- Ensure the WebDriver setup is invoked automatically before Protractor-based end-to-end tests. 
- Add documentation and explicit ownership so maintainers know when and how to refresh the WebDriver binary.

### Description
- Added `scripts/webdriver-set-version.sh` which detects a local Chrome/Chromium binary, determines its milestone, resolves the matching ChromeDriver version from Chrome for Testing metadata, and calls `webdriver-manager update` with that version. 
- Updated `package.json` to run a prepare step before e2e by adding `e2e:prepare` and changing `e2e` to `npm run e2e:prepare && ng e2e --webdriver-update=false`, and replaced the hard-coded `webdriver-set-version` entry with `bash ./scripts/webdriver-set-version.sh`. 
- Documented the new prep step and usage guidance in `README.md` and added a short ownership/usage note to `CONTRIBUTING.md` describing the `e2e -> e2e:prepare -> webdriver-set-version` chain. 
- Added the new script file and committed the changes.

### Testing
- Validated `package.json` is parseable with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`, which succeeded. 
- Performed a shell syntax check with `bash -n scripts/webdriver-set-version.sh`, which succeeded. 
- Executed `bash ./scripts/webdriver-set-version.sh` in the environment which failed as expected because there is no Chrome/Chromium binary on `PATH`, so runtime resolution could not complete (this is expected in CI-less/dev containers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e722b4a4832d83de91eaf8daefa2)