### PR TITLE
courses: smoother icons constants handling (fixes #10019)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.13",
+  "version": "0.23.19",
   "myplanet": {
     "latest": "v0.57.93",
     "min": "v0.54.94"

--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -4,13 +4,13 @@
       <span matListItemTitle i18n>{{(step.stepTitle || 'Step ' + (i+1)) | truncateText:50}}</span>
       <ng-container matListItemMeta>
         @if (step?.exam?.questions.length) {
-          <planet-course-icon [icon]="'assignment'"></planet-course-icon>
+          <planet-course-icon [icon]="courseIcons.assignment"></planet-course-icon>
         }
         @if (step?.resources?.length) {
-          <planet-course-icon [icon]="'attach_file'"></planet-course-icon>
+          <planet-course-icon [icon]="courseIcons.attachFile"></planet-course-icon>
         }
         @if (step?.survey?.questions.length) {
-          <planet-course-icon [icon]="'description'"></planet-course-icon>
+          <planet-course-icon [icon]="courseIcons.description"></planet-course-icon>
         }
         <span class="toolbar-fill"></span>
       </ng-container>

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -16,7 +16,7 @@ import {
 } from '../../shared/forms/planet-step-list.component';
 
 import { MatListItemTitle, MatListItemMeta } from '@angular/material/list';
-import { CoursesIconComponent } from '../courses-icon.component';
+import { CoursesIconComponent, courseIcons } from '../courses-icon.component';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { PlanetMarkdownTextboxComponent } from '../../shared/forms/planet-markdown-textbox.component';
@@ -74,6 +74,7 @@ export class CoursesStepComponent implements OnDestroy {
   dialogRef: MatDialogRef<DialogsAddResourcesComponent>;
   activeStep: any;
   activeStepIndex = -1;
+  courseIcons = courseIcons;
   private onDestroy$ = new Subject<void>();
   @ViewChild(PlanetStepListComponent) stepListComponent: PlanetStepListComponent;
 

--- a/src/app/courses/courses-icon.component.ts
+++ b/src/app/courses/courses-icon.component.ts
@@ -3,26 +3,36 @@ import { Component, Input } from '@angular/core';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatIcon } from '@angular/material/icon';
 
+export const courseIcons = {
+  assignment: 'assignment',
+  attachFile: 'attach_file',
+  description: 'description',
+  done: 'done',
+  rotateRight: 'rotate_right'
+} as const;
+
+export type CourseIcon = typeof courseIcons[keyof typeof courseIcons] | '';
+
 @Component({
   selector: 'planet-course-icon',
   template: `
     <div>
       @switch (icon) {
-        @case ('assignment') {
+        @case (courseIcons.assignment) {
           <span i18n-matTooltip matTooltip="Test"><mat-icon>assignment</mat-icon></span>
         }
-        @case ('attach_file') {
+        @case (courseIcons.attachFile) {
           <span i18n-matTooltip matTooltip="Resource(s)"><mat-icon>attach_file</mat-icon></span>
         }
-        @case ('description') {
+        @case (courseIcons.description) {
           <span i18n-matTooltip matTooltip="Survey">
             <mat-icon >description</mat-icon>
           </span>
         }
-        @case ('done') {
+        @case (courseIcons.done) {
           <span i18n-matTooltip matTooltip="This step has been completed."><mat-icon>done</mat-icon></span>
         }
-        @case ('rotate_right') {
+        @case (courseIcons.rotateRight) {
           <span i18n-matTooltip matTooltip="This step is in progress."><mat-icon >rotate_right</mat-icon></span>
         }
       }
@@ -32,6 +42,7 @@ import { MatIcon } from '@angular/material/icon';
 })
 export class CoursesIconComponent {
 
-  @Input() icon: 'assignment' | 'attach_file' | 'description' | 'done' | 'rotate_right' | '' = '';
+  courseIcons = courseIcons;
+  @Input() icon: CourseIcon = '';
 
 }

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -80,20 +80,20 @@
               </mat-panel-title>
               <mat-panel-description>
                 @if (step?.exam?.questions.length) {
-                  <planet-course-icon [icon]="'assignment'"></planet-course-icon>
+                  <planet-course-icon [icon]="courseIcons.assignment"></planet-course-icon>
                 }
                 @if (step?.resources?.length) {
-                  <planet-course-icon [icon]="'attach_file'"></planet-course-icon>
+                  <planet-course-icon [icon]="courseIcons.attachFile"></planet-course-icon>
                 }
                 @if (step?.survey?.questions.length) {
-                  <planet-course-icon [icon]="'description'"></planet-course-icon>
+                  <planet-course-icon [icon]="courseIcons.description"></planet-course-icon>
                 }
               </mat-panel-description>
               @if (step.progress && step.progress.passed) {
-                <planet-course-icon [icon]="'done'"></planet-course-icon>
+                <planet-course-icon [icon]="courseIcons.done"></planet-course-icon>
               }
               @if (step.progress && !step.progress.passed) {
-                <planet-course-icon [icon]="'rotate_right'"></planet-course-icon>
+                <planet-course-icon [icon]="courseIcons.rotateRight"></planet-course-icon>
               }
             </mat-expansion-panel-header>
             <planet-markdown [imageSource]="parent ? 'parent' : 'local'" [content]="step.description" class="img-resize"></planet-markdown>

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -22,7 +22,7 @@ import {
   MatExpansionPanelDescription,
   MatExpansionPanelActionRow
 } from '@angular/material/expansion';
-import { CoursesIconComponent } from '../courses-icon.component';
+import { CoursesIconComponent, courseIcons } from '../courses-icon.component';
 import { PlanetMarkdownComponent } from '../../shared/planet-markdown.component';
 import { ResourcesMenuComponent } from '../../resources/view-resources/resources-menu.component';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
@@ -72,6 +72,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   examText: 'retake' | 'take' = 'take';
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
+  courseIcons = courseIcons;
   trackByFn = trackByIndex;
   @ViewChild(MatMenuTrigger) previewButton: MatMenuTrigger;
 


### PR DESCRIPTION
Fixes #10019

Refactor `planet-course-icon` for single definition and allow reuse by current course templates