### PR TITLE
all: smoother image file selector placing (fixes #9979)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.1",
+  "version": "0.23.3",
   "myplanet": {
     "latest": "v0.56.60",
     "min": "v0.53.91"

--- a/src/app/shared/dialogs/dialogs-images.component.html
+++ b/src/app/shared/dialogs/dialogs-images.component.html
@@ -12,7 +12,7 @@
   </div>
   <mat-grid-list *ngIf="images.length !== 0" cols="3" rowHeight="1:1">
     <mat-grid-tile *ngFor="let image of filteredImages" (click)="selectImage(image)">
-      <img [src]="urlPrefix + '/' + image._id + '/' + image.filename" alt="{{ image.title || image.filename }}">
+      <img [src]="urlPrefix + '/' + image._id + '/' + image.filename" [alt]="image.title || image.filename">
       <mat-grid-tile-footer>{{image.title}}</mat-grid-tile-footer>
     </mat-grid-tile>
   </mat-grid-list>

--- a/src/app/shared/dialogs/dialogs-images.component.html
+++ b/src/app/shared/dialogs/dialogs-images.component.html
@@ -1,6 +1,8 @@
 <h3 *ngIf="images.length !== 0" mat-dialog-title i18n>Select an Image</h3>
 <h3 *ngIf="images.length === 0" mat-dialog-title i18n>No Images to Select</h3>
 <mat-dialog-content>
+  <p class="upload-label mat-caption" i18n>Upload a new image</p>
+  <planet-file-upload #imageUpload accept="image/*" i18n-hint hint="JPG, PNG, GIF or WEBP" [typePills]="['JPG','PNG','GIF','WEBP']" (fileSelected)="uploadImage($event)"></planet-file-upload>
   <div class="search-container">
     <mat-icon>search</mat-icon>
     <mat-form-field class="search-input">
@@ -10,12 +12,10 @@
   </div>
   <mat-grid-list *ngIf="images.length !== 0" cols="3" rowHeight="1:1">
     <mat-grid-tile *ngFor="let image of filteredImages" (click)="selectImage(image)">
-      <img [src]="urlPrefix + '/' + image._id + '/' + image.filename">
+      <img [src]="urlPrefix + '/' + image._id + '/' + image.filename" alt="{{ image.title || image.filename }}">
       <mat-grid-tile-footer>{{image.title}}</mat-grid-tile-footer>
     </mat-grid-tile>
   </mat-grid-list>
-  <p class="upload-label mat-caption" i18n>Or upload a new image</p>
-  <planet-file-upload #imageUpload accept="image/*" i18n-hint hint="JPG, PNG, GIF or WEBP" [typePills]="['JPG','PNG','GIF','WEBP']" (fileSelected)="uploadImage($event)"></planet-file-upload>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-raised-button mat-dialog-close i18n>Cancel</button>


### PR DESCRIPTION
Fixes #9979

Move the file upload selector to the top of the dialog

<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/a4615d07-94f7-4569-83ab-b14de92f6e5e" />
