### PR TITLE
teams: smoother member names comparing (fixes #9869)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.52",
+  "version": "0.22.58",
   "myplanet": {
     "latest": "v0.53.33",
     "min": "v0.51.90"

--- a/src/app/teams/teams.utils.ts
+++ b/src/app/teams/teams.utils.ts
@@ -1,7 +1,11 @@
 export const memberCompare = (member1, member2) => member1.userId === member2.userId && member1.userPlanetCode === member2.userPlanetCode;
 
 export const memberNameCompare = (member1, member2) => {
-  const memberName = (member) => (member.userDoc && member.userDoc.doc.lastName) || member.userId.split(':')[1];
+  const memberName = (member) =>
+    (member.userDoc && member.userDoc.doc.lastName) ||
+    (member.userId || '').split(':')[1] ||
+    member.userId ||
+    '';
   return memberName(member1).localeCompare(memberName(member2));
 };
 


### PR DESCRIPTION
Fixes #9869

Add fallback to prevent teams crash when the userId is populated with a uuid


<img width="1919" height="919" alt="image" src="https://github.com/user-attachments/assets/a22bc39e-c725-44de-ac9e-fdc332e36d22" />


For now, the affected user is still listed, albeit the user is unknown. Sample affected couch doc: https://planet.uriur.ole.org:2200/_utils/#database/teams/bb43f79de9b6db78f21bac338824ff99

