### PR TITLE
teams: smoother meetups spinner handling (fixes #9981)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.13",
+  "version": "0.23.16",
   "myplanet": {
-    "latest": "v0.57.93",
+    "latest": "v0.58.85",
     "min": "v0.54.94"
   },
   "scripts": {

--- a/src/app/shared/dialogs/dialogs-add-meetups.component.spec.ts
+++ b/src/app/shared/dialogs/dialogs-add-meetups.component.spec.ts
@@ -1,0 +1,88 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA, EventEmitter, Input, Output } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { EMPTY } from 'rxjs';
+import { vi } from 'vitest';
+
+import { DialogsAddMeetupsComponent } from './dialogs-add-meetups.component';
+import { DialogsLoadingService } from './dialogs-loading.service';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'planet-meetups-add',
+  template: ''
+})
+class MeetupsAddStubComponent {
+  @Input() isDialog = false;
+  @Input() link: any = {};
+  @Input() meetup: any = {};
+  @Input() sync: any;
+  @Output() goBackEvent = new EventEmitter<any>();
+
+  hasUnsavedChanges = false;
+
+  canDeactivate(): boolean {
+    return true;
+  }
+}
+
+@Component({
+  selector: 'planet-meetups-view',
+  template: ''
+})
+class MeetupsViewStubComponent {
+  @Input() isDialog = false;
+  @Input() meetupDetail: any = {};
+  @Input() editable = true;
+  @Output() switchView = new EventEmitter<any>();
+}
+
+describe('DialogsAddMeetupsComponent', () => {
+  let fixture: ComponentFixture<DialogsAddMeetupsComponent>;
+  let data: any;
+  let dialogRef: any;
+  let dialogsLoadingService: any;
+
+  beforeEach(() => {
+    data = {
+      onMeetupsChange: vi.fn()
+    };
+    dialogRef = {
+      disableClose: false,
+      backdropClick: () => EMPTY,
+      close: vi.fn()
+    };
+    dialogsLoadingService = {
+      stop: vi.fn()
+    };
+
+    TestBed.configureTestingModule({
+      imports: [DialogsAddMeetupsComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MatDialog, useValue: {} },
+        { provide: DialogsLoadingService, useValue: dialogsLoadingService }
+      ]
+    });
+    TestBed.overrideComponent(DialogsAddMeetupsComponent, {
+      set: {
+        imports: [MeetupsAddStubComponent, MeetupsViewStubComponent],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA]
+      }
+    });
+    fixture = TestBed.createComponent(DialogsAddMeetupsComponent);
+    fixture.detectChanges();
+  });
+
+  it('closes and refreshes meetups when the add form emits goBackEvent', () => {
+    const meetupsAdd = fixture.debugElement.query(By.directive(MeetupsAddStubComponent)).componentInstance as MeetupsAddStubComponent;
+
+    meetupsAdd.goBackEvent.emit({ ok: true });
+    fixture.detectChanges();
+
+    expect(data.onMeetupsChange).toHaveBeenCalled();
+    expect(dialogsLoadingService.stop).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/dialogs/dialogs-add-meetups.component.spec.ts
+++ b/src/app/shared/dialogs/dialogs-add-meetups.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { EMPTY } from 'rxjs';
@@ -69,8 +69,7 @@ describe('DialogsAddMeetupsComponent', () => {
     });
     TestBed.overrideComponent(DialogsAddMeetupsComponent, {
       set: {
-        imports: [MeetupsAddStubComponent, MeetupsViewStubComponent],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA]
+        imports: [MeetupsAddStubComponent, MeetupsViewStubComponent]
       }
     });
     fixture = TestBed.createComponent(DialogsAddMeetupsComponent);

--- a/src/app/shared/dialogs/dialogs-add-meetups.component.spec.ts
+++ b/src/app/shared/dialogs/dialogs-add-meetups.component.spec.ts
@@ -20,9 +20,10 @@ class MeetupsAddStubComponent {
   @Output() goBackEvent = new EventEmitter<any>();
 
   hasUnsavedChanges = false;
+  canDeactivateValue = true;
 
   canDeactivate(): boolean {
-    return true;
+    return this.canDeactivateValue;
   }
 }
 
@@ -38,6 +39,7 @@ class MeetupsViewStubComponent {
 }
 
 describe('DialogsAddMeetupsComponent', () => {
+  let component: DialogsAddMeetupsComponent;
   let fixture: ComponentFixture<DialogsAddMeetupsComponent>;
   let data: any;
   let dialogRef: any;
@@ -72,7 +74,28 @@ describe('DialogsAddMeetupsComponent', () => {
       }
     });
     fixture = TestBed.createComponent(DialogsAddMeetupsComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(dialogRef.disableClose).toBe(true);
+  });
+
+  it('uses provided dialog data', () => {
+    expect(component.link).toEqual({});
+    expect(component.meetup).toEqual({});
+    expect(component.view).toBe('add');
+    expect(component.editable).toBe(true);
+  });
+
+  it('delegates canDeactivate to the add form', () => {
+    const meetupsAdd = fixture.debugElement.query(By.directive(MeetupsAddStubComponent)).componentInstance as MeetupsAddStubComponent;
+
+    meetupsAdd.canDeactivateValue = false;
+
+    expect(component.canDeactivate()).toBe(false);
   });
 
   it('closes and refreshes meetups when the add form emits goBackEvent', () => {
@@ -80,6 +103,22 @@ describe('DialogsAddMeetupsComponent', () => {
 
     meetupsAdd.goBackEvent.emit({ ok: true });
     fixture.detectChanges();
+
+    expect(data.onMeetupsChange).toHaveBeenCalled();
+    expect(dialogsLoadingService.stop).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('switches to the view component', () => {
+    component.switchView('view');
+    fixture.detectChanges();
+
+    expect(component.view).toBe('view');
+    expect(fixture.debugElement.query(By.directive(MeetupsViewStubComponent))).toBeTruthy();
+  });
+
+  it('closes and refreshes meetups when switching to close', () => {
+    component.switchView('close');
 
     expect(data.onMeetupsChange).toHaveBeenCalled();
     expect(dialogsLoadingService.stop).toHaveBeenCalled();

--- a/src/app/shared/dialogs/dialogs-add-meetups.component.ts
+++ b/src/app/shared/dialogs/dialogs-add-meetups.component.ts
@@ -12,7 +12,7 @@ import { MeetupsViewComponent } from '../../meetups/view-meetups/meetups-view.co
 @switch (view) {
   @case ('add') {
     <planet-meetups-add #meetupsAdd [isDialog]="true" [link]="link"
-      [sync]="sync" [meetup]="meetup" (onGoBack)="checkUnsavedChangesAndClose()">
+      [sync]="sync" [meetup]="meetup" (goBackEvent)="checkUnsavedChangesAndClose()">
     </planet-meetups-add>
   }
   @case ('view') {


### PR DESCRIPTION
Fixes #9981

- Fixes the endless spinner when adding a meetup. 
- Add spec file for the dialogs-add-meetup component