### PR TITLE
login: smoother dialogs handling (#9796)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.18",
+  "version": "0.22.23",
   "myplanet": {
     "latest": "v0.51.0",
     "min": "v0.49.69"

--- a/src/app/dashboard/dashboard-notifications-dialog.component.ts
+++ b/src/app/dashboard/dashboard-notifications-dialog.component.ts
@@ -8,7 +8,6 @@ import { MaterialModule } from '../shared/material.module';
 @Component({
   templateUrl: './dashboard-notifications-dialog.component.html',
   styleUrls: ['./dashboard-notifications-dialog.component.scss'],
-  standalone: true,
   imports: [ CommonModule, RouterModule, MaterialModule ]
 })
 export class DashboardNotificationsDialogComponent implements OnInit {

--- a/src/app/dashboard/dashboard-notifications-dialog.component.ts
+++ b/src/app/dashboard/dashboard-notifications-dialog.component.ts
@@ -1,11 +1,15 @@
+import { CommonModule } from '@angular/common';
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { RouterModule } from '@angular/router';
 import { myDashboardRoute } from '../home/router-constants';
+import { MaterialModule } from '../shared/material.module';
 
 @Component({
   templateUrl: './dashboard-notifications-dialog.component.html',
   styleUrls: ['./dashboard-notifications-dialog.component.scss'],
-  standalone: false
+  standalone: true,
+  imports: [ CommonModule, RouterModule, MaterialModule ]
 })
 export class DashboardNotificationsDialogComponent implements OnInit {
 

--- a/src/app/login/login-dialog.component.ts
+++ b/src/app/login/login-dialog.component.ts
@@ -17,7 +17,6 @@ import { LoginFormComponent } from './login-form.component';
       </div>
     </mat-dialog-content>
   `,
-  standalone: true,
   imports: [ MaterialModule, LoginFormComponent ]
 })
 export class LoginDialogComponent {

--- a/src/app/login/login-dialog.component.ts
+++ b/src/app/login/login-dialog.component.ts
@@ -1,5 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '../shared/material.module';
+import { LoginFormComponent } from './login-form.component';
 
 @Component({
   template: `
@@ -15,7 +17,8 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
       </div>
     </mat-dialog-content>
   `,
-  standalone: false
+  standalone: true,
+  imports: [ MaterialModule, LoginFormComponent ]
 })
 export class LoginDialogComponent {
 

--- a/src/app/login/login-form.component.ts
+++ b/src/app/login/login-form.component.ts
@@ -41,7 +41,6 @@ type RegisterFormGroup = FormGroup<RegisterFormControls>;
   templateUrl: './login-form.component.html',
   selector: 'planet-login-form',
   styleUrls: ['./login.scss'],
-  standalone: true,
   imports: [ CommonModule, ReactiveFormsModule, MaterialModule, PlanetFormsModule, SharedComponentsModule ]
 })
 export class LoginFormComponent {

--- a/src/app/login/login-form.component.ts
+++ b/src/app/login/login-form.component.ts
@@ -1,12 +1,17 @@
+import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { CouchService } from '../shared/couchdb.service';
-import { Router, ActivatedRoute } from '@angular/router';
-import { UserService } from '../shared/user.service';
-import { switchMap, catchError } from 'rxjs/operators';
-import { from, Observable, of, throwError } from 'rxjs';
 import {
-  AbstractControl, AsyncValidatorFn, FormControl, FormGroup, NonNullableFormBuilder, ValidationErrors, ValidatorFn, Validators
+  AbstractControl, AsyncValidatorFn, FormControl, FormGroup, NonNullableFormBuilder, ReactiveFormsModule,
+  ValidationErrors, ValidatorFn, Validators
 } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+import { from, Observable, of, throwError } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { MaterialModule } from '../shared/material.module';
+import { PlanetFormsModule } from '../shared/forms/planet-forms.module';
+import { SharedComponentsModule } from '../shared/shared-components.module';
+import { CouchService } from '../shared/couchdb.service';
+import { UserService } from '../shared/user.service';
 import { CustomValidators } from '../validators/custom-validators';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { ValidatorService } from '../validators/validator.service';
@@ -36,7 +41,8 @@ type RegisterFormGroup = FormGroup<RegisterFormControls>;
   templateUrl: './login-form.component.html',
   selector: 'planet-login-form',
   styleUrls: ['./login.scss'],
-  standalone: false
+  standalone: true,
+  imports: [ CommonModule, ReactiveFormsModule, MaterialModule, PlanetFormsModule, SharedComponentsModule ]
 })
 export class LoginFormComponent {
   public userForm!: LoginFormGroup | RegisterFormGroup;

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -21,10 +21,12 @@ import { LoginDialogComponent } from './login-dialog.component';
     ReactiveFormsModule,
     PlanetFormsModule,
     ConfigurationModule,
-    SharedComponentsModule
+    SharedComponentsModule,
+    LoginFormComponent,
+    LoginDialogComponent
   ],
   declarations: [
-    LoginComponent, LoginFormComponent, DashboardNotificationsDialogComponent, LoginDialogComponent
+    LoginComponent, DashboardNotificationsDialogComponent
   ],
   providers: [ ConfigurationGuard ]
 })

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -9,7 +9,6 @@ import { LoginFormComponent } from './login-form.component';
 import { ConfigurationGuard } from '../configuration/configuration-guard.service';
 import { ConfigurationModule } from '../configuration/configuration.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
-import { DashboardNotificationsDialogComponent } from '../dashboard/dashboard-notifications-dialog.component';
 import { LoginDialogComponent } from './login-dialog.component';
 
 @NgModule({
@@ -26,7 +25,7 @@ import { LoginDialogComponent } from './login-dialog.component';
     LoginDialogComponent
   ],
   declarations: [
-    LoginComponent, DashboardNotificationsDialogComponent
+    LoginComponent
   ],
   providers: [ ConfigurationGuard ]
 })


### PR DESCRIPTION
Fixes #9796

The login module being lazy loaded results in the render issue of the some login module components (login form, login dialog & dashboard notifications)

We switch these PRs to be standalone components