### PR TITLE
Harden assistant activation and add integration coverage

### DIFF
--- a/chatapi/package.json
+++ b/chatapi/package.json
@@ -7,6 +7,7 @@
     "start": "ts-node src/index.ts",
     "build": "tsc",
     "dev": "nodemon --exec ts-node src/index.ts",
+    "test:integration": "COUCHDB_HOST=http://localhost:5984 ts-node --transpile-only src/tests/assistant.integration.test.ts",
     "lint": "eslint . --ext .ts",
     "lint-fix": "eslint . --ext .ts --fix"
   },

--- a/chatapi/src/config/ai-providers.config.ts
+++ b/chatapi/src/config/ai-providers.config.ts
@@ -55,6 +55,7 @@ const initialize = async () => {
     };
 
     assistant = {
+      'enabled': doc?.assistant?.enabled ?? true,
       'name': doc?.assistant?.name || '',
       'instructions': doc?.assistant?.instructions || '',
     };

--- a/chatapi/src/models/chat.model.ts
+++ b/chatapi/src/models/chat.model.ts
@@ -13,6 +13,7 @@ interface Providers {
 }
 
 interface Assistant {
+  enabled?: boolean;
   name: string;
   instructions: string;
 }
@@ -33,4 +34,3 @@ export interface ChatItem {
   query: string;
   response: string;
 }
-

--- a/chatapi/src/tests/assistant.integration.test.ts
+++ b/chatapi/src/tests/assistant.integration.test.ts
@@ -1,0 +1,144 @@
+/* eslint-disable quote-props, @typescript-eslint/naming-convention */
+import assert from 'assert';
+
+import { aiChat } from '../utils/chat.utils';
+import { assistant as assistantConfig, models } from '../config/ai-providers.config';
+import * as assistantUtils from '../utils/chat-assistant.utils';
+
+function createFakeProvider() {
+  return {
+    ai: {
+      chat: {
+        completions: {
+          create: async () => ({ choices: [ { message: { content: 'provider response' } } ] })
+        }
+      }
+    },
+    defaultModel: 'gpt-4o-mini'
+  };
+}
+
+async function testAssistantNonStreamingPath() {
+  const originalModel = models.openai;
+  const originalAssistantEnabled = assistantConfig.enabled;
+  const originalCreateAssistant = assistantUtils.createAssistant;
+  const originalCreateThread = assistantUtils.createThread;
+  const originalAddToThread = assistantUtils.addToThread;
+  const originalCreateRun = assistantUtils.createRun;
+  const originalWaitForRunCompletion = assistantUtils.waitForRunCompletion;
+  const originalRetrieveResponse = assistantUtils.retrieveResponse;
+
+  let runCreated = false;
+
+  try {
+    models.openai = createFakeProvider();
+    assistantConfig.enabled = true;
+
+    (assistantUtils as any).createAssistant = (async () => ({ id: 'asst_1' })) as typeof assistantUtils.createAssistant;
+    (assistantUtils as any).createThread = (async () => ({ id: 'thread_1' })) as typeof assistantUtils.createThread;
+    (assistantUtils as any).addToThread = (async () => ({})) as typeof assistantUtils.addToThread;
+    (assistantUtils as any).createRun = (async () => {
+      runCreated = true;
+      return { id: 'run_1' };
+    }) as typeof assistantUtils.createRun;
+    (assistantUtils as any).waitForRunCompletion = (async () => ({ status: 'completed' })) as typeof assistantUtils.waitForRunCompletion;
+    (assistantUtils as any).retrieveResponse = (async () => 'assistant non-stream response') as typeof assistantUtils.retrieveResponse;
+
+    const response = await aiChat(
+      [ { role: 'user', content: 'hello' } ],
+      { name: 'openai', model: 'gpt-4o-mini' },
+      true,
+      { data: 'context' },
+      false
+    );
+
+    assert.strictEqual(response, 'assistant non-stream response');
+    assert.strictEqual(runCreated, true);
+  } finally {
+    models.openai = originalModel;
+    assistantConfig.enabled = originalAssistantEnabled;
+    (assistantUtils as any).createAssistant = originalCreateAssistant;
+    (assistantUtils as any).createThread = originalCreateThread;
+    (assistantUtils as any).addToThread = originalAddToThread;
+    (assistantUtils as any).createRun = originalCreateRun;
+    (assistantUtils as any).waitForRunCompletion = originalWaitForRunCompletion;
+    (assistantUtils as any).retrieveResponse = originalRetrieveResponse;
+  }
+}
+
+async function testAssistantStreamingPath() {
+  const originalModel = models.openai;
+  const originalAssistantEnabled = assistantConfig.enabled;
+  const originalCreateAssistant = assistantUtils.createAssistant;
+  const originalCreateThread = assistantUtils.createThread;
+  const originalAddToThread = assistantUtils.addToThread;
+  const originalCreateAndHandleRunWithStreaming = assistantUtils.createAndHandleRunWithStreaming;
+
+  const streamedChunks: string[] = [];
+
+  try {
+    models.openai = createFakeProvider();
+    assistantConfig.enabled = true;
+
+    (assistantUtils as any).createAssistant = (async () => ({ id: 'asst_2' })) as typeof assistantUtils.createAssistant;
+    (assistantUtils as any).createThread = (async () => ({ id: 'thread_2' })) as typeof assistantUtils.createThread;
+    (assistantUtils as any).addToThread = (async () => ({})) as typeof assistantUtils.addToThread;
+    (assistantUtils as any).createAndHandleRunWithStreaming = (
+      (async (_threadID: string, _assistantID: string, _instructions: string, callback?: (response: string) => void) => {
+        callback?.('hello');
+        callback?.(' world');
+        return 'hello world';
+      }) as typeof assistantUtils.createAndHandleRunWithStreaming
+    );
+
+    const response = await aiChat(
+      [ { role: 'user', content: 'hello' } ],
+      { name: 'openai', model: 'gpt-4o-mini' },
+      true,
+      { data: 'context' },
+      true,
+      (chunk: string) => streamedChunks.push(chunk)
+    );
+
+    assert.strictEqual(response, 'hello world');
+    assert.deepStrictEqual(streamedChunks, [ 'hello', ' world' ]);
+  } finally {
+    models.openai = originalModel;
+    assistantConfig.enabled = originalAssistantEnabled;
+    (assistantUtils as any).createAssistant = originalCreateAssistant;
+    (assistantUtils as any).createThread = originalCreateThread;
+    (assistantUtils as any).addToThread = originalAddToThread;
+    (assistantUtils as any).createAndHandleRunWithStreaming = originalCreateAndHandleRunWithStreaming;
+  }
+}
+
+async function testAssistantProviderValidation() {
+  const originalModel = models.perplexity;
+  const originalAssistantEnabled = assistantConfig.enabled;
+  try {
+    models.perplexity = createFakeProvider();
+    assistantConfig.enabled = true;
+
+    await assert.rejects(
+      aiChat(
+        [ { role: 'user', content: 'hello' } ],
+        { name: 'perplexity', model: 'sonar' },
+        true,
+        { data: 'context' },
+        false
+      ),
+      /only compatible with openai provider/
+    );
+  } finally {
+    models.perplexity = originalModel;
+    assistantConfig.enabled = originalAssistantEnabled;
+  }
+}
+
+(async () => {
+  await testAssistantNonStreamingPath();
+  await testAssistantStreamingPath();
+  await testAssistantProviderValidation();
+  // eslint-disable-next-line no-console
+  console.log('assistant integration tests passed');
+})();

--- a/chatapi/src/utils/chat-assistant.utils.ts
+++ b/chatapi/src/utils/chat-assistant.utils.ts
@@ -1,55 +1,121 @@
 import { keys } from '../config/ai-providers.config';
 import { assistant } from '../config/ai-providers.config';
 
+const TERMINAL_RUN_STATUSES = new Set([ 'completed', 'failed', 'cancelled', 'expired' ]);
+
+export function normalizeAssistantError(error: unknown, operation: string): Error {
+  if (error instanceof Error) {
+    return new Error(`Assistant API ${operation} failed: ${error.message}`);
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const errorObj = error as { message?: string; status?: number; code?: string };
+    const details = [
+      errorObj.status ? `status=${errorObj.status}` : '',
+      errorObj.code ? `code=${errorObj.code}` : '',
+      errorObj.message ? `message=${errorObj.message}` : ''
+    ].filter(Boolean).join(' ');
+
+    return new Error(`Assistant API ${operation} failed${details ? ` (${details})` : ''}`);
+  }
+
+  return new Error(`Assistant API ${operation} failed`);
+}
+
 /**
  * Creates an assistant with the specified model
  * @param model - Model to use for assistant
  * @returns Assistant object
  */
 export async function createAssistant(model: string) {
-  return await keys.openai.beta.assistants.create({
-    'name': assistant?.name,
-    'instructions': assistant?.instructions,
-    'tools': [ { 'type': 'code_interpreter' } ],
-    model,
-  });
+  try {
+    return await keys.openai.beta.assistants.create({
+      'name': assistant?.name,
+      'instructions': assistant?.instructions,
+      'tools': [ { 'type': 'code_interpreter' } ],
+      model,
+    });
+  } catch (error) {
+    throw normalizeAssistantError(error, 'createAssistant');
+  }
 }
 
 export async function createThread() {
-  return await keys.openai.beta.threads.create();
+  try {
+    return await keys.openai.beta.threads.create();
+  } catch (error) {
+    throw normalizeAssistantError(error, 'createThread');
+  }
 }
 
 export async function addToThread(threadId: any, message: string) {
-  return await keys.openai.beta.threads.messages.create(
-    threadId,
-    {
-      'role': 'user',
-      'content': message
-    }
-  );
+  try {
+    return await keys.openai.beta.threads.messages.create(
+      threadId,
+      {
+        'role': 'user',
+        'content': message
+      }
+    );
+  } catch (error) {
+    throw normalizeAssistantError(error, 'addToThread');
+  }
 }
 
 export async function createRun(threadID: any, assistantID: any, instructions?: string) {
-  return await keys.openai.beta.threads.runs.create(
-    threadID,
-    {
-      'assistant_id': assistantID,
-      instructions
-    }
-  );
+  try {
+    return await keys.openai.beta.threads.runs.create(
+      threadID,
+      {
+        'assistant_id': assistantID,
+        instructions
+      }
+    );
+  } catch (error) {
+    throw normalizeAssistantError(error, 'createRun');
+  }
 }
 
 export async function waitForRunCompletion(threadId: any, runId: any) {
-  let runStatus = await keys.openai.beta.threads.runs.retrieve(threadId, runId);
-  while (runStatus.status !== 'completed') {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    runStatus = await keys.openai.beta.threads.runs.retrieve(threadId, runId);
+  const maxAttempts = 60;
+  const pollDelayMs = 1000;
+  const timeoutMs = 90_000;
+  const startedAt = Date.now();
+
+  let attempts = 0;
+  let runStatus: any;
+  while (attempts < maxAttempts) {
+    attempts += 1;
+    try {
+      runStatus = await keys.openai.beta.threads.runs.retrieve(threadId, runId);
+    } catch (error) {
+      throw normalizeAssistantError(error, 'waitForRunCompletion');
+    }
+
+    if (TERMINAL_RUN_STATUSES.has(runStatus.status)) {
+      if (runStatus.status === 'completed') {
+        return runStatus;
+      }
+      throw new Error(`Assistant run finished with status "${runStatus.status}"`);
+    }
+
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Assistant run timed out after ${timeoutMs}ms`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollDelayMs));
   }
-  return runStatus;
+
+  throw new Error(`Assistant run exceeded retry limit (${maxAttempts})`);
 }
 
 export async function retrieveResponse(threadId: any): Promise<string> {
-  const messages = await keys.openai.beta.threads.messages.list(threadId);
+  let messages;
+  try {
+    messages = await keys.openai.beta.threads.messages.list(threadId);
+  } catch (error) {
+    throw normalizeAssistantError(error, 'retrieveResponse');
+  }
   for (const msg of messages.data) {
     if ('text' in msg.content[0] && msg.role === 'assistant') {
       return msg.content[0].text.value;
@@ -65,39 +131,43 @@ export async function createAndHandleRunWithStreaming(
   let completionText = '';
 
   return new Promise((resolve, reject) => {
-    keys.openai.beta.threads.runs.stream(threadID, {
-      'assistant_id': assistantID,
-      instructions
-    })
-      .on('textDelta', (textDelta: { value: string }) => {
-        if (textDelta && textDelta.value) {
-          completionText += textDelta.value;
-          if (callback) {
-            callback(textDelta.value);
-          }
-        }
+    try {
+      keys.openai.beta.threads.runs.stream(threadID, {
+        'assistant_id': assistantID,
+        instructions
       })
-      .on('toolCallDelta', (toolCallDelta: { type: string; code_interpreter: { input: string; outputs: any[] } }) => {
-        if (toolCallDelta.type === 'code_interpreter') {
-          if (toolCallDelta && toolCallDelta.code_interpreter && toolCallDelta.code_interpreter.input) {
-            completionText += toolCallDelta.code_interpreter.input;
+        .on('textDelta', (textDelta: { value: string }) => {
+          if (textDelta && textDelta.value) {
+            completionText += textDelta.value;
             if (callback) {
-              callback(toolCallDelta.code_interpreter.input);
+              callback(textDelta.value);
             }
           }
-          if (toolCallDelta && toolCallDelta.code_interpreter && toolCallDelta.code_interpreter.outputs) {
-            toolCallDelta.code_interpreter.outputs.forEach((output) => {
-              if (output.type === 'logs' && output.logs) {
-                completionText += output.logs;
-                if (callback) {
-                  callback(output.logs);
-                }
+        })
+        .on('toolCallDelta', (toolCallDelta: { type: string; code_interpreter: { input: string; outputs: any[] } }) => {
+          if (toolCallDelta.type === 'code_interpreter') {
+            if (toolCallDelta && toolCallDelta.code_interpreter && toolCallDelta.code_interpreter.input) {
+              completionText += toolCallDelta.code_interpreter.input;
+              if (callback) {
+                callback(toolCallDelta.code_interpreter.input);
               }
-            });
+            }
+            if (toolCallDelta && toolCallDelta.code_interpreter && toolCallDelta.code_interpreter.outputs) {
+              toolCallDelta.code_interpreter.outputs.forEach((output) => {
+                if (output.type === 'logs' && output.logs) {
+                  completionText += output.logs;
+                  if (callback) {
+                    callback(output.logs);
+                  }
+                }
+              });
+            }
           }
-        }
-      })
-      .on('end', () => resolve(completionText))
-      .on('error', reject);
+        })
+        .on('end', () => resolve(completionText))
+        .on('error', (error: unknown) => reject(normalizeAssistantError(error, 'streamRun')));
+    } catch (error) {
+      reject(normalizeAssistantError(error, 'streamRun'));
+    }
   });
 }

--- a/chatapi/src/utils/chat-helpers.utils.ts
+++ b/chatapi/src/utils/chat-helpers.utils.ts
@@ -1,4 +1,4 @@
-import { models } from '../config/ai-providers.config';
+import { assistant as assistantConfig, models } from '../config/ai-providers.config';
 import { AIProvider, ChatMessage } from '../models/chat.model';
 import { Attachment } from '../models/db-doc.model';
 import { fetchFileFromCouchDB } from './db.utils';
@@ -13,6 +13,20 @@ import {
 } from './chat-assistant.utils';
 import { extractTextFromDocument } from './text-extraction.utils';
 
+export function validateAssistantCompatibility(aiProvider: AIProvider, assistant: boolean) {
+  if (!assistant) {
+    return;
+  }
+
+  if (assistantConfig.enabled === false) {
+    throw new Error('Assistant mode is disabled in configuration');
+  }
+
+  if (aiProvider.name !== 'openai') {
+    throw new Error(`Assistant mode is only compatible with openai provider, received "${aiProvider.name}"`);
+  }
+}
+
 /**
  * Uses openai's completions endpoint to generate chat completions with streaming enabled
  * @param messages - Array of chat messages
@@ -26,6 +40,7 @@ export async function aiChatStream(
   context: any = '',
   callback?: (response: string) => void
 ): Promise<string> {
+  validateAssistantCompatibility(aiProvider, assistant);
   const provider = models[aiProvider.name];
   if (!provider) {
     throw new Error('Unsupported AI provider');
@@ -81,6 +96,7 @@ export async function aiChatNonStream(
   assistant: boolean,
   context: any = '',
 ): Promise<string> {
+  validateAssistantCompatibility(aiProvider, assistant);
   const provider = models[aiProvider.name];
   if (!provider) {
     throw new Error('Unsupported AI provider');

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -25,6 +25,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   private onDestroy$ = new Subject<void>();
   spinnerOn = true;
   streaming: boolean;
+  assistantEnabled = true;
   disabled = false;
   clearChat = true;
   provider: AIProvider;
@@ -171,6 +172,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   checkStreamingStatusAndInitialize() {
     this.isStreamingEnabled();
+    this.isAssistantEnabled();
     if (this.streaming) {
       this.chatService.initializeWebSocket();
       this.initializeChatStream();
@@ -181,6 +183,11 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   isStreamingEnabled() {
     const configuration = this.stateService.configuration;
     this.streaming = configuration.streaming;
+  }
+
+  isAssistantEnabled() {
+    const configuration = this.stateService.configuration;
+    this.assistantEnabled = configuration?.assistant?.enabled ?? true;
   }
 
   initializeErrorStream() {
@@ -235,7 +242,12 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   submitPrompt() {
     const content = this.promptForm.controls.prompt.value;
-    this.data = { ...this.data, content, aiProvider: this.provider };
+    this.data = {
+      ...this.data,
+      content,
+      aiProvider: this.provider,
+      assistant: this.assistantEnabled && this.provider?.name === 'openai'
+    };
 
     this.chatService.setChatAIProvider(this.data.aiProvider);
     this.setSelectedConversation();

--- a/src/app/configuration/configuration.component.ts
+++ b/src/app/configuration/configuration.component.ts
@@ -279,6 +279,7 @@ export class ConfigurationComponent implements OnInit {
         gemini: ''
       },
       assistant: {
+        enabled: true,
         name: 'Planet Context',
         instructions: baseContextPrompt,
       }

--- a/src/app/manager-dashboard/manager-aiservices.component.html
+++ b/src/app/manager-dashboard/manager-aiservices.component.html
@@ -63,6 +63,12 @@
       <mat-list>
         <mat-list-item>
           <div matListItemTitle class="list-item-content">
+            <span i18n>Enable assistant endpoint:</span>
+            <mat-slide-toggle formControlName="assistantEnabled"></mat-slide-toggle>
+          </div>
+        </mat-list-item>
+        <mat-list-item>
+          <div matListItemTitle class="list-item-content">
             <span i18n>Name:</span>
             <mat-form-field>
               <mat-label i18n>Assistant name</mat-label>

--- a/src/app/manager-dashboard/manager-aiservices.component.spec.ts
+++ b/src/app/manager-dashboard/manager-aiservices.component.spec.ts
@@ -1,0 +1,77 @@
+import { NonNullableFormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+
+import { ManagerAIServicesComponent } from './manager-aiservices.component';
+
+class MockClipboard {
+  copy() {}
+}
+
+class MockConfigurationService {
+  updateConfiguration = jasmine.createSpy('updateConfiguration').and.returnValue(of({}));
+}
+
+class MockPlanetMessageService {
+  showAlert = jasmine.createSpy('showAlert');
+  showMessage = jasmine.createSpy('showMessage');
+}
+
+class MockRouter {
+  navigate = jasmine.createSpy('navigate');
+}
+
+class MockStateService {
+  configuration: any = {
+    _id: 'config-id',
+    _rev: '1-abc',
+    owner: 'planet-owner',
+    streaming: true,
+    keys: { openai: 'key' },
+    models: { openai: 'gpt-4o-mini' },
+    assistant: {
+      enabled: true,
+      name: 'Planet Context',
+      instructions: 'Be helpful'
+    }
+  };
+  keys = { openai: 'key' };
+  requestData = jasmine.createSpy('requestData');
+}
+
+describe('ManagerAIServicesComponent', () => {
+  let component: ManagerAIServicesComponent;
+  let configurationService: MockConfigurationService;
+  let stateService: MockStateService;
+
+  beforeEach(() => {
+    configurationService = new MockConfigurationService();
+    stateService = new MockStateService();
+
+    component = new ManagerAIServicesComponent(
+      new NonNullableFormBuilder(),
+      new MockClipboard() as any,
+      configurationService as any,
+      new MockPlanetMessageService() as any,
+      new MockRouter() as any,
+      stateService as any
+    );
+
+    component.ngOnInit();
+  });
+
+  it('should initialize assistant toggle from configuration', () => {
+    expect(component.configForm.controls.assistantEnabled.value).toBeTrue();
+  });
+
+  it('should persist assistant toggle and preserve ownership metadata on save', () => {
+    component.configForm.controls.assistantEnabled.setValue(false);
+
+    component.saveConfig();
+
+    const savedConfig = configurationService.updateConfiguration.calls.mostRecent().args[0];
+    expect(savedConfig.owner).toEqual('planet-owner');
+    expect(savedConfig._id).toEqual('config-id');
+    expect(savedConfig._rev).toEqual('1-abc');
+    expect(savedConfig.assistant.enabled).toBeFalse();
+  });
+});

--- a/src/app/manager-dashboard/manager-aiservices.component.ts
+++ b/src/app/manager-dashboard/manager-aiservices.component.ts
@@ -10,6 +10,7 @@ import { StateService } from '../shared/state.service';
 
 interface FixedConfigFormControls {
   streaming: FormControl<boolean>;
+  assistantEnabled: FormControl<boolean>;
   assistantName: FormControl<string>;
   assistantInstructions: FormControl<string>;
 }
@@ -23,6 +24,7 @@ interface AIConfiguration {
   keys?: Record<string, unknown>;
   models?: Record<string, unknown>;
   assistant?: {
+    enabled?: boolean;
     name?: string;
     instructions?: string;
   };
@@ -50,6 +52,7 @@ export class ManagerAIServicesComponent implements OnInit, OnDestroy {
   ) {
     this.configForm = this.fb.group<ConfigFormControls>({
       streaming: this.fb.control(false),
+      assistantEnabled: this.fb.control(true),
       assistantName: this.fb.control(''),
       assistantInstructions: this.fb.control('')
     });
@@ -69,6 +72,7 @@ export class ManagerAIServicesComponent implements OnInit, OnDestroy {
   initForm() {
     this.configForm = this.fb.group<ConfigFormControls>({
       streaming: this.fb.control(!!this.configuration.streaming),
+      assistantEnabled: this.fb.control(this.configuration.assistant?.enabled ?? true),
       ...this.mapConfigToFormControls(this.configuration.keys, 'keys_'),
       ...this.mapConfigToFormControls(this.configuration.models, 'models_'),
       assistantName: this.fb.control(this.configuration.assistant?.name || ''),
@@ -105,6 +109,7 @@ export class ManagerAIServicesComponent implements OnInit, OnDestroy {
       keys: this.extractFormValues(this.configuration.keys, 'keys_'),
       models: this.extractFormValues(this.configuration.models, 'models_'),
       assistant: {
+        enabled: this.configForm.controls.assistantEnabled.value,
         name: this.getStringControlValue('assistantName'),
         instructions: this.getStringControlValue('assistantInstructions')
       }


### PR DESCRIPTION
### Motivation
- Make assistant usage explicit and safe by validating the configured `assistant` flag and provider compatibility before calling OpenAI assistant endpoints.
- Stabilize runtime behavior of assistant runs by adding error normalization, retry/timeout guards and terminal-status handling to reduce flakiness and unclear errors.
- Provide automated coverage for both streaming and non-streaming assistant flows to catch regressions early.
- Expose and persist a frontend toggle so administrators can enable/disable the assistant endpoint and ensure ownership metadata is preserved when saving config.

### Description
- Add `validateAssistantCompatibility` that rejects assistant mode unless `assistant.enabled` is true and the provider is `openai`, and wire it into `aiChatStream`/`aiChatNonStream` (modified `chatapi/src/utils/chat-helpers.utils.ts`).
- Harden assistant API calls by adding `normalizeAssistantError`, wrapping assistant calls in try/catch, implementing terminal run status handling, retry limit and timeout in `waitForRunCompletion`, and normalizing streaming errors (modified `chatapi/src/utils/chat-assistant.utils.ts`).
- Persist assistant state in backend config initialization by adding `assistant.enabled` to provider config and typing (`chatapi/src/config/ai-providers.config.ts`, `chatapi/src/models/chat.model.ts`).
- Add integration tests exercising assistant non-streaming, streaming, and provider validation and a runnable script `test:integration` (new `chatapi/src/tests/assistant.integration.test.ts` and `chatapi/package.json`).
- Expose a frontend toggle and persist it: add `assistantEnabled` form control and UI slide toggle, include `assistant.enabled` in saved configuration and defaults, and only set `data.assistant` for chat submissions when the toggle is on and provider is OpenAI (modified `src/app/manager-dashboard/manager-aiservices.component.ts`, `src/app/manager-dashboard/manager-aiservices.component.html`, `src/app/configuration/configuration.component.ts`, and `src/app/chat/chat-window/chat-window.component.ts`).
- Add a frontend unit test verifying toggle initialization and that save preserves ownership metadata and the new `assistant.enabled` flag (`src/app/manager-dashboard/manager-aiservices.component.spec.ts`).

### Testing
- Ran `npm --prefix chatapi run build` to compile the chatapi TypeScript bundle and it succeeded.
- Ran `npm --prefix chatapi run lint` (ESLint) and it passed after adding test-file eslint disables.
- Ran `npm --prefix chatapi run test:integration` which executed the new assistant integration scenarios and reported `assistant integration tests passed`.
- Attempted the Angular unit test target `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/manager-dashboard/manager-aiservices.component.spec.ts`, which failed in this environment because the Angular CLI (`ng`) is not installed, so browser-based unit runner could not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43f746064832db3642c3a80c4c482)