### PR TITLE
Remove dead deferred logic from Protractor onPrepare

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -26,15 +26,13 @@ exports.config = {
     print: function() {}
   },
   onPrepare() {
-    var defer = protractor.promise.defer();
     require('ts-node').register({
       project: './e2e/tsconfig.e2e.json'
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
     browser.params.user = user.get();
 
-    return user.create().then(function(res) {
-      defer.fulfill();
+    return user.create().then(function() {
     })
     .catch(function(err) {
       console.log(err);


### PR DESCRIPTION
### Motivation
- Remove non-functional dead deferred code in `onPrepare` to simplify the promise flow and avoid misleading unused variables.

### Description
- Delete the unused `var defer = protractor.promise.defer();` and its `defer.fulfill()` call and change `.then(function(res) { ... })` to `.then(function() { ... })` while keeping `onPrepare` returning the `user.create()` promise chain.

### Testing
- Ran `node -c protractor.conf.js` to validate the configuration file and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e72035c0832d8fa74dad4b4e8da1)