### PR TITLE
all: smoother testing (fixes #9996)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.4",
+  "version": "0.23.10",
   "myplanet": {
-    "latest": "v0.56.74",
+    "latest": "v0.57.29",
     "min": "v0.54.94"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@angular-eslint/eslint-plugin-template": "20.7.0",
     "@angular-eslint/schematics": "20.7.0",
     "@angular-eslint/template-parser": "20.7.0",
+    "@angular/build": "^20.3.26",
     "@angular/cli": "20.3.26",
     "@angular/compiler-cli": "20.3.21",
     "@angular/language-service": "20.3.21",
@@ -101,7 +102,7 @@
     "ts-node": "~8.5.4",
     "typescript": "~5.8.3",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.1.8"
+    "vitest": "^3.2.6"
   },
   "overrides": {
     "@typescript-eslint/visitor-keys": {

--- a/src/app/__snapshots__/app.component.spec.ts.snap
+++ b/src/app/__snapshots__/app.component.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`App > Should be an AppComponent 1`] = `
 <planet-app>
   <div
     dir="ltr"
-    ng-reflect-dir="ltr"
   >
     <router-outlet />
     <!--container-->


### PR DESCRIPTION
Needed to install the `@angular/build` package that was being imported despite being a dependency of another package. To install it I needed to downgrade vitest. That was added in by Jules, which it looks like just added in the latest version instead of the version that lines up well with our current version of Angular.

Also updated the AppComponent snapshot since that test failed after getting the testing working again.

Fixes #9996 