### PR TITLE
chat: smoother api assistant mode providing (fixes #9924)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.72",
+  "version": "0.22.73",
   "myplanet": {
-    "latest": "v0.54.54",
+    "latest": "v0.54.91",
     "min": "v0.52.45"
   },
   "scripts": {

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -258,7 +258,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   submitPrompt() {
     const content = this.promptForm.controls.prompt.value;
-    this.data = { ...this.data, content, aiProvider: this.provider };
+    this.data = { ...this.data, content, aiProvider: this.provider, assistant: this.provider?.name === 'openai' };
 
     this.chatService.setChatAIProvider(this.data.aiProvider);
     this.setSelectedConversation();


### PR DESCRIPTION
Fixes #9924

Restrict assistants mode to openai provider only.

<img width="1919" height="934" alt="image" src="https://github.com/user-attachments/assets/26f4cda3-0264-4cd6-907b-ab8ca02bbcdc" />

<img width="1919" height="936" alt="image" src="https://github.com/user-attachments/assets/335036df-6657-4c7f-bd3b-faf9c71b96de" />
