### PR TITLE
teams: smoother meetups time picking (fixes #9109)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.23",
+  "version": "0.23.26",
   "myplanet": {
     "latest": "v0.58.88",
     "min": "v0.54.94"

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -37,36 +37,36 @@
           <planet-markdown-textbox class="full-width" required="true" [formControl]="meetupForm.controls.description"></planet-markdown-textbox>
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.description"></planet-form-error-messages></mat-error>
         </mat-form-field>
-        <mat-form-field>
+        <mat-form-field (click)="datepickerStart.open()">
           <mat-label i18n>Start Date</mat-label>
           <input matInput [matDatepicker]="datepickerStart" required="true" formControlName="startDate">
           <mat-datepicker-toggle matIconSuffix [for]="datepickerStart"></mat-datepicker-toggle>
           <mat-datepicker #datepickerStart></mat-datepicker>
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.startDate"></planet-form-error-messages></mat-error>
         </mat-form-field>
-        <mat-form-field>
+        <mat-form-field (click)="datepickerEnd.open()">
           <mat-label i18n>End Date</mat-label>
           <input matInput [matDatepicker]="datepickerEnd" formControlName="endDate">
           <mat-datepicker-toggle matIconSuffix [for]="datepickerEnd"></mat-datepicker-toggle>
           <mat-datepicker #datepickerEnd></mat-datepicker>
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.endDate"></planet-form-error-messages></mat-error>
         </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Start Time</mat-label>
-        <input #startTimeInput matInput type="time" planetTimeMask formControlName="startTime">
-        <button mat-icon-button matIconSuffix type="button" (click)="openTimePicker(startTimeInput)" aria-label="Open time picker" i18n-aria-label>
-          <mat-icon>access_time</mat-icon>
-        </button>
-        <mat-error><planet-form-error-messages [control]="meetupForm.controls.startTime"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>End Time</mat-label>
-        <input #endTimeInput matInput type="time" planetTimeMask formControlName="endTime">
-        <button mat-icon-button matIconSuffix type="button" (click)="openTimePicker(endTimeInput)" aria-label="Open time picker" i18n-aria-label>
-          <mat-icon>access_time</mat-icon>
-        </button>
-        <mat-error><planet-form-error-messages [control]="meetupForm.controls.endTime"></planet-form-error-messages></mat-error>
-      </mat-form-field>
+        <mat-form-field (click)="openNativePicker(startTimeInput)">
+          <mat-label i18n>Start Time</mat-label>
+          <input #startTimeInput matInput type="time" formControlName="startTime">
+          <button mat-icon-button matIconSuffix type="button" (click)="openNativePicker(startTimeInput); $event.stopPropagation()" aria-label="Open time picker" i18n-aria-label>
+            <mat-icon>access_time</mat-icon>
+          </button>
+          <mat-error><planet-form-error-messages [control]="meetupForm.controls.startTime"></planet-form-error-messages></mat-error>
+        </mat-form-field>
+        <mat-form-field (click)="openNativePicker(endTimeInput)">
+          <mat-label i18n>End Time</mat-label>
+          <input #endTimeInput matInput type="time" formControlName="endTime">
+          <button mat-icon-button matIconSuffix type="button" (click)="openNativePicker(endTimeInput); $event.stopPropagation()" aria-label="Open time picker" i18n-aria-label>
+            <mat-icon>access_time</mat-icon>
+          </button>
+          <mat-error><planet-form-error-messages [control]="meetupForm.controls.endTime"></planet-form-error-messages></mat-error>
+        </mat-form-field>
         <div class="full-width">
           <label i18n>Recurring Frequency</label>
           <mat-radio-group formControlName="recurring">

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -53,7 +53,7 @@
         </mat-form-field>
       <mat-form-field>
         <mat-label i18n>Start Time</mat-label>
-        <input #startTimeInput matInput type="time" planetTimeMask formControlName="startTime" required>
+        <input #startTimeInput matInput type="time" planetTimeMask formControlName="startTime">
         <button mat-icon-button matIconSuffix type="button" (click)="openTimePicker(startTimeInput)" aria-label="Open time picker" i18n-aria-label>
           <mat-icon>access_time</mat-icon>
         </button>

--- a/src/app/meetups/add-meetups/meetups-add.component.html
+++ b/src/app/meetups/add-meetups/meetups-add.component.html
@@ -51,16 +51,22 @@
           <mat-datepicker #datepickerEnd></mat-datepicker>
           <mat-error><planet-form-error-messages [control]="meetupForm.controls.endDate"></planet-form-error-messages></mat-error>
         </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>Start Time</mat-label>
-          <input matInput planetTimeMask formControlName="startTime">
-          <mat-error><planet-form-error-messages [control]="meetupForm.controls.startTime"></planet-form-error-messages></mat-error>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-label i18n>End Time</mat-label>
-          <input matInput planetTimeMask formControlName="endTime">
-          <mat-error><planet-form-error-messages [control]="meetupForm.controls.endTime"></planet-form-error-messages></mat-error>
-        </mat-form-field>
+      <mat-form-field>
+        <mat-label i18n>Start Time</mat-label>
+        <input #startTimeInput matInput type="time" planetTimeMask formControlName="startTime" required>
+        <button mat-icon-button matIconSuffix type="button" (click)="openTimePicker(startTimeInput)" aria-label="Open time picker" i18n-aria-label>
+          <mat-icon>access_time</mat-icon>
+        </button>
+        <mat-error><planet-form-error-messages [control]="meetupForm.controls.startTime"></planet-form-error-messages></mat-error>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label i18n>End Time</mat-label>
+        <input #endTimeInput matInput type="time" planetTimeMask formControlName="endTime">
+        <button mat-icon-button matIconSuffix type="button" (click)="openTimePicker(endTimeInput)" aria-label="Open time picker" i18n-aria-label>
+          <mat-icon>access_time</mat-icon>
+        </button>
+        <mat-error><planet-form-error-messages [control]="meetupForm.controls.endTime"></planet-form-error-messages></mat-error>
+      </mat-form-field>
         <div class="full-width">
           <label i18n>Recurring Frequency</label>
           <mat-radio-group formControlName="recurring">

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -17,7 +17,7 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-import { MatFormField, MatLabel, MatError, MatSuffix} from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatError, MatSuffix } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormErrorMessagesComponent } from '../../shared/forms/form-error-messages.component';
 import { PlanetMarkdownTextboxComponent } from '../../shared/forms/planet-markdown-textbox.component';

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -15,7 +15,7 @@ import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
 import { warningMsg } from '../../shared/unsaved-changes.component';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { MatToolbar } from '@angular/material/toolbar';
-import { MatIconAnchor, MatButton } from '@angular/material/button';
+import { MatIconAnchor, MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatFormField, MatLabel, MatError, MatSuffix } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -15,7 +15,8 @@ import { CanComponentDeactivate } from '../../shared/unsaved-changes.guard';
 import { warningMsg } from '../../shared/unsaved-changes.component';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { MatToolbar } from '@angular/material/toolbar';
-import { MatIconAnchor, MatButton, MatIconButton } from '@angular/material/button';
+import { MatIconAnchor, MatButton, MatIconButton } from '@angular/material/button';
+
 import { MatIcon } from '@angular/material/icon';
 import { MatFormField, MatLabel, MatError, MatSuffix } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
@@ -64,6 +65,7 @@ interface MeetupFormControls {
   `],
   imports: [
     MatToolbar,
+    MatIconButton,
     MatIconAnchor,
     RouterLink,
     MatIcon,

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -23,7 +23,6 @@ import { MatInput } from '@angular/material/input';
 import { FormErrorMessagesComponent } from '../../shared/forms/form-error-messages.component';
 import { PlanetMarkdownTextboxComponent } from '../../shared/forms/planet-markdown-textbox.component';
 import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
-import { PlanetTimeMaskDirective } from '../../shared/forms/planet-time-mask.directive';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { PlanetNumberValidatorDirective } from '../../shared/forms/planet-number-validator.directive';
@@ -65,7 +64,7 @@ interface MeetupFormControls {
   `],
   imports: [
     MatToolbar,
-    MatIconButton,
+    MatIconButton,
     MatIconAnchor,
     RouterLink,
     MatIcon,
@@ -82,7 +81,6 @@ interface MeetupFormControls {
     MatDatepickerToggle,
     MatSuffix,
     MatDatepicker,
-    PlanetTimeMaskDirective,
     MatRadioGroup,
     MatRadioButton,
     MatCheckbox,
@@ -370,16 +368,18 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
     })) };
   }
 
-  openTimePicker(input: HTMLInputElement): void {
-    const picker = input as HTMLInputElement & {
-      showPicker?: () => void;
-    };
-
-    if (picker.showPicker) {
-      picker.showPicker();
-    } else {
+  openNativePicker(input: HTMLInputElement): void {
+    if (input.disabled || input.readOnly) {
+      return;
+    }
+    if (!input.showPicker) {
       input.focus();
-      input.click();
+      return;
+    }
+    try {
+      input.showPicker();
+    } catch {
+      input.focus();
     }
   }
 

--- a/src/app/meetups/add-meetups/meetups-add.component.ts
+++ b/src/app/meetups/add-meetups/meetups-add.component.ts
@@ -17,7 +17,7 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-import { MatFormField, MatLabel, MatError, MatSuffix } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatError, MatSuffix} from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormErrorMessagesComponent } from '../../shared/forms/form-error-messages.component';
 import { PlanetMarkdownTextboxComponent } from '../../shared/forms/planet-markdown-textbox.component';
@@ -366,6 +366,19 @@ export class MeetupsAddComponent implements OnInit, CanComponentDeactivate {
       'status': 'unread',
       'time': this.couchService.datePlaceholder
     })) };
+  }
+
+  openTimePicker(input: HTMLInputElement): void {
+    const picker = input as HTMLInputElement & {
+      showPicker?: () => void;
+    };
+
+    if (picker.showPicker) {
+      picker.showPicker();
+    } else {
+      input.focus();
+      input.click();
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #9109 
- Change manual time input to interactive timepicker for creating meetups

## Before
<img width="3406" height="1830" alt="image" src="https://github.com/user-attachments/assets/387586e2-05d4-427a-8d11-5e14a5967ca8" />

## After
<img width="862" height="828" alt="{2FCD47C9-6BE7-4846-A34C-C3B0426DB1B7}" src="https://github.com/user-attachments/assets/9e69cfbb-5d7c-4e02-93cc-7f986d86f092" /> 