### PR TITLE
remove dead code from users.component.spec.ts

### DIFF
--- a/src/app/users/users.component.spec.ts
+++ b/src/app/users/users.component.spec.ts
@@ -24,8 +24,6 @@ describe('Users', () => {
     });
     const fixture = TestBed.createComponent(UsersComponent);
     const comp = fixture.componentInstance;
-    // let de = fixture.debugElement.query(By.css('#login-status'));
-    // let statusElement = de.nativeElement;
     const couchService = fixture.debugElement.injector.get(CouchService);
     const userService = fixture.debugElement.injector.get(UserService);
     const testUsers: any = {
@@ -103,43 +101,4 @@ describe('Users', () => {
     });
 
   });
-  /*
-  it('Should display create user message', () => {
-    let { fixture, comp, statusElement, couchService, testModel } = setup();
-    spy = spyOn(couchService, 'put').and.returnValue(Promise.resolve({id:'org.couchdb.user:' + testModel.name}));
-    comp.createUser(testModel);
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expect(statusElement.textContent).toBe('User created: ' + testModel.name,'Create user message displays correctly');
-    });
-  });
-
-  it('Should reject nonmatching passwords', () => {
-    let { fixture, comp, statusElement, couchService, testModel } = setup();
-    testModel.repeatPassword = 'passwor';
-    comp.createUser(testModel);
-    fixture.detectChanges();
-    expect(statusElement.textContent).toBe('Passwords do not match','Create user message displays correctly');
-  });
-
-  it('Should greet users', () => {
-    let { fixture, comp, statusElement, couchService, testModel } = setup();
-    spy = spyOn(couchService, 'post').and.returnValue(Promise.resolve({name:testModel.name}));
-    comp.login(testModel);
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expect(statusElement.textContent).toBe('Hi, ' + testModel.name + '!','Create user message displays correctly');
-    });
-  });
-
-  it('Should message when user & password do not match', () => {
-    let { fixture, comp, statusElement, couchService, testModel } = setup();
-    spy = spyOn(couchService, 'post').and.returnValue(Promise.reject({}));
-    comp.login(testModel);
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expect(statusElement.textContent).toBe('Username and/or password do not match');
-    });
-  });
-  */
 });


### PR DESCRIPTION
Addresses issue #9734 

🎯 **What:** Removed commented-out debug elements and old, commented-out test blocks from `src/app/users/users.component.spec.ts`.


💡 **Why:** Dead, commented-out code creates clutter, reduces readability, and causes confusion for developers trying to maintain the test suite. Removing it improves overall code health.



✅ **Verification:** Used `sed` to precisely delete the targeted lines and confirmed their removal. Tests weren't runnable in this specific environment, but the changes only involve deleting `//` and `/* ... */` comments, guaranteeing zero risk of altering functionality.



✨ **Result:** A cleaner, more maintainable test file that conforms to better code health standards.

---
*PR created automatically by Jules for task [1052006354613613500]