### PR TITLE
all: smoother dialogs guarding (fixes #9863)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.52",
+  "version": "0.22.69",
   "myplanet": {
     "latest": "v0.53.33",
     "min": "v0.51.90"

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -92,7 +92,7 @@
           <span i18n>Send Courses</span>
           <span *ngIf="selectedLocal > 0"> ({{selectedLocal}})</span>
         </button>
-        <button *ngIf="planetType !== 'community'" mat-menu-item (click)="openSendCourseDialog()" [disabled]="!selection.selected.length">
+        <button *ngIf="planetType !== 'community'" mat-menu-item (click)="openSendCourseDialog()" [disabled]="!selection.selected.length || dialogGuard.isActive('send-course')">
           <mat-icon aria-hidden="true" class="margin-lr-3" >compare_arrows</mat-icon>
           <span i18n>Push To {planetType, select, center {Nation} other {Community}}</span>
           <span *ngIf="selection?.selected?.length"> ({{selection?.selected?.length}})</span>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -10,7 +10,7 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Subject, of } from 'rxjs';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
 import { FuzzySearchService } from '../shared/fuzzy-search.service';
 import {
   filterSpecificFields, composeFilterFunctions, createDeleteArray, filterTags,
@@ -29,6 +29,7 @@ import { CoursesService } from './courses.service';
 import { dedupeShelfReduce, doesMarkdownPreviewTruncate, findByIdInArray, hasMarkdownImages, itemsShown } from '../shared/utils';
 import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
+import { DialogGuardService } from '../shared/dialogs/dialog-guard.service';
 import { TagsService } from '../shared/forms/tags.service';
 import { PlanetTagInputComponent } from '../shared/forms/planet-tag-input.component';
 import { SearchService } from '../shared/forms/search.service';
@@ -95,7 +96,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   @Input() displayedColumns = [ 'select', 'courseTitle', 'info', 'createdDate', 'rating' ];
   @Input() excludeIds = [];
   @Input() includeIds: string[] = [];
-  dialogRef: MatDialogRef<DialogsListComponent>;
+  dialogRef: MatDialogRef<DialogsListComponent> | null = null;
   message = '';
   deleteDialog: any;
   readonly dbName = 'courses';
@@ -162,6 +163,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     private syncService: SyncService,
     private stateService: StateService,
     private dialogsLoadingService: DialogsLoadingService,
+    public dialogGuard: DialogGuardService,
     private tagsService: TagsService,
     private searchService: SearchService,
     private deviceInfoService: DeviceInfoService,
@@ -467,17 +469,19 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   }
 
   openSendCourseDialog() {
-    this.dialogsListService.getListAndColumns('communityregistrationrequests', { 'registrationRequest': 'accepted' }).pipe(
-      takeUntil(this.onDestroy$)
-    ).subscribe((planet) => {
-      const data = { okClick: this.sendCourse().bind(this),
-        filterPredicate: filterSpecificFields([ 'name' ]),
-        allowMulti: true,
-        ...planet };
-      this.dialogRef = this.dialog.open(DialogsListComponent, {
-        data, maxHeight: '500px', width: '600px', autoFocus: false
-      });
-    });
+    this.dialogGuard.open('send-course', () =>
+      this.dialogsListService.getListAndColumns('communityregistrationrequests', { 'registrationRequest': 'accepted' }).pipe(
+        map(planet => this.dialog.open(DialogsListComponent, {
+          data: {
+            okClick: this.sendCourse().bind(this),
+            filterPredicate: filterSpecificFields([ 'name' ]),
+            allowMulti: true,
+            ...planet
+          },
+          maxHeight: '500px', width: '600px', autoFocus: false
+        }))
+      )
+    ).pipe(takeUntil(this.onDestroy$)).subscribe(ref => this.dialogRef = ref);
   }
 
   sendCourse() {

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -42,7 +42,7 @@
         <a [routerLink]="['reports/pending']" mat-raised-button i18n>View</a>
       </p>
     </div>
-    <div class="view-container send-view" *ngIf="planetType !== 'community'">
+    <div class="view-container send-view">
       <h3 i18n>Send On Accept</h3><br />
       <button i18n mat-raised-button (click)="sendOnAccept('resources')">Resources</button>
       <button i18n mat-raised-button (click)="sendOnAccept('courses')">Courses</button>

--- a/src/app/manager-dashboard/manager-dashboard.component.html
+++ b/src/app/manager-dashboard/manager-dashboard.component.html
@@ -42,7 +42,7 @@
         <a [routerLink]="['reports/pending']" mat-raised-button i18n>View</a>
       </p>
     </div>
-    <div class="view-container send-view">
+    <div class="view-container send-view" *ngIf="planetType !== 'community'">
       <h3 i18n>Send On Accept</h3><br />
       <button i18n mat-raised-button (click)="sendOnAccept('resources')">Resources</button>
       <button i18n mat-raised-button (click)="sendOnAccept('courses')">Courses</button>

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit, isDevMode, OnDestroy, HostListener } from '@angular/
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { findDocuments } from '../shared/mangoQueries';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
 import { forkJoin, Subject } from 'rxjs';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router, RouterLink } from '@angular/router';
 import { DialogsListService } from '../shared/dialogs/dialogs-list.service';
+import { DialogGuardService } from '../shared/dialogs/dialog-guard.service';
 import { filterSpecificFields, createDeleteArray } from '../shared/table-helpers';
 import { DialogsListComponent } from '../shared/dialogs/dialogs-list.component';
 import { CoursesService } from '../courses/courses.service';
@@ -66,7 +67,8 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private configurationService: ConfigurationService,
     private stateService: StateService,
-    private managerService: ManagerService
+    private managerService: ManagerService,
+    private dialogGuard: DialogGuardService
   ) {}
 
   ngOnInit() {
@@ -203,25 +205,29 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
   }
 
   sendOnAccept(db: string) {
-    this.dialogsListService.getListAndColumns(db).pipe(takeUntil(this.onDestroy$)).subscribe(res => {
-      const previousList = res.tableData.filter((doc: any) => doc.sendOnAccept === true),
-        initialSelection = previousList.map((doc: any) => doc._id);
-      const data = {
-        okClick: this.sendOnAcceptOkClick(db, previousList).bind(this),
-        filterPredicate: this.setFilterPredicate(db),
-        itemDescription: db,
-        nameProperty: db === 'courses' ? 'courseTitle' : 'title',
-        allowMulti: true,
-        initialSelection,
-        selectionOptional: true,
-        ...res };
-      this.dialogRef = this.dialog.open(DialogsListComponent, {
-        data: data,
-        maxHeight: '500px',
-        width: '600px',
-        autoFocus: false
-      });
-    });
+    this.dialogGuard.open(`send-on-accept:${db}`, () =>
+      this.dialogsListService.getListAndColumns(db).pipe(
+        map(res => {
+          const previousList = res.tableData.filter((doc: any) => doc.sendOnAccept === true);
+          const initialSelection = previousList.map((doc: any) => doc._id);
+          return this.dialog.open(DialogsListComponent, {
+            data: {
+              okClick: this.sendOnAcceptOkClick(db, previousList).bind(this),
+              filterPredicate: this.setFilterPredicate(db),
+              itemDescription: db,
+              nameProperty: db === 'courses' ? 'courseTitle' : 'title',
+              allowMulti: true,
+              initialSelection,
+              selectionOptional: true,
+              ...res
+            },
+            maxHeight: '500px',
+            width: '600px',
+            autoFocus: false
+          });
+        })
+      )
+    ).pipe(takeUntil(this.onDestroy$)).subscribe(ref => this.dialogRef = ref);
   }
 
   sendOnAcceptOkClick(db: string, previousList: any) {

--- a/src/app/manager-dashboard/requests/requests-table.component.ts
+++ b/src/app/manager-dashboard/requests/requests-table.component.ts
@@ -8,10 +8,11 @@ import {
   MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell,
   MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatNoDataRow
 } from '@angular/material/table';
-import { switchMap, takeUntil, finalize } from 'rxjs/operators';
+import { map, switchMap, takeUntil, finalize } from 'rxjs/operators';
 import { forkJoin, of, Subject } from 'rxjs';
 import { filterSpecificFields, sortNumberOrString } from '../../shared/table-helpers';
 import { DialogsListService } from '../../shared/dialogs/dialogs-list.service';
+import { DialogGuardService } from '../../shared/dialogs/dialog-guard.service';
 import { DialogsListComponent } from '../../shared/dialogs/dialogs-list.component';
 import { StateService } from '../../shared/state.service';
 import { PlanetMessageService } from '../../shared/planet-message.service';
@@ -75,7 +76,8 @@ export class RequestsTableComponent implements OnChanges, AfterViewInit, OnDestr
     private dialogsFormService: DialogsFormService,
     private dialogsLoadingService: DialogsLoadingService,
     private validatorService: ValidatorService,
-    private reportsService: ReportsService
+    private reportsService: ReportsService,
+    private dialogGuard: DialogGuardService
   ) {}
 
   ngOnChanges() {
@@ -182,22 +184,24 @@ export class RequestsTableComponent implements OnChanges, AfterViewInit, OnDestr
   }
 
   getChildPlanet(url: string) {
-    this.dialogsListService.getListAndColumns(
-      this.dbName,
-      { 'registrationRequest': 'accepted' },
-      url
-    ).pipe(takeUntil(this.onDestroy$)).subscribe((planets) => {
-      const data = {
-        disableSelection: true,
-        filterPredicate: filterSpecificFields([ 'name', 'code' ]),
-        ...planets };
-      this.dialogRef = this.dialog.open(DialogsListComponent, {
-        data: data,
-        maxHeight: '500px',
-        width: '600px',
-        autoFocus: false
-      });
-    });
+    this.dialogGuard.open(`child-planet:${url}`, () =>
+      this.dialogsListService.getListAndColumns(
+        this.dbName,
+        { 'registrationRequest': 'accepted' },
+        url
+      ).pipe(
+        map(planets => this.dialog.open(DialogsListComponent, {
+          data: {
+            disableSelection: true,
+            filterPredicate: filterSpecificFields([ 'name', 'code' ]),
+            ...planets
+          },
+          maxHeight: '500px',
+          width: '600px',
+          autoFocus: false
+        }))
+      )
+    ).pipe(takeUntil(this.onDestroy$)).subscribe(ref => this.dialogRef = ref);
   }
 
   addHubClick(planetCode, hubName) {

--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnInit, OnDestroy, Input, Output, EventEmitter, Inject, Optional } from '@angular/core';
 import { CouchService } from '../../shared/couchdb.service';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 import { MeetupService } from '../meetups.service';
 import { Subject } from 'rxjs';
 import { UserService } from '../../shared/user.service';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 import { PlanetMessageService } from '../../shared/planet-message.service';
 import { DialogsListService } from '../../shared/dialogs/dialogs-list.service';
+import { DialogGuardService } from '../../shared/dialogs/dialog-guard.service';
 import { DialogsListComponent } from '../../shared/dialogs/dialogs-list.component';
 import { filterSpecificFields } from '../../shared/table-helpers';
 import { findDocuments } from '../../shared/mangoQueries';
@@ -56,7 +57,8 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
     private planetMessageService: PlanetMessageService,
     private userService: UserService,
     private dialogsListService: DialogsListService,
-    private stateService: StateService
+    private stateService: StateService,
+    private dialogGuard: DialogGuardService
   ) {
     this.couchService.currentTime().subscribe((date) => this.dateNow = date);
   }
@@ -116,23 +118,26 @@ export class MeetupsViewComponent implements OnInit, OnDestroy {
   }
 
   openInviteMemberDialog() {
-    this.dialogsListService.getListAndColumns('_users').pipe(takeUntil(this.onDestroy$)).subscribe((res) => {
-      res.tableData = res.tableData.filter((tableValue: any) => this.members.indexOf(tableValue.name) === -1);
-      const data = {
-        okClick: this.sendInvitations.bind(this),
-        filterPredicate: filterSpecificFields([ 'name' ]),
-        allowMulti: true,
-        itemDescription: 'members',
-        nameProperty: 'name',
-        ...res
-      };
-      this.listDialogRef = this.dialog.open(DialogsListComponent, {
-        data: data,
-        maxHeight: '500px',
-        width: '600px',
-        autoFocus: false
-      });
-    });
+    this.dialogGuard.open('invite-member', () =>
+      this.dialogsListService.getListAndColumns('_users').pipe(
+        map(res => {
+          res.tableData = res.tableData.filter((tableValue: any) => this.members.indexOf(tableValue.name) === -1);
+          return this.dialog.open(DialogsListComponent, {
+            data: {
+              okClick: this.sendInvitations.bind(this),
+              filterPredicate: filterSpecificFields([ 'name' ]),
+              allowMulti: true,
+              itemDescription: 'members',
+              nameProperty: 'name',
+              ...res
+            },
+            maxHeight: '500px',
+            width: '600px',
+            autoFocus: false
+          });
+        })
+      )
+    ).pipe(takeUntil(this.onDestroy$)).subscribe(ref => this.listDialogRef = ref);
   }
 
   sendInvitations(selected: string[]) {

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnChanges, EventEmitter, Output, AfterViewInit, ViewChild, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { forkJoin, Subscription } from 'rxjs';
+import { forkJoin, of, Subscription } from 'rxjs';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { NewsService } from './news.service';
@@ -9,6 +9,7 @@ import { PlanetMessageService } from '../shared/planet-message.service';
 import { CustomValidators } from '../validators/custom-validators';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { CommunityListDialogComponent } from '../community/community-list-dialog.component';
+import { DialogGuardService } from '../shared/dialogs/dialog-guard.service';
 import { dedupeShelfReduce } from '../shared/utils';
 import { trackById } from '../shared/table-helpers';
 import { NgIf, NgFor } from '@angular/common';
@@ -43,7 +44,7 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   showMainPostShare = false;
   replyViewing: any = { _id: 'root' };
   deleteDialog: any;
-  shareDialog: MatDialogRef<CommunityListDialogComponent>;
+  shareDialog: MatDialogRef<CommunityListDialogComponent> | null = null;
   isLoadingMore = false;
   hasMoreNews = false;
   pageSize = 10;
@@ -66,6 +67,7 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
     private dialogsLoadingService: DialogsLoadingService,
     private newsService: NewsService,
     private planetMessageService: PlanetMessageService,
+    private dialogGuard: DialogGuardService,
     private router: Router,
     private route: ActivatedRoute
   ) {}
@@ -281,13 +283,13 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
       });
     } else {
       const okClick = (planets) =>
-        this.newsService.shareNews(news, planets.map(planet => planet.doc)).subscribe(() => this.shareDialog.close());
-      this.shareDialog = this.dialog.open(CommunityListDialogComponent, {
+        this.newsService.shareNews(news, planets.map(planet => planet.doc)).subscribe(() => this.shareDialog?.close());
+      this.dialogGuard.open('share-news', () => of(this.dialog.open(CommunityListDialogComponent, {
         data: {
           okClick,
           excludeIds: (news.viewIn || []).map(shared => shared._id)
         }
-      });
+      }))).subscribe(ref => this.shareDialog = ref);
     }
   }
 

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -92,7 +92,7 @@
         <span i18n>Send Resources</span>
         <span *ngIf="selectedSync?.length"> ({{selectedSync.length}})</span>
       </button>
-      <button *ngIf="planetType !== 'community'" mat-menu-item (click)="openSendResourceDialog()" [disabled]="!selection.selected.length">
+      <button *ngIf="planetType !== 'community'" mat-menu-item (click)="openSendResourceDialog()" [disabled]="!selection.selected.length || dialogGuard.isActive('send-resource')">
         <mat-icon aria-hidden="true" class="margin-lr-3" >compare_arrows</mat-icon>
         <span i18n>Push To {planetType, select, center {Nation} other {Community}}</span>
         <span *ngIf="selection?.selected?.length"> ({{selection?.selected?.length}})</span>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -28,6 +28,7 @@ import { DialogsListComponent } from '../shared/dialogs/dialogs-list.component';
 import { doesMarkdownPreviewTruncate, findByIdInArray, hasMarkdownImages, itemsShown } from '../shared/utils';
 import { StateService } from '../shared/state.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
+import { DialogGuardService } from '../shared/dialogs/dialog-guard.service';
 import { ResourcesSearchComponent } from './search-resources/resources-search.component';
 import { levelList } from './resources-constants';
 import { SearchService } from '../shared/forms/search.service';
@@ -79,7 +80,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   @HostBinding('class') readonly hostClass = 'resources-list';
   @Input() isDialog = false;
   @Input() excludeIds = [];
-  dialogRef: MatDialogRef<DialogsListComponent>;
+  dialogRef: MatDialogRef<DialogsListComponent> | null = null;
   readonly dbName = 'resources';
   message = '';
   deleteDialog: any;
@@ -146,6 +147,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     private dialogsListService: DialogsListService,
     private stateService: StateService,
     private dialogsLoadingService: DialogsLoadingService,
+    public dialogGuard: DialogGuardService,
     private searchService: SearchService,
     private deviceInfoService: DeviceInfoService,
     private fuzzySearchService: FuzzySearchService
@@ -389,17 +391,19 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   openSendResourceDialog() {
-    this.dialogsListService.getListAndColumns('communityregistrationrequests', { 'registrationRequest': 'accepted' })
-      .pipe(takeUntil(this.onDestroy$))
-      .subscribe((planet) => {
-        const data = { okClick: this.sendResource().bind(this),
-          filterPredicate: filterSpecificFields([ 'name' ]),
-          allowMulti: true,
-          ...planet };
-        this.dialogRef = this.dialog.open(DialogsListComponent, {
-          data, maxHeight: '500px', width: '600px', autoFocus: false
-        });
-      });
+    this.dialogGuard.open('send-resource', () =>
+      this.dialogsListService.getListAndColumns('communityregistrationrequests', { 'registrationRequest': 'accepted' }).pipe(
+        map(planet => this.dialog.open(DialogsListComponent, {
+          data: {
+            okClick: this.sendResource().bind(this),
+            filterPredicate: filterSpecificFields([ 'name' ]),
+            allowMulti: true,
+            ...planet
+          },
+          maxHeight: '500px', width: '600px', autoFocus: false
+        }))
+      )
+    ).pipe(takeUntil(this.onDestroy$)).subscribe(ref => this.dialogRef = ref);
   }
 
   sendResource() {

--- a/src/app/shared/dialogs/dialog-guard.service.ts
+++ b/src/app/shared/dialogs/dialog-guard.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { EMPTY, Observable } from 'rxjs';
+import { finalize, take, tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class DialogGuardService {
+  private active = new Set<string>();
+
+  isActive(key: string): boolean {
+    return this.active.has(key);
+  }
+
+  open<T, R>(key: string, work: () => Observable<MatDialogRef<T, R>>): Observable<MatDialogRef<T, R>> {
+    if (this.active.has(key)) {
+      return EMPTY;
+    }
+    this.active.add(key);
+    let opened = false;
+    return work().pipe(
+      take(1),
+      tap(ref => {
+        opened = true;
+        ref.afterClosed().subscribe(() => this.active.delete(key));
+      }),
+      finalize(() => {
+        if (!opened) {
+          this.active.delete(key);
+        }
+      })
+    );
+  }
+}

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -4,6 +4,8 @@ import { AbstractControl, FormArray, FormBuilder, FormGroup, FormsModule, Reacti
 import { DialogsLoadingService } from './dialogs-loading.service';
 import { DialogsListService } from './dialogs-list.service';
 import { DialogsListComponent } from './dialogs-list.component';
+import { DialogGuardService } from './dialog-guard.service';
+import { map } from 'rxjs/operators';
 import { UserService } from '../user.service';
 import { DialogField, DialogFormGroupInput, DialogsFormData } from './dialogs-form.service';
 import { MatIcon } from '@angular/material/icon';
@@ -76,7 +78,8 @@ export class DialogsFormComponent {
     @Inject(MAT_DIALOG_DATA) public data: DialogsFormData,
     private dialogsLoadingService: DialogsLoadingService,
     private dialogsListService: DialogsListService,
-    private userService: UserService
+    private userService: UserService,
+    private dialogGuard: DialogGuardService
   ) {
     if (this.data && this.data.formGroup) {
       this.modalForm = this.createModalForm(this.data.formGroup);
@@ -116,17 +119,25 @@ export class DialogsFormComponent {
     const control = this.modalForm.controls[field.name];
     const currentValue = control.value as Array<{ _id: string }> | null;
     const initialSelection = (currentValue || []).map((value) => value._id);
+    const key = `dialogs-form:${field.db}:${field.name}`;
     this.dialogsLoadingService.start();
-    this.dialogsListService.attachDocsData(field.db, 'title', this.dialogOkClick(field).bind(this), initialSelection)
-      .subscribe((data) => {
-        this.dialogsLoadingService.stop();
-        this.dialogListRef = this.dialog.open(DialogsListComponent, {
-          data: data,
+    this.dialogGuard.open(key, () =>
+      this.dialogsListService.attachDocsData(field.db, 'title', this.dialogOkClick(field).bind(this), initialSelection).pipe(
+        map(data => this.dialog.open(DialogsListComponent, {
+          data,
           maxHeight: '500px',
           width: '600px',
           autoFocus: false
-        });
-      });
+        }))
+      )
+    ).subscribe({
+      next: ref => {
+        this.dialogsLoadingService.stop();
+        this.dialogListRef = ref;
+      },
+      error: () => this.dialogsLoadingService.stop(),
+      complete: () => this.dialogsLoadingService.stop()
+    });
   }
 
   dialogOkClick(field: DialogField) {

--- a/src/app/shared/dialogs/dialogs-list.service.ts
+++ b/src/app/shared/dialogs/dialogs-list.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { map } from 'rxjs/operators';
+import { last, map } from 'rxjs/operators';
 import { findDocuments } from '../mangoQueries';
 import { UserService } from '../user.service';
 import { StateService } from '../state.service';
@@ -55,6 +55,7 @@ export class DialogsListService {
         .pipe(map((newData) => ({ tableData: this.filterResults(newData, selector), columns: listColumns[db] })));
     }
     return this.stateService.getCouchState(db, planetField).pipe(
+      last(),
       map((newData: any) => {
         if (db === 'communityregistrationrequests') {
           newData = attachNamesToPlanets(newData).map(

--- a/src/app/shared/dialogs/dialogs-list.service.ts
+++ b/src/app/shared/dialogs/dialogs-list.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { last, map } from 'rxjs/operators';
+import { defaultIfEmpty, map } from 'rxjs/operators';
 import { findDocuments } from '../mangoQueries';
 import { UserService } from '../user.service';
 import { StateService } from '../state.service';
@@ -55,7 +55,7 @@ export class DialogsListService {
         .pipe(map((newData) => ({ tableData: this.filterResults(newData, selector), columns: listColumns[db] })));
     }
     return this.stateService.getCouchState(db, planetField).pipe(
-      last(),
+      defaultIfEmpty([]),
       map((newData: any) => {
         if (db === 'communityregistrationrequests') {
           newData = attachNamesToPlanets(newData).map(


### PR DESCRIPTION
Fixes #9863

Prevent duplicate dialog openings caused by repeated clicks while dialog data is still loading.
  - add a shared `DialogGuardService`
  - guard async-open dialog flows so only one dialog can open per action
  - disable affected triggers while a guarded dialog is active