### PR TITLE
courses: smoother creating (fixes #9977)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.10",
+  "version": "0.23.22",
   "myplanet": {
     "latest": "v0.57.29",
     "min": "v0.54.94"

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -6,51 +6,57 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</mat-toolbar>
   <div class="view-container view-full-height">
-    <div class="form-container">
-      <form [formGroup]="courseForm" class="form-spacing" novalidate>
-        <mat-form-field class="full-width">
-          <mat-label i18n>Course Title</mat-label>
-          <input matInput formControlName="courseTitle" required>
-          <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field class="full-width mat-form-field-type-no-underline">
-          <mat-label i18n>Description</mat-label>
-          <planet-markdown-textbox class="full-width" required="true" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-          <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Language of Instruction</mat-label>
-          <input matInput formControlName="languageOfInstruction" [matAutocomplete]="auto">
-          <mat-autocomplete #auto="matAutocomplete">
-            <mat-option *ngFor="let language of languageNames" [value]="language">
-              {{ language }}
-            </mat-option>
-          </mat-autocomplete>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Grade Level</mat-label>
-          <mat-select formControlName="gradeLevel" required>
-            <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Subject Level</mat-label>
-          <mat-select formControlName="subjectLevel" required>
-            <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field appearance="outline" subscriptSizing="dynamic" class="full-width mdc-form-field-no-outline">
-          <!--
-            Label (and previous placeholder) is not rendered. Keeping the label because I'm not sure if it's picked up
-            by screen readers. Could remove or change for better accessibility.
-          -->
-          <mat-label i18n>Labels</mat-label>
-          <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
-        </mat-form-field>
-      </form>
-    </div>
-    <div [ngClass]="{'steps-container': steps.length > 0 }">
-      <planet-courses-step [(steps)]="steps" (addStepEvent)="addStep()"></planet-courses-step>
+    <mat-accordion>
+      <mat-expansion-panel class="course-details-panel" [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded" (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
+        <mat-expansion-panel-header>
+          <mat-panel-title class="course-title-header" i18n>
+            Course Details: {{ (courseForm.controls.courseTitle.value || newCourseLabel) | truncateText:50 }}
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <div class="form-container">
+          <form [formGroup]="courseForm" class="form-spacing" novalidate>
+            <mat-form-field class="full-width">
+              <mat-label i18n>Course Title</mat-label>
+              <input matInput formControlName="courseTitle" required>
+              <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+            </mat-form-field>
+            <mat-form-field class="full-width mat-form-field-type-no-underline">
+              <mat-label i18n>Description</mat-label>
+              <planet-markdown-textbox class="full-width" required="true" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+              <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+            </mat-form-field>
+            <div class="collections-field">
+              <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
+            </div>
+            <div class="field-grid">
+              <mat-form-field>
+                <mat-label i18n>Language of Instruction</mat-label>
+                <input matInput formControlName="languageOfInstruction" [matAutocomplete]="auto">
+                <mat-autocomplete #auto="matAutocomplete">
+                  <mat-option *ngFor="let language of languageNames" [value]="language">
+                    {{ language }}
+                  </mat-option>
+                </mat-autocomplete>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Grade Level</mat-label>
+                <mat-select formControlName="gradeLevel" required>
+                  <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
+                </mat-select>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Subject Level</mat-label>
+                <mat-select formControlName="subjectLevel" required>
+                  <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          </form>
+        </div>
+      </mat-expansion-panel>
+    </mat-accordion>
+    <div class="steps-container" *ngIf="steps.length > 0">
+      <planet-courses-step [(steps)]="steps" (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
     </div>
     <div class="actions-container">
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -6,63 +6,68 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</mat-toolbar>
   <div class="view-container view-full-height">
-    <mat-accordion>
-      <mat-expansion-panel class="course-details-panel" [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded" (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
-        <mat-expansion-panel-header>
-          <mat-panel-title class="course-title-header" i18n>
-            Course Details: {{ (courseForm.controls.courseTitle.value || newCourseLabel) | truncateText:50 }}
-          </mat-panel-title>
-        </mat-expansion-panel-header>
-        <div class="form-container">
-          <form [formGroup]="courseForm" class="form-spacing" novalidate>
-            <mat-form-field class="full-width">
-              <mat-label i18n>Course Title</mat-label>
-              <input matInput formControlName="courseTitle" required>
-              <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
-            </mat-form-field>
-            <mat-form-field class="full-width mat-form-field-type-no-underline">
-              <mat-label i18n>Description</mat-label>
-              <planet-markdown-textbox class="full-width" required="true" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-              <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-            </mat-form-field>
-            <div class="collections-field">
-              <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
-            </div>
-            <div class="field-grid">
-              <mat-form-field>
-                <mat-label i18n>Language of Instruction</mat-label>
-                <input matInput formControlName="languageOfInstruction" [matAutocomplete]="auto">
-                <mat-autocomplete #auto="matAutocomplete">
-                  <mat-option *ngFor="let language of languageNames" [value]="language">
-                    {{ language }}
-                  </mat-option>
-                </mat-autocomplete>
+    <div class="course-content">
+      <mat-accordion>
+        <mat-expansion-panel class="course-details-panel" [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded" (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="course-title-header" i18n>
+              Course Details: {{ (courseForm.controls.courseTitle.value || newCourseLabel) | truncateText:50 }}
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <div class="form-container">
+            <form [formGroup]="courseForm" class="form-spacing" novalidate>
+              <mat-form-field class="full-width">
+                <mat-label i18n>Course Title</mat-label>
+                <input matInput formControlName="courseTitle" required>
+                <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
               </mat-form-field>
-              <mat-form-field>
-                <mat-label i18n>Grade Level</mat-label>
-                <mat-select formControlName="gradeLevel" required>
-                  <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
-                </mat-select>
+              <mat-form-field class="full-width mat-form-field-type-no-underline">
+                <mat-label i18n>Description</mat-label>
+                <planet-markdown-textbox class="full-width" required="true" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+                <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
               </mat-form-field>
-              <mat-form-field>
-                <mat-label i18n>Subject Level</mat-label>
-                <mat-select formControlName="subjectLevel" required>
-                  <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
-                </mat-select>
-              </mat-form-field>
-            </div>
-          </form>
-        </div>
-      </mat-expansion-panel>
-    </mat-accordion>
-    <div class="steps-container" *ngIf="steps.length > 0">
-      <planet-courses-step [(steps)]="steps" (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
+              <div class="collections-field">
+                <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
+              </div>
+              <div class="field-grid">
+                <mat-form-field>
+                  <mat-label i18n>Language of Instruction</mat-label>
+                  <input matInput formControlName="languageOfInstruction" [matAutocomplete]="auto">
+                  <mat-autocomplete #auto="matAutocomplete">
+                    <mat-option *ngFor="let language of languageNames" [value]="language">
+                      {{ language }}
+                    </mat-option>
+                  </mat-autocomplete>
+                </mat-form-field>
+                <mat-form-field>
+                  <mat-label i18n>Grade Level</mat-label>
+                  <mat-select formControlName="gradeLevel" required>
+                    <mat-option *ngFor="let grade of gradeLevels" [value]="grade.value">{{grade.label}}</mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <mat-form-field>
+                  <mat-label i18n>Subject Level</mat-label>
+                  <mat-select formControlName="subjectLevel" required>
+                    <mat-option *ngFor="let sub of subjectLevels" [value]="sub.value">{{sub.label}}</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+            </form>
+          </div>
+        </mat-expansion-panel>
+      </mat-accordion>
+      <div class="steps-container" [hidden]="steps.length === 0">
+        <planet-courses-step [(steps)]="steps" (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
+      </div>
     </div>
     <div class="actions-container">
       <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
-      <button *ngIf="draftExists" class="margin-lr-2" type="button" mat-raised-button (click)="deleteDraft()" i18n="@@discardDraftButton">Discard Draft</button>
-      <button class="margin-lr-2" type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
-      <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
+      <button type="button" mat-stroked-button color="primary" (click)="addStep()">
+        <mat-icon>add</mat-icon>
+        <span i18n>Add Step</span>
+      </button>
+      <button *ngIf="draftExists" type="button" mat-stroked-button (click)="deleteDraft()" i18n="@@discardDraftButton">Discard Draft</button>
+      <button type="button" mat-stroked-button color="warn" (click)="cancel()" i18n>Cancel</button>
     </div>
   </div>
 </div>

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
-import { AbstractControl, FormControl, FormGroup, NonNullableFormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subject, forkJoin, of, combineLatest, race, interval } from 'rxjs';
 import { takeWhile, debounce, catchError, switchMap } from 'rxjs/operators';
@@ -30,6 +30,8 @@ import { MatAutocompleteTrigger, MatAutocomplete, MatOption } from '@angular/mat
 import { MatSelect } from '@angular/material/select';
 import { PlanetTagInputComponent } from '../../shared/forms/planet-tag-input.component';
 import { SubmitDirective } from '../../shared/submit.directive';
+import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
+import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 
 interface CourseFormModel {
   courseTitle: FormControl<string>;
@@ -50,10 +52,11 @@ type DateValue = number | string | CouchService['datePlaceholder'];
   templateUrl: 'courses-add.component.html',
   styleUrls: ['./courses-add.scss'],
   imports: [
-    MatToolbar, MatIconAnchor, MatIcon, NgIf, FormsModule, ReactiveFormsModule, MatFormField,
+    MatToolbar, MatIconAnchor, MatIcon, NgIf, ReactiveFormsModule, MatFormField,
     MatLabel, MatInput, MatError, FormErrorMessagesComponent, PlanetMarkdownTextboxComponent,
     MatAutocompleteTrigger, MatAutocomplete, NgFor, MatOption, MatSelect, PlanetTagInputComponent,
-    NgClass, CoursesStepComponent, MatButton, SubmitDirective
+    CoursesStepComponent, MatButton, SubmitDirective,
+    MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, TruncateTextPipe
   ]
 })
 export class CoursesAddComponent implements OnInit, OnDestroy {
@@ -71,6 +74,9 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   documentInfo = { '_rev': undefined, '_id': undefined };
   courseId = this.route.snapshot.paramMap.get('id') || undefined;
   pageType: string | null = null;
+  isFormExpanded = true;
+  submitAttempted = false;
+  newCourseLabel = $localize`New Course`;
   tags = this.fb.control<string[]>([]);
   // from the constants import
   gradeLevels = constants.gradeLevels;
@@ -78,7 +84,6 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   images: any[] = [];
   // from the languages import
   languageNames = languages.map(list => list.name);
-  mockStep = { stepTitle: $localize`Add title`, description: '!!!' };
   @ViewChild(CoursesStepComponent) coursesStepComponent: CoursesStepComponent;
   get steps() {
     return this._steps;
@@ -122,9 +127,11 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
         this.setDocumentInfo(saved);
         this.savedCourse = saved;
         this.pageType = 'Edit';
+        this.isFormExpanded = !(saved.steps && saved.steps.length > 0);
       } else {
         this.pageType = 'Add';
         this.savedCourse = null;
+        this.isFormExpanded = true;
       }
       this.draftExists = draft !== undefined;
       const doc = draft === undefined ? saved : draft;
@@ -268,6 +275,8 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
 
   onSubmit(shouldNavigate = true) {
     if (!this.courseForm.valid) {
+      this.submitAttempted = true;
+      this.isFormExpanded = true;
       showFormErrors(this.courseForm.controls as unknown as { [key: string]: AbstractControl });
       return;
     }
@@ -303,6 +312,17 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       images: []
     });
     this.planetStepListService.addStep(this.steps.length - 1);
+  }
+
+  openCourseDetails() {
+    this.isFormExpanded = true;
+    this.coursesStepComponent?.toList();
+  }
+
+  onStepEditorOpenChange(isOpen: boolean) {
+    if (isOpen) {
+      this.isFormExpanded = false;
+    }
   }
 
   cancel() {

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -2,18 +2,70 @@
 
 :host {
   .view-container {
-    display: grid;
-    grid-template-columns: 1.5fr 1fr;
-    grid-template-rows: auto 42px;
-    grid-column-gap: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding-bottom: 10px;
+    min-height: 70vh;
+
+    > * {
+      overflow-y: visible;
+    }
+  }
+
+  .course-details-panel {
+    margin-bottom: 1rem;
+
+    &.course-details-invalid {
+      border: 1px solid v.$warn;
+    }
+
+    .course-title-header {
+      margin: 0;
+    }
+
+    ::ng-deep .mat-expansion-panel-header {
+      height: 64px;
+      padding: 0 24px;
+      overflow: hidden;
+    }
+
+    ::ng-deep .mat-expansion-panel-body {
+      padding: 0 24px 16px;
+    }
   }
 
   .steps-container {
-    grid-row: span 2;
+    margin: 1rem 0;
   }
 
   .actions-container {
-    align-self: center;
+    align-self: flex-start;
+    margin-top: auto;
+    padding-top: 1rem;
+  }
+
+  .collections-field {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    margin: 0.75rem 0 1rem;
+
+    planet-tag-input {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+    }
+  }
+
+  .field-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0 1rem;
+
+    mat-form-field {
+      width: 100%;
+    }
   }
 
   .form-container {
@@ -22,43 +74,7 @@
 
   .form-spacing {
     width: auto;
+    display: block;
   }
 
-  .draft-btn {
-    background: v.$grey;
-  }
-
-  @media (max-width: v.$screen-md) {
-    .form-spacing {
-      justify-content: center;
-    }
-
-    .view-container {
-      grid-template-columns: 1fr;
-      grid-row-gap: 2rem;
-      grid-template-rows: 1fr;
-      grid-template-areas:
-      'form-area form-area'
-      'steps-area steps-area'
-      'actions-area actions-area';
-      > * {
-        overflow-y: visible;
-      }
-    }
-
-    .steps-container {
-      grid-area: steps-area;
-      border-top: 2px solid #000;
-      border-bottom: 2px solid #000;
-      padding: 2rem;
-    }
-
-    .form-container {
-      grid-area: form-area;
-    }
-
-    .actions-container{
-      grid-area: actions-area;
-    }
-  }
 }

--- a/src/app/courses/add-courses/courses-add.scss
+++ b/src/app/courses/add-courses/courses-add.scss
@@ -2,15 +2,15 @@
 
 :host {
   .view-container {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto;
+    gap: 1rem;
     position: relative;
-    padding-bottom: 10px;
-    min-height: 70vh;
+  }
 
-    > * {
-      overflow-y: visible;
-    }
+  .course-content {
+    min-height: 0;
+    overflow-y: auto;
   }
 
   .course-details-panel {
@@ -40,9 +40,10 @@
   }
 
   .actions-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     align-self: flex-start;
-    margin-top: auto;
-    padding-top: 1rem;
   }
 
   .collections-field {

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -1,5 +1,5 @@
 <planet-step-list [steps]="steps" (stepsChange)="stepsMoved($event)" [nameProp]="'stepTitle'" (stepClicked)="stepClick($event)">
-  <planet-step-list-item *ngFor="let step of steps; index as i; first as isFirst; last as isLast">
+  <planet-step-list-item *ngFor="let step of steps; index as i">
     <span matListItemTitle i18n>{{(step.stepTitle || 'Step ' + (i+1)) | truncateText:50}}</span>
     <ng-container matListItemMeta>
       <planet-course-icon *ngIf="step?.exam?.questions.length" [icon]="'assignment'"></planet-course-icon>
@@ -36,10 +36,26 @@
       </mat-chip-set>
     </ng-container>
   </div>
-  <div planetStepListActions>
-    <a mat-raised-button color="primary" (click)="addExam()">{{ examButtonLabel }}</a>
-    <button mat-raised-button color="primary" (click)="addResources()" i18n>Add Resource</button>
-    <a mat-raised-button color="primary" (click)="addExam('survey')">{{ surveyButtonLabel }}</a>
-    <button mat-raised-button color="accent" (click)="addStep()" i18n>Add Step</button>
+  <div planetStepListActions class="course-attach">
+    <div class="attach-grid">
+      <button type="button" class="attach-card" (click)="addExam()">
+        <mat-icon>assignment</mat-icon>
+        <span class="ac-title">{{ examButtonLabel }}</span>
+        <span class="ac-sub" i18n>Quiz learners</span>
+        <span class="ac-count" *ngIf="activeStep?.exam?.questions?.length">{{ activeStep.exam.questions.length }}&nbsp;<span i18n>questions</span></span>
+      </button>
+      <button type="button" class="attach-card" (click)="addResources()">
+        <mat-icon>attach_file</mat-icon>
+        <span class="ac-title" i18n>Add Resource</span>
+        <span class="ac-sub" i18n>Attach from library</span>
+        <span class="ac-count" *ngIf="activeStep?.resources?.length">{{ activeStep.resources.length }}&nbsp;<span i18n>attached</span></span>
+      </button>
+      <button type="button" class="attach-card" (click)="addExam('survey')">
+        <mat-icon>description</mat-icon>
+        <span class="ac-title">{{ surveyButtonLabel }}</span>
+        <span class="ac-sub" i18n>Collect feedback</span>
+        <span class="ac-count" *ngIf="activeStep?.survey?.questions?.length">{{ activeStep.survey.questions.length }}&nbsp;<span i18n>questions</span></span>
+      </button>
+    </div>
   </div>
 </planet-step-list>

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnDestroy, ViewEncapsulation, ViewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
-import { NonNullableFormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NonNullableFormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -23,7 +23,6 @@ import { PlanetMarkdownTextboxComponent } from '../../shared/forms/planet-markdo
 import { FormErrorMessagesComponent } from '../../shared/forms/form-error-messages.component';
 import { MatChipSet, MatChip, MatChipRemove } from '@angular/material/chips';
 import { MatIcon } from '@angular/material/icon';
-import { MatAnchor, MatButton } from '@angular/material/button';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 
 interface CoursesStepForm {
@@ -40,16 +39,16 @@ interface CoursesStepForm {
   imports: [
     PlanetStepListComponent, NgFor, PlanetStepListItemComponent, MatListItemTitle, MatListItemMeta,
     NgIf, CoursesIconComponent, PlanetStepListNumberDirective, PlanetStepListFormDirective,
-    FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, PlanetMarkdownTextboxComponent,
+    ReactiveFormsModule, MatFormField, MatLabel, MatInput, PlanetMarkdownTextboxComponent,
     MatError, FormErrorMessagesComponent, MatChipSet, MatChip, RouterLink, MatChipRemove, MatIcon,
-    PlanetStepListActionsDirective, MatAnchor, MatButton, TruncateTextPipe
+    PlanetStepListActionsDirective, TruncateTextPipe
   ]
 })
 export class CoursesStepComponent implements OnDestroy {
 
   @Input() steps: any[];
   @Output() stepsChange = new EventEmitter<any>();
-  @Output() addStepEvent = new EventEmitter<void>();
+  @Output() stepEditorOpenChange = new EventEmitter<boolean>();
 
   stepForm: FormGroup<CoursesStepForm>;
   dialogRef: MatDialogRef<DialogsAddResourcesComponent>;
@@ -95,6 +94,7 @@ export class CoursesStepComponent implements OnDestroy {
       this.activeStep = this.steps[index];
       this.stepForm.patchValue(this.steps[index]);
     }
+    this.stepEditorOpenChange.emit(index > -1);
   }
 
   addResources() {
@@ -140,10 +140,6 @@ export class CoursesStepComponent implements OnDestroy {
   stepsMoved(steps) {
     this.steps = steps;
     this.stepsChange.emit(this.steps);
-  }
-
-  addStep() {
-    this.addStepEvent.emit();
   }
 
   toList() {

--- a/src/app/courses/add-courses/courses-step.scss
+++ b/src/app/courses/add-courses/courses-step.scss
@@ -1,5 +1,9 @@
 @use '../../variables' as v;
 
+planet-courses-step .planet-step-list-form-container .planet-step-list-form {
+  overflow: visible;
+}
+
 .course-attach {
   .attach-grid {
     display: grid;

--- a/src/app/courses/add-courses/courses-step.scss
+++ b/src/app/courses/add-courses/courses-step.scss
@@ -1,9 +1,65 @@
-.step-form-container {
-  display: grid;
-  grid-template-rows: minmax(auto, min-content) auto;
-  height: calc(100% - 36px - 1rem);
+@use '../../variables' as v;
 
-  .vertical-form {
-    overflow-y: auto;
+.course-attach {
+  .attach-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .attach-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.125rem;
+    padding: 1rem;
+    border: 1px dashed rgba(0, 0, 0, 0.18);
+    border-radius: 10px;
+    background: v.$white;
+    cursor: pointer;
+    font: inherit;
+    transition: border-color 0.15s, background 0.15s;
+
+    &:hover,
+    &:focus-visible {
+      border-color: v.$primary;
+      background: v.$primary-lighter;
+      outline: none;
+    }
+
+    mat-icon {
+      color: v.$primary;
+    }
+
+    .ac-title {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      margin-top: 0.25rem;
+    }
+
+    .ac-sub {
+      font-size: 0.6875rem;
+      color: v.$grey-text;
+    }
+
+    .ac-count {
+      display: inline-flex;
+      align-items: baseline;
+      margin-top: 0.375rem;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      color: v.$primary-text;
+      background: v.$primary;
+      border-radius: 10px;
+      padding: 0.0625rem 0.5rem;
+    }
+  }
+
+  @media (max-width: v.$screen-xs) {
+    .attach-grid {
+      grid-template-columns: 1fr;
+    }
   }
 }


### PR DESCRIPTION
Fixes #9977

- Place the course's details section into a collapsible section, giving more screen real estate to the steps while they are in focus.
- Update the courses step action buttons styling

<img width="1921" height="1127" alt="image" src="https://github.com/user-attachments/assets/87877e3f-c003-4ab4-b3c7-08908c043bba" />

<img width="1921" height="1059" alt="image" src="https://github.com/user-attachments/assets/4d001f14-e654-4ccd-ae42-e7b0b74c7d14" />

