### PR TITLE
Add scaleLabel axis formatting to ReportsHealthComponent chart

### DIFF
--- a/src/app/manager-dashboard/reports/reports-health.component.ts
+++ b/src/app/manager-dashboard/reports/reports-health.component.ts
@@ -146,9 +146,14 @@ export class ReportsHealthComponent implements OnChanges {
         scales: {
           y: {
             type: 'linear',
-            ticks: {  precision: 0 }
+            ticks: {  precision: 0 },
+            // Formats the user-visible y-axis label text for diagnosis counts.
+            scaleLabel: scaleLabel('Diagnoses')
           },
-          x: { title: { display: true, text: 'Week of' } }
+          x: {
+            // Formats the user-visible x-axis label text showing week ranges.
+            scaleLabel: scaleLabel('Week of')
+          }
         },
       }
     };


### PR DESCRIPTION
### Motivation
- Provide user-visible axis labels for the health trends chart by applying the shared `scaleLabel(...)` formatter so axis text (y: diagnoses counts, x: week ranges) is rendered consistently.

### Description
- Updated `ReportsHealthComponent.setChart()` to call `scaleLabel('Diagnoses')` on `scales.y.scaleLabel` and `scaleLabel('Week of')` on `scales.x.scaleLabel`, retained the `scaleLabel` import, and added brief inline comments describing the formatted user-facing axis text.

### Testing
- Ran `npm run lint`, which failed in this environment because the Angular CLI binary is not available (`sh: 1: ng: not found`), and attempted a Playwright screenshot script which failed with `ERR_EMPTY_RESPONSE` when connecting to `http://127.0.0.1:4200`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85d5acce8832dae56dc0c137904aa)