### PR TITLE
all: smoother rule consistent type asserting (connects #9082)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -86,7 +86,7 @@
         "@angular-eslint/use-pipe-transform-interface": "error",
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/array-type": "off",
-        // "@typescript-eslint/consistent-type-assertions": "error",
+        "@typescript-eslint/consistent-type-assertions": "error",
         // "@typescript-eslint/member-ordering": "error",
         // "@typescript-eslint/naming-convention": [
         //   "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,6 +87,7 @@ export default defineConfig([globalIgnores(["projects/**/*", "chatapi/**/*"]), {
         "@angular-eslint/use-pipe-transform-interface": "error",
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/array-type": "off",
+        "@typescript-eslint/consistent-type-assertions": "error",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-empty-interface": "error",
         "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.42",
+  "version": "0.22.46",
   "myplanet": {
     "latest": "v0.52.60",
     "min": "v0.51.90"

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -89,9 +89,9 @@ export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
   documentInfo: ExamDocumentInfo = {};
   pageType: 'Add' | 'Update' | 'Copy' = 'Add';
   courseName = '';
-  examType: 'exam' | 'survey' = <'exam' | 'survey'>this.route.snapshot.paramMap.get('type') || 'exam';
+  examType: 'exam' | 'survey';
   teamId = this.route.parent?.snapshot.paramMap.get('teamId') || null;
-  successMessage = this.examType === 'survey' ? $localize`New survey added` : $localize`New test added`;
+  successMessage: string;
   steps = [];
   showFormError = false;
   showPreviewError = false;
@@ -127,6 +127,9 @@ export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
     private dialog: MatDialog,
     private submissionsService: SubmissionsService
   ) {
+    const typeParam = this.route.snapshot.paramMap.get('type');
+    this.examType = typeParam === 'exam' || typeParam === 'survey' ? typeParam : 'exam';
+    this.successMessage = this.examType === 'survey' ? $localize`New survey added` : $localize`New test added`;
     this.createForm();
   }
 

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -249,8 +249,8 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
         this.editor.options.insertTexts.image = [ markdown, '' ];
         this.editor.easyMDE.drawImage();
         this.value = {
-          ...<ValueWithImages>this._value,
-          images: [ ...(<ValueWithImages>this._value).images, { resourceId: image._id, filename: image.filename, markdown } ]
+          ...this._value as ValueWithImages,
+          images: [ ...(this._value as ValueWithImages).images, { resourceId: image._id, filename: image.filename, markdown } ]
         };
       }
     });

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -312,7 +312,7 @@ export class SubmissionsService {
           ...submission,
           teamInfo: submission.team ? { name: submission.team.name, type: submission.team.type } : null
         }));
-        return <[any[], number, string[]]>[submissionsWithTeamInfo, time, questionTexts];
+        return [submissionsWithTeamInfo, time, questionTexts] as [any[], number, string[]];
       }),
       tap(([ updatedSubmissions, time, questionTexts ]: [any[], number, string[]]) => {
         const title = `${toProperCase($localize`${type}`)} - ${$localize`${exam.name}`} (${updatedSubmissions.length})`;
@@ -502,7 +502,7 @@ export class SubmissionsService {
             planetName: codeToPlanetName(submission.source, this.stateService.configuration, planetsWithName),
             teamInfo: submission.team ? { name: submission.team.name, type: submission.team.type } : null
           }));
-          return <[any[], number, string[]]>[submissionsWithPlanetName, time, questionTexts];
+          return [submissionsWithPlanetName, time, questionTexts] as [any[], number, string[]];
         })
       ).subscribe(async tuple => {
         if (!tuple) {

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -22,6 +22,19 @@ import { MatCard, MatCardHeader, MatCardTitle, MatCardSubtitle, MatCardContent, 
 import { TeamsReportsDetailComponent } from './teams-reports-detail.component';
 import { MatIcon } from '@angular/material/icon';
 
+interface NewReportForm {
+  _id?: string,
+  _rev?: string,
+  beginningBalance: string,
+  description: string,
+  endDate: Date,
+  otherExpenses: number,
+  otherIncome: number,
+  sales: number,
+  startDate: Date,
+  wages: string
+}
+
 @Component({
   selector: 'planet-teams-reports',
   styleUrls: ['./teams-reports.scss'],
@@ -153,18 +166,23 @@ export class TeamsReportsComponent implements DoCheck {
         () => {};
   }
 
-  updateReport(oldReport, newReport: any = {}) {
+  updateReport(oldReport, newReport: NewReportForm | {} = {}) {
     const dateFields = [ 'startDate', 'endDate' ];
     const numberFields = [ 'beginningBalance', 'sales', 'otherIncome', 'wages', 'otherExpenses' ];
-    const transformFields = (key: string, value: Date | string) => dateFields.indexOf(key) > -1 ?
-      (<Date>value).getTime() :
+    const transformFields = (key: string, value: string | Date | number) => dateFields.indexOf(key) > -1 ?
+      (value as Date).getTime() :
       numberFields.indexOf(key) > -1 ?
         +value :
         value;
-    const { _id, _rev, ...newDoc } = <any>Object.entries(newReport).reduce(
-      (obj, [ key, value ]: [ string, Date | string ]) => ({ ...obj, [key]: transformFields(key, value) }),
+    const { _id, _rev, ...newDoc } = Object.entries(newReport).reduce(
+      (obj, [ key, value ]: [ string, string | Date | number ]) => {
+        return {
+          ...obj,
+          [key]: transformFields(key, value)
+        };
+      },
       {}
-    );
+    ) as any;
     const docs = [ { ...oldReport, status: 'archived' }, newDoc ].filter(doc => doc.startDate !== undefined);
     return this.teamsService.updateAdditionalDocs(docs, this.team, 'report', { utcKeys: dateFields }).pipe(tap(() => {
       this.reportsChanged.emit();


### PR DESCRIPTION
Adding in the consistent type assertions rule.
https://typescript-eslint.io/rules/consistent-type-assertions/

I went with the standard switch from `<type>` to `as type` with some but tried to do a little refactor to get rid of the type assertions altogether with a few.

connects #9082 