### PR TITLE
all: smoother couchdb url addressing (fixes #9807)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.20",
+  "version": "0.22.34",
   "myplanet": {
-    "latest": "v0.51.38",
+    "latest": "v0.52.37",
     "min": "v0.49.69"
   },
   "scripts": {

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -168,8 +168,15 @@ export class CouchService {
     const domain = domainWithPort ? domainWithPort.split(':')[0].split('/db')[0] : '';
     const urlPrefix = domain ?
       (protocol || environment.parentProtocol) + '://' + domain :
-      (environment.backendAddress || window.location.origin);
-    return this.http.get(urlPrefix + '/' + url, opts);
+      window.location.origin;
+    return this.http.get(urlPrefix + '/' + url, opts).pipe(
+      map((response: any) => {
+        if (typeof response === 'string' && response.trimStart().startsWith('<!')) {
+          throw new Error('Received HTML instead of expected response');
+        }
+        return response;
+      })
+    );
   }
 
   private compareRev = (parent, local) => {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,7 +5,6 @@ export const environment = {
   // couchAddress: 'planet-db-host:planet-db-port/',
   chatAddress: window.location.origin + '/ml/',
   couchAddress: window.location.origin + '/db',
-  backendAddress: window.location.origin,
   centerAddress: 'planet-center-address',
   centerProtocol: 'https',
   parentProtocol: 'planet-parent-protocol',

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -3,7 +3,6 @@ export const environment = {
   test: false,
   chatAddress: window.location.protocol + '//' + window.location.hostname + ':{{CHAT_PORT}}',
   couchAddress: window.location.protocol + '//' + window.location.hostname + ':{{COUCH_PORT}}',
-  backendAddress: window.location.protocol + '//' + window.location.hostname,
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
   parentProtocol: '{{PARENT_PROTOCOL}}',

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -2,7 +2,6 @@ export const environment = {
   production: false,
   test: true,
   couchAddress: 'http://127.0.0.1:5984',
-  backendAddress: window.location.origin,
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
   parentProtocol: 'https',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,7 +8,6 @@ export const environment = {
   test: false,
   chatAddress: window.location.protocol + '//' + window.location.hostname + ':5000',
   couchAddress: window.location.protocol + '//' + window.location.hostname + ':2200',
-  backendAddress: window.location.protocol + '//' + window.location.hostname,
   centerAddress: 'planet.earth.ole.org/db',
   centerProtocol: 'https',
   parentProtocol: 'https',


### PR DESCRIPTION
Fixes #9807

Clean up on the `backendAddress` and instead allow response to fail as usual skipping the html output