### PR TITLE
all: smoother angular building (fixes #9797)

### DIFF
--- a/docker/planet/scripts/docker-entrypoint.sh
+++ b/docker/planet/scripts/docker-entrypoint.sh
@@ -16,21 +16,25 @@ check_protocol() {
   echo "$PROTO"
 }
 
+replace_in_bundles() {
+  find /usr/share/nginx/html -type f \( -name '*.js' -o -name '*.mjs' \) -exec sed -i -e "$1" {} +
+}
+
 PROTOCOL=$(check_protocol $HOST_PROTOCOL "http")
 P_PROTOCOL=$(check_protocol $PARENT_PROTOCOL "https")
 S_ADDRESS=${SYNC_ADDRESS:-http://localhost:5984}
 
 if [ "$MULTIPLE_IPS" = "true" ]
 then
-    sed -i -e 's#couchAddress:"planet-db-host:planet-db-port/"#couchAddress:window.location.protocol+"//"+window.location.hostname+":planet-db-port/"#g' /usr/share/nginx/html/**/main*
+    replace_in_bundles 's#couchAddress:"planet-db-host:planet-db-port/"#couchAddress:window.location.protocol+"//"+window.location.hostname+":planet-db-port/"#g'
 else
-    sed -i -e "s#planet-db-host#$PROTOCOL://$DB_HOST#g" /usr/share/nginx/html/**/main*
+    replace_in_bundles "s#planet-db-host#$PROTOCOL://$DB_HOST#g"
 fi
 
-sed -i -e "s#planet-db-port#$DB_PORT#g" /usr/share/nginx/html/**/main*
-sed -i -e "s#planet-center-address#$CENTER_ADDRESS#g" /usr/share/nginx/html/**/main*
-sed -i -e "s#planet-parent-protocol#$P_PROTOCOL#g" /usr/share/nginx/html/**/main*
-sed -i -e "s#planet-sync-address#$S_ADDRESS#g" /usr/share/nginx/html/**/main*
+replace_in_bundles "s#planet-db-port#$DB_PORT#g"
+replace_in_bundles "s#planet-center-address#$CENTER_ADDRESS#g"
+replace_in_bundles "s#planet-parent-protocol#$P_PROTOCOL#g"
+replace_in_bundles "s#planet-sync-address#$S_ADDRESS#g"
 
 cd / && ./create_version_json.sh
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.18",
+  "version": "0.22.20",
   "myplanet": {
-    "latest": "v0.51.0",
+    "latest": "v0.51.38",
     "min": "v0.49.69"
   },
   "scripts": {

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -166,7 +166,9 @@ export class CouchService {
   getUrl(url: string, reqOpts?: any) {
     const [ domainWithPort = '', protocol, opts ] = this.setOpts(reqOpts);
     const domain = domainWithPort ? domainWithPort.split(':')[0].split('/db')[0] : '';
-    const urlPrefix = domain ? (protocol || environment.parentProtocol) + '://' + domain : window.location.origin;
+    const urlPrefix = domain ?
+      (protocol || environment.parentProtocol) + '://' + domain :
+      (environment.backendAddress || window.location.origin);
     return this.http.get(urlPrefix + '/' + url, opts);
   }
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,6 +5,7 @@ export const environment = {
   // couchAddress: 'planet-db-host:planet-db-port/',
   chatAddress: window.location.origin + '/ml/',
   couchAddress: window.location.origin + '/db',
+  backendAddress: window.location.origin,
   centerAddress: 'planet-center-address',
   centerProtocol: 'https',
   parentProtocol: 'planet-parent-protocol',

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -3,6 +3,7 @@ export const environment = {
   test: false,
   chatAddress: window.location.protocol + '//' + window.location.hostname + ':{{CHAT_PORT}}',
   couchAddress: window.location.protocol + '//' + window.location.hostname + ':{{COUCH_PORT}}',
+  backendAddress: window.location.protocol + '//' + window.location.hostname,
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
   parentProtocol: '{{PARENT_PROTOCOL}}',

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -2,6 +2,7 @@ export const environment = {
   production: false,
   test: true,
   couchAddress: 'http://127.0.0.1:5984',
+  backendAddress: window.location.origin,
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
   parentProtocol: 'https',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,6 +8,7 @@ export const environment = {
   test: false,
   chatAddress: window.location.protocol + '//' + window.location.hostname + ':5000',
   couchAddress: window.location.protocol + '//' + window.location.hostname + ':2200',
+  backendAddress: window.location.protocol + '//' + window.location.hostname,
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
   parentProtocol: 'https',


### PR DESCRIPTION
fixes #9797 

Restore production nation/center connectivity and fix local /login version/time behavior under ng serve:
- Fix runtime placeholder replacement after switching to the Angular application builder.
- Updates container startup to rewrite env placeholders across all emitted JS bundles instead of only main*.
- Adds a separate backendAddress for non-Couch backend endpoints so local version and time requests do not hit the Angular dev server.
