### PR TITLE
Remove Dec 2024/Jan 2025 challengePeriod branches

### DIFF
--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -21,10 +21,7 @@ import { environment } from '../../environments/environment';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import {
-  DialogsAnnouncementComponent,
-  DialogsAnnouncementSuccessComponent,
-  includedCodes,
-  challengePeriod
+  DialogsAnnouncementSuccessComponent
 } from '../shared/dialogs/dialogs-announcement.component';
 import { UserChallengeStatusService } from '../shared/user-challenge-status.service';
 import { ConfigurationCheckService } from '../shared/configuration-check.service';
@@ -139,7 +136,6 @@ export class CommunityComponent implements OnInit, OnDestroy {
         this.setCouncillors(users);
       }
     });
-    this.communityChallenge();
     iif(
       () => this.stateService.configuration?._id !== undefined,
       of(this.stateService.configuration),
@@ -161,34 +157,6 @@ export class CommunityComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.onDestroy$.next();
     this.onDestroy$.complete();
-  }
-
-  communityChallenge() {
-    const challengeActive = includedCodes.includes(this.configuration.code) && challengePeriod;
-
-    if (challengeActive) {
-      const dialogRef = this.dialog.open(DialogsAnnouncementComponent, {
-        width: '50vw',
-        maxHeight: '100vh'
-      });
-      dialogRef.afterClosed().subscribe(() => {
-        if (!this.userStatusService.getCompleteChallenge()) {
-          this.sendChallengeNotification(this.user).subscribe();
-        }
-      });
-    }
-  }
-
-  sendChallengeNotification(user) {
-    const data = {
-      'user': user._id,
-      'message': `El reto está en`,
-      'type': 'challenges',
-      'priority': 1,
-      'status': 'unread',
-      'time': this.couchService.datePlaceholder
-    };
-    return this.couchService.updateDocument('notifications', data);
   }
 
   getCommunityData() {

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -11,9 +11,6 @@ import { ResourcesService } from '../../resources/resources.service';
 import { DialogsSubmissionsComponent } from '../../shared/dialogs/dialogs-submissions.component';
 import { StateService } from '../../shared/state.service';
 import { ChatService } from '../../shared/chat.service';
-import {
-  DialogsAnnouncementComponent, includedCodes, challengeCourseId, challengePeriod
-} from '../../shared/dialogs/dialogs-announcement.component';
 import { coursesStepPrompt } from '../../shared/ai-prompts.constants';
 
 @Component({
@@ -179,13 +176,6 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
 
   backToCourseDetail() {
     this.router.navigate([ '../../' ], { relativeTo: this.route });
-    // Challenge option only
-    if (includedCodes.includes(this.stateService.configuration.code) && challengePeriod && this.courseId === challengeCourseId) {
-      this.dialog.open(DialogsAnnouncementComponent, {
-        width: '50vw',
-        maxHeight: '100vh'
-      });
-    }
   }
 
   setResourceUrl(resourceUrl: string) {

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -11,10 +11,6 @@ import { SubmissionsService } from '../submissions/submissions.service';
 import { CouchService } from '../shared/couchdb.service';
 import { Exam, ExamQuestion } from './exams.model';
 import { PlanetMessageService } from '../shared/planet-message.service';
-import {
-  DialogsAnnouncementComponent, includedCodes, challengeCourseId, challengePeriod
-} from '../shared/dialogs/dialogs-announcement.component';
-import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 
 interface ExamAnswerOption {
@@ -105,7 +101,6 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
     private couchService: CouchService,
     private planetMessageService: PlanetMessageService,
     private dialog: MatDialog,
-    private stateService: StateService,
     private dialogsLoadingService: DialogsLoadingService,
     private formBuilder: FormBuilder,
   ) {
@@ -193,18 +188,6 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
         this.question.choices.forEach(choice => this.checkboxState[choice.id] = false);
       } else {
         this.routeToNext(nextQuestion, previousStatus);
-        // Challenge option only
-        if (
-          isFinish &&
-          includedCodes.includes(this.stateService.configuration.code) &&
-          challengePeriod &&
-          this.courseId === challengeCourseId
-        ) {
-          this.dialog.open(DialogsAnnouncementComponent, {
-            width: '50vw',
-            maxHeight: '100vh'
-          });
-        }
       }
     });
   }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -12,7 +12,6 @@ import { PouchAuthService } from '../shared/database/pouch-auth.service';
 import { StateService } from '../shared/state.service';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import { NotificationsService } from '../notifications/notifications.service';
-import { DialogsAnnouncementComponent, includedCodes, challengePeriod } from '../shared/dialogs/dialogs-announcement.component';
 import { LoginDialogComponent } from '../login/login-dialog.component';
 import { PlanetLanguageComponent } from '../shared/planet-language.component';
 
@@ -265,12 +264,5 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
 
   openAnnouncementDialog(notification) {
     this.readNotification(notification);
-    const challengeActive = includedCodes.includes(this.configuration.code) && challengePeriod;
-    if (challengeActive) {
-      this.dialog.open(DialogsAnnouncementComponent, {
-        width: '50vw',
-        maxHeight: '100vh'
-      });
-    }
   }
 }

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -8,10 +8,7 @@ import { Subject } from 'rxjs';
 
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { MatDialog } from '@angular/material/dialog';
 import { NotificationsService } from './notifications.service';
-import { DialogsAnnouncementComponent, includedCodes, challengePeriod } from '../shared/dialogs/dialogs-announcement.component';
-import { StateService } from '../shared/state.service';
 
 @Component({
   templateUrl: './notifications.component.html',
@@ -32,8 +29,6 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
   anyUnread = true;
 
   constructor(
-    private dialog: MatDialog,
-    private stateService: StateService,
     private notificationsService: NotificationsService,
     private couchService: CouchService,
     private userService: UserService,
@@ -97,12 +92,6 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
   }
 
   openAnnouncementDialog() {
-    const challengeActive = includedCodes.includes(this.stateService.configuration.code) && challengePeriod;
-    if (challengeActive) {
-      this.dialog.open(DialogsAnnouncementComponent, {
-        width: '50vw',
-        maxHeight: '100vh'
-      });
-    }
+    // Dec 2024 / Jan 2025 challenge campaign has ended permanently.
   }
 }

--- a/src/app/shared/dialogs/dialogs-announcement.component.ts
+++ b/src/app/shared/dialogs/dialogs-announcement.component.ts
@@ -17,7 +17,6 @@ import { planetAndParentId } from '../../manager-dashboard/reports/reports.utils
 export const includedCodes = [ 'guatemala', 'san.pablo', 'xela', 'okuro', 'uriur', 'mutugi', 'vi' ];
 export const challengeCourseId = '4e6b78800b6ad18b4e8b0e1e38a98cac';
 export const examId = '4e6b78800b6ad18b4e8b0e1e38b382ab';
-export const challengePeriod = (new Date() > new Date(2024, 10, 31)) && (new Date() < new Date(2025, 0, 16));
 
 @Component({
   template: `


### PR DESCRIPTION
### Motivation

- The Dec 2024 / Jan 2025 time-gated campaign is being retired, so the date-gated `challengePeriod` checks and related UI flows should be removed.

### Description

- Removed the exported `challengePeriod` constant from `src/app/shared/dialogs/dialogs-announcement.component.ts` so the date gate no longer exists.
- Removed conditional branches that opened the announcement dialog when the campaign was active from `courses-step-view.component.ts`, `exams-view.component.ts`, `home.component.ts`, and `notifications.component.ts` and simplified `openAnnouncementDialog` to stop trying to open the campaign dialog.
- Deleted the automatic community startup campaign flow (`communityChallenge`) and its invocation in `community.component.ts`, and removed the campaign notification sender that only ran under the date-gated branch.
- Cleaned up imports/usages of the announcement dialog where it was only referenced for the expired campaign check so the code no longer depends on `challengePeriod` at those call sites.

### Testing

- Ran `npm run -s lint` in the environment; it failed due to missing Angular CLI (`ng: not found`), so lint could not be validated here (failed).
- Ran TypeScript compile check `npx tsc -p tsconfig.json --noEmit`; it failed because project dependencies (Angular packages / `tslib`) are not installed in this environment, so a full type-check could not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cd8e4a00832da3c5f1fb5c5573bf)