### PR TITLE
all: smoother feedback list viewing (fixes #9868)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.58",
+  "version": "0.22.59",
   "myplanet": {
     "latest": "v0.53.91",
     "min": "v0.51.90"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.52",
+  "version": "0.22.58",
   "myplanet": {
-    "latest": "v0.53.33",
+    "latest": "v0.53.91",
     "min": "v0.51.90"
   },
   "scripts": {

--- a/src/app/feedback/feedback.component.html
+++ b/src/app/feedback/feedback.component.html
@@ -57,7 +57,7 @@
       [disabled]="feedback.filter.trim() === '' && filter.type === '' && filter.status === '' && titleSearch.trim() === ''">
       <span i18n>Clear</span>
     </button>
-</ng-template>
+  </ng-template>
 </mat-toolbar>
 <div class="space-container">
   <mat-toolbar>

--- a/src/app/feedback/feedback.component.ts
+++ b/src/app/feedback/feedback.component.ts
@@ -33,6 +33,7 @@ import { FormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatChipSet, MatChip } from '@angular/material/chips';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 
 @Component({
   templateUrl: './feedback.component.html',
@@ -54,7 +55,7 @@ import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
     MatLabel, MatSelect, MatOption, NgFor, MatInput, FormsModule, MatButton, MatTable, MatSort,
     MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatSortHeader, MatCellDef, MatCell, MatTooltip,
     NgSwitch, NgSwitchCase, MatChipSet, MatChip, MatMenuTrigger, MatMenu, MatMenuItem, RouterLink,
-    MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatNoDataRow, MatPaginator, DatePipe
+    MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatNoDataRow, MatPaginator, DatePipe, TruncateTextPipe
   ]
 })
 export class FeedbackComponent implements OnInit, AfterViewInit, OnDestroy {


### PR DESCRIPTION
Fixes #9868

`TruncateTextPipe` import was missing, leading to issues rendering the feedback table.

<img width="1919" height="846" alt="image" src="https://github.com/user-attachments/assets/587794ba-1485-4551-a27b-6f08a969a31c" />
