### PR TITLE
Simplify dev workflow: stop generating environment.dev and regenerate environment.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ bash couchdb-setup.sh -p 2200 -i
 Install dependencies and serve the app:
 ```
 npm install
-ng serve
+npm run dev
 ```
+`npm run dev` regenerates `src/environments/environment.ts` from `src/environments/environment.template` using values from `.env` (if present).
 
 Visit localhost:3000 to access the Planet app.
-If port 3000 is in use, try ```ng serve --port 3001```
+If port 3000 is in use, try ```npm run dev -- --port 3001```
 
 ## Chatapi Notes
 
@@ -94,9 +95,9 @@ For chatapi development instructions, refer to the [chatapi README](chatapi/READ
 
 To run planet in development with a different locale, you can set the configuration to one of the supported language tags. For example, to run in Spanish, use:
 ```
-  npm run dev -- --configuration spa 
+  npm run dev -- --configuration spa
 
-  or 
+  or
 
   ng serve --configuration spa
 ```
@@ -119,7 +120,7 @@ End-to-end test automation is not currently wired up in this repository. There i
 ## Additional Commands
 
 
-Run: `ng serve`
+Run: `npm run dev`
 
 Build: `ng build`
 
@@ -166,7 +167,7 @@ npm install
 ```
 Restart the app:
 `
-ng serve
+npm run dev
 `
 
 ### Error on initial npm install

--- a/angular.json
+++ b/angular.json
@@ -89,14 +89,6 @@
                 }
               ]
             },
-            "dev": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.dev.ts"
-                }
-              ]
-            },
             "test": {
               "budgets": [
                 {
@@ -208,9 +200,6 @@
           "configurations": {
             "production": {
               "buildTarget": "planet-app:build:production"
-            },
-            "dev": {
-              "buildTarget": "planet-app:build:dev"
             },
             "test": {
               "buildTarget": "planet-app:build:test"

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -12,7 +12,7 @@ sed \
   -e "s/{{CHAT_PORT}}/${CHAT_PORT}/g" \
   -e "s/{{COUCH_PORT}}/${COUCH_PORT}/g" \
   -e "s/{{PARENT_PROTOCOL}}/${PARENT_PROTOCOL}/g" \
-  src/environments/environment.template > src/environments/environment.dev.ts
+  src/environments/environment.template > src/environments/environment.ts
 
 echo "chatapi running on port: ${CHAT_PORT}"
 echo "couchdb running on port: ${COUCH_PORT}"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ng": "ng",
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "ng serve",
-    "dev": "bash dev-env.sh && ng serve --configuration dev",
+    "dev": "bash dev-env.sh && ng serve",
     "build": "npm run ng-high-memory -- build --configuration production",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",


### PR DESCRIPTION
### Motivation
- Remove the special-case generated `environment.dev.ts` path and simplify the local development workflow so `npm run dev` consistently prepares environment values and runs the dev server. 
- Avoid relying on an extra generated file that diverged from `environment.ts`, while documenting the new behaviour for local developers.

### Description
- Removed the `build.configurations.dev` file replacement (the `environment.dev.ts` replacement) from `angular.json` and removed the corresponding `serve.configurations.dev` entry so Angular no longer expects `src/environments/environment.dev.ts`.
- Updated the `dev` npm script in `package.json` to `bash dev-env.sh && ng serve` (removed `--configuration dev`).
- Updated `dev-env.sh` to generate `src/environments/environment.ts` from `src/environments/environment.template` (instead of writing `environment.dev.ts`).
- Updated `README.md` to use `npm run dev`, to document that `npm run dev` regenerates `src/environments/environment.ts`, and to update related examples and restart guidance.

### Testing
- Parsed `package.json` and `angular.json` with Node JSON parsing (`node -e ...`) which succeeded.
- Validated shell syntax for `dev-env.sh` using `bash -n dev-env.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc30f00a40832d8da35f3b57eb519c)