### PR TITLE
teams: smoother voices button sizing (fixes #9791)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.20",
+  "version": "0.22.33",
   "myplanet": {
     "latest": "v0.51.38",
     "min": "v0.49.69"

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -73,7 +73,7 @@
         <planet-loading-spinner *ngIf="newsLoading" text="Loading messages..." i18n-text></planet-loading-spinner>
         <ng-container *ngIf="!newsLoading">
           <planet-news-list [items]="news" viewableBy="teams" [viewableId]="team?._id" [shareTarget]="configuration?.planetType" (viewChange)="toggleAdd($event)" editSuccessMessage="Message has been updated successfully" [editable]="userStatus === 'member'">
-            <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot" class="full-width" i18n>New message</button>
+            <button mat-stroked-button (click)="openAddMessageDialog()" *ngIf="isRoot" i18n>New message</button>
             <p *ngIf="news?.length === 0" i18n>No messages available.</p>
           </planet-news-list>
         </ng-container>


### PR DESCRIPTION
Fixes #9791 

This PR fixes issue #9791 by reducing the visual size of the publish button in the Teams Chat view.

<img width="829" height="460" alt="image" src="https://github.com/user-attachments/assets/d9eba9a0-f02d-4699-be63-fa2aa0d8efa3" />


Updated teams-view.component.html.