### PR TITLE
enterprises: smoother finances pictures attaching (fixes #9966)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.9",
+  "version": "0.23.11",
   "myplanet": {
-    "latest": "v0.57.30",
+    "latest": "v0.57.80",
     "min": "v0.54.94"
   },
   "scripts": {

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -66,6 +66,11 @@ export class CouchService {
     return this.couchDBReq('delete', db, this.setOpts(opts));
   }
 
+  getAttachment(url: string, opts?: any): Observable<Blob> {
+    const [ , , httpOpts ] = this.setOpts(opts);
+    return this.formatHttpReq(this.http.get(url, { ...httpOpts, responseType: 'blob' as const })) as Observable<Blob>;
+  }
+
   putAttachment(db: string, file: File | FormData, opts?: any) {
     return this.couchDBReq('put', db, this.setOpts(opts), file);
   }

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -2,16 +2,16 @@
   <h1 mat-dialog-title><span><mat-icon>create</mat-icon>{{title}}</span></h1>
   <mat-dialog-content>
     <div *ngFor="let field of fields" [ngClass]="{ 'checkbox-wrapper': field.type === 'checkbox' || field.type === 'toggle' || field.type === 'markdown' }">
-      
+
       <!--checkbox field-->
-      <mat-checkbox *ngIf="field.type === 'checkbox'" 
+      <mat-checkbox *ngIf="field.type === 'checkbox'"
         formControlName="{{field.name}}"
         [disabled]="field.disabled"
         [matTooltip]="field.tooltip || ''"
         [matTooltipDisabled]="!field.tooltip">
         {{field.placeholder}}
       </mat-checkbox>
-      
+
       <!-- input field -->
       <mat-form-field *ngIf="field.type === 'textbox'" class="full-width">
         <mat-label>{{field.placeholder}}</mat-label>
@@ -92,6 +92,21 @@
 
       <!-- Slide Toggle -->
       <mat-slide-toggle *ngIf="field.type === 'toggle'" class="full-width" [formControl]="modalForm.controls[field.name]">{{field.label}}</mat-slide-toggle>
+
+      <!-- File Upload -->
+      <div *ngIf="field.type === 'file-upload'" class="full-width">
+        <p class="mat-caption" *ngIf="field.placeholder">{{ field.placeholder }}</p>
+        <planet-file-upload
+          [accept]="field.fileUpload?.accept || ''"
+          [existingAttachments]="field.fileUpload?.existingAttachments || []"
+          [hint]="field.fileUpload?.hint || ''"
+          [imagePreview]="!!field.fileUpload?.imagePreview"
+          [maxFiles]="field.fileUpload?.maxFiles || 1"
+          [multiple]="!!field.fileUpload?.multiple"
+          [typePills]="field.fileUpload?.typePills || []"
+          (stateChange)="updateFileUploadState(field.name, $event)">
+        </planet-file-upload>
+      </div>
 
     </div>
   </mat-dialog-content>

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -27,6 +27,7 @@ import { AuthorizedRolesDirective } from '../authorized-roles.directive';
 import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { SubmitDirective } from '../submit.directive';
+import { deepEqual } from '../utils';
 
 @Component({
   templateUrl: './dialogs-form.component.html',
@@ -166,7 +167,13 @@ export class DialogsFormComponent {
   }
 
   updateFileUploadState(fieldName: string, state: AttachmentInputState) {
-    this.modalForm.controls[fieldName].setValue(state);
+    const control = this.modalForm.controls[fieldName];
+    const changed = !deepEqual(control.value, state);
+    control.setValue(state);
+    if (changed) {
+      control.markAsDirty();
+      this.modalForm.markAsDirty();
+    }
   }
 
   private createModalForm(formGroup: DialogFormGroupInput<Record<string, unknown>>): FormGroup {

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -22,6 +22,7 @@ import { MatOption } from '@angular/material/autocomplete';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { PlanetRatingStarsComponent } from '../forms/planet-rating-stars.component';
 import { PlanetMarkdownTextboxComponent } from '../forms/planet-markdown-textbox.component';
+import { AttachmentInputState, FileUploadComponent } from '../forms/file-upload.component';
 import { AuthorizedRolesDirective } from '../authorized-roles.directive';
 import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
@@ -46,7 +47,7 @@ import { SubmitDirective } from '../submit.directive';
     FormsModule, ReactiveFormsModule, MatDialogTitle, MatIcon, CdkScrollable, MatDialogContent, NgFor,
     NgClass, NgIf, MatCheckbox, MatTooltip, MatFormField, MatLabel, MatInput, MatError, FormErrorMessagesComponent,
     MatIconButton, MatSuffix, MatSelect, MatOption, MatRadioGroup, MatRadioButton, PlanetRatingStarsComponent,
-    PlanetMarkdownTextboxComponent, AuthorizedRolesDirective, MatButton, MatDatepickerInput, MatDatepickerToggle,
+    PlanetMarkdownTextboxComponent, FileUploadComponent, AuthorizedRolesDirective, MatButton, MatDatepickerInput, MatDatepickerToggle,
     MatDatepicker, MatSlideToggle, MatDialogActions, SubmitDirective
   ]
 })
@@ -162,6 +163,10 @@ export class DialogsFormComponent {
 
   getRadioOptionValue(option: { name: string; value?: unknown } | string) {
     return typeof option === 'string' ? option : option.value;
+  }
+
+  updateFileUploadState(fieldName: string, state: AttachmentInputState) {
+    this.modalForm.controls[fieldName].setValue(state);
   }
 
   private createModalForm(formGroup: DialogFormGroupInput<Record<string, unknown>>): FormGroup {

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -3,9 +3,10 @@ import { DialogsFormComponent } from './dialogs-form.component';
 import { MatDialogRef, MatDialog } from '@angular/material/dialog';
 import { Injectable } from '@angular/core';
 import { AbstractControlOptions, AsyncValidatorFn, FormArray, FormControl, FormControlState, FormGroup, ValidatorFn } from '@angular/forms';
+import { ExistingAttachment } from '../forms/file-upload.component';
 
 type DialogFieldType = | 'checkbox' | 'textbox' | 'password'| 'selectbox' | 'radio'
-  | 'rating' | 'textarea' | 'markdown' | 'dialog' | 'date' | 'time' | 'toggle' | string;
+  | 'rating' | 'textarea' | 'markdown' | 'dialog' | 'date' | 'time' | 'toggle' | 'file-upload' | string;
 
 export interface DialogField<TName extends string = string> {
   name: TName;
@@ -23,6 +24,15 @@ export interface DialogField<TName extends string = string> {
   authorizedRoles?: string | string[];
   imageGroup?: unknown;
   db?: string;
+  fileUpload?: {
+    accept?: string;
+    existingAttachments?: ExistingAttachment[];
+    hint?: string;
+    imagePreview?: boolean;
+    maxFiles?: number;
+    multiple?: boolean;
+    typePills?: string[];
+  };
   [key: string]: unknown;
 }
 

--- a/src/app/teams/teams-attachments.service.ts
+++ b/src/app/teams/teams-attachments.service.ts
@@ -17,8 +17,9 @@ export class TeamsAttachmentsService {
 
   readonly maxReceiptImages = 2;
   readonly receiptImageAccept = 'image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp';
-  readonly receiptImageHint = $localize`JPG, PNG or WEBP receipt images`;
+  readonly receiptImageHint = $localize`JPG, PNG or WEBP attached images`;
   readonly receiptImagePills = [ 'JPG', 'PNG', 'WEBP' ];
+  private readonly receiptImageTypes = [ 'image/jpeg', 'image/png', 'image/webp' ];
 
   constructor(private couchService: CouchService) {}
 
@@ -101,7 +102,7 @@ export class TeamsAttachmentsService {
   }
 
   private isReceiptImage(attachment: any) {
-    return attachment?.content_type?.startsWith('image/');
+    return this.receiptImageTypes.includes((attachment?.content_type || '').toLowerCase());
   }
 
 }

--- a/src/app/teams/teams-attachments.service.ts
+++ b/src/app/teams/teams-attachments.service.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@angular/core';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { CouchService } from '../shared/couchdb.service';
+import { AttachmentInputState, ExistingAttachment, PendingAttachment } from '../shared/forms/file-upload.component';
+
+export interface TeamsAttachmentUploadResult {
+  latestRev: string;
+  failedAttachments: string[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TeamsAttachmentsService {
+
+  readonly maxReceiptImages = 2;
+  readonly receiptImageAccept = 'image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp';
+  readonly receiptImageHint = $localize`JPG, PNG or WEBP receipt images`;
+  readonly receiptImagePills = [ 'JPG', 'PNG', 'WEBP' ];
+
+  constructor(private couchService: CouchService) {}
+
+  emptyAttachmentState(): AttachmentInputState {
+    return { retained: [], removed: [], added: [] };
+  }
+
+  attachmentStateForDoc(doc: any): AttachmentInputState {
+    return { ...this.emptyAttachmentState(), retained: this.receiptAttachments(doc) };
+  }
+
+  receiptAttachments(doc: any): ExistingAttachment[] {
+    return (Object.entries(doc?._attachments || {}) as [ string, any ][])
+      .filter(([ , attachment ]) => this.isReceiptImage(attachment))
+      .sort(([ a ], [ b ]) => a.localeCompare(b))
+      .map(([ name, attachment ]) => ({
+        contentType: attachment.content_type,
+        name,
+        size: attachment.length,
+        url: `${environment.couchAddress}/teams/${doc._id}/${encodeURIComponent(name)}`
+      }));
+  }
+
+  retainSelectedAttachments(doc: any, state: AttachmentInputState) {
+    const retainedNames = new Set(state.retained.map(attachment => attachment.name));
+    const attachments = Object.entries(doc?._attachments || {}).reduce((result, [ name, attachment ]: [ string, any ]) => {
+      if (!this.isReceiptImage(attachment) || retainedNames.has(name)) {
+        result[name] = attachment;
+      }
+      return result;
+    }, {});
+    return attachments;
+  }
+
+  uploadReceiptImages(
+    docId: string,
+    startingRev: string,
+    state: AttachmentInputState,
+    includeRetained = true
+  ): Observable<TeamsAttachmentUploadResult> {
+    const attachments = [
+      ...(includeRetained ? state.retained : []),
+      ...state.added
+    ];
+    return attachments.reduce((request$, attachment) => request$.pipe(
+      switchMap(result => this.uploadReceiptImage(docId, result.latestRev, attachment).pipe(
+        map((response: any) => ({ ...result, latestRev: response.rev })),
+        catchError(() => of({
+          ...result,
+          failedAttachments: [ ...result.failedAttachments, this.attachmentName(attachment) ]
+        }))
+      ))
+    ), of({ latestRev: startingRev, failedAttachments: [] }));
+  }
+
+  private uploadReceiptImage(docId: string, rev: string, attachment: ExistingAttachment | PendingAttachment) {
+    return this.receiptFile(attachment).pipe(switchMap(({ file, name, contentType }) =>
+      this.couchService.putAttachment(`teams/${docId}/${encodeURIComponent(name)}?rev=${rev}`, file, {
+        headers: { 'Content-Type': contentType }
+      })
+    ));
+  }
+
+  private receiptFile(attachment: ExistingAttachment | PendingAttachment) {
+    if ('file' in attachment) {
+      return of({ file: attachment.file, name: attachment.safeName, contentType: attachment.contentType || attachment.file.type });
+    }
+    if (!attachment.url) {
+      return throwError(() => new Error('Existing attachment is missing a URL'));
+    }
+    return this.couchService.getAttachment(attachment.url).pipe(map((blob) => ({
+      file: new File([ blob ], attachment.name, { type: attachment.contentType || blob.type }),
+      name: attachment.name,
+      contentType: attachment.contentType || blob.type
+    })));
+  }
+
+  private attachmentName(attachment: ExistingAttachment | PendingAttachment) {
+    return 'file' in attachment ? attachment.safeName : attachment.name;
+  }
+
+  private isReceiptImage(attachment: any) {
+    return attachment?.content_type?.startsWith('image/');
+  }
+
+}

--- a/src/app/teams/teams-reports-detail.component.html
+++ b/src/app/teams/teams-reports-detail.component.html
@@ -21,7 +21,7 @@
     <h4 i18n>Report Summary</h4>
     <planet-markdown [content]="report.description"></planet-markdown>
     <div class="report-receipt-images" *ngIf="receiptImages.length > 0">
-      <h4 i18n>Receipt Images</h4>
+      <h4 i18n>Attached Images</h4>
       <div class="report-receipt-images-grid">
         <a class="report-receipt-images-link" *ngFor="let image of receiptImages" [href]="image.url" target="_blank" rel="noopener noreferrer">
           <img class="report-receipt-images-image" [src]="image.url" [alt]="image.name">

--- a/src/app/teams/teams-reports-detail.component.html
+++ b/src/app/teams/teams-reports-detail.component.html
@@ -20,6 +20,14 @@
   <ng-container *ngIf="showSummary">
     <h4 i18n>Report Summary</h4>
     <planet-markdown [content]="report.description"></planet-markdown>
+    <div class="report-receipt-images" *ngIf="receiptImages.length > 0">
+      <h4 i18n>Receipt Images</h4>
+      <div class="report-receipt-images-grid">
+        <a class="report-receipt-images-link" *ngFor="let image of receiptImages" [href]="image.url" target="_blank" rel="noopener noreferrer">
+          <img class="report-receipt-images-image" [src]="image.url" [alt]="image.name">
+        </a>
+      </div>
+    </div>
     <div><ng-container i18n>Report created on:</ng-container> {{report.createdDate | date }}<ng-container *ngIf="report.createdDate !== report.updatedDate"> | <ng-container i18n>Updated on:</ng-container> {{report.updatedDate | date}}</ng-container></div>
   </ng-container>
 </div>

--- a/src/app/teams/teams-reports-detail.component.ts
+++ b/src/app/teams/teams-reports-detail.component.ts
@@ -1,19 +1,21 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { StateService } from '../shared/state.service';
 import { MatDivider } from '@angular/material/list';
-import { NgIf, NgClass, CurrencyPipe, DatePipe } from '@angular/common';
+import { NgFor, NgIf, NgClass, CurrencyPipe, DatePipe } from '@angular/common';
 import { PlanetMarkdownComponent } from '../shared/planet-markdown.component';
+import { TeamsAttachmentsService } from './teams-attachments.service';
 
 @Component({
   selector: 'planet-teams-reports-detail',
   templateUrl: './teams-reports-detail.component.html',
   styleUrls: ['./teams-reports-detail.scss'],
-  imports: [MatDivider, NgIf, NgClass, PlanetMarkdownComponent, CurrencyPipe, DatePipe]
+  imports: [MatDivider, NgIf, NgFor, NgClass, PlanetMarkdownComponent, CurrencyPipe, DatePipe]
 })
 export class TeamsReportsDetailComponent implements OnChanges {
 
   @Input() report;
   @Input() showSummary = false;
+  receiptImages: any[] = [];
   expenses: number;
   income: number;
   net: number;
@@ -21,7 +23,8 @@ export class TeamsReportsDetailComponent implements OnChanges {
   curCode = this.stateService.configuration.currency || {};
 
   constructor(
-    private stateService: StateService
+    private stateService: StateService,
+    private teamsAttachmentsService: TeamsAttachmentsService
   ) {}
 
   ngOnChanges() {
@@ -29,6 +32,7 @@ export class TeamsReportsDetailComponent implements OnChanges {
     this.income = this.report.sales + this.report.otherIncome;
     this.net = this.income - this.expenses;
     this.endingBalance = this.net + this.report.beginningBalance;
+    this.receiptImages = this.teamsAttachmentsService.receiptAttachments(this.report);
   }
 
 }

--- a/src/app/teams/teams-reports-detail.scss
+++ b/src/app/teams/teams-reports-detail.scss
@@ -54,3 +54,27 @@
   line-height: 1.15;
   word-break: break-all;
 }
+
+.report-receipt-images {
+  margin: 16px 0;
+}
+
+.report-receipt-images-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.report-receipt-images-link {
+  border: 1px solid v.$grey;
+  border-radius: 6px;
+  display: block;
+  overflow: hidden;
+}
+
+.report-receipt-images-image {
+  aspect-ratio: 4 / 3;
+  display: block;
+  object-fit: cover;
+  width: 100%;
+}

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -62,6 +62,12 @@
           <span i18n>Ending Balance</span>
           <span class="num">{{ card.endingBalance | currency:curCode?.code:curCode?.symbol:'1.0-2' }}</span>
         </div>
+
+        <div class="report-card-receipt-images" *ngIf="card.receiptImageCount > 0">
+          <mat-icon>photo_library</mat-icon>
+          <span *ngIf="card.receiptImageCount === 1" i18n>1 receipt image</span>
+          <span *ngIf="card.receiptImageCount !== 1">{{ card.receiptImageCount }} <ng-container i18n>receipt images</ng-container></span>
+        </div>
       </mat-card-content>
 
       <mat-card-actions class="report-card-actions">

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -65,8 +65,7 @@
 
         <div class="report-card-receipt-images" *ngIf="card.receiptImageCount > 0">
           <mat-icon>photo_library</mat-icon>
-          <span *ngIf="card.receiptImageCount === 1" i18n>1 receipt image</span>
-          <span *ngIf="card.receiptImageCount !== 1">{{ card.receiptImageCount }} <ng-container i18n>receipt images</ng-container></span>
+          <span i18n>{card.receiptImageCount, plural, =1 {1 attached image} other {# attached images}}</span>
         </div>
       </mat-card-content>
 

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -239,7 +239,8 @@ export class TeamsReportsComponent implements OnChanges {
       switchMap((response: any) => {
         const savedReport = response.res?.[newDocIndex];
         return savedReport ?
-          this.teamsAttachmentsService.uploadReceiptImages(savedReport.id, savedReport.rev, receiptImages).pipe(map(uploadResult => ({ uploadResult }))) :
+          this.teamsAttachmentsService.uploadReceiptImages(savedReport.id, savedReport.rev, receiptImages)
+            .pipe(map(uploadResult => ({ uploadResult }))) :
           of({ uploadResult: { failedAttachments: [] } });
       }),
       tap(() => {

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -123,7 +123,7 @@ export class TeamsReportsComponent implements OnChanges {
           { name: 'otherExpenses', placeholder: $localize`Non-Personnel`, type: 'textbox', inputType: 'number', required: true, min: 0 },
           {
             name: 'receiptImages',
-            placeholder: $localize`Receipt Images`,
+            placeholder: $localize`Attached Images`,
             type: 'file-upload',
             fileUpload: {
               accept: this.teamsAttachmentsService.receiptImageAccept,
@@ -145,7 +145,7 @@ export class TeamsReportsComponent implements OnChanges {
               const action = isEdit ? $localize`:@@report-edited:edited` : $localize`:@@report-added:added`;
               this.planetMessageService.showMessage($localize`Report ${action}`);
               if (result?.failedAttachments?.length) {
-                this.planetMessageService.showAlert($localize`Report saved, but some receipt images could not be uploaded.`);
+                this.planetMessageService.showAlert($localize`Report saved, but some attached images could not be uploaded.`);
               }
             },
             error: () => {

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -8,12 +8,15 @@ import { TeamsService } from './teams.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { TeamsReportsDialogComponent } from './teams-reports-dialog.component';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
-import { tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
 import { convertUtcDate } from './teams.utils';
 import { CsvService } from '../shared/csv.service';
 import { StateService } from '../shared/state.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { fullLabel } from '../manager-dashboard/reports/reports.utils';
+import { AttachmentInputState } from '../shared/forms/file-upload.component';
+import { TeamsAttachmentsService } from './teams-attachments.service';
 import { NgIf, NgFor, NgClass, DatePipe, CurrencyPipe } from '@angular/common';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
@@ -28,6 +31,7 @@ interface NewReportForm {
   endDate: Date,
   otherExpenses: number,
   otherIncome: number,
+  receiptImages?: AttachmentInputState,
   sales: number,
   startDate: Date,
   wages: string
@@ -62,6 +66,7 @@ export class TeamsReportsComponent implements OnChanges {
         const net = income - expenses;
         return {
           report,
+          receiptImageCount: this.teamsAttachmentsService.receiptAttachments(report).length,
           income,
           expenses,
           net,
@@ -92,6 +97,7 @@ export class TeamsReportsComponent implements OnChanges {
     private dialogsFormService: DialogsFormService,
     private dialogsLoadingService: DialogsLoadingService,
     private teamsService: TeamsService,
+    private teamsAttachmentsService: TeamsAttachmentsService,
     private csvService: CsvService,
     private stateService: StateService,
     private planetMessageService: PlanetMessageService,
@@ -114,15 +120,38 @@ export class TeamsReportsComponent implements OnChanges {
           { name: 'sales', placeholder: $localize`Sales`, type: 'textbox', inputType: 'number', required: true, min: 0 },
           { name: 'otherIncome', placeholder: $localize`Other Income`, type: 'textbox', inputType: 'number', required: true, min: 0 },
           { name: 'wages', placeholder: $localize`Personnel`, type: 'textbox', inputType: 'number', required: true, min: 0 },
-          { name: 'otherExpenses', placeholder: $localize`Non-Personnel`, type: 'textbox', inputType: 'number', required: true, min: 0 }
+          { name: 'otherExpenses', placeholder: $localize`Non-Personnel`, type: 'textbox', inputType: 'number', required: true, min: 0 },
+          {
+            name: 'receiptImages',
+            placeholder: $localize`Receipt Images`,
+            type: 'file-upload',
+            fileUpload: {
+              accept: this.teamsAttachmentsService.receiptImageAccept,
+              existingAttachments: this.teamsAttachmentsService.receiptAttachments(oldReport),
+              hint: this.teamsAttachmentsService.receiptImageHint,
+              imagePreview: true,
+              maxFiles: this.teamsAttachmentsService.maxReceiptImages,
+              multiple: true,
+              typePills: this.teamsAttachmentsService.receiptImagePills
+            }
+          }
         ],
         this.addFormInitialValues(oldReport, { startDate: lastMonthStart, endDate: lastMonthEnd }),
         {
           disableIfInvalid: true,
-          onSubmit: (newReport) => this.updateReport(oldReport, newReport).subscribe(() => {
-            this.dialogsFormService.closeDialogsForm();
-            const action = isEdit ? $localize`:@@report-edited:edited` : $localize`:@@report-added:added`;
-            this.planetMessageService.showMessage($localize`Report ${action}`);
+          onSubmit: (newReport) => this.updateReport(oldReport, newReport).subscribe({
+            next: (result: any) => {
+              this.dialogsFormService.closeDialogsForm();
+              const action = isEdit ? $localize`:@@report-edited:edited` : $localize`:@@report-added:added`;
+              this.planetMessageService.showMessage($localize`Report ${action}`);
+              if (result?.failedAttachments?.length) {
+                this.planetMessageService.showAlert($localize`Report saved, but some receipt images could not be uploaded.`);
+              }
+            },
+            error: () => {
+              this.dialogsLoadingService.stop();
+              this.dialogsFormService.showErrorMessage($localize`There was a problem saving the report.`);
+            }
           })
         }
       );
@@ -155,7 +184,9 @@ export class TeamsReportsComponent implements OnChanges {
 
   addFormInitialValues(oldReport, { startDate, endDate }) {
     // Only these fields are shown in the dialog, so only these get validators.
-    const formFields = [ 'startDate', 'endDate', 'description', 'beginningBalance', 'sales', 'otherIncome', 'wages', 'otherExpenses' ];
+    const formFields = [
+      'startDate', 'endDate', 'description', 'beginningBalance', 'sales', 'otherIncome', 'wages', 'otherExpenses'
+    ];
     const initialValues = {
       description: '',
       beginningBalance: 0,
@@ -164,6 +195,7 @@ export class TeamsReportsComponent implements OnChanges {
       wages: 0,
       otherExpenses: 0,
       ...oldReport,
+      receiptImages: this.teamsAttachmentsService.attachmentStateForDoc(oldReport),
       startDate: new Date(convertUtcDate(oldReport.startDate) || startDate),
       endDate: new Date(convertUtcDate(oldReport.endDate) || endDate)
     };
@@ -191,7 +223,8 @@ export class TeamsReportsComponent implements OnChanges {
       numberFields.indexOf(key) > -1 ?
         +value :
         value;
-    const { _id, _rev, ...newDoc } = Object.entries(newReport).reduce(
+    const { receiptImages = this.teamsAttachmentsService.emptyAttachmentState(), ...reportFields } = newReport as NewReportForm;
+    const { _id, _rev, _attachments, ...newDoc } = Object.entries(reportFields).reduce(
       (obj, [ key, value ]: [ string, string | Date | number ]) => {
         return {
           ...obj,
@@ -201,10 +234,20 @@ export class TeamsReportsComponent implements OnChanges {
       {}
     ) as any;
     const docs = [ { ...oldReport, status: 'archived' }, newDoc ].filter(doc => doc.startDate !== undefined);
-    return this.teamsService.updateAdditionalDocs(docs, this.team, 'report', { utcKeys: dateFields }).pipe(tap(() => {
-      this.reportsChanged.emit();
-      this.dialogsLoadingService.stop();
-    }));
+    const newDocIndex = docs.length - 1;
+    return this.teamsService.updateAdditionalDocs(docs, this.team, 'report', { utcKeys: dateFields }).pipe(
+      switchMap((response: any) => {
+        const savedReport = response.res?.[newDocIndex];
+        return savedReport ?
+          this.teamsAttachmentsService.uploadReceiptImages(savedReport.id, savedReport.rev, receiptImages).pipe(map(uploadResult => ({ uploadResult }))) :
+          of({ uploadResult: { failedAttachments: [] } });
+      }),
+      tap(() => {
+        this.reportsChanged.emit();
+        this.dialogsLoadingService.stop();
+      }),
+      map(({ uploadResult }) => ({ failedAttachments: uploadResult.failedAttachments }))
+    );
   }
 
   openReportDialog(report) {

--- a/src/app/teams/teams-reports.scss
+++ b/src/app/teams/teams-reports.scss
@@ -190,6 +190,20 @@
   }
 }
 
+.report-card-receipt-images {
+  align-items: center;
+  color: v.$grey-text;
+  display: inline-flex;
+  gap: 6px;
+  margin-top: 8px;
+
+  mat-icon {
+    font-size: 18px;
+    height: 18px;
+    width: 18px;
+  }
+}
+
 .reports-empty {
   text-align: center;
   color: v.$grey-text;

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -38,7 +38,21 @@
       </ng-container>
       <ng-container matColumnDef="description">
         <mat-header-cell *matHeaderCellDef i18n>Note</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{ element.description }}</mat-cell>
+        <mat-cell *matCellDef="let element">
+          <span>{{ element.description }}</span>
+          <span class="transaction-receipts" *ngIf="element.receiptImages?.length">
+            <a
+              *ngFor="let image of element.receiptImages"
+              [href]="image.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              i18n-aria-label
+              aria-label="Open receipt image"
+              (click)="$event.stopPropagation()">
+              <mat-icon>image</mat-icon>
+            </a>
+          </span>
+        </mat-cell>
       </ng-container>
       <ng-container matColumnDef="credit">
         <mat-header-cell *matHeaderCellDef class="num" i18n>Credit</mat-header-cell>

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -47,7 +47,7 @@
               target="_blank"
               rel="noopener noreferrer"
               i18n-aria-label
-              aria-label="Open attached image"
+              aria-label="Open attached image: {{ image.name }}"
               (click)="$event.stopPropagation()">
               <mat-icon>image</mat-icon>
             </a>

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -47,7 +47,7 @@
               target="_blank"
               rel="noopener noreferrer"
               i18n-aria-label
-              aria-label="Open receipt image"
+              aria-label="Open attached image"
               (click)="$event.stopPropagation()">
               <mat-icon>image</mat-icon>
             </a>

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -143,7 +143,7 @@ export class TeamsViewFinancesComponent implements OnChanges {
           { name: 'date', placeholder: $localize`Date`, type: 'date', required: true },
           {
             name: 'receiptImages',
-            placeholder: $localize`Receipt Images`,
+            placeholder: $localize`Attached Images`,
             type: 'file-upload',
             fileUpload: {
               accept: this.teamsAttachmentsService.receiptImageAccept,
@@ -168,7 +168,7 @@ export class TeamsViewFinancesComponent implements OnChanges {
             next: (result: any) => {
               this.planetMessageService.showMessage(transaction._id ? $localize`Transaction Updated` : $localize`Transaction Added`);
               if (result?.failedAttachments?.length) {
-                this.planetMessageService.showAlert($localize`Transaction saved, but some receipt images could not be uploaded.`);
+                this.planetMessageService.showAlert($localize`Transaction saved, but some attached images could not be uploaded.`);
               }
               this.dialogsFormService.closeDialogsForm();
             },
@@ -185,11 +185,13 @@ export class TeamsViewFinancesComponent implements OnChanges {
   submitTransaction(newTransaction: TransactionForm, oldTransaction: any) {
     const { _id: teamId, teamType, teamPlanetCode } = this.team;
     const { receiptImages, ...transactionFields } = newTransaction;
+    const oldTransactionFields = this.transactionDocFields(oldTransaction);
+    const newTransactionFields = this.transactionDocFields(transactionFields);
     const amount = +(transactionFields.amount);
     const date = new Date(transactionFields.date).getTime();
     const transaction = {
-      ...oldTransaction,
-      ...transactionFields,
+      ...oldTransactionFields,
+      ...newTransactionFields,
       date,
       amount,
       docType: 'transaction',
@@ -234,6 +236,11 @@ export class TeamsViewFinancesComponent implements OnChanges {
       },
       onError: () => this.planetMessageService.showAlert($localize`There was a problem deleting this transaction.`)
     };
+  }
+
+  private transactionDocFields(transaction: any = {}) {
+    const { receiptImages, credit, debit, balance, ...docFields } = transaction;
+    return docFields;
   }
 
   resetDateFilter() {

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -4,7 +4,7 @@ import {
   MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef,
   MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow
 } from '@angular/material/table';
-import { map } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 import { TeamsService } from './teams.service';
 import { CouchService } from '../shared/couchdb.service';
 import { CustomValidators } from '../validators/custom-validators';
@@ -24,6 +24,18 @@ import { FormsModule } from '@angular/forms';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
+import { AttachmentInputState } from '../shared/forms/file-upload.component';
+import { TeamsAttachmentsService } from './teams-attachments.service';
+import { of } from 'rxjs';
+
+interface TransactionForm {
+  amount: number | string;
+  date: Date | number;
+  description: string;
+  receiptImages?: AttachmentInputState;
+  type: 'credit' | 'debit';
+  [key: string]: any;
+}
 
 @Component({
   selector: 'planet-teams-view-finances',
@@ -77,7 +89,8 @@ export class TeamsViewFinancesComponent implements OnChanges {
     private dialogsLoadingService: DialogsLoadingService,
     private planetMessageService: PlanetMessageService,
     private stateService: StateService,
-    private teamsService: TeamsService
+    private teamsService: TeamsService,
+    private teamsAttachmentsService: TeamsAttachmentsService
   ) {}
 
   ngOnChanges() {
@@ -93,7 +106,13 @@ export class TeamsViewFinancesComponent implements OnChanges {
   private setTransactionsTable(transactions: any[]): any[] {
     return transactions.filter(transaction => transaction.status !== 'archived')
       // Overwrite values for credit and debit from early document versions on database
-      .map(transaction => ({ ...transaction, credit: 0, debit: 0, [transaction.type]: transaction.amount }))
+      .map(transaction => ({
+        ...transaction,
+        credit: 0,
+        debit: 0,
+        receiptImages: this.teamsAttachmentsService.receiptAttachments(transaction),
+        [transaction.type]: transaction.amount
+      }))
       .sort((a, b) => a.date - b.date).reduce(this.combineTransactionData, []).reverse();
   }
 
@@ -121,31 +140,56 @@ export class TeamsViewFinancesComponent implements OnChanges {
           },
           { name: 'description', placeholder: $localize`Note`, type: 'textbox', required: true },
           { name: 'amount', placeholder: $localize`Amount`, type: 'textbox', inputType: 'number', required: true, step: '0.01' },
-          { name: 'date', placeholder: $localize`Date`, type: 'date', required: true }
+          { name: 'date', placeholder: $localize`Date`, type: 'date', required: true },
+          {
+            name: 'receiptImages',
+            placeholder: $localize`Receipt Images`,
+            type: 'file-upload',
+            fileUpload: {
+              accept: this.teamsAttachmentsService.receiptImageAccept,
+              existingAttachments: this.teamsAttachmentsService.receiptAttachments(transaction),
+              hint: this.teamsAttachmentsService.receiptImageHint,
+              imagePreview: true,
+              maxFiles: this.teamsAttachmentsService.maxReceiptImages,
+              multiple: true,
+              typePills: this.teamsAttachmentsService.receiptImagePills
+            }
+          }
         ],
         {
           type: [ transaction.type || 'credit', CustomValidators.required ],
           description: [ transaction.description || '', CustomValidators.required ],
           amount: [ transaction.amount || '', [ CustomValidators.nonNegativeNumberValidator ] ],
-          date: [ transaction.date ? new Date(new Date(transaction.date).setHours(0, 0, 0)) : new Date(time), CustomValidators.required ]
+          date: [ transaction.date ? new Date(new Date(transaction.date).setHours(0, 0, 0)) : new Date(time), CustomValidators.required ],
+          receiptImages: [ this.teamsAttachmentsService.attachmentStateForDoc(transaction) ]
         },
         {
-          onSubmit: (newTransaction) => this.submitTransaction(newTransaction, transaction).subscribe(() => {
-            this.planetMessageService.showMessage(transaction._id ? $localize`Transaction Updated` : $localize`Transaction Added`);
-            this.dialogsFormService.closeDialogsForm();
+          onSubmit: (newTransaction: TransactionForm) => this.submitTransaction(newTransaction, transaction).subscribe({
+            next: (result: any) => {
+              this.planetMessageService.showMessage(transaction._id ? $localize`Transaction Updated` : $localize`Transaction Added`);
+              if (result?.failedAttachments?.length) {
+                this.planetMessageService.showAlert($localize`Transaction saved, but some receipt images could not be uploaded.`);
+              }
+              this.dialogsFormService.closeDialogsForm();
+            },
+            error: () => {
+              this.dialogsLoadingService.stop();
+              this.dialogsFormService.showErrorMessage($localize`There was a problem saving the transaction.`);
+            }
           })
         }
       );
     });
   }
 
-  submitTransaction(newTransaction, oldTransaction) {
+  submitTransaction(newTransaction: TransactionForm, oldTransaction: any) {
     const { _id: teamId, teamType, teamPlanetCode } = this.team;
-    const amount = +(newTransaction.amount);
-    const date = new Date(newTransaction.date).getTime();
+    const { receiptImages, ...transactionFields } = newTransaction;
+    const amount = +(transactionFields.amount);
+    const date = new Date(transactionFields.date).getTime();
     const transaction = {
       ...oldTransaction,
-      ...newTransaction,
+      ...transactionFields,
       date,
       amount,
       docType: 'transaction',
@@ -153,10 +197,20 @@ export class TeamsViewFinancesComponent implements OnChanges {
       teamType,
       teamPlanetCode
     };
-    return this.teamsService.updateTeam(transaction).pipe(map(() => {
-      this.financesChanged.emit();
-      this.dialogsLoadingService.stop();
-    }));
+    if (receiptImages) {
+      transaction._attachments = this.teamsAttachmentsService.retainSelectedAttachments(oldTransaction, receiptImages);
+    }
+    return this.teamsService.updateTeam(transaction).pipe(
+      switchMap(savedTransaction => receiptImages ?
+        this.teamsAttachmentsService.uploadReceiptImages(savedTransaction._id, savedTransaction._rev, receiptImages, false) :
+        of({ failedAttachments: [] })
+      ),
+      tap(() => {
+        this.financesChanged.emit();
+        this.dialogsLoadingService.stop();
+      }),
+      map(uploadResult => ({ failedAttachments: uploadResult.failedAttachments }))
+    );
   }
 
   openArchiveTransactionDialog(transaction) {
@@ -171,8 +225,9 @@ export class TeamsViewFinancesComponent implements OnChanges {
   }
 
   archiveTransaction(transaction) {
+    const { receiptImages, ...transactionDoc } = transaction;
     return {
-      request: this.submitTransaction(transaction, { status: 'archived' }),
+      request: this.submitTransaction({ ...transactionDoc, status: 'archived' }, {}),
       onNext: () => {
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`You have deleted a transaction.`);

--- a/src/app/teams/teams-view-finances.scss
+++ b/src/app/teams/teams-view-finances.scss
@@ -119,6 +119,24 @@
   }
 }
 
+.transaction-receipts {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+
+  a {
+    display: inline-flex;
+    color: v.$primary;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    height: 18px;
+    width: 18px;
+  }
+}
+
 .finance-empty {
   text-align: center;
   color: v.$grey-text;


### PR DESCRIPTION
Fixes https://github.com/open-learning-exchange/planet/issues/9966

Add optional finances & report attachments.
Limited to 2 images.

<img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/cbbb7a8a-33e1-4e25-ac43-2875b6b97b91" />

<img width="1919" height="936" alt="image" src="https://github.com/user-attachments/assets/3e664c09-f888-4c4f-9083-9532834904f6" />
