### PR TITLE
life: smoother achievements username overflow handling (fixes #9681)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.29",
+  "version": "0.22.39",
   "myplanet": {
-    "latest": "v0.51.90",
+    "latest": "v0.52.44",
     "min": "v0.49.69"
   },
   "scripts": {

--- a/src/app/users/users-achievements/users-achievements-update.component.html
+++ b/src/app/users/users-achievements/users-achievements-update.component.html
@@ -6,8 +6,8 @@
 
 <div class="planet-users-achievements-update space-container">
   <mat-toolbar class="primary-color font-size-1">
-    <span *ngIf="user?.firstName; else elseBlock">{{ user.firstName}} {{user.middleName}} {{user.lastName }}</span>
-    <ng-template #elseBlock>{{ user.name }}</ng-template>
+    <span *ngIf="user?.firstName; else elseBlock">{{ (user.firstName + ' ' + user.middleName + ' ' + user.lastName) | truncateText:40 }}</span>
+    <ng-template #elseBlock>{{ user.name | truncateText:40 }}</ng-template>
   </mat-toolbar>
   <div class="view-container view-full-height">
     <div class="achievements-forms-container">


### PR DESCRIPTION
Fixes #9681

- Fix add/edit achievements form username overflow

<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/f4827dd2-deb1-4a70-a937-ce11490e7102" />
