### PR TITLE
🔒 Fix overly permissive CORS policy in chatapi

### DIFF
--- a/chatapi/src/index.ts
+++ b/chatapi/src/index.ts
@@ -13,7 +13,11 @@ const app = express();
 const server = http.createServer(app);
 const wss = new WebSocket.Server({ server });
 
-app.use(cors());
+const corsOptions = {
+  'origin': process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : false
+};
+
+app.use(cors(corsOptions));
 // Parse JSON bodies (as sent by API clients)
 app.use(express.json());
 


### PR DESCRIPTION
Isuue #9821 


🎯 **What:** Fixed an overly permissive CORS policy in the `chatapi` service. The default `cors()` invocation allowed cross-origin requests from any origin (`*`).
⚠️ **Risk:** Left unfixed, an attacker could potentially launch Cross-Site Request Forgery (CSRF) or other cross-origin attacks (like exfiltrating chat data or sending malicious commands through the WebSocket/POST API) from a malicious domain.
🛡️ **Solution:** Configured the `cors` middleware to explicitly read `ALLOWED_ORIGINS` from the environment. If undefined, it defaults to `false`, effectively disabling cross-origin access and applying the browser's default same-origin policy securely.

---
*PR created automatically by Jules for task [6339279357360750237](https://jules.google.com/task/6339279357360750237) started by @uj-sxn*