### PR TITLE
courses: smoother collection creating (fixes #9563)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.20",
+  "version": "0.22.40",
   "myplanet": {
-    "latest": "v0.51.38",
+    "latest": "v0.52.45",
     "min": "v0.49.69"
   },
   "scripts": {

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -461,6 +461,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.tagsService.updateManyTags(
       this.courses.data, this.dbName, { selectedIds: this.selection.selected, tagIds: selected, indeterminateIds: indeterminate }
     ).subscribe(() => {
+      this.tagInputComponent?.initTags();
       this.getCourses();
       this.planetMessageService.showMessage($localize`Collections updated`);
     });

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -306,6 +306,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   addTagsToSelected({ selected, indeterminate }) {
     this.resourcesService.updateResourceTags(this.selection.selected, selected, indeterminate).subscribe(() => {
+      this.tagInputComponent?.initTags();
       this.planetMessageService.showMessage($localize`Collections updated`);
     });
   }


### PR DESCRIPTION
Fixes #9563

Refresh collection filter labels so newly created collections display their user-facing name in filters immediately.
