### PR TITLE
all: point codex to the claude.md (fixes #9904)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+project_doc_fallback_filenames = ["CLAUDE.md"]

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ docker/planet-*.yml
 planet.yml
 
 .env
+.codex/*
+!.codex/config.toml
 
 # Dev environment
 environment.dev.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides shared AI-agent guidance for working with this repository.
+Claude Code can consume it directly, and other agents can reuse the same project context.
 
 ## Commands
 


### PR DESCRIPTION
Fixes #9904

Point codex to the `claude.md`, as codex expects an `agents.md`