### PR TITLE
actions: smoother docker tagging (fixes #9940)

### DIFF
--- a/.github/workflows/planet-chat.yml
+++ b/.github/workflows/planet-chat.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$SAFE_BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -86,7 +86,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
@@ -102,7 +102,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"

--- a/.github/workflows/planet-chat.yml
+++ b/.github/workflows/planet-chat.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Build image
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$SAFE_BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -84,7 +85,8 @@ jobs:
       - name: Multiarch Deploy
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
@@ -99,7 +101,8 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"

--- a/.github/workflows/planet-chat.yml
+++ b/.github/workflows/planet-chat.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Build image
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$BRANCH"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-chatapi-$PLANET_VERSION-$SAFE_BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker build \
             -f './docker/chatapi/Dockerfile' \
@@ -83,10 +84,11 @@ jobs:
       - name: Multiarch Deploy
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           docker manifest create $manifesttag $amd64tag $armtag $arm64tag
           docker manifest annotate $manifesttag $amd64tag --os linux --arch amd64
           docker manifest annotate $manifesttag $armtag --os linux --arch arm
@@ -97,9 +99,10 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-chatapi-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           for tag in "$DOCKER_ORG/$DOCKER_REPO:chatapi-$PLANET_VERSION" "$DOCKER_ORG/$DOCKER_REPO:chatapi"; do
             docker manifest create $tag $amd64tag $armtag $arm64tag
             docker manifest annotate $tag $amd64tag --os linux --arch amd64

--- a/.github/workflows/planet-db.yml
+++ b/.github/workflows/planet-db.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Build image
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$SAFE_BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -84,7 +85,8 @@ jobs:
       - name: Multiarch Deploy
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
@@ -99,7 +101,8 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"

--- a/.github/workflows/planet-db.yml
+++ b/.github/workflows/planet-db.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$SAFE_BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -86,7 +86,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
@@ -102,7 +102,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"

--- a/.github/workflows/planet-db.yml
+++ b/.github/workflows/planet-db.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Build image
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$BRANCH"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-db-init-$PLANET_VERSION-$SAFE_BRANCH"
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker build \
             -f './docker/db-init/Dockerfile' \
@@ -83,10 +84,11 @@ jobs:
       - name: Multiarch Deploy
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           docker manifest create $manifesttag $amd64tag $armtag $arm64tag
           docker manifest annotate $manifesttag $amd64tag --os linux --arch amd64
           docker manifest annotate $manifesttag $armtag --os linux --arch arm
@@ -97,9 +99,10 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-db-init-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           for tag in "$DOCKER_ORG/$DOCKER_REPO:db-init-$PLANET_VERSION" "$DOCKER_ORG/$DOCKER_REPO:db-init"; do
             docker manifest create $tag $amd64tag $armtag $arm64tag
             docker manifest annotate $tag $amd64tag --os linux --arch amd64

--- a/.github/workflows/planet.yml
+++ b/.github/workflows/planet.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           mkdir -p ./ng-app/dist
           docker build -f './docker/planet/pre-builder-Dockerfile' -t $repo .
@@ -78,7 +78,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           latestrepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker tag $repo $latestrepo
@@ -108,7 +108,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           prerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           latestprerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker pull $prerepo
@@ -118,7 +118,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH"
           export NODE_OPTIONS=--max_old_space_size=4096
@@ -159,7 +159,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$SAFE_BRANCH"
           LANGUAGES=( 'eng' 'ara' 'fra' 'spa' 'nep' 'som')
@@ -207,7 +207,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
@@ -223,7 +223,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
           BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
-          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
+          SAFE_BRANCH="${BRANCH:0:75}-$BRANCH_HASH"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"

--- a/.github/workflows/planet.yml
+++ b/.github/workflows/planet.yml
@@ -65,7 +65,8 @@ jobs:
         if: ${{ env.SHOULD_UPDATE_PACKAGES == 1 || github.event.inputs.buildtype == 'prebuild' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           mkdir -p ./ng-app/dist
           docker build -f './docker/planet/pre-builder-Dockerfile' -t $repo .
@@ -76,7 +77,8 @@ jobs:
         if: ${{ (github.ref == 'refs/heads/master' || env.IS_RELEASE == 'true') && (env.SHOULD_UPDATE_PACKAGES == 1 || github.event.inputs.buildtype == 'prebuild') }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           latestrepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker tag $repo $latestrepo
@@ -105,7 +107,8 @@ jobs:
         continue-on-error: true # If there are no package changes, the commit specific image will not be built so an error is expected here
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           prerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           latestprerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker pull $prerepo
@@ -114,7 +117,8 @@ jobs:
       - name: Build single language build
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH"
           export NODE_OPTIONS=--max_old_space_size=4096
@@ -154,7 +158,8 @@ jobs:
       - name: Build image
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$SAFE_BRANCH"
           LANGUAGES=( 'eng' 'ara' 'fra' 'spa' 'nep' 'som')
@@ -201,7 +206,8 @@ jobs:
       - name: Multiarch Deploy
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
@@ -216,7 +222,8 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          SAFE_BRANCH="${BRANCH:0:48}"
+          BRANCH_HASH="$(printf '%s' "$BRANCH" | sha256sum | cut -c1-8)"
+          SAFE_BRANCH="${BRANCH:0:39}-$BRANCH_HASH"
           amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"

--- a/.github/workflows/planet.yml
+++ b/.github/workflows/planet.yml
@@ -65,7 +65,8 @@ jobs:
         if: ${{ env.SHOULD_UPDATE_PACKAGES == 1 || github.event.inputs.buildtype == 'prebuild' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           mkdir -p ./ng-app/dist
           docker build -f './docker/planet/pre-builder-Dockerfile' -t $repo .
           docker images
@@ -75,7 +76,8 @@ jobs:
         if: ${{ (github.ref == 'refs/heads/master' || env.IS_RELEASE == 'true') && (env.SHOULD_UPDATE_PACKAGES == 1 || github.event.inputs.buildtype == 'prebuild') }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           latestrepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker tag $repo $latestrepo
           docker push $latestrepo
@@ -103,7 +105,8 @@ jobs:
         continue-on-error: true # If there are no package changes, the commit specific image will not be built so an error is expected here
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          prerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          prerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           latestprerepo="$DOCKER_ORG/$DOCKER_REPO_PRE:latest"
           docker pull $prerepo
           docker tag $prerepo $latestprerepo
@@ -111,8 +114,9 @@ jobs:
       - name: Build single language build
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          repo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$BRANCH"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH"
           export NODE_OPTIONS=--max_old_space_size=4096
           mkdir -p ./ng-app/dist
           docker build -f './docker/planet/builder-Dockerfile' -t $repo .
@@ -150,12 +154,13 @@ jobs:
       - name: Build image
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$BRANCH"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          repo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          branchrepo="$DOCKER_ORG/$DOCKER_REPO_TAG:${{ matrix.arch }}-$PLANET_VERSION-$SAFE_BRANCH"
           LANGUAGES=( 'eng' 'ara' 'fra' 'spa' 'nep' 'som')
           mkdir -p ./ng-app/dist
           mkdir -p ./ng-app/langbuild
-          docker create --name langbuild "$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$BRANCH"
+          docker create --name langbuild "$DOCKER_ORG/$DOCKER_REPO_LANG:$PLANET_VERSION-$SAFE_BRANCH"
           docker export langbuild > langbuild.tar
           tar -xf langbuild.tar -C ./ng-app/langbuild
           for LANGUAGE in "${LANGUAGES[@]}"; do
@@ -196,10 +201,11 @@ jobs:
       - name: Multiarch Deploy
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          manifesttag="$DOCKER_ORG/$DOCKER_REPO_TAG:$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           docker manifest create $manifesttag $amd64tag $armtag $arm64tag
           docker manifest annotate $manifesttag $amd64tag --os linux --arch amd64
           docker manifest annotate $manifesttag $armtag --os linux --arch arm
@@ -210,9 +216,10 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           BRANCH="${GITHUB_REF_NAME//\//-}"
-          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
-          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$BRANCH-${GITHUB_SHA::8}"
+          SAFE_BRANCH="${BRANCH:0:48}"
+          amd64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:amd64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          armtag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
+          arm64tag="$DOCKER_ORG/$DOCKER_REPO_TAG:arm64-$PLANET_VERSION-$SAFE_BRANCH-${GITHUB_SHA::8}"
           for tag in "$DOCKER_ORG/$DOCKER_REPO:$PLANET_VERSION" "$DOCKER_ORG/$DOCKER_REPO:latest"; do
             docker manifest create $tag $amd64tag $armtag $arm64tag
             docker manifest annotate $tag $amd64tag --os linux --arch amd64

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.22.81",
+  "version": "0.22.82",
   "myplanet": {
-    "latest": "v0.54.94",
-    "min": "v0.52.45"
+    "latest": "v0.55.45",
+    "min": "v0.53.91"
   },
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Fixes #9940

This PR truncates docker tags to adhere to Github's workflow character limits.

Builds are failing in https://github.com/open-learning-exchange/planet/pull/9939 as a result of the long branch names (auto-generated from the issue title). Tested on `9937-app-currently-mixes-shared-viewport-classification-with-page-specific-toolbar-overflow-behavior-1` branch