### PR TITLE
Fix chatapi linting breaking due to root flat config

### DIFF
--- a/chatapi/package.json
+++ b/chatapi/package.json
@@ -7,8 +7,8 @@
     "start": "ts-node src/index.ts",
     "build": "tsc",
     "dev": "nodemon --exec ts-node src/index.ts",
-    "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint . --ext .ts --fix"
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts",
+    "lint-fix": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts --fix"
   },
   "repository": {
     "type": "git",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,7 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default defineConfig([globalIgnores(["projects/**/*"]), {
+export default defineConfig([globalIgnores(["projects/**/*", "chatapi/**/*"]), {
     files: ["**/*.ts"],
     extends: compat.extends("plugin:@angular-eslint/template/process-inline-templates"),
 


### PR DESCRIPTION
Restored chatapi linting by isolating it from the root flat ESLint configuration and explicitly forcing legacy configuration mode for its lint scripts.

---
*PR created automatically by Jules for task [10677057459570158222](https://jules.google.com/task/10677057459570158222) started by @paulbert*