### PR TITLE
all: smoother page breakpoints handling (fixes #9937)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.82",
+  "version": "0.22.84",
   "myplanet": {
     "latest": "v0.55.45",
     "min": "v0.53.91"

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { NonNullableFormBuilder, FormGroup, Validators, FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
@@ -99,7 +99,9 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
     private searchService: SearchService,
     private userService: UserService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
     this.lastRenderedConversation = -1;
   }
 
@@ -114,10 +116,6 @@ export class ChatSidebarComponent implements OnInit, OnDestroy {
     this.onDestroy$.next();
     this.onDestroy$.complete();
     this.recordSearch(true);
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
   }
 
   subscribeToNewChats() {

--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewEncapsulation, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { NonNullableFormBuilder, FormControl, FormGroup, FormsModule } from '@angular/forms';
@@ -168,7 +168,9 @@ export class CommunityComponent implements OnInit, OnDestroy {
     private fb: NonNullableFormBuilder,
     private configurationCheckService: ConfigurationCheckService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {
@@ -214,10 +216,6 @@ export class CommunityComponent implements OnInit, OnDestroy {
       this.isCommunityLeader = this.user.isUserAdmin || this.user?.roles?.indexOf('leader') > -1;
       this.getCommunityData();
     });
-  }
-
-  @HostListener('window:resize') onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
   }
 
   ngOnDestroy() {

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, ViewChild, OnDestroy, HostListener, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild, OnDestroy, Input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -176,13 +176,10 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
         this.setupList(this.courses.data, shelf.courseIds);
       });
     this.dialogsLoadingService.start();
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
   }
 
   ngOnInit() {

--- a/src/app/courses/progress-courses/courses-progress-leader.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-leader.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
@@ -69,7 +69,9 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {
@@ -92,11 +94,6 @@ export class CoursesProgressLeaderComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.onDestroy$.next();
     this.onDestroy$.complete();
-  }
-
-  @HostListener('window:resize')
-  onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
   }
 
   setProgress(course) {

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { Subject } from 'rxjs';
@@ -66,11 +66,9 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -1,7 +1,8 @@
 import {
   Component, Input, ElementRef, ViewChild, Output, EventEmitter, AfterViewChecked,
-  ChangeDetectorRef, HostBinding, HostListener, OnInit, forwardRef
+  ChangeDetectorRef, DestroyRef, HostBinding, OnInit, forwardRef, inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { tap } from 'rxjs/operators';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { UserService } from '../shared/user.service';
@@ -49,6 +50,7 @@ export class DashboardTileTitleComponent {
   ]
 })
 export class DashboardTileComponent implements AfterViewChecked, OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   @Input() cardTitle: string;
   private _cardType: string;
   @Input() set cardType(value: string) {
@@ -80,14 +82,6 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
   @HostBinding('class.accordion-expanded') get isExpandedClass() {
     return this.isExpanded;
   }
-  @HostListener('window:resize')
-  onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    if (this.cardType === 'myLife' && this.deviceType === DeviceType.MOBILE) {
-      this.isExpanded = true;
-    }
-  }
-
   constructor(
     private planetMessageService: PlanetMessageService,
     private userService: UserService,
@@ -96,7 +90,14 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
     private cd: ChangeDetectorRef,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((deviceType) => {
+        this.deviceType = deviceType;
+        if (this.cardType === 'myLife' && (deviceType === DeviceType.SMALL_MOBILE || deviceType === DeviceType.MOBILE)) {
+          this.isExpanded = true;
+        }
+      });
   }
 
   ngOnInit() {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, HostBinding, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostBinding } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { finalize, map, catchError, switchMap, auditTime, takeUntil } from 'rxjs/operators';
 import { of, forkJoin, Subject, combineLatest } from 'rxjs';
@@ -59,13 +59,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.deviceType === DeviceType.MOBILE;
   }
 
-  @HostListener('window:resize')
-  onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.SMALL_MOBILE || this.deviceType === DeviceType.MOBILE;
-    this.updateMyLifeItemsFormat();
-  }
-
   constructor(
     private userService: UserService,
     private couchService: CouchService,
@@ -90,8 +83,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     ).pipe(auditTime(500), takeUntil(this.onDestroy$)).subscribe(([ courses, certifications ]) => {
       this.setBadgesCourses(courses, certifications);
     });
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.SMALL_MOBILE || this.deviceType === DeviceType.MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.SMALL_MOBILE || deviceType === DeviceType.MOBILE;
+      this.updateMyLifeItemsFormat();
+    });
     this.initMyLifeItems();
   }
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -83,12 +83,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     ).pipe(auditTime(500), takeUntil(this.onDestroy$)).subscribe(([ courses, certifications ]) => {
       this.setBadgesCourses(courses, certifications);
     });
+    this.initMyLifeItems();
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
       this.isMobile = deviceType === DeviceType.SMALL_MOBILE || deviceType === DeviceType.MOBILE;
       this.updateMyLifeItemsFormat();
     });
-    this.initMyLifeItems();
   }
 
   ngOnInit() {

--- a/src/app/feedback/feedback.component.ts
+++ b/src/app/feedback/feedback.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { combineLatest, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -100,11 +100,9 @@ export class FeedbackComponent implements OnInit, AfterViewInit, OnDestroy {
     private usersService: UsersService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, DoCheck, AfterViewChecked, HostListener, OnDestroy } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, DoCheck, AfterViewChecked, OnDestroy } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { MatDialog } from '@angular/material/dialog';
@@ -102,8 +102,10 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
       });
     this.couchService.get('_node/nonode@nohost/_config/planet').subscribe((res: any) => this.layout = res.layout || 'classic');
     this.onlineStatus = this.stateService.configuration.registrationRequest;
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
     this.isAndroid = this.deviceInfoService.isAndroid();
   }
 
@@ -125,7 +127,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   }
 
   ngDoCheck() {
-    this.onResize();
+    this.syncToolbarLayout();
   }
 
   ngAfterViewChecked() {
@@ -151,13 +153,11 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
     this.onDestroy$.complete();
   }
 
-  @HostListener('window:resize') onResize() {
+  syncToolbarLayout() {
     const isScreenTooNarrow = window.innerWidth < this.classicToolbarWidth;
     if (this.forceModern !== isScreenTooNarrow) {
       this.forceModern = isScreenTooNarrow;
     }
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
   }
 
   openLanguageSelector(): void {

--- a/src/app/manager-dashboard/certifications/certifications.component.ts
+++ b/src/app/manager-dashboard/certifications/certifications.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, AfterViewInit, ViewChild, HostListener } from '@angular/core';
+import { Component, DestroyRef, OnInit, AfterViewInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { SelectionModel } from '@angular/cdk/collections';
@@ -38,6 +39,7 @@ import { MatInput } from '@angular/material/input';
   ]
 })
 export class CertificationsComponent implements OnInit, AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   certifications = new MatTableDataSource();
   selection = new SelectionModel(true, []);
@@ -57,11 +59,11 @@ export class CertificationsComponent implements OnInit, AfterViewInit {
     private deviceInfoService: DeviceInfoService,
     private dialogsLoadingService: DialogsLoadingService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((deviceType) => {
+        this.deviceType = deviceType;
+      });
   }
 
   ngOnInit() {

--- a/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.html
+++ b/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.html
@@ -1,4 +1,4 @@
-<planet-myplanet-toolbar i18n-title title="Logs"
+<planet-myplanet-toolbar i18n-title title="myPlanet Logs"
   [types]="types"
   [showTypeFilter]="true"
   [versions]="versions"

--- a/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.html
+++ b/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar>
   <ng-container *ngIf="deviceType === deviceTypes.DESKTOP; else mobileView">
-    <mat-toolbar-row>
+    <mat-toolbar-row class="desktop-toolbar-stacked">
       <ng-container *ngTemplateOutlet="backAction"></ng-container>
       <ng-container *ngTemplateOutlet="typeVersionFilters"></ng-container>
       <ng-container *ngIf="showCustomDateFields">
@@ -42,14 +42,14 @@
   <span class="toolbar-fill"></span>
 </ng-template>
 <ng-template #typeVersionFilters>
-  <mat-form-field *ngIf="showTypeFilter" class="margin-lr-5 font-size-1">
+  <mat-form-field *ngIf="showTypeFilter" class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
     <mat-label i18n>Type</mat-label>
     <mat-select (selectionChange)="onTypeChange($event.value)" [value]="selectedType">
       <mat-option [value]="" i18n>All Types</mat-option>
       <mat-option *ngFor="let type of types" [value]="type">{{type}}</mat-option>
     </mat-select>
   </mat-form-field>
-  <mat-form-field class="margin-lr-5 font-size-1">
+  <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
     <mat-label i18n>Version</mat-label>
     <mat-select (selectionChange)="onVersionChange($event.value)" [value]="selectedVersion">
       <mat-option [value]="" i18n>All Versions</mat-option>
@@ -58,8 +58,8 @@
   </mat-form-field>
 </ng-template>
 <ng-template #formStartDate>
-  <div [formGroup]="formGroup">
-    <mat-form-field class="margin-lr-5 font-size-1">
+  <div [formGroup]="formGroup" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
+    <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
       <mat-label i18n>Start Date</mat-label>
       <input matInput [matDatepicker]="startPicker" formControlName="startDate" [min]="minDate" [max]="formGroup.controls.endDate.value">
       <mat-datepicker-toggle matIconSuffix [for]="startPicker"></mat-datepicker-toggle>
@@ -69,8 +69,8 @@
   </div>
 </ng-template>
 <ng-template #formEndDate>
-  <div [formGroup]="formGroup">
-    <mat-form-field class="margin-lr-5 font-size-1">
+  <div [formGroup]="formGroup" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
+    <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
       <mat-label i18n>End Date</mat-label>
       <input matInput [matDatepicker]="endPicker" formControlName="endDate" [min]="formGroup.controls.startDate.value" [max]="today">
       <mat-datepicker-toggle matIconSuffix [for]="endPicker"></mat-datepicker-toggle>
@@ -79,7 +79,7 @@
   </div>
 </ng-template>
 <ng-template #timeFrameFilter>
-  <mat-form-field class="margin-lr-5 font-size-1">
+  <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
     <mat-label i18n>Time Frame</mat-label>
     <mat-select (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
       <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
@@ -87,7 +87,7 @@
   </mat-form-field>
 </ng-template>
 <ng-template #actionButtons>
-  <mat-form-field class="font-size-1">
+  <mat-form-field class="font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
     <mat-label i18n>Search</mat-label>
     <input matInput (keyup)="onSearch($event.target.value)" [value]="searchValue">
   </mat-form-field>

--- a/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, Output, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DeviceInfoService, DeviceType } from '../../../shared/device-info.service';
 import { MyPlanetFiltersForm } from './filter.base';
@@ -24,6 +25,7 @@ import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular
   ]
 })
 export class MyPlanetToolbarComponent {
+  private readonly destroyRef = inject(DestroyRef);
 
   @Input() title = '';
   @Input() versions: string[] = [];
@@ -50,12 +52,11 @@ export class MyPlanetToolbarComponent {
   showFiltersRow = false;
 
   constructor(private deviceInfoService: DeviceInfoService) {
-    this.deviceType = this.deviceInfoService.getDeviceType({ tablet: 1300 });
-  }
-
-  @HostListener('window:resize')
-  OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType({ tablet: 1300 });
+    this.deviceInfoService.watchDeviceType()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((deviceType) => {
+        this.deviceType = deviceType;
+      });
   }
 
   onVersionChange(value: string) {

--- a/src/app/manager-dashboard/reports/myplanet/myplanet.scss
+++ b/src/app/manager-dashboard/reports/myplanet/myplanet.scss
@@ -1,28 +1,10 @@
-@use '../../../variables' as v;
-
-$screen-md: 1300px;
-
-:host {
-  @include v.screen-sizes($screen-md, v.$screen-sm);
-}
-
 button {
   flex-shrink: 0;
   margin: 4px;
 }
 
-@media(max-width: #{$screen-md}) {
-  .mat-mdc-form-field {
-    width: 100%;
-  }
-
-  mat-toolbar-row {
-    form {
-      width: 100%;
-
-      .mat-mdc-form-field {
-        width: 100%;
-      }
-    }
-  }
+.desktop-toolbar-stacked {
+  height: auto;
+  align-items: center;
+  flex-wrap: wrap;
 }

--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar>
   <ng-container *ngIf="deviceType === deviceTypes.DESKTOP; else mobileView">
-    <mat-toolbar-row>
+    <mat-toolbar-row [ngClass]="{ 'desktop-toolbar-stacked': showCustomDateFields }">
       <ng-container *ngTemplateOutlet="backBtn"></ng-container>
       <ng-container *ngIf="showCustomDateFields">
         <ng-container *ngTemplateOutlet="startDateField"></ng-container>
@@ -51,7 +51,7 @@
   <span class="toolbar-fill"></span>
 </ng-template>
 <ng-template #timeFilterSelect>
-  <mat-form-field class="margin-lr-5 font-size-1">
+  <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
     <mat-label i18n>Time Frame</mat-label>
     <mat-select (selectionChange)="onTimeFilterChange($event.value)" [value]="selectedTimeFilter">
       <mat-option *ngFor="let option of timeFilterOptions" [value]="option.value">{{option.label}}</mat-option>
@@ -59,7 +59,7 @@
   </mat-form-field>
 </ng-template>
 <ng-template #teamsFilterSelect>
-  <mat-form-field class="font-size-1 margin-lr-5">
+  <mat-form-field class="font-size-1 margin-lr-5" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
     <mat-label i18n>Filter Member</mat-label>
     <mat-select (selectionChange)="onTeamsFilterChange($event.value)" [value]="selectedTeam">
       <mat-option i18n value="All">All Members</mat-option>
@@ -73,7 +73,7 @@
   </mat-form-field>
 </ng-template>
 <ng-template #planetToggleGroup>
-  <mat-button-toggle-group class="font-size-1 margin-lr-5" (change)="onFilterChange($event.value)" #filterGroup="matButtonToggleGroup">
+  <mat-button-toggle-group class="font-size-1 margin-lr-5" [class.full-width]="deviceType !== deviceTypes.DESKTOP" (change)="onFilterChange($event.value)" #filterGroup="matButtonToggleGroup">
     <mat-button-toggle value="planet" [checked]="this.filter.app === 'planet'" i18n>Planet</mat-button-toggle>
     <mat-button-toggle value="myplanet" [checked]="this.filter.app === 'myplanet'" i18n>myPlanet</mat-button-toggle>
     <mat-button-toggle value="" [checked]="this.filter.app === ''" i18n>Both</mat-button-toggle>
@@ -83,8 +83,8 @@
   <button mat-raised-button color="primary" (click)="clearFilters()" class="margin-lr-5"><span i18n>Clear</span></button>
 </ng-template>
 <ng-template #startDateField>
-  <div [formGroup]="dateFilterForm">
-    <mat-form-field class="margin-lr-5 font-size-1">
+  <div [formGroup]="dateFilterForm" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
+    <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
       <mat-label i18n>Start Date</mat-label>
       <input matInput formControlName="startDate" [matDatepicker]="startPicker" [min]="minDate" [max]="dateFilterForm.value.endDate || today">
       <mat-datepicker-toggle matIconSuffix [for]="startPicker"></mat-datepicker-toggle>
@@ -94,8 +94,8 @@
     </div>
 </ng-template>
 <ng-template #endDateField>
-  <div [formGroup]="dateFilterForm">
-    <mat-form-field class="margin-lr-5 font-size-1">
+  <div [formGroup]="dateFilterForm" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
+    <mat-form-field class="margin-lr-5 font-size-1" [class.full-width]="deviceType !== deviceTypes.DESKTOP">
       <mat-label i18n>End Date</mat-label>
       <input matInput formControlName="endDate" [matDatepicker]="endPicker" [min]="dateFilterForm.value.startDate || minDate" [max]="today">
       <mat-datepicker-toggle matIconSuffix [for]="endPicker"></mat-datepicker-toggle>

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewEncapsulation, HostBinding, ViewChild, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewEncapsulation, HostBinding, ViewChild } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { FormControl, FormGroup, NonNullableFormBuilder, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -146,7 +146,9 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     private planetMessageService: PlanetMessageService
   ) {
     this.initDateFilterForm();
-    this.deviceType = this.deviceInfoService.getDeviceType({ tablet: 1200 });
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {
@@ -200,11 +202,6 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     this.onDestroy$.complete();
     this.charts.forEach((chart) => chart.destroy());
     this.charts = [];
-  }
-
-  @HostListener('window:resize')
-  OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType({ tablet: 1200 });
   }
 
   onFilterChange(filterValue: '' | 'planet' | 'myplanet') {

--- a/src/app/manager-dashboard/reports/reports-detail.scss
+++ b/src/app/manager-dashboard/reports/reports-detail.scss
@@ -1,11 +1,5 @@
 @use '../../variables' as v;
 
-$screen-md: 1200px;
-
-:host {
-  @include v.screen-sizes($screen-md);
-}
-
 mat-toolbar mat-form-field {
   margin-top: 10px;
   &.mat-form-field-type-no-underline {
@@ -86,17 +80,15 @@ mat-toolbar mat-form-field {
       }
     }
   }
+
+  .desktop-toolbar-stacked {
+    height: auto;
+    flex-wrap: wrap;
+  }
 }
 
-@media(max-width: #{$screen-md}) {
-  .mat-mdc-form-field {
-    width: 100%;
-  }
-
-  mat-button-toggle-group {
-    width: 100%;
-    display: flex;
-
+@media(max-width: #{v.$screen-md}) {
+  mat-button-toggle-group.full-width {
     mat-button-toggle {
       flex: 1;
     }

--- a/src/app/manager-dashboard/requests/requests-table.component.ts
+++ b/src/app/manager-dashboard/requests/requests-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, AfterViewInit, ViewChild, OnDestroy, Input, Output, EventEmitter, HostListener } from '@angular/core';
+import { Component, OnChanges, AfterViewInit, ViewChild, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { CouchService } from '../../shared/couchdb.service';
 import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -83,13 +83,10 @@ export class RequestsTableComponent implements OnChanges, AfterViewInit, OnDestr
     private dialogGuard: DialogGuardService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
-  }
-
-  @HostListener('window:resize') onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
   }
 
   ngOnChanges() {

--- a/src/app/manager-dashboard/requests/requests.component.ts
+++ b/src/app/manager-dashboard/requests/requests.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { CouchService } from '../../shared/couchdb.service';
 import { switchMap, takeUntil } from 'rxjs/operators';
@@ -60,8 +60,10 @@ export class RequestsComponent implements OnInit, OnDestroy {
     private managerService: ManagerService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
   }
 
   ngOnInit() {
@@ -72,12 +74,6 @@ export class RequestsComponent implements OnInit, OnDestroy {
       this.searchValue = searchValue || '';
       this.getCommunityList();
     });
-  }
-
-  @HostListener('window:resize')
-  onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE;
   }
 
   ngOnDestroy() {

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnChanges, OnDestroy, HostListener } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { MatDialog } from '@angular/material/dialog';
@@ -74,8 +74,10 @@ export class NewsListItemComponent implements OnInit, OnChanges, OnDestroy {
     private clipboard: Clipboard,
     private deviceInfoService: DeviceInfoService,
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.SMALL_MOBILE || this.deviceType === DeviceType.MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.SMALL_MOBILE || deviceType === DeviceType.MOBILE;
+    });
   }
 
   ngOnInit() {
@@ -100,11 +102,6 @@ export class NewsListItemComponent implements OnInit, OnChanges, OnDestroy {
       this.item.sharedSourceInfo = null;
     }
     this.handleItemExpansion();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.SMALL_MOBILE || this.deviceType === DeviceType.MOBILE;
   }
 
   ngOnDestroy() {

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -46,7 +46,7 @@
     <ng-container *ngIf="isAuthorized">
       <button *ngIf="!parent && myView !== 'myPersonals'" mat-mini-fab routerLink="add"><mat-icon>add</mat-icon></button>
       <div class="column margin-lr-5">
-        <planet-filtered-amount [table]="resources"></planet-filtered-amount>
+        <planet-filtered-amount class="filtered-amount-label" [table]="resources"></planet-filtered-amount>
         <planet-tag-selected-input *ngIf="myView !== 'myPersonals'" [selectedIds]="tagFilter.value" [allTags]="tagInputComponent?.tags"></planet-tag-selected-input>
       </div>
       <span class="toolbar-fill"></span>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, ViewEncapsulation, HostBinding, Input, HostListener } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, ViewEncapsulation, HostBinding, Input } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -153,15 +153,11 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     private deviceInfoService: DeviceInfoService,
     private fuzzySearchService: FuzzySearchService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
-    this.isTablet = window.innerWidth <= 1040;
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
-    this.isTablet = window.innerWidth <= 1040;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+      this.isTablet = deviceType !== DeviceType.DESKTOP;
+    });
   }
 
   ngOnInit() {

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -50,10 +50,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
-
-  // .resource-toolbar-actions {
-  //   flex-shrink: 0;
-  // }
 }
 
 .list-content-menu .header {

--- a/src/app/resources/resources.scss
+++ b/src/app/resources/resources.scss
@@ -39,11 +39,21 @@
   .column {
     display: flex;
     flex-direction: column;
+    min-width: 0;
 
     > * {
       line-height: normal;
     }
   }
+
+  .filtered-amount-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // .resource-toolbar-actions {
+  //   flex-shrink: 0;
+  // }
 }
 
 .list-content-menu .header {

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -71,11 +71,9 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
     private planetMessageService: PlanetMessageService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {

--- a/src/app/shared/device-info.service.ts
+++ b/src/app/shared/device-info.service.ts
@@ -1,4 +1,7 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
 
 export enum DeviceType {
   SMALL_MOBILE = 'SMALL_MOBILE',
@@ -13,39 +16,74 @@ export interface DeviceBreakpoints {
   smallMobile?: number;
 }
 
+export const DEFAULT_DEVICE_BREAKPOINTS: Required<DeviceBreakpoints> = {
+  tablet: 1000,
+  mobile: 780,
+  smallMobile: 480
+};
+
 @Injectable({
   providedIn: 'root'
 })
 export class DeviceInfoService {
-  private screenWidth: number;
+  private readonly deviceTypeCache = new Map<string, Observable<DeviceType>>();
 
-  constructor() {
-    this.screenWidth = window.innerWidth;
-    window.addEventListener('resize', this.updateScreenWidth.bind(this));
-  }
-
-  private updateScreenWidth(): void {
-    this.screenWidth = window.innerWidth;
-  }
+  constructor(private breakpointObserver: BreakpointObserver) {}
 
   public getDeviceType(breakpoints: DeviceBreakpoints = {}): DeviceType {
-    const smallMobileWidth = breakpoints.smallMobile || 480;
-    const mobileWidth = breakpoints.mobile || 780;
-    const tabletWidth = breakpoints.tablet || 1000;
+    const resolvedBreakpoints = this.resolveBreakpoints(breakpoints);
 
-    if (this.screenWidth <= smallMobileWidth) {
+    if (this.breakpointObserver.isMatched(this.maxWidthQuery(resolvedBreakpoints.smallMobile))) {
       return DeviceType.SMALL_MOBILE;
-    } else if (this.screenWidth <= mobileWidth) {
+    } else if (this.breakpointObserver.isMatched(this.maxWidthQuery(resolvedBreakpoints.mobile))) {
       return DeviceType.MOBILE;
-    } else if (this.screenWidth <= tabletWidth) {
+    } else if (this.breakpointObserver.isMatched(this.maxWidthQuery(resolvedBreakpoints.tablet))) {
       return DeviceType.TABLET;
     } else {
       return DeviceType.DESKTOP;
     }
   }
 
+  public watchDeviceType(breakpoints: DeviceBreakpoints = {}): Observable<DeviceType> {
+    const resolvedBreakpoints = this.resolveBreakpoints(breakpoints);
+    const cacheKey = this.getCacheKey(resolvedBreakpoints);
+    const existingStream = this.deviceTypeCache.get(cacheKey);
+
+    if (existingStream) {
+      return existingStream;
+    }
+
+    const deviceType$ = this.breakpointObserver.observe([
+      this.maxWidthQuery(resolvedBreakpoints.smallMobile),
+      this.maxWidthQuery(resolvedBreakpoints.mobile),
+      this.maxWidthQuery(resolvedBreakpoints.tablet)
+    ]).pipe(
+      map(() => this.getDeviceType(resolvedBreakpoints)),
+      distinctUntilChanged(),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+
+    this.deviceTypeCache.set(cacheKey, deviceType$);
+    return deviceType$;
+  }
+
   public isAndroid(): boolean {
     return /Android/i.test(navigator.userAgent);
+  }
+
+  private resolveBreakpoints(breakpoints: DeviceBreakpoints): Required<DeviceBreakpoints> {
+    return {
+      ...DEFAULT_DEVICE_BREAKPOINTS,
+      ...breakpoints
+    };
+  }
+
+  private maxWidthQuery(width: number): string {
+    return `(max-width: ${width}px)`;
+  }
+
+  private getCacheKey(breakpoints: Required<DeviceBreakpoints>): string {
+    return `${breakpoints.smallMobile}-${breakpoints.mobile}-${breakpoints.tablet}`;
   }
 
 }

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -1,4 +1,5 @@
-import { Component, Inject, Input, HostListener, forwardRef } from '@angular/core';
+import { Component, DestroyRef, Inject, Input, forwardRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   AbstractControl, AsyncValidatorFn, NonNullableFormBuilder, FormControl, FormGroup, ValidationErrors,
   ValidatorFn, FormsModule, ReactiveFormsModule
@@ -71,6 +72,7 @@ export class PlanetTagInputToggleIconComponent {
   ]
 })
 export class PlanetTagInputDialogComponent {
+  private readonly destroyRef = inject(DestroyRef);
 
   deleteDialog: any;
   tags: any[] = [];
@@ -128,11 +130,11 @@ export class PlanetTagInputDialogComponent {
       attachedTo: ['']
     });
     this.isUserAdmin = this.userService.get().isUserAdmin;
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((deviceType) => {
+        this.deviceType = deviceType;
+      });
   }
 
   dataInit() {

--- a/src/app/shared/forms/planet-tag-selected-input.component.ts
+++ b/src/app/shared/forms/planet-tag-selected-input.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnChanges, HostListener } from '@angular/core';
+import { Component, DestroyRef, Input, OnChanges, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TagsService } from './tags.service';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
 import { truncateText } from '../../shared/utils';
@@ -18,6 +19,7 @@ import { MatTooltip } from '@angular/material/tooltip';
   imports: [NgSwitch, NgSwitchCase, NgSwitchDefault, MatTooltip]
 })
 export class PlanetTagSelectedInputComponent implements OnChanges {
+  private readonly destroyRef = inject(DestroyRef);
 
   @Input() selectedIds: string[] = [];
   @Input() allTags: any[] = [];
@@ -29,14 +31,16 @@ export class PlanetTagSelectedInputComponent implements OnChanges {
   constructor(
     private tagsService: TagsService,
     private deviceInfoService: DeviceInfoService
-  ) {}
+  ) {
+    this.deviceInfoService.watchDeviceType()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((deviceType) => {
+        this.deviceType = deviceType;
+      });
+  }
 
   ngOnChanges() {
     this.setTooltipLabels(this.selectedIds, this.allTags);
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
   }
 
   setTooltipLabels(selectedIds, allTags) {

--- a/src/app/submissions/submissions.component.ts
+++ b/src/app/submissions/submissions.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/material/table';
 import { composeFilterFunctions, filterDropdowns, dropdownsFill, filterSpecificFieldsByWord } from '../shared/table-helpers';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
-import { takeUntil } from 'rxjs/operators';
+import { skip, takeUntil } from 'rxjs/operators';
 import { Subject, zip } from 'rxjs';
 import { SubmissionsService } from './submissions.service';
 import { UserService } from '../shared/user.service';
@@ -83,11 +83,13 @@ export class SubmissionsComponent implements OnInit, AfterViewChecked, OnDestroy
     private deviceInfoService: DeviceInfoService
   ) {
     this.dialogsLoadingService.start();
-    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+    this.deviceInfoService.watchDeviceType().pipe(skip(1), takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
       this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
       this.showFiltersRow = false;
     });
+    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
     this.surveyId = this.route.snapshot.paramMap.get('surveyId');
     this.isManagerSurveysRoute = !!this.surveyId;
   }

--- a/src/app/submissions/submissions.component.ts
+++ b/src/app/submissions/submissions.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener, ViewChild, AfterViewChecked, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewChecked, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -83,8 +83,11 @@ export class SubmissionsComponent implements OnInit, AfterViewChecked, OnDestroy
     private deviceInfoService: DeviceInfoService
   ) {
     this.dialogsLoadingService.start();
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+      this.showFiltersRow = false;
+    });
     this.surveyId = this.route.snapshot.paramMap.get('surveyId');
     this.isManagerSurveysRoute = !!this.surveyId;
   }
@@ -148,12 +151,6 @@ export class SubmissionsComponent implements OnInit, AfterViewChecked, OnDestroy
     });
     this.submissionsService.updateSubmissions(this.submissionQuery());
     this.setupTable();
-  }
-
-  @HostListener('window:resize') onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE;
-    this.showFiltersRow = false;
   }
 
   ngAfterViewChecked() {

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, Input, Output, EventEmitter, HostListener } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { FormGroup, FormControl, NonNullableFormBuilder, FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -100,13 +100,10 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
     private fb: NonNullableFormBuilder,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
-  }
-
-  @HostListener('window:resize') onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
   }
 
   ngOnInit() {

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, AfterViewChecked, ViewEncapsulation, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, AfterViewChecked, ViewEncapsulation } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatTab, MatTabGroup, MatTabLabel } from '@angular/material/tabs';
@@ -119,11 +119,9 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     private tasksService: TasksService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, ViewChild, AfterViewInit, Input, EventEmitter, Output, HostListener } from '@angular/core';
+import { Component, DestroyRef, OnInit, ViewChild, AfterViewInit, Input, EventEmitter, Output, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -44,6 +45,7 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
   ]
 })
 export class TeamsComponent implements OnInit, AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   teams = new MatTableDataSource<any>();
   @ViewChild(MatSort) sort: MatSort;
@@ -100,8 +102,12 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     private route: ActivatedRoute,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+    this.deviceInfoService.watchDeviceType()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((deviceType) => {
+        this.deviceType = deviceType;
+        this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+      });
   }
 
   ngOnInit() {
@@ -124,11 +130,6 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     this.displayedColumns = this.isDialog ?
       [ 'doc.name', 'visitLog.lastVisit', 'visitLog.visitCount', 'doc.teamType' ] :
       [ 'doc.name', 'visitLog.lastVisit', 'visitLog.visitCount', 'doc.teamType', 'action' ];
-  }
-
-  @HostListener('window:resize') onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
   }
 
   getTeams() {

--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, Input, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router, RouterLink } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -64,8 +64,10 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
     private deviceInfoService: DeviceInfoService,
     private teamsService: TeamsService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
   }
 
   ngOnInit() {
@@ -82,12 +84,6 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
         this.userDetail = user;
       }
     });
-  }
-
-  @HostListener('window:resize')
-  onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
   }
 
   ngOnDestroy() {

--- a/src/app/users/users-table.component.ts
+++ b/src/app/users/users-table.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, OnInit, OnDestroy, ViewChild, AfterViewInit, Input, Output, EventEmitter, OnChanges, HostListener
+  Component, OnInit, OnDestroy, ViewChild, AfterViewInit, Input, Output, EventEmitter, OnChanges
 } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
@@ -117,8 +117,10 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
     private planetMessageService: PlanetMessageService,
     private deviceInfoService: DeviceInfoService
   ) {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+      this.isMobile = deviceType === DeviceType.MOBILE || deviceType === DeviceType.SMALL_MOBILE;
+    });
   }
 
   ngOnInit() {
@@ -162,11 +164,6 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
     }
     this.usersTable.sort = this.sort;
     this.usersTable.paginator = this.paginator;
-  }
-
-  @HostListener('window:resize') onResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
-    this.isMobile = this.deviceType === DeviceType.MOBILE || this.deviceType === DeviceType.SMALL_MOBILE;
   }
 
   isAllSelected() {

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, Input, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, Input } from '@angular/core';
 import { UserService } from '../shared/user.service';
 import { Subject } from 'rxjs';
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
@@ -82,11 +82,9 @@ export class UsersComponent implements OnInit, OnDestroy {
     private deviceInfoService: DeviceInfoService
   ) {
     this.dialogsLoadingService.start();
-    this.deviceType = this.deviceInfoService.getDeviceType();
-  }
-
-  @HostListener('window:resize') OnResize() {
-    this.deviceType = this.deviceInfoService.getDeviceType();
+    this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
+      this.deviceType = deviceType;
+    });
   }
 
   ngOnInit() {


### PR DESCRIPTION
Fixes #9937

- DeviceInfoService now uses `BreakpointObserver` as the shared reactive viewport source.
- Consumers that previously used local @HostListener('window:resize') for device updates were migrated to the shared service stream
- The shared device breakpoints were normalized back to the default 1000 / 780 / 480
- Page-specific toolbar overflow handling was moved into local layout behavior instead of custom device breakpoints
  - Resources: the selection/count summary now shrinks and truncates cleanly so the existing actions menu can switch at the normal breakpoint
  - Reports detail & MyPlanet toolbar: non-desktop controls use full-width, and stacked toolbar alignment was adjusted so dropdowns, toggle group, and Clear align better
