### PR TITLE
courses: smoother progress handling (fixes #9815)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.20",
+  "version": "0.22.22",
   "myplanet": {
     "latest": "v0.51.38",
     "min": "v0.49.69"

--- a/src/app/courses/courses.module.ts
+++ b/src/app/courses/courses.module.ts
@@ -13,10 +13,7 @@ import { CoursesStepComponent } from './add-courses/courses-step.component';
 import { CoursesStepViewComponent } from './step-view-courses/courses-step-view.component';
 import { ResourcesModule } from '../resources/resources.module';
 import { ExamsModule } from '../exams/exams.module';
-import { CoursesProgressLeaderComponent } from './progress-courses/courses-progress-leader.component';
-import { CoursesProgressBarComponent } from './progress-courses/courses-progress-bar.component';
-import { CoursesProgressChartComponent } from './progress-courses/courses-progress-chart.component';
-import { CoursesProgressLearnerComponent } from './progress-courses/courses-progress-learner.component';
+import { CoursesProgressModule } from './progress-courses/courses-progress.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { DialogsAddResourcesModule } from '../shared/dialogs/dialogs-add-resources.module';
 import { CoursesEnrollComponent } from './enroll-courses/courses-enroll.component';
@@ -43,7 +40,8 @@ import { ChatModule } from '../chat/chat.module';
     DialogsSubmissionsModule,
     UsersModule,
     CoursesViewDetailModule,
-    ChatModule
+    ChatModule,
+    CoursesProgressModule
   ],
   declarations: [
     CoursesComponent,
@@ -53,10 +51,6 @@ import { ChatModule } from '../chat/chat.module';
     CoursesStepViewComponent,
     CoursesSearchComponent,
     CoursesSearchListComponent,
-    CoursesProgressLeaderComponent,
-    CoursesProgressLearnerComponent,
-    CoursesProgressBarComponent,
-    CoursesProgressChartComponent,
     CoursesEnrollComponent,
     CoursesIconComponent
   ],

--- a/src/app/courses/progress-courses/courses-progress.module.ts
+++ b/src/app/courses/progress-courses/courses-progress.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { MaterialModule } from '../../shared/material.module';
+import { PlanetFormsModule } from '../../shared/forms/planet-forms.module';
+import { SharedComponentsModule } from '../../shared/shared-components.module';
+import { CoursesProgressBarComponent } from './courses-progress-bar.component';
+import { CoursesProgressChartComponent } from './courses-progress-chart.component';
+import { CoursesProgressLeaderComponent } from './courses-progress-leader.component';
+import { CoursesProgressLearnerComponent } from './courses-progress-learner.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MaterialModule,
+    PlanetFormsModule,
+    SharedComponentsModule
+  ],
+  declarations: [
+    CoursesProgressBarComponent,
+    CoursesProgressChartComponent,
+    CoursesProgressLeaderComponent,
+    CoursesProgressLearnerComponent
+  ],
+  exports: [
+    CoursesProgressBarComponent,
+    CoursesProgressChartComponent,
+    CoursesProgressLeaderComponent,
+    CoursesProgressLearnerComponent
+  ]
+})
+export class CoursesProgressModule {}

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -22,6 +22,7 @@ import { CommunityLinkDialogComponent } from '../community/community-link-dialog
 import { HealthListComponent } from '../health/health-list.component';
 import { UsersModule } from '../users/users.module';
 import { CoursesViewDetailModule } from '../courses/view-courses/courses-view-detail.module';
+import { CoursesProgressModule } from '../courses/progress-courses/courses-progress.module';
 import { ChatModule } from '../chat/chat.module';
 import { SurveysModule } from '../surveys/surveys.module';
 
@@ -53,6 +54,7 @@ import { SurveysModule } from '../surveys/surveys.module';
     PlanetCalendarModule,
     UsersModule,
     CoursesViewDetailModule,
+    CoursesProgressModule,
     ChatModule,
     SurveysModule
   ]


### PR DESCRIPTION
Fixes #9815 

The new builder + ng 19 exposed the current courses progress component to be using components not declared in its scope. 

Create a new courses progress module to resolve the module-scope errors.