### PR TITLE
all: smoother js zip handling (fixes #9790)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.18",
+  "version": "0.22.26",
   "myplanet": {
     "latest": "v0.51.0",
     "min": "v0.49.69"

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -4,7 +4,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { Observable, of, forkJoin, combineLatest, race, interval } from 'rxjs';
 import { switchMap, first, debounce, map, startWith } from 'rxjs/operators';
 import mime from 'mime';
-import * as JSZip from 'jszip/dist/jszip.min';
+import JSZip from 'jszip/dist/jszip.min';
 import * as constants from './resources-constants';
 import { FileInputComponent } from '../shared/forms/file-input.component';
 import { UserService } from '../shared/user.service';


### PR DESCRIPTION
Fixes #9790

- Fix JSZip warning when running `ng serve`