### PR TITLE
dashboard: smoother chat linking (fixes #10014)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.13",
+  "version": "0.23.18",
   "myplanet": {
     "latest": "v0.57.93",
     "min": "v0.54.94"

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -53,6 +53,11 @@ export class ChatComponent implements OnInit {
   }
 
   goBack(): void {
+    const returnState = history.state?.returnState;
+    if (returnState) {
+      this.router.navigate([ `${returnState.route}` ]);
+      return;
+    }
     this.router.navigate([ '/' ], { relativeTo: this.route });
   }
 

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -29,6 +29,7 @@
               class="dashboard-item"
               [ngClass]="{'bg-grey': even, 'cursor-pointer': item.link && !recentlyDragged, 'accordion-item': isAccordionMode}"
               [routerLink]="recentlyDragged ? null : item.link"
+              [state]="item.returnState ? { returnState: item.returnState } : undefined"
               [matTooltip]="item.tooltip"
               cdkDrag
               [cdkDragDisabled]="cardType==='myLife' || isAccordionMode"

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -126,7 +126,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.myLifeItems = [
       { baseFirstLine: $localize`my`, title: $localize`Submissions`, link: 'submissions', authorization: 'leader,manager',
         badge: this.examsCount },
-      { baseFirstLine: $localize` my `, title: $localize`Chat`, link: '/chat' },
+      { baseFirstLine: $localize` my `, title: $localize`Chat`, link: '/chat', returnState: { route: 'myDashboard' } },
       { baseFirstLine: $localize` my `, title: $localize`Progress`, link: 'myProgress' },
       { baseFirstLine: $localize`my`, title: $localize`Personals`, link: 'myPersonals' },
       { baseFirstLine: $localize`my`, title: $localize`Achievements`, link: 'myAchievements' },


### PR DESCRIPTION
Fixes #10014

Ensure that the `myChat` back button link returns to the `myDashboard` screen