### PR TITLE
chore(chatapi): mark unused request param in /checkproviders route

### DIFF
--- a/chatapi/src/index.ts
+++ b/chatapi/src/index.ts
@@ -91,7 +91,7 @@ app.post('/', async (req: any, res: any) => {
   }
 });
 
-app.get('/checkproviders', async (req: any, res: any) => {
+app.get('/checkproviders', async (_req: any, res: any) => {
   res.status(200).json({
     'openai': keys.openai.apiKey ? true : false,
     'perplexity': keys.perplexity.apiKey ? true : false,


### PR DESCRIPTION
### Motivation
- Mark the unused `req` parameter in the `GET /checkproviders` handler to satisfy lint rules that require intentional unused parameters to be named accordingly.

### Description
- Updated the handler signature in `chatapi/src/index.ts` from `(req: any, res: any)` to `(_req: any, res: any)` without changing response payload or route logic.

### Testing
- Ran `npm run lint` in `chatapi`, which failed due to ESLint v9 expecting `eslint.config.js` while the project uses legacy config, and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85d67ac18832dbbd1be089936dd31)