### PR TITLE
all: add hooks rule to avoid master pushes unless overrode (fixes #9951)

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -11,14 +11,18 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 protected_branch_pattern='^(refs/heads/)?(master|main)$'
-override_env_var='ALLOW_PROTECTED_PUSH'
 
 while read -r local_ref local_sha remote_ref remote_sha
 do
-  if [[ $remote_ref =~ $protected_branch_pattern ]] && [[ "${!override_env_var}" != "1" ]]; then
-    printf "${RED}Push blocked.${NC}\n"
-    printf "Refusing to push to ${YELLOW}%s${NC}.\n" "$remote_ref"
-    exit 1
+  if [[ $remote_ref =~ $protected_branch_pattern ]]; then
+    if [[ "$ALLOW_PROTECTED_PUSH" != "1" ]]; then
+      printf "${RED}Push blocked.${NC}\n"
+      printf "Refusing to push to ${YELLOW}%s${NC}.\n" "$remote_ref"
+      printf "If this is intentional, rerun with ${YELLOW}ALLOW_PROTECTED_PUSH=1 git push ...${NC}\n"
+      exit 1
+    fi
+
+    printf "${YELLOW}Warning:${NC} pushing to protected branch %s with override enabled.\n" "$remote_ref"
   fi
 done
 

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -7,7 +7,20 @@
 pass=true
 RED='\033[1;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
 NC='\033[0m'
+
+protected_branch_pattern='^(refs/heads/)?(master|main)$'
+override_env_var='ALLOW_PROTECTED_PUSH'
+
+while read -r local_ref local_sha remote_ref remote_sha
+do
+  if [[ $remote_ref =~ $protected_branch_pattern ]] && [[ "${!override_env_var}" != "1" ]]; then
+    printf "${RED}Push blocked.${NC}\n"
+    printf "Refusing to push to ${YELLOW}%s${NC}.\n" "$remote_ref"
+    exit 1
+  fi
+done
 
 # Function to output result of tests
 output_result() {


### PR DESCRIPTION
Fixes #9951

Update the pre-push hooks to restrict pushes to master unless overrode with the `ALLOW_PROTECTED_PUSH` flag