### PR TITLE
teams: add optional report attachments (fixes #9966)

### DIFF
--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -66,6 +66,11 @@ export class CouchService {
     return this.couchDBReq('delete', db, this.setOpts(opts));
   }
 
+  getAttachment(url: string, opts?: any): Observable<Blob> {
+    const [ , , httpOpts ] = this.setOpts(opts);
+    return this.formatHttpReq(this.http.get(url, { ...httpOpts, responseType: 'blob' as const })) as Observable<Blob>;
+  }
+
   putAttachment(db: string, file: File | FormData, opts?: any) {
     return this.couchDBReq('put', db, this.setOpts(opts), file);
   }

--- a/src/app/teams/teams-report-editor-dialog.component.html
+++ b/src/app/teams/teams-report-editor-dialog.component.html
@@ -1,0 +1,78 @@
+<div mat-dialog-title>
+  <h3>{{ data.title }}</h3>
+</div>
+
+<mat-dialog-content>
+  <form [formGroup]="reportForm" class="report-form">
+    <div class="report-form-grid">
+      <mat-form-field>
+        <mat-label i18n>Start Date</mat-label>
+        <input matInput [matDatepicker]="startDatePicker" formControlName="startDate" required>
+        <mat-datepicker-toggle matIconSuffix [for]="startDatePicker"></mat-datepicker-toggle>
+        <mat-datepicker #startDatePicker></mat-datepicker>
+        <mat-error><planet-form-error-messages [control]="reportForm.controls.startDate"></planet-form-error-messages></mat-error>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label i18n>End Date</mat-label>
+        <input matInput [matDatepicker]="endDatePicker" formControlName="endDate" required>
+        <mat-datepicker-toggle matIconSuffix [for]="endDatePicker"></mat-datepicker-toggle>
+        <mat-datepicker #endDatePicker></mat-datepicker>
+        <mat-error><planet-form-error-messages [control]="reportForm.controls.endDate"></planet-form-error-messages></mat-error>
+      </mat-form-field>
+    </div>
+
+    <mat-form-field class="full-width mat-form-field-type-no-underline">
+      <mat-label i18n>Summary</mat-label>
+      <planet-markdown-textbox class="full-width" [formControl]="reportForm.controls.description"></planet-markdown-textbox>
+      <mat-error><planet-form-error-messages [control]="reportForm.controls.description"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+
+    <div class="report-form-grid">
+      <mat-form-field *ngFor="let field of amountFields">
+        <mat-label>{{ field.label }}</mat-label>
+        <input matInput type="number" [formControlName]="field.name" required>
+        <mat-error><planet-form-error-messages [control]="reportForm.controls[field.name]"></planet-form-error-messages></mat-error>
+      </mat-form-field>
+    </div>
+
+    <section class="receipt-images-section">
+      <div class="receipt-images-header">
+        <div>
+          <h4 i18n>Receipt Images</h4>
+          <p class="mat-caption" i18n>Upload up to {{ maxImages }} JPG, PNG, or WEBP receipt images.</p>
+        </div>
+        <button type="button" mat-stroked-button (click)="openImagePicker()" [disabled]="!canAddMoreImages">
+          <mat-icon>add_photo_alternate</mat-icon>
+          <span i18n>Add Image</span>
+        </button>
+      </div>
+
+      <input #imageInput hidden type="file" accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp" multiple
+        (change)="onFilesSelected($event)">
+
+      <p class="warn-text-color mat-caption" *ngIf="imageError">{{ imageError }}</p>
+
+      <div class="receipt-images-grid" *ngIf="receiptImages.length > 0; else noImages">
+        <article class="receipt-images-card" *ngFor="let image of receiptImages; index as i">
+          <img class="receipt-images-preview" [src]="image.previewUrl" [alt]="image.name">
+          <div class="receipt-images-meta">
+            <span class="receipt-images-name">{{ image.name }}</span>
+            <button type="button" mat-icon-button (click)="removeImage(i)" i18n-aria-label aria-label="Remove image">
+              <mat-icon color="warn">delete</mat-icon>
+            </button>
+          </div>
+        </article>
+      </div>
+
+      <ng-template #noImages>
+        <p class="mat-caption receipt-images-empty" i18n>No receipt images added.</p>
+      </ng-template>
+    </section>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-raised-button color="primary" (click)="submit()" i18n>Save Report</button>
+</mat-dialog-actions>

--- a/src/app/teams/teams-report-editor-dialog.component.scss
+++ b/src/app/teams/teams-report-editor-dialog.component.scss
@@ -1,0 +1,74 @@
+.report-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.report-form-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.full-width {
+  width: 100%;
+}
+
+.receipt-images-section {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.receipt-images-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+
+  h4 {
+    margin: 0 0 4px;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+.receipt-images-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.receipt-images-card {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.receipt-images-preview {
+  aspect-ratio: 4 / 3;
+  display: block;
+  object-fit: cover;
+  width: 100%;
+}
+
+.receipt-images-meta {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  padding: 8px 10px;
+}
+
+.receipt-images-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.receipt-images-empty {
+  margin: 0;
+}

--- a/src/app/teams/teams-report-editor-dialog.component.ts
+++ b/src/app/teams/teams-report-editor-dialog.component.ts
@@ -96,14 +96,12 @@ export class TeamsReportEditorDialogComponent implements OnDestroy {
     }
 
     const remainingSlots = this.maxImages - this.receiptImages.length;
-    const validFiles: File[] = [];
+    const validFiles: Array<{ file: File; contentType: string }> = [];
     const errors: string[] = [];
 
     files.forEach((file) => {
-      const normalizedType = file.type === 'image/jpg' ? 'image/jpeg' : file.type;
-      const isAllowedType = this.allowedImageTypes.includes(normalizedType) ||
-        /\.(jpe?g|png|webp)$/i.test(file.name);
-      if (!isAllowedType) {
+      const contentType = this.imageContentType(file);
+      if (!contentType) {
         errors.push($localize`${file.name} is not a supported image format`);
         return;
       }
@@ -111,12 +109,12 @@ export class TeamsReportEditorDialogComponent implements OnDestroy {
         errors.push($localize`${file.name} exceeds ${this.maxImageSizeMb} MB`);
         return;
       }
-      validFiles.push(file);
+      validFiles.push({ file, contentType });
     });
 
-    validFiles.slice(0, remainingSlots).forEach((file) => {
+    validFiles.slice(0, remainingSlots).forEach(({ file, contentType }) => {
       this.receiptImages.push({
-        contentType: file.type === 'image/jpg' ? 'image/jpeg' : file.type,
+        contentType,
         file,
         name: file.name,
         previewUrl: URL.createObjectURL(file)
@@ -165,6 +163,20 @@ export class TeamsReportEditorDialogComponent implements OnDestroy {
         name: attachmentKey,
         previewUrl: `${environment.couchAddress}/teams/${report._id}/${encodeURIComponent(attachmentKey)}`
       }));
+  }
+
+  private imageContentType(file: File) {
+    const normalizedType = file.type === 'image/jpg' ? 'image/jpeg' : file.type;
+    if (this.allowedImageTypes.includes(normalizedType)) {
+      return normalizedType;
+    }
+    const extensionType = {
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      png: 'image/png',
+      webp: 'image/webp'
+    }[ (file.name.split('.').pop() || '').toLowerCase() ];
+    return extensionType || '';
   }
 
 }

--- a/src/app/teams/teams-report-editor-dialog.component.ts
+++ b/src/app/teams/teams-report-editor-dialog.component.ts
@@ -1,0 +1,170 @@
+import { Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle
+} from '@angular/material/dialog';
+import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatDatepicker, MatDatepickerInput, MatDatepickerToggle } from '@angular/material/datepicker';
+import { MatSuffix } from '@angular/material/form-field';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { NgFor, NgIf } from '@angular/common';
+import { PlanetMarkdownTextboxComponent } from '../shared/forms/planet-markdown-textbox.component';
+import { FormErrorMessagesComponent } from '../shared/forms/form-error-messages.component';
+import { CustomValidators } from '../validators/custom-validators';
+import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
+import { finalize } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+interface TeamsReportEditorData {
+  defaultDates: { startDate: Date; endDate: Date };
+  maxImages: number;
+  report: any;
+  saveReport: (result: any) => any;
+  title: string;
+}
+
+@Component({
+  templateUrl: './teams-report-editor-dialog.component.html',
+  styleUrls: [ './teams-report-editor-dialog.component.scss' ],
+  imports: [
+    ReactiveFormsModule, MatDialogTitle, MatDialogContent, MatFormField, MatLabel, MatInput, MatError,
+    FormErrorMessagesComponent, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker,
+    PlanetMarkdownTextboxComponent, NgIf, NgFor, MatButton, MatIconButton, MatIcon, MatDialogActions, MatDialogClose
+  ]
+})
+export class TeamsReportEditorDialogComponent implements OnDestroy {
+
+  readonly allowedImageTypes = [ 'image/jpeg', 'image/png', 'image/webp' ];
+  readonly amountFields = [
+    { name: 'beginningBalance', label: $localize`Beginning Balance` },
+    { name: 'sales', label: $localize`Sales` },
+    { name: 'otherIncome', label: $localize`Other Income` },
+    { name: 'wages', label: $localize`Personnel` },
+    { name: 'otherExpenses', label: $localize`Non-Personnel` }
+  ];
+  readonly maxImageSizeMb = 10;
+  readonly maxImages: number;
+  receiptImages: any[] = [];
+  imageError = '';
+  reportForm: FormGroup;
+  @ViewChild('imageInput') imageInput?: ElementRef<HTMLInputElement>;
+
+  constructor(
+    private fb: FormBuilder,
+    private dialogsLoadingService: DialogsLoadingService,
+    public dialogRef: MatDialogRef<TeamsReportEditorDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: TeamsReportEditorData
+  ) {
+    this.maxImages = data.maxImages;
+    this.reportForm = this.fb.group({
+      startDate: [ data.report.startDate || data.defaultDates.startDate, Validators.required ],
+      endDate: [ data.report.endDate || data.defaultDates.endDate, [ Validators.required, CustomValidators.endDateValidator() ] ],
+      description: [ data.report.description || '', Validators.required ],
+      beginningBalance: [ data.report.beginningBalance ?? 0, Validators.required ],
+      sales: [ data.report.sales ?? 0, [ Validators.required, Validators.min(0) ] ],
+      otherIncome: [ data.report.otherIncome ?? 0, [ Validators.required, Validators.min(0) ] ],
+      wages: [ data.report.wages ?? 0, [ Validators.required, Validators.min(0) ] ],
+      otherExpenses: [ data.report.otherExpenses ?? 0, [ Validators.required, Validators.min(0) ] ]
+    });
+    this.receiptImages = this.createExistingImages(data.report);
+  }
+
+  ngOnDestroy() {
+    this.receiptImages.forEach((image) => {
+      if (image.file) {
+        URL.revokeObjectURL(image.previewUrl);
+      }
+    });
+  }
+
+  get canAddMoreImages(): boolean {
+    return this.receiptImages.length < this.maxImages;
+  }
+
+  openImagePicker() {
+    this.imageInput?.nativeElement.click();
+  }
+
+  onFilesSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const files = Array.from(input.files || []);
+    this.imageError = '';
+    if (files.length === 0) {
+      return;
+    }
+
+    const remainingSlots = this.maxImages - this.receiptImages.length;
+    const validFiles: File[] = [];
+    const errors: string[] = [];
+
+    files.forEach((file) => {
+      const normalizedType = file.type === 'image/jpg' ? 'image/jpeg' : file.type;
+      const isAllowedType = this.allowedImageTypes.includes(normalizedType) ||
+        /\.(jpe?g|png|webp)$/i.test(file.name);
+      if (!isAllowedType) {
+        errors.push($localize`${file.name} is not a supported image format`);
+        return;
+      }
+      if (file.size / 1024 / 1024 > this.maxImageSizeMb) {
+        errors.push($localize`${file.name} exceeds ${this.maxImageSizeMb} MB`);
+        return;
+      }
+      validFiles.push(file);
+    });
+
+    validFiles.slice(0, remainingSlots).forEach((file) => {
+      this.receiptImages.push({
+        contentType: file.type === 'image/jpg' ? 'image/jpeg' : file.type,
+        file,
+        name: file.name,
+        previewUrl: URL.createObjectURL(file)
+      });
+    });
+
+    if (validFiles.length > remainingSlots) {
+      errors.push($localize`Only ${remainingSlots} more image(s) can be added`);
+    }
+
+    this.imageError = errors.join(' ');
+    input.value = '';
+  }
+
+  removeImage(index: number) {
+    const [ image ] = this.receiptImages.splice(index, 1);
+    if (image?.file) {
+      URL.revokeObjectURL(image.previewUrl);
+    }
+    this.imageError = '';
+  }
+
+  submit() {
+    if (this.reportForm.invalid) {
+      this.reportForm.markAllAsTouched();
+      return;
+    }
+
+    this.dialogsLoadingService.start();
+    this.data.saveReport({
+      receiptImages: this.receiptImages,
+      report: this.reportForm.getRawValue()
+    }).pipe(
+      finalize(() => this.dialogsLoadingService.stop())
+    ).subscribe(() => {
+      this.dialogRef.close(true);
+    });
+  }
+
+  private createExistingImages(report: any): any[] {
+    return (Object.entries(report?._attachments || {}) as [ string, any ][])
+      .filter(([ , attachment ]) => attachment?.content_type?.startsWith('image/'))
+      .sort(([ a ], [ b ]) => a.localeCompare(b))
+      .map(([ attachmentKey, attachment ]) => ({
+        contentType: attachment.content_type,
+        name: attachmentKey,
+        previewUrl: `${environment.couchAddress}/teams/${report._id}/${encodeURIComponent(attachmentKey)}`
+      }));
+  }
+
+}

--- a/src/app/teams/teams-reports-detail.component.html
+++ b/src/app/teams/teams-reports-detail.component.html
@@ -20,6 +20,14 @@
   <ng-container *ngIf="showSummary">
     <h4 i18n>Report Summary</h4>
     <planet-markdown [content]="report.description"></planet-markdown>
+    <div class="report-receipt-images" *ngIf="receiptImages.length > 0">
+      <h4 i18n>Attached Images</h4>
+      <div class="report-receipt-images-grid">
+        <a class="report-receipt-images-link" *ngFor="let image of receiptImages" [href]="image.url" target="_blank" rel="noopener noreferrer">
+          <img class="report-receipt-images-image" [src]="image.url" [alt]="image.key">
+        </a>
+      </div>
+    </div>
     <div><ng-container i18n>Report created on:</ng-container> {{report.createdDate | date }}<ng-container *ngIf="report.createdDate !== report.updatedDate"> | <ng-container i18n>Updated on:</ng-container> {{report.updatedDate | date}}</ng-container></div>
   </ng-container>
 </div>

--- a/src/app/teams/teams-reports-detail.component.ts
+++ b/src/app/teams/teams-reports-detail.component.ts
@@ -1,19 +1,21 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { StateService } from '../shared/state.service';
 import { MatDivider } from '@angular/material/list';
-import { NgIf, NgClass, CurrencyPipe, DatePipe } from '@angular/common';
+import { NgFor, NgIf, NgClass, CurrencyPipe, DatePipe } from '@angular/common';
 import { PlanetMarkdownComponent } from '../shared/planet-markdown.component';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'planet-teams-reports-detail',
   templateUrl: './teams-reports-detail.component.html',
   styleUrls: ['./teams-reports-detail.scss'],
-  imports: [MatDivider, NgIf, NgClass, PlanetMarkdownComponent, CurrencyPipe, DatePipe]
+  imports: [MatDivider, NgIf, NgFor, NgClass, PlanetMarkdownComponent, CurrencyPipe, DatePipe]
 })
 export class TeamsReportsDetailComponent implements OnChanges {
 
   @Input() report;
   @Input() showSummary = false;
+  receiptImages: any[] = [];
   expenses: number;
   income: number;
   net: number;
@@ -25,10 +27,26 @@ export class TeamsReportsDetailComponent implements OnChanges {
   ) {}
 
   ngOnChanges() {
-    this.expenses = this.report.wages + this.report.otherExpenses;
-    this.income = this.report.sales + this.report.otherIncome;
+    this.expenses = this.num(this.report.wages) + this.num(this.report.otherExpenses);
+    this.income = this.num(this.report.sales) + this.num(this.report.otherIncome);
     this.net = this.income - this.expenses;
-    this.endingBalance = this.net + this.report.beginningBalance;
+    this.endingBalance = this.net + this.num(this.report.beginningBalance);
+    this.receiptImages = this.getReceiptImages(this.report);
+  }
+
+  private getReceiptImages(report) {
+    return (Object.entries(report?._attachments || {}) as [ string, any ][])
+      .filter(([ , attachment ]) => attachment?.content_type?.startsWith('image/'))
+      .sort(([ a ], [ b ]) => a.localeCompare(b))
+      .map(([ attachmentKey ]) => ({
+        key: attachmentKey,
+        url: `${environment.couchAddress}/teams/${report._id}/${encodeURIComponent(attachmentKey)}`
+      }));
+  }
+
+  private num(value: any): number {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
   }
 
 }

--- a/src/app/teams/teams-reports-detail.scss
+++ b/src/app/teams/teams-reports-detail.scss
@@ -54,3 +54,27 @@
   line-height: 1.15;
   word-break: break-all;
 }
+
+.report-receipt-images {
+  margin: 16px 0;
+}
+
+.report-receipt-images-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.report-receipt-images-link {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  display: block;
+  overflow: hidden;
+}
+
+.report-receipt-images-image {
+  aspect-ratio: 4 / 3;
+  display: block;
+  object-fit: cover;
+  width: 100%;
+}

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -11,7 +11,7 @@
     <button mat-stroked-button *ngIf="reportCards.length > 0" (click)="exportReports()">
       <mat-icon>file_download</mat-icon><span i18n>Export as CSV</span>
     </button>
-    <button mat-raised-button color="primary" *ngIf="editable" (click)="openAddReportDialog(false)">
+    <button mat-raised-button color="primary" *ngIf="editable" (click)="openAddReportDialog({}, false)">
       <mat-icon>add</mat-icon><span i18n>Add Report</span>
     </button>
   </div>
@@ -62,6 +62,14 @@
           <span i18n>Ending Balance</span>
           <span class="num">{{ card.endingBalance | currency:curCode?.code:curCode?.symbol:'1.0-2' }}</span>
         </div>
+
+        <ng-container *ngIf="card.receiptImageCount > 0">
+          <div class="report-card-receipt-images">
+            <mat-icon>photo_library</mat-icon>
+            <span *ngIf="card.receiptImageCount === 1" i18n>1 attached image</span>
+            <span *ngIf="card.receiptImageCount !== 1">{{ card.receiptImageCount }} <ng-container i18n>receipt images</ng-container></span>
+          </div>
+        </ng-container>
       </mat-card-content>
 
       <mat-card-actions class="report-card-actions">

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -1,15 +1,12 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
-import { Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
-import { CustomValidators } from '../validators/custom-validators';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { forkJoin, of, throwError } from 'rxjs';
 import { CouchService } from '../shared/couchdb.service';
 import { TeamsService } from './teams.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { TeamsReportsDialogComponent } from './teams-reports-dialog.component';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
-import { tap } from 'rxjs/operators';
-import { convertUtcDate } from './teams.utils';
 import { CsvService } from '../shared/csv.service';
 import { StateService } from '../shared/state.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
@@ -19,19 +16,7 @@ import { MatButton, MatIconButton } from '@angular/material/button';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { MatCard, MatCardContent, MatCardActions } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
-
-interface NewReportForm {
-  _id?: string,
-  _rev?: string,
-  beginningBalance: string,
-  description: string,
-  endDate: Date,
-  otherExpenses: number,
-  otherIncome: number,
-  sales: number,
-  startDate: Date,
-  wages: string
-}
+import { TeamsReportEditorDialogComponent } from './teams-report-editor-dialog.component';
 
 @Component({
   selector: 'planet-teams-reports',
@@ -44,6 +29,7 @@ interface NewReportForm {
 })
 export class TeamsReportsComponent implements OnChanges {
 
+  readonly maxReportImages = 2;
   @Input() reports: any[];
   @Input() editable = false;
   @Input() isLoading = false;
@@ -62,6 +48,8 @@ export class TeamsReportsComponent implements OnChanges {
         const net = income - expenses;
         return {
           report,
+          receiptImageCount: Object.values(report._attachments || {})
+            .filter((attachment: any) => attachment?.content_type?.startsWith('image/')).length,
           income,
           expenses,
           net,
@@ -89,7 +77,6 @@ export class TeamsReportsComponent implements OnChanges {
   constructor(
     private couchService: CouchService,
     private dialog: MatDialog,
-    private dialogsFormService: DialogsFormService,
     private dialogsLoadingService: DialogsLoadingService,
     private teamsService: TeamsService,
     private csvService: CsvService,
@@ -97,35 +84,23 @@ export class TeamsReportsComponent implements OnChanges {
     private planetMessageService: PlanetMessageService,
   ) {}
 
-  openAddReportDialog(oldReport = {}, isEdit: boolean) {
+  openAddReportDialog(oldReport: any = {}, isEdit = false) {
     const dialogTitle = isEdit ? $localize`:@@edit-report-dialog-title:Edit Report` : $localize`:@@add-report-dialog-title:Add Report`;
-
     this.couchService.currentTime().subscribe((time: number) => {
       const currentDate = new Date(time);
       const lastMonthStart = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
-      const lastMonthEnd = currentDate.setDate(0);
-      this.dialogsFormService.openDialogsForm(
-        dialogTitle,
-        [
-          { name: 'startDate', placeholder: $localize`Start Date`, type: 'date', required: true },
-          { name: 'endDate', placeholder: $localize`End Date`, type: 'date', required: true },
-          { name: 'description', placeholder: $localize`Summary`, type: 'markdown', required: true },
-          { name: 'beginningBalance', placeholder: $localize`Beginning Balance`, type: 'textbox', inputType: 'number', required: true },
-          { name: 'sales', placeholder: $localize`Sales`, type: 'textbox', inputType: 'number', required: true, min: 0 },
-          { name: 'otherIncome', placeholder: $localize`Other Income`, type: 'textbox', inputType: 'number', required: true, min: 0 },
-          { name: 'wages', placeholder: $localize`Personnel`, type: 'textbox', inputType: 'number', required: true, min: 0 },
-          { name: 'otherExpenses', placeholder: $localize`Non-Personnel`, type: 'textbox', inputType: 'number', required: true, min: 0 }
-        ],
-        this.addFormInitialValues(oldReport, { startDate: lastMonthStart, endDate: lastMonthEnd }),
-        {
-          disableIfInvalid: true,
-          onSubmit: (newReport) => this.updateReport(oldReport, newReport).subscribe(() => {
-            this.dialogsFormService.closeDialogsForm();
-            const action = isEdit ? $localize`:@@report-edited:edited` : $localize`:@@report-added:added`;
-            this.planetMessageService.showMessage($localize`Report ${action}`);
-          })
-        }
-      );
+      const lastMonthEnd = new Date(currentDate.getFullYear(), currentDate.getMonth(), 0);
+      this.dialog.open(TeamsReportEditorDialogComponent, {
+        data: {
+          defaultDates: { startDate: lastMonthStart, endDate: lastMonthEnd },
+          maxImages: this.maxReportImages,
+          report: this.reportFormInitialValues(oldReport, { startDate: lastMonthStart, endDate: lastMonthEnd }),
+          saveReport: (result: any) => this.saveReport(oldReport, result, isEdit),
+          title: dialogTitle
+        },
+        maxWidth: '90vw',
+        width: '72ch'
+      });
     });
   }
 
@@ -137,7 +112,7 @@ export class TeamsReportsComponent implements OnChanges {
         displayName: `${$localize`Report from`} ${new Date(report.startDate).toLocaleDateString('en-US', { timeZone: 'UTC' })}
           ${$localize`to`} ${new Date(report.endDate).toLocaleDateString('en-US', { timeZone: 'UTC' })}`,
         okClick: {
-          request: this.updateReport(report),
+          request: this.archiveReport(report),
           onNext: () => {
             this.planetMessageService.showMessage($localize`Report deleted`);
             this.dialogsLoadingService.stop();
@@ -153,80 +128,27 @@ export class TeamsReportsComponent implements OnChanges {
     });
   }
 
-  addFormInitialValues(oldReport, { startDate, endDate }) {
-    // Only these fields are shown in the dialog, so only these get validators.
-    const formFields = [ 'startDate', 'endDate', 'description', 'beginningBalance', 'sales', 'otherIncome', 'wages', 'otherExpenses' ];
-    const initialValues = {
-      description: '',
-      beginningBalance: 0,
-      sales: 0,
-      otherIncome: 0,
-      wages: 0,
-      otherExpenses: 0,
-      ...oldReport,
-      startDate: new Date(convertUtcDate(oldReport.startDate) || startDate),
-      endDate: new Date(convertUtcDate(oldReport.endDate) || endDate)
-    };
-    const formControl = (initialValue, fieldName: string) => formFields.indexOf(fieldName) > -1 ?
-      [ initialValue, [ CustomValidators.required, this.addFormValidator(fieldName) ] ] :
-      [ initialValue ];
-    return Object.entries(initialValues).reduce(
-      (formObj, [ key, value ]) => ({ ...formObj, [key]: formControl(value, key) }), {}
-    );
-  }
-
-  addFormValidator(fieldName) {
-    return fieldName === 'endDate' ?
-      CustomValidators.endDateValidator() :
-      [ 'sales', 'otherIncome', 'wages', 'otherExpenses' ].indexOf(fieldName) > -1 ?
-        Validators.min(0) :
-        () => {};
-  }
-
-  updateReport(oldReport, newReport: NewReportForm | {} = {}) {
-    const dateFields = [ 'startDate', 'endDate' ];
-    const numberFields = [ 'beginningBalance', 'sales', 'otherIncome', 'wages', 'otherExpenses' ];
-    const transformFields = (key: string, value: string | Date | number) => dateFields.indexOf(key) > -1 ?
-      (value as Date).getTime() :
-      numberFields.indexOf(key) > -1 ?
-        +value :
-        value;
-    const { _id, _rev, ...newDoc } = Object.entries(newReport).reduce(
-      (obj, [ key, value ]: [ string, string | Date | number ]) => {
-        return {
-          ...obj,
-          [key]: transformFields(key, value)
-        };
-      },
-      {}
-    ) as any;
-    const docs = [ { ...oldReport, status: 'archived' }, newDoc ].filter(doc => doc.startDate !== undefined);
-    return this.teamsService.updateAdditionalDocs(docs, this.team, 'report', { utcKeys: dateFields }).pipe(tap(() => {
-      this.reportsChanged.emit();
-      this.dialogsLoadingService.stop();
-    }));
-  }
-
   openReportDialog(report) {
     this.dialog.open(TeamsReportsDialogComponent, {
       data: { report, team: this.team },
-      width: '70ch'
+      maxWidth: '90vw',
+      width: '80ch'
     });
   }
 
   exportReports() {
-    const exportData = this.reportCards.map(({ report }) => ({
+    const exportData = this.reportCards.map(({ report, net, endingBalance }) => ({
       [$localize`Start Date`]: fullLabel(report.startDate),
       [$localize`End Date`]: fullLabel(report.endDate),
       [$localize`Created Date`]: fullLabel(report.createdDate),
       [$localize`Updated Date`]: fullLabel(report.updatedDate),
-      [$localize`Beginning Balance`]: report.beginningBalance,
-      [$localize`Sales`]: report.sales,
-      [$localize`Other Income`]: report.otherIncome,
-      [$localize`Wages`]: report.wages,
-      [$localize`Other Expenses`]: report.otherExpenses,
-      [$localize`Profit/Loss`]: report.sales + report.otherIncome - report.wages - report.otherExpenses,
-      [$localize`Ending Balance`]: report.beginningBalance + report.sales + report.otherIncome - report.wages - report.otherExpenses
+      [$localize`Beginning Balance`]: this.num(report.beginningBalance),
+      [$localize`Sales`]: this.num(report.sales),
+      [$localize`Other Income`]: this.num(report.otherIncome),
+      [$localize`Wages`]: this.num(report.wages),
+      [$localize`Other Expenses`]: this.num(report.otherExpenses),
+      [$localize`Profit/Loss`]: net,
+      [$localize`Ending Balance`]: endingBalance
     }));
     const planetName = this.stateService.configuration.name || 'Unnamed';
     const entityLabel = this.configuration.planetType === 'nation' ? 'Nation' : 'Community';
@@ -235,6 +157,132 @@ export class TeamsReportsComponent implements OnChanges {
       data: exportData,
       title: $localize`Financial Summary for ${titleName}`
     });
+  }
+
+  private reportFormInitialValues(oldReport, { startDate, endDate }) {
+    return {
+      description: oldReport.description || '',
+      beginningBalance: this.num(oldReport.beginningBalance),
+      sales: this.num(oldReport.sales),
+      otherIncome: this.num(oldReport.otherIncome),
+      wages: this.num(oldReport.wages),
+      otherExpenses: this.num(oldReport.otherExpenses),
+      ...oldReport,
+      startDate: new Date(oldReport.startDate || startDate),
+      endDate: new Date(oldReport.endDate || endDate)
+    };
+  }
+
+  private archiveReport(report) {
+    return this.teamsService.updateAdditionalDocs([ { ...report, status: 'archived' } ], this.team, 'report').pipe(tap(() => {
+      this.reportsChanged.emit();
+      this.dialogsLoadingService.stop();
+    }));
+  }
+
+  private saveReport(oldReport, { report, receiptImages }: any, isEdit: boolean) {
+    const dateFields = [ 'startDate', 'endDate' ];
+    const newDoc = this.transformReport(report);
+    const docs = [ { ...oldReport, status: 'archived' }, newDoc ].filter(doc => doc.startDate !== undefined);
+    const newDocIndex = docs.length - 1;
+
+    return this.teamsService.updateAdditionalDocs(docs, this.team, 'report', { utcKeys: dateFields }).pipe(
+      switchMap((response: any) => {
+        const newDocResponse = response.res[newDocIndex];
+        return this.prepareReceiptUploads(receiptImages).pipe(
+          switchMap((uploads) => uploads.length === 0 ?
+            of(undefined) :
+            this.uploadReceiptImages(newDocResponse.id, newDocResponse.rev, uploads)
+          )
+        );
+      }),
+      tap(() => {
+        this.reportsChanged.emit();
+        const action = isEdit ? $localize`:@@report-edited:edited` : $localize`:@@report-added:added`;
+        this.planetMessageService.showMessage($localize`Report ${action}`);
+      }),
+      catchError((error) => {
+        this.planetMessageService.showAlert(isEdit ?
+          $localize`There was a problem updating the report.` :
+          $localize`There was a problem adding the report.`
+        );
+        return throwError(error);
+      })
+    );
+  }
+
+  private transformReport(report: any) {
+    return {
+      ...report,
+      startDate: report.startDate.getTime(),
+      endDate: report.endDate.getTime(),
+      beginningBalance: +report.beginningBalance,
+      sales: +report.sales,
+      otherIncome: +report.otherIncome,
+      wages: +report.wages,
+      otherExpenses: +report.otherExpenses
+    };
+  }
+
+  private prepareReceiptUploads(receiptImages: any[]) {
+    return receiptImages.length === 0 ?
+      of([]) :
+      forkJoin(receiptImages.map((image, index) =>
+        this.resolveReceiptFile(image, this.attachmentKey(image, index, receiptImages))
+      ));
+  }
+
+  private resolveReceiptFile(image: any, key: string) {
+    if (image.file) {
+      return of({ file: image.file, key });
+    }
+
+    return this.couchService.getAttachment(image.previewUrl).pipe(map((blob: Blob) => ({
+      file: new File([ blob ], key, { type: image.contentType || blob.type }),
+      key
+    })));
+  }
+
+  private uploadReceiptImages(reportId: string, startingRev: string, uploads: any[]) {
+    return uploads.reduce((request$, upload) => request$.pipe(
+      switchMap((rev) => this.couchService.putAttachment(
+        `teams/${reportId}/${upload.key}?rev=${rev}`,
+        upload.file,
+        { headers: { 'Content-Type': upload.file.type } }
+      ).pipe(map((response: any) => response.rev)))
+    ), of(startingRev));
+  }
+
+  private attachmentKey(image: any, index: number, images: any[]) {
+    const key = this.sanitizeAttachmentName(image.name, image.contentType);
+    const duplicateIndex = images
+      .slice(0, index)
+      .filter((existingImage) => this.sanitizeAttachmentName(existingImage.name, existingImage.contentType) === key)
+      .length;
+    return duplicateIndex === 0 ? key : key.replace(/(\.[^.]+)?$/, `-${duplicateIndex + 1}$1`);
+  }
+
+  private sanitizeAttachmentName(name: string, contentType: string) {
+    const extension = (name.split('.').pop() || '').toLowerCase();
+    const typeMap = {
+      'image/jpeg': 'jpeg',
+      'image/png': 'png',
+      'image/webp': 'webp'
+    };
+    const safeExtension = [ 'jpg', 'jpeg', 'png', 'webp' ].indexOf(extension) > -1 ? extension : typeMap[contentType] || 'jpeg';
+    const baseName = name
+      .replace(/\.[^.]*$/, '')
+      .trim()
+      .replace(/[\\/?#%:*|"<>]/g, '-')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'image';
+    return `${baseName}.${safeExtension}`;
+  }
+
+  private num(value: any): number {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
   }
 
 }

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -11,6 +11,7 @@ import { CsvService } from '../shared/csv.service';
 import { StateService } from '../shared/state.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { fullLabel } from '../manager-dashboard/reports/reports.utils';
+import { convertUtcDate } from './teams.utils';
 import { NgIf, NgFor, NgClass, DatePipe, CurrencyPipe } from '@angular/common';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
@@ -168,8 +169,8 @@ export class TeamsReportsComponent implements OnChanges {
       wages: this.num(oldReport.wages),
       otherExpenses: this.num(oldReport.otherExpenses),
       ...oldReport,
-      startDate: new Date(oldReport.startDate || startDate),
-      endDate: new Date(oldReport.endDate || endDate)
+      startDate: new Date(convertUtcDate(oldReport.startDate) || startDate),
+      endDate: new Date(convertUtcDate(oldReport.endDate) || endDate)
     };
   }
 

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -194,6 +194,10 @@ export class TeamsReportsComponent implements OnChanges {
           switchMap((uploads) => uploads.length === 0 ?
             of(undefined) :
             this.uploadReceiptImages(newDocResponse.id, newDocResponse.rev, uploads)
+              .pipe(catchError(() => {
+                this.planetMessageService.showAlert($localize`Report saved, but there was a problem uploading receipt images.`);
+                return of(undefined);
+              }))
           )
         );
       }),

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -235,10 +235,11 @@ export class TeamsReportsComponent implements OnChanges {
 
   private resolveReceiptFile(image: any, key: string) {
     if (image.file) {
-      return of({ file: image.file, key });
+      return of({ contentType: image.contentType || image.file.type, file: image.file, key });
     }
 
     return this.couchService.getAttachment(image.previewUrl).pipe(map((blob: Blob) => ({
+      contentType: image.contentType || blob.type,
       file: new File([ blob ], key, { type: image.contentType || blob.type }),
       key
     })));
@@ -249,7 +250,7 @@ export class TeamsReportsComponent implements OnChanges {
       switchMap((rev) => this.couchService.putAttachment(
         `teams/${reportId}/${upload.key}?rev=${rev}`,
         upload.file,
-        { headers: { 'Content-Type': upload.file.type } }
+        { headers: { 'Content-Type': upload.contentType || upload.file.type } }
       ).pipe(map((response: any) => response.rev)))
     ), of(startingRev));
   }

--- a/src/app/teams/teams-reports.scss
+++ b/src/app/teams/teams-reports.scss
@@ -180,6 +180,20 @@
   }
 }
 
+.report-card-receipt-images {
+  align-items: center;
+  color: v.$grey-text;
+  display: inline-flex;
+  gap: 6px;
+  margin-top: 2px;
+
+  mat-icon {
+    font-size: 18px;
+    height: 18px;
+    width: 18px;
+  }
+}
+
 .report-card-actions {
   display: flex;
   align-items: center;

--- a/src/app/teams/teams.module.ts
+++ b/src/app/teams/teams.module.ts
@@ -17,6 +17,7 @@ import { TeamsMemberComponent } from './teams-member.component';
 import { TeamsReportsComponent } from './teams-reports.component';
 import { TeamsReportsDialogComponent } from './teams-reports-dialog.component';
 import { TeamsReportsDetailComponent } from './teams-reports-detail.component';
+import { TeamsReportEditorDialogComponent } from './teams-report-editor-dialog.component';
 import { SurveysModule } from '../surveys/surveys.module';
 
 @NgModule({
@@ -38,6 +39,7 @@ import { SurveysModule } from '../surveys/surveys.module';
     TeamsViewComponent,
     TeamsViewFinancesComponent,
     TeamsReportsComponent,
+    TeamsReportEditorDialogComponent,
     TeamsReportsDetailComponent,
     TeamsMemberComponent,
     TeamsReportsDialogComponent


### PR DESCRIPTION
Fixes #9966

Add optional report attachments.
- Extracts the report add/edit form from the teams-reports component and places it in standalone dialog component

Branched out of #9948

