### PR TITLE
courses: smoother toolbar color styling (fixes #9855)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.44",
+  "version": "0.22.48",
   "myplanet": {
     "latest": "v0.52.96",
     "min": "v0.49.69"

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -66,7 +66,7 @@
       <span>{{stepNum}}/{{maxStep}}</span>
       <button mat-icon-button *ngIf="maxStep !== 1" [disabled]="stepNum === 1 || isLoading" (click)="changeStep(-1)"><mat-icon>navigate_before</mat-icon></button>
       <button mat-icon-button *ngIf="stepNum !== maxStep"  [disabled]="isLoading || !canProceedToNextStep()" (click)="changeStep(1)"><mat-icon>navigate_next</mat-icon></button>
-      <button mat-raised-button class="finish-button" *ngIf="stepNum === maxStep" [disabled]="isLoading || !canProceedToNextStep()" (click)="backToCourseDetail()" i18n>Finish</button>
+      <button mat-raised-button color="accent" class="margin-lr-10" *ngIf="stepNum === maxStep" [disabled]="isLoading || !canProceedToNextStep()" (click)="backToCourseDetail()" i18n>Finish</button>
     </div>
   </mat-toolbar>
   <div class="view-container view-full-height" [ngClass]="{'grid-view': showChat, 'flex-view': !isGridView && !showChat}" *ngIf="stepDetail?.description || resource?._attachments; else emptyRecord">

--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -58,10 +58,6 @@
     text-overflow: ellipsis;
   }
 
-  .finish-button {
-    margin-left: 10px;
-  }
-
   @media (max-width: v.$screen-sm) {
     .grid-view {
       display: grid;


### PR DESCRIPTION
Fixes issue #9855 

The Finish button now renders consistently with Preview/Retake/Review buttons in the exam action bar.

<img width="1917" height="366" alt="image" src="https://github.com/user-attachments/assets/6e146037-4b39-4ffb-a135-18d0cca08e62" />
