### PR TITLE
Fix Protractor onPrepare readiness signaling

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -33,12 +33,19 @@ exports.config = {
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
     browser.params.user = user.get();
 
-    return user.create().then(function(res) {
-      defer.fulfill();
-    })
-    .catch(function(err) {
-      console.log(err);
-    });
+    // We return defer.promise (instead of the native user.create() promise) so
+    // Protractor's control flow only starts specs after the explicit readiness
+    // signal and reliably fails startup if user creation cannot complete.
+    user.create()
+      .then(function() {
+        defer.fulfill();
+      })
+      .catch(function(err) {
+        console.log(err);
+        defer.reject(err);
+      });
+
+    return defer.promise;
   },
   onComplete() {
     return user.delete().then(function(res) {


### PR DESCRIPTION
### Motivation
- Ensure Protractor only starts specs after the e2e test user is created and that startup deterministically fails if user creation fails.

### Description
- Updated `onPrepare` in `protractor.conf.js` to return `defer.promise` and wired `defer.fulfill()` / `defer.reject()` to the outcome of `user.create()`, and added a short comment explaining why the deferred promise is used instead of returning the native `user.create()` chain.

### Testing
- Ran `node --check /workspace/planet/protractor.conf.js` to verify syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e7210914832d9faefa6f6556be20)