### PR TITLE
Add HostListener handlers to ManagerDashboardComponent

### DIFF
--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -89,6 +89,18 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
     this.onDestroy$.complete();
   }
 
+  // Keep the dashboard grid and overlays in sync with host window events for responsive UX.
+  @HostListener('window:resize')
+  onWindowResize() {
+    this.gridRowHeight = window.innerWidth < 960 ? '2.5rem' : '2rem';
+    this.overlayOpen = false;
+  }
+
+  @HostListener('window:keydown.escape')
+  onEscapeKey() {
+    this.overlayOpen = false;
+  }
+
   getSatellitePin() {
     this.couchService.get('_node/nonode@nohost/_config/satellite/pin').subscribe((res) => this.pin = res);
   }


### PR DESCRIPTION
### Motivation
- Ensure host window events update dashboard UI state so the grid and overlays remain consistent and responsive.
- Close overlays on disruptive host events (resize, Escape) to avoid stale UI state and improve UX.

### Description
- Added a short comment documenting expected event behavior above the new handlers in `ManagerDashboardComponent`.
- Implemented `@HostListener('window:resize')` as `onWindowResize()` which recalculates `gridRowHeight` (uses `window.innerWidth < 960 ? '2.5rem' : '2rem'`) and sets `overlayOpen = false`.
- Implemented `@HostListener('window:keydown.escape')` as `onEscapeKey()` which sets `overlayOpen = false`, and preserved the existing `HostListener` import.

### Testing
- Ran lint via `npm run lint -- --silent` which failed in this environment because the Angular CLI (`ng`) is not available on the PATH.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85d591f94832db079b60c7c31ab8a)