### PR TITLE
Remove unused scaleLabel import from reports-health component

### DIFF
--- a/src/app/manager-dashboard/reports/reports-health.component.ts
+++ b/src/app/manager-dashboard/reports/reports-health.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnChanges, EventEmitter, Output, ViewChild } from '@a
 import { Chart, ChartConfiguration, LineController } from 'chart.js';
 import { StateService } from '../../shared/state.service';
 import { HealthService } from '../../health/health.service';
-import { generateWeeksArray, filterByDate, weekDataLabels, scaleLabel } from './reports.utils';
+import { generateWeeksArray, filterByDate, weekDataLabels } from './reports.utils';
 import { ReportsService } from './reports.service';
 import { millisecondsToDay } from '../../meetups/constants';
 import { dedupeShelfReduce, styleVariables } from '../../shared/utils';


### PR DESCRIPTION
### Motivation
- Remove an unused import to eliminate a lint warning and keep the component import list minimal and low-risk.

### Description
- Deleted `scaleLabel` from the destructured import of `./reports.utils` in `src/app/manager-dashboard/reports/reports-health.component.ts` so the file now imports only `generateWeeksArray`, `filterByDate`, and `weekDataLabels`.

### Testing
- Ran a source check with `rg -n "scaleLabel|setChart\(|scales:" src/app/manager-dashboard/reports/reports-health.component.ts` and inspected the chart setup to confirm `setChart()` defines axis options inline and no `scaleLabel` references remain, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85d605e90832d847d0b12fde04205)