### PR TITLE
all: smoother spanish developing (fixes #9957)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,23 @@ npm install
 ng serve
 ```
 
+By default, Planet expects CouchDB on port `2200` and the gateway on port `5000`. To use different local values, add a `.env` file in the project root:
+
+```
+CHAT_PORT=5000
+COUCH_PORT=2200
+PARENT_PROTOCOL=https
+```
+
+Add only the values you need to override, then run:
+```
+npm run dev
+```
+
+`npm run dev` runs `dev-env.sh` before starting Angular. The script generates `src/environments/environment.dev.ts` from `src/environments/environment.template` so local development can point to the configured CouchDB and gateway ports. Both `.env` and `src/environments/environment.dev.ts` are local development files and should not be committed.
+
 Visit localhost:3000 to access the Planet app.
-If port 3000 is in use, try ```ng serve --port 3001```
+If port 3000 is in use, try ```ng serve --port 3001``` or ```npm run dev -- --port 3001``` when using generated environment values.
 
 ## Gateway Notes
 
@@ -94,11 +109,11 @@ For gateway development instructions, refer to the [gateway README](gateway/READ
 
 To run planet in development with a different locale, you can set the configuration to one of the supported language tags. For example, to run in Spanish, use:
 ```
-  npm run dev -- --configuration spa 
-
-  or 
-
-  ng serve --configuration spa
+ng serve --configuration spa
+```
+If you are using generated environment values from `.env`, run:
+```
+npm run dev -- --configuration spa
 ```
 *You can use the short-hand `-c` in place of `--configuration`*
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ ng serve --configuration spa
 ```
 If you are using generated environment values from `.env`, run:
 ```
-npm run dev -- --configuration spa
+npm run dev:spa
 ```
-*You can use the short-hand `-c` in place of `--configuration`*
+*You can use the short-hand `-c` in place of `--configuration` for direct `ng serve` commands.*
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ ng serve --configuration spa
 ```
 If you are using generated environment values from `.env`, run:
 ```
-npm run dev:spa
+npm run dev:locale --locale=spa
 ```
+Replace `spa` with any supported locale configuration, such as `eng`, `som`, `fra`, `nep`, or `ara`.
 *You can use the short-hand `-c` in place of `--configuration` for direct `ng serve` commands.*
 
 ## Tests

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -14,6 +14,6 @@ sed \
   -e "s/{{PARENT_PROTOCOL}}/${PARENT_PROTOCOL}/g" \
   src/environments/environment.template > src/environments/environment.dev.ts
 
-echo "gateway running on port: ${CHAT_PORT}"
+echo "chatapi running on port: ${CHAT_PORT}"
 echo "couchdb running on port: ${COUCH_PORT}"
 echo "parent protocol: ${PARENT_PROTOCOL}"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.10",
+  "version": "0.23.20",
   "myplanet": {
     "latest": "v0.57.29",
     "min": "v0.54.94"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "ng serve",
     "dev": "bash dev-env.sh && ng serve --configuration dev",
-    "dev:spa": "bash dev-env.sh && ng serve --build-target planet-app:build:dev,spa",
+    "dev:locale": "bash -c ': \"${npm_config_locale:?Set a locale with --locale=spa}\"; bash dev-env.sh && ng serve --build-target planet-app:build:dev,$npm_config_locale \"$@\"' --",
     "build": "npm run ng-high-memory -- build --configuration production",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "start": "ng serve",
     "dev": "bash dev-env.sh && ng serve --configuration dev",
+    "dev:spa": "bash dev-env.sh && ng serve --build-target planet-app:build:dev,spa",
     "build": "npm run ng-high-memory -- build --configuration production",
     "test": "ng test",
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",


### PR DESCRIPTION
Fixes #9957

- Support spanish & other locales development using custom env vars.
- Update the documentation to note the developer workflow when working with non-default environment variables