### PR TITLE
manager: smoother reports timeframe selecting (fixes #9858)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.44",
+  "version": "0.22.49",
   "myplanet": {
     "latest": "v0.52.96",
     "min": "v0.49.69"

--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -53,7 +53,7 @@
 <ng-template #timeFilterSelect>
   <mat-form-field class="margin-lr-5 font-size-1">
     <mat-label i18n>Time Frame</mat-label>
-    <mat-select selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
+    <mat-select (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
       <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
     </mat-select>
   </mat-form-field>


### PR DESCRIPTION
Fixes #9858

Fix the reports detail timeframe selector

<img width="1912" height="905" alt="image" src="https://github.com/user-attachments/assets/64e45d71-75ce-4f3d-8c77-5a225dc438a4" />
