### PR TITLE
teams: smoother reports toolbar handling (fixes #9992)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.4",
+  "version": "0.23.8",
   "myplanet": {
     "latest": "v0.56.74",
     "min": "v0.54.94"

--- a/src/app/teams/teams-reports.scss
+++ b/src/app/teams/teams-reports.scss
@@ -9,8 +9,10 @@
 
 .reports-toolbar {
   display: flex;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  background: v.$white;
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   padding: 10px 16px;


### PR DESCRIPTION
Fixes #9992

Fixes community/teams reports toolbar background

<img width="1275" height="836" alt="image" src="https://github.com/user-attachments/assets/cb002532-1f33-4b0c-a4e9-086aa41b5fc2" />
