### PR TITLE
all: smoother notifications selector aligning (fixes #9828)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.29",
+  "version": "0.22.36",
   "myplanet": {
     "latest": "v0.51.90",
     "min": "v0.49.69"

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -5,7 +5,7 @@
       <button mat-stroked-button [disabled]="!anyUnread" (click)="readAllNotification()" i18n class="margin-lr">Mark all as Read</button>
     </div>
     <span class="toolbar-fill"></span>
-    <mat-form-field class="font-size-1 margin-lr-3">
+    <mat-form-field class="font-size-1 margin-lr-3 mdc-toolbar-input">
       <mat-label i18n>Notification Status</mat-label>
       <mat-select value="all" (selectionChange)="onFilterChange($event.value)">
         <mat-option *ngFor="let option of notificationStatus" [value]="option.value">{{option.label}}</mat-option>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -531,6 +531,9 @@ body {
     --mdc-outlined-button-outline-color: rgba(0, 0, 0, 0.38);
     --mdc-outlined-button-disabled-outline-color: rgba(0, 0, 0, 0.38);
 
+    // Keep form-field labels readable on the blue toolbar when focused.
+    --mdc-filled-text-field-focus-label-text-color: currentColor;
+
     // Explicit fallback for unthemed toolbar buttons/icons after MDC migration.
     .mat-mdc-button-base:not(.mat-primary):not(.mat-accent):not(.mat-warn) {
       color: inherit !important;


### PR DESCRIPTION
Fixes issue #9828 

Added the shared toolbar alignment class to the Notification Status form field in the Notifications toolbar.


<img width="1911" height="412" alt="image" src="https://github.com/user-attachments/assets/40d7e2e1-07f6-4062-a4b4-0e6849100286" />

