### PR TITLE
refactor(teams): make memberNameCompare local to teams utils

### DIFF
--- a/src/app/teams/teams.utils.ts
+++ b/src/app/teams/teams.utils.ts
@@ -1,6 +1,6 @@
 export const memberCompare = (member1, member2) => member1.userId === member2.userId && member1.userPlanetCode === member2.userPlanetCode;
 
-export const memberNameCompare = (member1, member2) => {
+const memberNameCompare = (member1, member2) => {
   const memberName = (member) => (member.userDoc && member.userDoc.doc.lastName) || member.userId.split(':')[1];
   return memberName(member1).localeCompare(memberName(member2));
 };


### PR DESCRIPTION
### Motivation
- Reduce the public API surface of the teams utilities by keeping `memberNameCompare` as an internal helper while preserving existing sorting behavior.

### Description
- Converted `export const memberNameCompare` to a file-local `const memberNameCompare` in `src/app/teams/teams.utils.ts` and left `memberSort` unchanged so internal usage remains the same.

### Testing
- Attempted `npm run lint -- --lint-file-patterns src/app/teams/teams.utils.ts` but it could not run in this environment because `ng` is not installed (`sh: 1: ng: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc30e93c50832dbb6252ad0c7fffa9)