### PR TITLE
chore(teams): make memberNameCompare internal helper

### DIFF
--- a/src/app/teams/teams.utils.ts
+++ b/src/app/teams/teams.utils.ts
@@ -1,6 +1,6 @@
 export const memberCompare = (member1, member2) => member1.userId === member2.userId && member1.userPlanetCode === member2.userPlanetCode;
 
-export const memberNameCompare = (member1, member2) => {
+const memberNameCompare = (member1, member2) => {
   const memberName = (member) => (member.userDoc && member.userDoc.doc.lastName) || member.userId.split(':')[1];
   return memberName(member1).localeCompare(memberName(member2));
 };


### PR DESCRIPTION
### Motivation
- Reduce the public API surface by keeping `memberNameCompare` as an internal helper used only by `memberSort` rather than exporting it from `src/app/teams/teams.utils.ts`.

### Description
- Replace `export const memberNameCompare` with `const memberNameCompare` in `src/app/teams/teams.utils.ts` and leave `memberSort` usage unchanged.

### Testing
- Ran a repo-wide search `rg "memberNameCompare" -n` and confirmed only occurrences are inside `src/app/teams/teams.utils.ts`, indicating no external imports reference the now-internal helper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cd8fd360832dbe8ff022b114d42b)