### PR TITLE
chore(chatapi): rename unused req params in route handlers

### DIFF
--- a/chatapi/src/index.ts
+++ b/chatapi/src/index.ts
@@ -17,7 +17,7 @@ app.use(cors());
 // Parse JSON bodies (as sent by API clients)
 app.use(express.json());
 
-app.get('/', (req: any, res: any) => {
+app.get('/', (_req: any, res: any) => {
   res.status(200).json({
     'status': 'Success',
     'message': 'OLE Chat API Service',
@@ -91,7 +91,7 @@ app.post('/', async (req: any, res: any) => {
   }
 });
 
-app.get('/checkproviders', async (req: any, res: any) => {
+app.get('/checkproviders', async (_req: any, res: any) => {
   res.status(200).json({
     'openai': keys.openai.apiKey ? true : false,
     'perplexity': keys.perplexity.apiKey ? true : false,


### PR DESCRIPTION
### Motivation
- Remove unused `req` variable declarations in two Express route handlers to satisfy linter rules and improve readability while keeping existing responses intact.

### Description
- In `chatapi/src/index.ts` renamed the unused `req` parameter to `_req` in the `app.get('/')` and `app.get('/checkproviders')` handlers so the health-check payload and provider-flag response behavior remain unchanged.

### Testing
- Ran `npm --prefix chatapi run -s lint`, which failed due to the repository ESLint v9 configuration being absent (`eslint.config.*`), so lint validation could not be completed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cd7d1ef0832d9f0362ddc3d439bc)