### PR TITLE
teams: smoother member list task status toggling (fixes #9496)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.52",
+  "version": "0.22.58",
   "myplanet": {
     "latest": "v0.53.33",
     "min": "v0.51.90"

--- a/src/app/teams/teams-member.component.ts
+++ b/src/app/teams/teams-member.component.ts
@@ -86,9 +86,6 @@ export class TeamsMemberComponent implements OnInit, OnChanges {
 
   toggleTask(event: MatSelectionListChange) {
     const [ option ] = event.options;
-    if (!option) {
-      return;
-    }
 
     this.tasksService.addTask({ ...option.value, completed: option.selected }).subscribe(() => {
       this.tasksService.getTasks();

--- a/src/app/teams/teams-member.component.ts
+++ b/src/app/teams/teams-member.component.ts
@@ -9,7 +9,7 @@ import { NgIf, NgFor, DatePipe } from '@angular/common';
 import { MatIconButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { MatIcon } from '@angular/material/icon';
-import { MatSelectionList, MatListOption, MatListItemTitle } from '@angular/material/list';
+import { MatSelectionList, MatSelectionListChange, MatListOption, MatListItemTitle } from '@angular/material/list';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 
 @Component({
@@ -84,7 +84,12 @@ export class TeamsMemberComponent implements OnInit, OnChanges {
     });
   }
 
-  toggleTask({ option }) {
+  toggleTask(event: MatSelectionListChange) {
+    const [ option ] = event.options;
+    if (!option) {
+      return;
+    }
+
     this.tasksService.addTask({ ...option.value, completed: option.selected }).subscribe(() => {
       this.tasksService.getTasks();
     });


### PR DESCRIPTION
Fixes issue #9496 

Updated the member-card task toggle handler to use the Angular Material selection change event shape correctly.

<img width="1156" height="754" alt="image" src="https://github.com/user-attachments/assets/86c1e399-1bdd-4f24-bc97-44e78e5683da" />

<img width="1886" height="662" alt="image" src="https://github.com/user-attachments/assets/861bdf95-576d-4b29-bafd-220b3f8d7660" />
