### PR TITLE
Clean up ignored callback parameters in create-design-docs

### DIFF
--- a/design/create-design-docs.js
+++ b/design/create-design-docs.js
@@ -2,10 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const basePath = __dirname;
 
-const readDirectories = (err, directories) => {
+const readDirectories = (_err, directories) => {
   directories.forEach((dir) => {
     const dirFullPath = path.join(basePath, dir);
-    fs.stat(dirFullPath, (err, stat) => {
+    fs.stat(dirFullPath, (_err, stat) => {
       if (stat.isDirectory()) {
         readDir(dir, readFiles(dir));
       }
@@ -13,10 +13,10 @@ const readDirectories = (err, directories) => {
   });
 };
 
-const readFiles = (dirPath) => (err, files) => {
+const readFiles = (dirPath) => (_err, files) => {
   files.forEach((file) => {
     const filePath = path.join(basePath, dirPath, file);
-    fs.stat(filePath, (err, stat) => {
+    fs.stat(filePath, (_err) => {
       if (path.extname(file) === '.js' && file !== 'create-design-docs.js') {
         const modulePath = './' + path.join(dirPath, file);
         writeDesignDoc(require(modulePath), filePath);


### PR DESCRIPTION
### Motivation
- Clarify intent by marking intentionally ignored callback error parameters and removing unused callback args while keeping runtime behavior unchanged.

### Description
- Rename ignored error parameters to `_err` in `readDirectories` and its nested `fs.stat` callback to indicate they are intentionally unused.
- Rename ignored error parameter to `_err` in `readFiles` and remove the unused `stat` parameter from the inner `fs.stat` callback used for file checks.
- Preserve all traversal logic and processing order; no functional changes to how files or directories are discovered or handled.

### Testing
- Ran `node --check design/create-design-docs.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85d5f3c78832d81febd9a2545ed02)