### PR TITLE
Ignore PouchDB test database directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ planet.yml
 
 # Dev environment
 environment.dev.ts
+
+# PouchDB test databases
+courses_new/
+local-*/


### PR DESCRIPTION
This change updates the `.gitignore` file to exclude transient PouchDB database directories that are created when running unit tests.

### Explanation of the directories:
- **`courses_new/`**: This is created by the `PouchService.docEditingDB` method. When a user is adding a new course, the application uses this local database to store drafts. The name is constructed as `${db}_${id}`, which results in `courses_new` for a new course draft.
- **`local-feedback/`**: The `PouchService` initializes local versions of certain databases (like `feedback`) on startup using the prefix `local-`.

### Why they appear during tests:
When running in a browser, PouchDB typically uses IndexedDB for storage. However, during unit tests running in a Node.js/JSDOM environment, PouchDB falls back to using the file system (via the LevelDB adapter) in the project root, creating these directories.

Ignoring them in `.gitignore` ensures they don't clutter the version control status while allowing developers to run tests locally without manually cleaning up these artifacts.

---
*PR created automatically by Jules for task [5810347268443207505](https://jules.google.com/task/5810347268443207505) started by @paulbert*