### PR TITLE
🔒 Sanitize extraMessage in DialogsPromptComponent to prevent XSS

### DIFF
--- a/src/app/shared/dialogs/dialogs-prompt.component.html
+++ b/src/app/shared/dialogs/dialogs-prompt.component.html
@@ -37,7 +37,7 @@
       }
     }
   </p>
-  <p [innerHTML]=data.extraMessage></p>
+  <p [innerHTML]="extraMessage"></p>
   <b class = break-word>{{data.displayName | truncateText:140}}</b>
   <b *ngIf="data.displayDates">{{data.displayDates.startDate | date : 'mediumDate' : isDateUtc ? '+0000' : undefined }} - {{data.displayDates.endDate | date: 'mediumDate' : isDateUtc ? '+0000' : undefined }}</b>
   <ng-container *ngFor="let label of labels; last as last">

--- a/src/app/shared/dialogs/dialogs-prompt.component.spec.ts
+++ b/src/app/shared/dialogs/dialogs-prompt.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { DialogsPromptComponent } from './dialogs-prompt.component';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('DialogsPromptComponent', () => {
+  let component: DialogsPromptComponent;
+  let fixture: ComponentFixture<DialogsPromptComponent>;
+  const mockDialogRef = {
+    close: jasmine.createSpy('close')
+  };
+
+  const mockData = {
+    extraMessage: 'Initial extra message',
+    showMainParagraph: true,
+    cancelable: true,
+    spinnerOn: true,
+    showLabels: [],
+    isDateUtc: false
+  };
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        DialogsPromptComponent,
+        NoopAnimationsModule
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: mockData }
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DialogsPromptComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have access to data.extraMessage', () => {
+    expect(component.data.extraMessage).toBe('Initial extra message');
+  });
+
+  it('should sanitize extraMessage', () => {
+    const maliciousExtraMessage = 'Safe text <script>alert("xss")</script>';
+    const testData = { ...mockData, extraMessage: maliciousExtraMessage };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ DialogsPromptComponent, NoopAnimationsModule ],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: testData }
+      ]
+    }).compileComponents();
+
+    const newFixture = TestBed.createComponent(DialogsPromptComponent);
+    const newComponent = newFixture.componentInstance;
+    newFixture.detectChanges();
+
+    expect(newComponent.extraMessage).not.toContain('<script>');
+    expect(newComponent.extraMessage).toContain('Safe text');
+  });
+});

--- a/src/app/shared/dialogs/dialogs-prompt.component.ts
+++ b/src/app/shared/dialogs/dialogs-prompt.component.ts
@@ -10,8 +10,9 @@
  *  display to the user what is being deleted.
  * okClick - Optional.  Function to call when user clicks OK.
  */
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, SecurityContext } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
+import { DomSanitizer } from '@angular/platform-browser';
 import { timer, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { CdkScrollable } from '@angular/cdk/scrolling';
@@ -43,10 +44,12 @@ export class DialogsPromptComponent {
   spinnerOn: boolean;
   labels: string[];
   isDateUtc = false;
+  extraMessage = '';
 
   constructor(
     public dialogRef: MatDialogRef<DialogsPromptComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private sanitizer: DomSanitizer
   ) {
     // Support dialogs created before the amount field was added
     this.data.amount = this.setDefault(this.data.amount, 'single');
@@ -56,6 +59,7 @@ export class DialogsPromptComponent {
     this.spinnerOn = this.setDefault(this.data.spinnerOn, true);
     this.labels = this.data.showLabels;
     this.isDateUtc = this.data.isDateUtc;
+    this.extraMessage = this.sanitizer.sanitize(SecurityContext.HTML, this.data.extraMessage) || '';
   }
 
   ok() {


### PR DESCRIPTION
🎯 **What:** Fixed an Unsanitized HTML (XSS) vulnerability in `DialogsPromptComponent`.
⚠️ **Risk:** Binding untrusted data directly to `innerHTML` could allow attackers to execute malicious scripts in the context of the application.
🛡️ **Solution:** Used Angular's `DomSanitizer` to explicitly sanitize the `extraMessage` content before it is rendered, ensuring that only safe HTML is allowed and script tags are removed. Added a unit test to verify this behavior.

---
*PR created automatically by Jules for task [16207983800265061156](https://jules.google.com/task/16207983800265061156) started by @dogi*