### PR TITLE
resources: smoother creating (fixes #9967)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.10",
+  "version": "0.23.21",
   "myplanet": {
-    "latest": "v0.57.29",
+    "latest": "v0.58.88",
     "min": "v0.54.94"
   },
   "scripts": {

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -43,7 +43,7 @@
           </div>
         </mat-expansion-panel>
 
-        <mat-expansion-panel class="section-panel"
+        <mat-expansion-panel class="section-panel" [class.section-invalid]="submitAttempted && fileInvalid"
           [expanded]="sectionsExpanded.file" (opened)="sectionsExpanded.file = true" (closed)="sectionsExpanded.file = false">
           <mat-expansion-panel-header>
             <mat-panel-title class="section-title"><span class="num">2</span><mat-icon>cloud_upload</mat-icon><span i18n>File</span></mat-panel-title>
@@ -59,7 +59,7 @@
               <label class="markdown-label"><b i18n>Existing Resource/file:</b></label>
               <div class="existing-file-container">
                 <span class="filename">{{resourceFilename}}</span>
-                <button mat-icon-button type="button" [disabled]="disableDelete" (click)="markAttachmentForDeletion()" i18n-matTooltip matTooltip="Remove existing attachment">
+                <button mat-icon-button type="button" [disabled]="disableDelete" (click)="markAttachmentForDeletion()" i18n-matTooltip matTooltip="Remove existing attachment" i18n-aria-label aria-label="Remove existing attachment">
                   <mat-icon color="warn">delete</mat-icon>
                 </button>
               </div>
@@ -163,7 +163,7 @@
     </form>
     <div class="actions-container inner-gaps by-column" *ngIf="!isDialog">
       <button mat-raised-button type="button" [planetSubmit]="resourceForm.valid" color="primary" (click)="onSubmit()" i18n>Submit</button>
-      <button mat-raised-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
+      <button mat-stroked-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
     </div>
   </div>
 </div>

--- a/src/app/resources/resources-add.component.html
+++ b/src/app/resources/resources-add.component.html
@@ -4,131 +4,165 @@
 </mat-toolbar>
 
 <div [ngClass]="{'space-container':!isDialog}">
-  <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}} Resource</mat-toolbar>
+  <mat-toolbar *ngIf="!isDialog" class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}} Resource</mat-toolbar>
   <div class="view-container view-full-height">
-    <div>
-      <form class="form-spacing" [formGroup]="resourceForm" novalidate>
-        <mat-form-field>
-          <mat-label i18n>Title</mat-label>
-          <input matInput formControlName="title" required>
-          <mat-error><planet-form-error-messages [control]="resourceForm.controls.title"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Author</mat-label>
-          <input matInput   formControlName="author">
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Year</mat-label>
-          <input matInput   formControlName="year">
-        </mat-form-field>
-        <div class="full-width markdown-field">
-          <label for="resource-description" class="header-label markdown-label" i18n>Description</label>
-          <planet-markdown-textbox id="resource-description" class="full-width" required="true" [formControl]="resourceForm.controls.description"></planet-markdown-textbox>
-          <p class="mat-caption warn-text-color markdown-error" *ngIf="resourceForm.controls.description.touched && resourceForm.controls.description.invalid">
-            <planet-form-error-messages [control]="resourceForm.controls.description"></planet-form-error-messages>
-          </p>
-        </div>
-        <mat-form-field appearance="outline" subscriptSizing="dynamic" class="full-width mdc-form-field-no-outline">
-          <mat-label i18n>Labels</mat-label>
-          <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Language</mat-label>
-          <mat-select formControlName="language">
-            <mat-option *ngFor="let lang of languages" [value]="lang.name">{{lang.name}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Publisher/Attribution</mat-label>
-          <input matInput formControlName="publisher">
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Link to License</mat-label>
-          <input matInput formControlName="linkToLicense">
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Subject(s)</mat-label>
-          <mat-select formControlName="subject" multiple required>
-            <mat-option *ngFor="let subject of constants.subjectList" [value]="subject.value">{{subject.label}}</mat-option>
-          </mat-select>
-          <mat-error><planet-form-error-messages [control]="resourceForm.controls.subject"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Level(s)</mat-label>
-          <mat-select formControlName="level" multiple required>
-            <mat-option *ngFor="let level of constants.levelList" [value]="level.value">{{level.label}}</mat-option>
-          </mat-select>
-          <mat-error><planet-form-error-messages [control]="resourceForm.controls.level"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Open</mat-label>
-          <mat-select formControlName="openWith">
-            <mat-option *ngFor="let open of constants.openWith" [value]="open.value">
-            {{ open.label }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Resource For</mat-label>
-          <mat-select formControlName="resourceFor" multiple>
-            <mat-option *ngFor="let role of constants.resourceFor" [value]="role.value">{{role.label}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Media</mat-label>
-          <mat-select formControlName="medium">
-            <mat-option *ngFor="let medium of constants.media" [value]="medium.value">
-            {{ medium.label }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Resource Type</mat-label>
-          <mat-select formControlName="resourceType">
-            <mat-option *ngFor="let type of constants.resourceType" [value]="type.value">
-            {{ type.label}}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Added By</mat-label>
-          <input matInput formControlName="addedBy" readonly>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Open Which File</mat-label>
-          <input type="text" matInput formControlName="openWhichFile" [matAutocomplete]="auto">
-          <mat-autocomplete #auto="matAutocomplete">
-            <mat-option *ngFor="let file of filteredZipFiles | async" [value]="file">
-              {{file}}
-            </mat-option>
-          </mat-autocomplete>
-          <mat-error><planet-form-error-messages [control]="resourceForm.controls.openWhichFile"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <div class="file-upload inner-gaps full-width">
-          <label class="header-label"><b i18n>File Upload:</b></label>
-          <planet-file-upload #fileUpload (fileSelected)="onFileSelected($event)" (fileRemoved)="removeNewFile()"></planet-file-upload>
-          <label i18n class="warn-text-color" *ngIf="resourceForm?.errors?.fileTooBig">File size cannot exceed more than 512 MB</label>
-          <div *ngIf="existingResource.doc?._attachments && !attachmentMarkedForDeletion && file" class="warn-text-color">
-            <p i18n>Warning: Existing Resource/file will be replaced</p>
+    <form [formGroup]="resourceForm" novalidate>
+
+        <mat-expansion-panel class="section-panel" [class.section-invalid]="submitAttempted && detailsInvalid"
+          [expanded]="sectionsExpanded.details" (opened)="sectionsExpanded.details = true" (closed)="sectionsExpanded.details = false">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="section-title"><span class="num">1</span><span i18n>Details</span></mat-panel-title>
+            <mat-panel-description class="section-hint" i18n>Title is required</mat-panel-description>
+          </mat-expansion-panel-header>
+          <div class="section-body">
+            <mat-form-field class="full-width">
+              <mat-label i18n>Title</mat-label>
+              <input matInput formControlName="title" required>
+              <mat-error><planet-form-error-messages [control]="resourceForm.controls.title"></planet-form-error-messages></mat-error>
+            </mat-form-field>
+            <div class="field-grid">
+              <mat-form-field>
+                <mat-label i18n>Author</mat-label>
+                <input matInput formControlName="author">
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Year</mat-label>
+                <input matInput formControlName="year">
+              </mat-form-field>
+            </div>
+            <div class="full-width markdown-field">
+              <label for="resource-description" class="markdown-label" i18n>Description</label>
+              <planet-markdown-textbox id="resource-description" class="full-width" required="true" [formControl]="resourceForm.controls.description"></planet-markdown-textbox>
+              <p class="mat-caption warn-text-color markdown-error" *ngIf="resourceForm.controls.description.touched && resourceForm.controls.description.invalid">
+                <planet-form-error-messages [control]="resourceForm.controls.description"></planet-form-error-messages>
+              </p>
+            </div>
+            <div class="collections-field">
+              <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
+            </div>
           </div>
-        </div>
-        <div *ngIf="existingResource.doc?._attachments && !attachmentMarkedForDeletion">
-          <label class="header-label"><b i18n>Existing Resource/file:</b></label>
-          <div class="existing-file-container">
-            <span class="filename">{{resourceFilename}}</span>
-            <button mat-icon-button [disabled]="disableDelete" (click)="markAttachmentForDeletion()" i18n-matTooltip matTooltip="Remove existing attachment">
-              <mat-icon color ="warn">delete</mat-icon>
-            </button>
+        </mat-expansion-panel>
+
+        <mat-expansion-panel class="section-panel"
+          [expanded]="sectionsExpanded.file" (opened)="sectionsExpanded.file = true" (closed)="sectionsExpanded.file = false">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="section-title"><span class="num">2</span><mat-icon>cloud_upload</mat-icon><span i18n>File</span></mat-panel-title>
+            <mat-panel-description class="section-hint" i18n>Drag &amp; drop supported</mat-panel-description>
+          </mat-expansion-panel-header>
+          <div class="section-body">
+            <planet-file-upload #fileUpload (fileSelected)="onFileSelected($event)" (fileRemoved)="removeNewFile()"></planet-file-upload>
+            <label i18n class="warn-text-color file-error" *ngIf="resourceForm?.errors?.fileTooBig">File size cannot exceed more than 512 MB</label>
+            <div *ngIf="existingResource.doc?._attachments && !attachmentMarkedForDeletion && file" class="warn-text-color replace-warning">
+              <p i18n>Warning: Existing Resource/file will be replaced</p>
+            </div>
+            <div *ngIf="existingResource.doc?._attachments && !attachmentMarkedForDeletion" class="existing-file">
+              <label class="markdown-label"><b i18n>Existing Resource/file:</b></label>
+              <div class="existing-file-container">
+                <span class="filename">{{resourceFilename}}</span>
+                <button mat-icon-button type="button" [disabled]="disableDelete" (click)="markAttachmentForDeletion()" i18n-matTooltip matTooltip="Remove existing attachment">
+                  <mat-icon color="warn">delete</mat-icon>
+                </button>
+              </div>
+            </div>
+            <div class="field-grid open-fields">
+              <mat-form-field>
+                <mat-label i18n>Open</mat-label>
+                <mat-select formControlName="openWith">
+                  <mat-option *ngFor="let open of constants.openWith" [value]="open.value">{{ open.label }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+              <mat-form-field *ngIf="resourceForm.controls.openWhichFile.enabled">
+                <mat-label i18n>Open Which File</mat-label>
+                <input type="text" matInput formControlName="openWhichFile" [matAutocomplete]="auto">
+                <mat-autocomplete #auto="matAutocomplete">
+                  <mat-option *ngFor="let file of filteredZipFiles | async" [value]="file">{{file}}</mat-option>
+                </mat-autocomplete>
+                <mat-error><planet-form-error-messages [control]="resourceForm.controls.openWhichFile"></planet-form-error-messages></mat-error>
+              </mat-form-field>
+            </div>
+            <div class="checkbox-row">
+              <mat-checkbox *ngIf="showDownloadCheckbox" [disabled]="resourceForm?.errors?.fileTooBig" formControlName="isDownloadable" i18n>File downloadable</mat-checkbox>
+              <mat-checkbox *ngIf="privateFor" formControlName="private" i18n-matTooltip matTooltip="If checked, resource will only be viewable by this team" i18n>Private Resource</mat-checkbox>
+            </div>
           </div>
-        </div>
-        <div class="inner-gaps full-width">
-          <mat-checkbox *ngIf="showDownloadCheckbox" [disabled]="resourceForm?.errors?.fileTooBig" formControlName="isDownloadable" i18n>File downloadable</mat-checkbox>
-          <mat-checkbox *ngIf="privateFor" formControlName="private" i18n-matTooltip matTooltip="If checked, resource will only be viewable by this team" i18n>Private Resource</mat-checkbox>
-        </div>
-      </form>
-    </div>
+        </mat-expansion-panel>
+
+        <mat-expansion-panel class="section-panel" [class.section-invalid]="submitAttempted && classificationInvalid"
+          [expanded]="sectionsExpanded.classification" (opened)="sectionsExpanded.classification = true" (closed)="sectionsExpanded.classification = false">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="section-title"><span class="num">3</span><span i18n>Classification</span></mat-panel-title>
+            <mat-panel-description class="section-hint" i18n>Subject &amp; level required</mat-panel-description>
+          </mat-expansion-panel-header>
+          <div class="section-body">
+            <div class="field-grid">
+              <mat-form-field>
+                <mat-label i18n>Subject(s)</mat-label>
+                <mat-select formControlName="subject" multiple required>
+                  <mat-option *ngFor="let subject of constants.subjectList" [value]="subject.value">{{subject.label}}</mat-option>
+                </mat-select>
+                <mat-error><planet-form-error-messages [control]="resourceForm.controls.subject"></planet-form-error-messages></mat-error>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Level(s)</mat-label>
+                <mat-select formControlName="level" multiple required>
+                  <mat-option *ngFor="let level of constants.levelList" [value]="level.value">{{level.label}}</mat-option>
+                </mat-select>
+                <mat-error><planet-form-error-messages [control]="resourceForm.controls.level"></planet-form-error-messages></mat-error>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Language</mat-label>
+                <mat-select formControlName="language">
+                  <mat-option *ngFor="let lang of languages" [value]="lang.name">{{lang.name}}</mat-option>
+                </mat-select>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Media</mat-label>
+                <mat-select formControlName="medium">
+                  <mat-option *ngFor="let medium of constants.media" [value]="medium.value">{{ medium.label }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Resource Type</mat-label>
+                <mat-select formControlName="resourceType">
+                  <mat-option *ngFor="let type of constants.resourceType" [value]="type.value">{{ type.label}}</mat-option>
+                </mat-select>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Resource For</mat-label>
+                <mat-select formControlName="resourceFor" multiple>
+                  <mat-option *ngFor="let role of constants.resourceFor" [value]="role.value">{{role.label}}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          </div>
+        </mat-expansion-panel>
+
+        <mat-expansion-panel class="section-panel"
+          [expanded]="sectionsExpanded.attribution" (opened)="sectionsExpanded.attribution = true" (closed)="sectionsExpanded.attribution = false">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="section-title"><span class="num">4</span><span i18n>Attribution &amp; License</span></mat-panel-title>
+          </mat-expansion-panel-header>
+          <div class="section-body">
+            <div class="field-grid">
+              <mat-form-field>
+                <mat-label i18n>Publisher/Attribution</mat-label>
+                <input matInput formControlName="publisher">
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Link to License</mat-label>
+                <input matInput formControlName="linkToLicense">
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Added By</mat-label>
+                <input matInput formControlName="addedBy" readonly>
+              </mat-form-field>
+            </div>
+          </div>
+        </mat-expansion-panel>
+
+    </form>
     <div class="actions-container inner-gaps by-column" *ngIf="!isDialog">
-      <button mat-raised-button type="button" [planetSubmit]="resourceForm.valid" color="primary" (click)="onSubmit()"  i18n>Submit</button>
+      <button mat-raised-button type="button" [planetSubmit]="resourceForm.valid" color="primary" (click)="onSubmit()" i18n>Submit</button>
       <button mat-raised-button type="button" color="warn" (click)="cancel()" i18n>Cancel</button>
     </div>
   </div>

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter, HostListener, ViewChild } from '@angular/core';
-import { FormControl, FormGroup, NonNullableFormBuilder, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, NonNullableFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { Observable, of, forkJoin, combineLatest, race, interval } from 'rxjs';
 import { switchMap, first, debounce, map, startWith } from 'rxjs/operators';
@@ -34,6 +34,9 @@ import { MatOption, MatAutocompleteTrigger, MatAutocomplete } from '@angular/mat
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { SubmitDirective } from '../shared/submit.directive';
+import {
+  MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription
+} from '@angular/material/expansion';
 
 type DatePlaceholderType = CouchService['datePlaceholder'];
 
@@ -66,10 +69,11 @@ interface ResourceFormModel {
   templateUrl: './resources-add.component.html',
   styleUrls: ['./resources-add.scss'],
   imports: [
-    NgIf, MatToolbar, MatIconAnchor, RouterLink, MatIcon, NgClass, FormsModule, ReactiveFormsModule,
+    NgIf, MatToolbar, MatIconAnchor, RouterLink, MatIcon, NgClass, ReactiveFormsModule,
     MatFormField, MatLabel, MatInput, MatError, FormErrorMessagesComponent, PlanetMarkdownTextboxComponent,
     PlanetTagInputComponent, MatSelect, NgFor, MatOption, MatAutocompleteTrigger, MatAutocomplete, FileUploadComponent,
-    MatIconButton, MatTooltip, MatCheckbox, MatButton, SubmitDirective, AsyncPipe
+    MatIconButton, MatTooltip, MatCheckbox, MatButton, SubmitDirective, AsyncPipe,
+    MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription
   ]
 })
 
@@ -78,7 +82,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   file: any;
   attachedZipFiles: string[] = [];
   filteredZipFiles: Observable<string[]>;
-  deleteAttachment = false;
   resourceForm!: FormGroup<ResourceFormModel>;
   readonly dbName = 'resources'; // make database name a constant
   currentUsername = '';
@@ -103,8 +106,18 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   @Output() afterSubmit = new EventEmitter<any>();
   attachmentMarkedForDeletion = false;
   hasUnsavedChanges = false;
+  submitAttempted = false;
+  sectionsExpanded = { details: true, file: false, classification: false, attribution: false };
   private initialState = '';
   @ViewChild('fileUpload') fileUpload!: FileUploadComponent;
+
+  get detailsInvalid(): boolean {
+    return this.resourceForm.controls.title.invalid || this.resourceForm.controls.description.invalid;
+  }
+
+  get classificationInvalid(): boolean {
+    return this.resourceForm.controls.subject.invalid || this.resourceForm.controls.level.invalid;
+  }
 
   constructor(
     private router: Router,
@@ -254,6 +267,13 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     }
     if (!this.resourceForm.valid) {
       this.dialogsLoadingService.stop();
+      this.submitAttempted = true;
+      if (this.detailsInvalid) {
+        this.sectionsExpanded.details = true;
+      }
+      if (this.classificationInvalid) {
+        this.sectionsExpanded.classification = true;
+      }
       showFormErrors(this.resourceForm.controls);
       return;
     }
@@ -316,13 +336,6 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
       this.router.navigate([ '/resources' ]);
     }
     this.planetMessageService.showMessage(message);
-  }
-
-  deleteAttachmentToggle(event) {
-    this.deleteAttachment = event.checked;
-    // Also disable downloadable toggle if user is removing file
-    this.showDownloadCheckbox = !event.checked;
-    this.resourceForm.patchValue({ isDownloadable: false });
   }
 
   markAttachmentForDeletion() {

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -115,6 +115,10 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     return this.resourceForm.controls.title.invalid || this.resourceForm.controls.description.invalid;
   }
 
+  get fileInvalid(): boolean {
+    return !!this.resourceForm.errors?.fileTooBig || this.resourceForm.controls.openWhichFile.invalid;
+  }
+
   get classificationInvalid(): boolean {
     return this.resourceForm.controls.subject.invalid || this.resourceForm.controls.level.invalid;
   }
@@ -270,6 +274,9 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
       this.submitAttempted = true;
       if (this.detailsInvalid) {
         this.sectionsExpanded.details = true;
+      }
+      if (this.fileInvalid) {
+        this.sectionsExpanded.file = true;
       }
       if (this.classificationInvalid) {
         this.sectionsExpanded.classification = true;

--- a/src/app/resources/resources-add.scss
+++ b/src/app/resources/resources-add.scss
@@ -3,37 +3,119 @@
 :host {
   .view-container {
     display: grid;
-    grid-template-rows: auto 42px;
-    > :first-child {
+    grid-template-rows: 1fr auto;
+
+    > form {
       overflow-y: auto;
     }
   }
 
   .actions-container {
     align-self: flex-start;
+    margin-top: 1rem;
   }
 
-  .form-spacing {
-    width: auto;
+  .section-panel {
+    margin-bottom: 1rem;
+    border-radius: 4px;
+
+    &.section-invalid {
+      border: 1px solid v.$warn;
+    }
+
+    ::ng-deep .mat-expansion-panel-header {
+      height: 64px;
+      padding: 0 24px;
+    }
+
+    ::ng-deep .mat-expansion-panel-body {
+      padding: 0 24px 16px;
+    }
+  }
+
+  .section-title {
+    align-items: center;
+    gap: 0.5rem;
+
+    .num {
+      width: 26px;
+      height: 26px;
+      flex: none;
+      border-radius: 50%;
+      background: v.$primary-lighter;
+      color: v.$primary;
+      font-size: 0.8125rem;
+      font-weight: 700;
+      display: grid;
+      place-items: center;
+    }
+
+    mat-icon {
+      color: v.$primary;
+    }
+  }
+
+  .section-hint {
+    align-items: center;
+    justify-content: flex-end;
+    color: v.$grey-text;
+  }
+
+  .section-body {
+    padding-top: 0.5rem;
+
+    mat-form-field {
+      width: 100%;
+    }
+  }
+
+  .field-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0 1rem;
+  }
+
+  .collections-field {
+    display: flex;
+    align-items: center;
     justify-content: flex-start;
-  }
+    margin: 0.75rem 0 1rem;
 
-  .header-label {
-    display: block;
-    margin-top: 10px;
+    planet-tag-input {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+    }
   }
 
   .markdown-field {
     display: block;
+    margin-bottom: 0.5rem;
   }
 
   .markdown-label {
+    display: block;
     margin-top: 0;
     margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: v.$grey-text;
   }
 
   .markdown-error {
     margin: 0.25rem 0 0;
+  }
+
+  .file-error {
+    display: block;
+    margin-top: 0.5rem;
+  }
+
+  .replace-warning p {
+    margin: 0.5rem 0;
+  }
+
+  .existing-file {
+    margin-top: 0.75rem;
   }
 
   .existing-file-container {
@@ -45,11 +127,18 @@
     flex: 1;
   }
 
-  @media (max-width: v.$screen-md) {
-    .form-container {
-      width: auto;
-    }
+  .open-fields,
+  .checkbox-row {
+    margin-top: 0.75rem;
+  }
 
+  .checkbox-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
+
+  @media (max-width: v.$screen-md) {
     .filename {
       white-space: nowrap;
       overflow: hidden;

--- a/src/app/shared/forms/planet-tag-input.component.html
+++ b/src/app/shared/forms/planet-tag-input.component.html
@@ -3,9 +3,9 @@
 </ng-container>
 
 <mat-chip-set *ngIf="helperText && mode === 'add' && value.length > 0" aria-label="Selected collections" i18n-aria-label>
-  <mat-chip *ngFor="let tagId of value" [removable]="!disabled">
+  <mat-chip *ngFor="let tagId of value" [removable]="!disabled" (removed)="removeTag(tagId)">
     {{ tagName(tagId) }}
-    <button matChipRemove type="button" *ngIf="!disabled" (click)="removeTag(tagId)" i18n-aria-label aria-label="Remove collection">
+    <button matChipRemove type="button" *ngIf="!disabled" i18n-aria-label aria-label="Remove collection">
       <mat-icon>cancel</mat-icon>
     </button>
   </mat-chip>

--- a/src/app/shared/forms/planet-tag-input.component.html
+++ b/src/app/shared/forms/planet-tag-input.component.html
@@ -1,6 +1,15 @@
-<ng-container *ngIf="helperText">
+<ng-container *ngIf="helperText && (mode !== 'add' || value.length === 0)">
   <planet-tag-selected-input [selectedIds]="value" [allTags]="tags"></planet-tag-selected-input>
 </ng-container>
+
+<mat-chip-set *ngIf="helperText && mode === 'add' && value.length > 0" aria-label="Selected collections" i18n-aria-label>
+  <mat-chip *ngFor="let tagId of value" [removable]="!disabled">
+    {{ tagName(tagId) }}
+    <button matChipRemove type="button" *ngIf="!disabled" (click)="removeTag(tagId)" i18n-aria-label aria-label="Remove collection">
+      <mat-icon>cancel</mat-icon>
+    </button>
+  </mat-chip>
+</mat-chip-set>
 
 <button type="button" mat-stroked-button (click)="openPresetDialog()" [disabled]="disabled">
   <span [ngSwitch]="labelType" [ngClass]="{'mat-title': largeFont}">

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -2,7 +2,7 @@ import {
   Component, Input, Optional, Self, OnInit, OnChanges, OnDestroy, HostBinding, EventEmitter, Output, ElementRef
 } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { ControlValueAccessor, FormControl, NgControl } from '@angular/forms';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldControl } from '@angular/material/form-field';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -11,9 +11,11 @@ import { Subject } from 'rxjs';
 import { TagsService } from './tags.service';
 import { PlanetTagInputDialogComponent } from './planet-tag-input-dialog.component';
 import { dedupeShelfReduce } from '../utils';
-import { NgIf, NgSwitch, NgClass, NgSwitchCase } from '@angular/common';
+import { NgFor, NgIf, NgSwitch, NgClass, NgSwitchCase } from '@angular/common';
 import { PlanetTagSelectedInputComponent } from './planet-tag-selected-input.component';
 import { MatButton } from '@angular/material/button';
+import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
+import { MatIcon } from '@angular/material/icon';
 
 interface SelectedDialogTag { tagId: string; indeterminate: boolean; }
 type DialogStartingTag = string | SelectedDialogTag;
@@ -37,7 +39,10 @@ interface PlanetTagDialogData {
   'providers': [
     { provide: MatFormFieldControl, useExisting: PlanetTagInputComponent }
   ],
-  imports: [NgIf, PlanetTagSelectedInputComponent, MatButton, NgSwitch, NgClass, NgSwitchCase]
+  imports: [
+    NgFor, NgIf, PlanetTagSelectedInputComponent, MatButton, NgSwitch, NgClass, NgSwitchCase,
+    MatChip, MatChipRemove, MatChipSet, MatIcon
+  ]
 })
 export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, OnChanges, OnDestroy {
 
@@ -96,7 +101,6 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
   onTouched: () => void = () => {};
   stateChanges = new Subject<void>();
   tags: TagWithId[] = [];
-  inputControl = new FormControl<string>('', { nonNullable: true });
   focused = false;
   dialogRef: MatDialogRef<PlanetTagInputDialogComponent>;
   tagUrlDelimiter = '_,_';
@@ -163,6 +167,10 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
 
   removeTag(tagToRemove: string) {
     this.writeValue(this.value.filter(tag => tag !== tagToRemove));
+  }
+
+  tagName(tagId: string) {
+    return this.tagsService.findTag(tagId, this.tags).name;
   }
 
   writeValue(tags: string[] | null = []) {

--- a/src/app/shared/forms/planet-tag-input.scss
+++ b/src/app/shared/forms/planet-tag-input.scss
@@ -2,10 +2,16 @@
 
   display: inline-flex;
   align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   box-sizing: border-box;
   width: 100%;
 
-  button {
+  mat-chip-set {
+    max-width: 100%;
+  }
+
+  > button {
     width: 100%;
     max-width: 196px;
   }


### PR DESCRIPTION
Fixes #9967

- Organize the page into collapsible sections; less crowded & less overwhelming to users on initial view 

<img width="1921" height="1300" alt="image" src="https://github.com/user-attachments/assets/a52482f2-714b-46a6-8c41-663a98de4be7" />

<img width="1921" height="2002" alt="image" src="https://github.com/user-attachments/assets/36b0f226-69d4-4317-9208-949810eb1d06" />

