### PR TITLE
all: smoother feedback details username truncating (fixes #9993)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.8",
+  "version": "0.23.9",
   "myplanet": {
     "latest": "v0.57.30",
     "min": "v0.54.94"

--- a/src/app/feedback/feedback-view.component.html
+++ b/src/app/feedback/feedback-view.component.html
@@ -49,8 +49,8 @@
     <div class="chat-list" #chatList>
       <div class="chat-list-item" *ngFor="let message of feedback.messages; trackBy: trackById">
         <div class="chat-list-user">
-          <p *ngIf="users[message.user]" [matTooltip]="users[message.user]">{{users[message.user] | truncateText:80}}</p>
-          <p class="mat-caption">{{message.time | date:'medium'}}</p>
+          <span *ngIf="users[message.user]" [matTooltip]="users[message.user]">{{users[message.user] | truncateText:80}}</span>
+          <span class="mat-caption">{{message.time | date:'medium'}}</span>
         </div>
         <mat-card [ngClass]="{ 'primary-color': message.user !== user.name }">
           <mat-card-content>

--- a/src/app/feedback/feedback-view.component.html
+++ b/src/app/feedback/feedback-view.component.html
@@ -49,7 +49,8 @@
     <div class="chat-list" #chatList>
       <div class="chat-list-item" *ngFor="let message of feedback.messages; trackBy: trackById">
         <div class="chat-list-user">
-          <span *ngIf="users[message.user]">{{users[message.user] + ', '}}</span><span class="mat-caption">{{message.time | date:'medium'}}</span>
+          <p *ngIf="users[message.user]" [matTooltip]="users[message.user]">{{users[message.user] | truncateText:80}}</p>
+          <p class="mat-caption">{{message.time | date:'medium'}}</p>
         </div>
         <mat-card [ngClass]="{ 'primary-color': message.user !== user.name }">
           <mat-card-content>

--- a/src/app/feedback/feedback-view.component.html
+++ b/src/app/feedback/feedback-view.component.html
@@ -56,9 +56,8 @@
       @for (message of feedback.messages; track trackById($index, message)) {
         <div class="chat-list-item">
           <div class="chat-list-user">
-            @if (users[message.user]) {
-              <span [matTooltip]="users[message.user]">{{users[message.user] | truncateText:80}}</span>
-              }<span class="mat-caption">{{message.time | date:'medium'}}</span>
+            <span [matTooltip]="users[message.user] || message.user">{{(users[message.user] || message.user) | truncateText:80}}</span>
+            <span class="mat-caption">{{message.time | date:'medium'}}</span>
             </div>
             <mat-card [ngClass]="{ 'primary-color': message.user !== user.name }">
               <mat-card-content>

--- a/src/app/feedback/feedback-view.component.ts
+++ b/src/app/feedback/feedback-view.component.ts
@@ -28,7 +28,7 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 @Component({
   templateUrl: './feedback-view.component.html',
   styleUrls: ['./feedback-view.scss'],
-  imports: [ 
+  imports: [
     MatToolbar, MatIconButton, RouterLink, MatIcon, MatToolbarRow, MatTooltip, MatIconAnchor,
     AuthorizedRolesDirective, MatButton, MatFormField, MatLabel, MatInput, FormsModule,
     MatAnchor, MatCard, MatCardContent, NgClass, DatePipe, KeyValuePipe, TruncateTextPipe

--- a/src/app/feedback/feedback-view.component.ts
+++ b/src/app/feedback/feedback-view.component.ts
@@ -29,9 +29,26 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
   templateUrl: './feedback-view.component.html',
   styleUrls: ['./feedback-view.scss'],
   imports: [
-    MatToolbar, MatIconButton, RouterLink, MatIcon, MatToolbarRow, MatTooltip, MatIconAnchor,
-    AuthorizedRolesDirective, MatButton, MatFormField, MatLabel, MatInput, FormsModule,
-    MatAnchor, MatCard, MatCardContent, NgClass, DatePipe, KeyValuePipe, TruncateTextPipe
+    MatToolbar,
+    MatIconButton,
+    RouterLink,
+    MatIcon,
+    MatToolbarRow,
+    MatTooltip,
+    MatIconAnchor,
+    AuthorizedRolesDirective,
+    MatButton,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    FormsModule,
+    MatAnchor,
+    MatCard,
+    MatCardContent,
+    NgClass,
+    DatePipe,
+    KeyValuePipe,
+    TruncateTextPipe
   ]
 })
 export class FeedbackViewComponent implements OnInit, OnDestroy {

--- a/src/app/feedback/feedback-view.component.ts
+++ b/src/app/feedback/feedback-view.component.ts
@@ -23,6 +23,7 @@ import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { getFeedbackDisplayTitle, getFeedbackTypeIcon, normalizeFeedbackStatus, normalizeFeedbackType } from './feedback.utils';
+import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 
 @Component({
   templateUrl: './feedback-view.component.html',
@@ -30,7 +31,7 @@ import { getFeedbackDisplayTitle, getFeedbackTypeIcon, normalizeFeedbackStatus, 
   imports: [
     MatToolbar, MatIconButton, RouterLink, MatIcon, MatToolbarRow, NgIf,
     MatTooltip, MatIconAnchor, AuthorizedRolesDirective, MatButton, MatFormField, MatLabel, MatInput,
-    FormsModule, MatAnchor, MatCard, MatCardContent, NgFor, NgClass, DatePipe, KeyValuePipe
+    FormsModule, MatAnchor, MatCard, MatCardContent, NgFor, NgClass, DatePipe, KeyValuePipe, TruncateTextPipe
   ]
 })
 export class FeedbackViewComponent implements OnInit, OnDestroy {

--- a/src/app/feedback/feedback-view.scss
+++ b/src/app/feedback/feedback-view.scss
@@ -20,13 +20,19 @@
   flex-direction: column;
   align-items: flex-start;
   .chat-list-user {
+    display: flex;
+    align-items: baseline;
+    align-self: stretch;
+    gap: 0.5rem;
     color: v.$primary;
     .mat-caption {
+      margin-left: auto;
+      flex-shrink: 0;
       color: v.$grey-text;
     }
   }
   &:not(:last-child) {
-    margin-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
   }
 }
 

--- a/src/app/feedback/feedback-view.scss
+++ b/src/app/feedback/feedback-view.scss
@@ -21,6 +21,9 @@
   align-items: flex-start;
   .chat-list-user {
     color: v.$primary;
+    .mat-caption {
+      color: v.$grey-text;
+    }
   }
   &:not(:last-child) {
     margin-bottom: 0.5rem;


### PR DESCRIPTION
Fixes #9993

- Truncate long username in feedback details page 
- update alignment and color of the `date` detail

<img width="1919" height="841" alt="image" src="https://github.com/user-attachments/assets/80cf9359-a2d3-4dae-ba9b-edf19955802c" />
