### PR TITLE
Harden dev env generation and add dev preflight checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ planet.yml
 .env
 
 # Dev environment
-environment.dev.ts
+src/environments/environment.dev.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,17 @@ For those comfortable with GitHub and with the above languages please jump right
 
 # Asking for help // OLE support communities
 OLE maintains a community of developers who actively maintain the Planet Learning system. You can discuss issue and ask for help in via our Gitter channel [here](https://gitter.im/open-learning-exchange/chat).
+
+
+## Local development environment file (`environment.dev.ts`)
+
+`angular.json` uses the `dev` build configuration to replace `src/environments/environment.ts`
+with `src/environments/environment.dev.ts`. That dev file is generated from
+`src/environments/environment.template` by `dev-env.sh`.
+
+- Use `npm run dev` for local development. It runs `dev-env.sh`, then a preflight check that fails
+  fast if `src/environments/environment.dev.ts` is missing or empty.
+- You can also run `bash dev-env.sh` directly if you only need to regenerate the file.
+- Optionally create a `.env` file in the repo root to override `CHAT_PORT`, `COUCH_PORT`, and
+  `PARENT_PROTOCOL` before running `npm run dev`.
+- Do not commit `src/environments/environment.dev.ts`; it is generated locally and ignored in Git.

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -8,12 +8,25 @@ CHAT_PORT="${CHAT_PORT:-5000}"
 COUCH_PORT="${COUCH_PORT:-2200}"
 PARENT_PROTOCOL="${PARENT_PROTOCOL:-https}"
 
+TEMPLATE_FILE="src/environments/environment.template"
+OUTPUT_FILE="src/environments/environment.dev.ts"
+
+if [ ! -f "${TEMPLATE_FILE}" ]; then
+  echo "Error: ${TEMPLATE_FILE} not found. Cannot generate ${OUTPUT_FILE}." >&2
+  exit 1
+fi
+
 sed \
   -e "s/{{CHAT_PORT}}/${CHAT_PORT}/g" \
   -e "s/{{COUCH_PORT}}/${COUCH_PORT}/g" \
   -e "s/{{PARENT_PROTOCOL}}/${PARENT_PROTOCOL}/g" \
-  src/environments/environment.template > src/environments/environment.dev.ts
+  "${TEMPLATE_FILE}" > "${OUTPUT_FILE}"
 
 echo "chatapi running on port: ${CHAT_PORT}"
 echo "couchdb running on port: ${COUCH_PORT}"
 echo "parent protocol: ${PARENT_PROTOCOL}"
+
+if [ ! -s "${OUTPUT_FILE}" ]; then
+  echo "Error: failed to generate ${OUTPUT_FILE}." >&2
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ng": "ng",
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "ng serve",
-    "dev": "bash dev-env.sh && ng serve --configuration dev",
+    "dev": "bash dev-env.sh && bash scripts/preflight-dev.sh && ng serve --configuration dev",
     "build": "npm run ng-high-memory -- build --configuration production",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",

--- a/scripts/preflight-dev.sh
+++ b/scripts/preflight-dev.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEV_ENV_FILE="src/environments/environment.dev.ts"
+
+if [ ! -f "${DEV_ENV_FILE}" ]; then
+  cat <<'MSG'
+Error: src/environments/environment.dev.ts is missing.
+
+The Angular dev build in angular.json replaces src/environments/environment.ts
+with this generated file.
+
+Run `bash dev-env.sh` (or `npm run dev`) to generate it.
+MSG
+  exit 1
+fi
+
+if [ ! -s "${DEV_ENV_FILE}" ]; then
+  echo "Error: ${DEV_ENV_FILE} exists but is empty. Re-run bash dev-env.sh." >&2
+  exit 1
+fi


### PR DESCRIPTION
### Motivation

- Preserve the Angular `dev` file replacement workflow but make the generated `src/environments/environment.dev.ts` requirement explicit to reduce brittle developer setups. 
- Fail early and provide actionable messages when the template is missing or generation produces an empty file so `ng serve --configuration dev` does not start with a broken environment. 
- Document the local workflow and ensure generated files are not accidentally committed.

### Description

- Add template/existence and non-empty output checks to `dev-env.sh` so generation fails fast when `src/environments/environment.template` is missing or the output is empty. 
- Add `scripts/preflight-dev.sh` which verifies that `src/environments/environment.dev.ts` exists and is non-empty and prints remediation instructions if it is missing. 
- Update the `dev` npm script in `package.json` to run `bash dev-env.sh && bash scripts/preflight-dev.sh && ng serve --configuration dev` so generation and preflight are performed before starting the dev server. 
- Update `.gitignore` to ignore the generated path `src/environments/environment.dev.ts` and add contributor notes to `CONTRIBUTING.md` documenting the `dev-env.sh` requirement, `.env` overrides, and the recommended `npm run dev` workflow.

### Testing

- Ran `bash dev-env.sh && bash scripts/preflight-dev.sh && node -e "const p=require('./package.json'); console.log(p.scripts.dev)"` which completed successfully. 
- Simulated the missing-file failure by temporarily moving `src/environments/environment.dev.ts` and running `bash scripts/preflight-dev.sh`, which exited with an error and printed the expected remediation message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc30f1556c832da7a59cae6eddb2c0)