### PR TITLE
all: smoother form change handling (fixes #9989)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.4",
+  "version": "0.23.6",
   "myplanet": {
     "latest": "v0.56.74",
     "min": "v0.54.94"

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -148,8 +148,11 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
   }
 
   private captureInitialState() {
-    const formValue = this.meetupForm.getRawValue();
-    this.initialFormValues = JSON.stringify({
+    this.initialFormValues = this.serializeFormValue(this.meetupForm.getRawValue());
+  }
+
+  private serializeFormValue(formValue: any): string {
+    return JSON.stringify({
       ...formValue,
       startDate: formValue.startDate ? this.parseDateValue(formValue.startDate) : null,
       endDate: formValue.endDate ? this.parseDateValue(formValue.endDate) : null,
@@ -163,13 +166,7 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
         debounce(() => race(interval(200), of(true)))
       )
       .subscribe(formValue => {
-        const currentState = JSON.stringify({
-          ...formValue,
-          startDate: formValue.startDate ? this.parseDateValue(formValue.startDate) : null,
-          endDate: formValue.endDate ? this.parseDateValue(formValue.endDate) : null,
-          day: formValue.day || []
-        });
-        this.hasUnsavedChanges = currentState !== this.initialFormValues;
+        this.hasUnsavedChanges = this.serializeFormValue(formValue) !== this.initialFormValues;
       });
   }
 

--- a/src/app/users/users-achievements/users-achievements-update.component.ts
+++ b/src/app/users/users-achievements/users-achievements-update.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewEncapsulation, OnDestroy, HostListener, ViewChild } from '@angular/core';
 import { FormArray, FormControl, FormGroup, NonNullableFormBuilder, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { combineLatest, forkJoin, Subject, interval, of, race } from 'rxjs';
+import { combineLatest, forkJoin, Subject, interval, merge, of, race } from 'rxjs';
 import { catchError, takeUntil, debounce, filter, startWith, take, switchMap } from 'rxjs/operators';
 import { CouchService } from '../../shared/couchdb.service';
 import { UserService } from '../../shared/user.service';
@@ -181,14 +181,7 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
   }
 
   onFormChanges() {
-    this.editForm.valueChanges
-      .pipe(
-        debounce(() => race(interval(200), of(true))),
-        takeUntil(this.onDestroy$)
-      )
-      .subscribe(() => this.updateUnsavedChangesFlag());
-
-    this.profileForm.valueChanges
+    merge(this.editForm.valueChanges, this.profileForm.valueChanges)
       .pipe(
         debounce(() => race(interval(200), of(true))),
         takeUntil(this.onDestroy$)


### PR DESCRIPTION
Fixes #9989

Using fallow to run a duplication audit -> https://docs.fallow.tools/
- reuse meetups form state serialization
- combine achievement form change subscriptions