### PR TITLE
teams: smoother survey chart exporting (fixes #9898)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.59",
+  "version": "0.22.63",
   "myplanet": {
-    "latest": "v0.53.91",
-    "min": "v0.51.90"
+    "latest": "v0.54.48",
+    "min": "v0.52.45"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/chart-utils.ts
+++ b/src/app/shared/chart-utils.ts
@@ -39,10 +39,15 @@ export async function loadChart(keys: RegisterableKey[] = []): Promise<ChartJsMo
 }
 
 export function createChartCanvas(width = 300, height = 400): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D | null } {
+  const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
   const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-  return { canvas, ctx: canvas.getContext('2d') };
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  const ctx = canvas.getContext('2d');
+  if (ctx) { ctx.scale(dpr, dpr); }
+  return { canvas, ctx };
 }
 
 export function renderNoDataPlaceholder(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, message = 'No data available'): string {

--- a/src/app/shared/chart-utils.ts
+++ b/src/app/shared/chart-utils.ts
@@ -46,7 +46,9 @@ export function createChartCanvas(width = 300, height = 400): { canvas: HTMLCanv
   canvas.style.width = `${width}px`;
   canvas.style.height = `${height}px`;
   const ctx = canvas.getContext('2d');
-  if (ctx) { ctx.scale(dpr, dpr); }
+  if (ctx) {
+    ctx.scale(dpr, dpr);
+  }
   return { canvas, ctx };
 }
 

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -605,13 +605,15 @@ export class SubmissionsService {
     }
 
     const maxCount = Math.max(...data.data);
+    const axisTitleFont = { size: 12, weight: 'bold' as const };
+    const xAxisText = isRatingScale ? $localize`Rating` : $localize`Choice`;
+    const yAxisText = isRatingScale ? $localize`Number of responses` : $localize`% of responders`;
     const chartConfig: ChartConfiguration<'bar' | 'doughnut', number[], string> = {
       type: isBar ? 'bar' : 'doughnut',
       data: {
         labels: data.labels,
         datasets: [ {
           data: data.data,
-          label: isRatingScale ? 'selection/choices(1-9)' : (isBar ? '% of responders/selection' : undefined),
           backgroundColor: CHART_COLORS
         } ]
       },
@@ -621,19 +623,24 @@ export class SubmissionsService {
         indexAxis: 'x',
         plugins: {
           legend: {
-            display: true,
+            display: !isBar,
             labels: {
-              boxWidth: isBar ? 0 : 50,
-              boxHeight: isBar ? 0 : 20
+              boxWidth: 50,
+              boxHeight: 20
             }
           }
         },
         scales: isBar ? {
+          x: {
+            type: 'category',
+            title: { display: true, text: xAxisText, font: axisTitleFont }
+          },
           y: {
             type: 'linear',
             beginAtZero: true,
             max: isRatingScale ? maxCount > 0 ? Math.ceil(maxCount / 10) * 10 : 10 : 100,
-            ticks: { precision: 0, stepSize: 2 }
+            ticks: { precision: 0, stepSize: 2 },
+            title: { display: true, text: yAxisText, font: axisTitleFont }
           }
         } : {},
         animation: false

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -588,12 +588,13 @@ export class SubmissionsService {
   }
 
   async generateChartImage(data: any): Promise<string> {
-    const { Chart } = await loadChart([
-      'BarController', 'DoughnutController', 'BarElement', 'ArcElement', 'LinearScale', 'CategoryScale', 'Legend', 'Tooltip', 'Title'
-    ]);
-    const { canvas, ctx } = createChartCanvas(300, 400);
     const isBar = data.chartType === 'bar';
     const isRatingScale = data.isRatingScale || false;
+    const { Chart } = await loadChart(isBar
+      ? [ 'BarController', 'BarElement', 'LinearScale', 'CategoryScale', 'Legend', 'Tooltip', 'Title' ]
+      : [ 'DoughnutController', 'ArcElement', 'Legend', 'Tooltip', 'Title' ]
+    );
+    const { canvas, ctx } = createChartCanvas(300, 400);
 
     if (!ctx) {
       return '';
@@ -601,26 +602,26 @@ export class SubmissionsService {
     const hasData = Array.isArray(data.data) && data.data.some((value: number) => Number(value) > 0);
 
     if (!hasData) {
-      renderNoDataPlaceholder(ctx, canvas, 'No data available');
+      return renderNoDataPlaceholder(ctx, canvas, 'No data available');
     }
 
     const maxCount = Math.max(...data.data);
     const axisTitleFont = { size: 12, weight: 'bold' as const };
     const xAxisText = isRatingScale ? $localize`Rating` : $localize`Choice`;
     const yAxisText = isRatingScale ? $localize`Number of responses` : $localize`% of responders`;
+    const backgroundColor = data.labels.map((_, i) => CHART_COLORS[i % CHART_COLORS.length]);
     const chartConfig: ChartConfiguration<'bar' | 'doughnut', number[], string> = {
       type: isBar ? 'bar' : 'doughnut',
       data: {
         labels: data.labels,
         datasets: [ {
           data: data.data,
-          backgroundColor: CHART_COLORS
+          backgroundColor
         } ]
       },
       options: {
         responsive: false,
         maintainAspectRatio: false,
-        devicePixelRatio: typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1,
         indexAxis: 'x',
         plugins: {
           legend: {
@@ -640,7 +641,7 @@ export class SubmissionsService {
             type: 'linear',
             beginAtZero: true,
             max: isRatingScale ? maxCount > 0 ? Math.ceil(maxCount / 10) * 10 : 10 : 100,
-            ticks: { precision: 0, stepSize: 2 },
+            ticks: { precision: 0 },
             title: { display: true, text: yAxisText, font: axisTitleFont }
           }
         } : {},
@@ -652,11 +653,16 @@ export class SubmissionsService {
     try {
       chart.update();
 
+      ctx.fillStyle = '#000000';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.font = '12px sans-serif';
+
       if (isBar && data.userCounts) {
         chart.getDatasetMeta(0).data.forEach((bar, index) => {
           const count = data.userCounts[index];
           if (count > 0) {
-            ctx.fillText(`${count}`, bar.x - 2.5 , bar.y);
+            ctx.fillText(`${count}`, bar.x, bar.y - 6);
           }
         });
       } else {
@@ -666,7 +672,7 @@ export class SubmissionsService {
           const percentage = total > 0 ? ((count / total) * 100).toFixed(1) : '0';
           if (count > 0) {
             const pos = element.tooltipPosition();
-            ctx.fillText(`${count}(${percentage}%)`, pos.x - 15, pos.y);
+            ctx.fillText(`${count} (${percentage}%)`, pos.x, pos.y);
           }
         });
       }

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -620,6 +620,7 @@ export class SubmissionsService {
       options: {
         responsive: false,
         maintainAspectRatio: false,
+        devicePixelRatio: typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1,
         indexAxis: 'x',
         plugins: {
           legend: {


### PR DESCRIPTION
Fixes #9898

In the surveys, improve the current chart pdf exports

- Add scale titles and drop the label title usage
- Improve chart blur
- cleanup

<img width="892" height="799" alt="image" src="https://github.com/user-attachments/assets/6cb779e1-39e4-4e12-9845-ba083c274e86" />
