### PR TITLE
courses: smoother exams survey creating (fixes #9662)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.24",
+  "version": "0.23.30",
   "myplanet": {
     "latest": "v0.58.93",
     "min": "v0.54.94"

--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -11,8 +11,8 @@
     <form [formGroup]="examForm" (ngSubmit)="onSubmit()" [ngClass]="{'survey-form':!isCourseContent}" novalidate>
       <div class="exam-buttons">
         <div class="button-group">
-          <button mat-raised-button color="primary" type="submit" i18n>Save</button>
-          <button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" (click)="onSubmit(true)" i18n>Save & Return</button>
+          <button mat-raised-button color="primary" type="submit" [disabled]="questions.length === 0" i18n>Save</button>
+          <button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" [disabled]="questions.length === 0" [planetSubmit]="examForm.valid" (click)="onSubmit(true)" i18n>Save & Return</button>
           <div class="menu-button"><button mat-raised-button color="accent" type="button" [matMenuTriggerFor]="questionMenu" i18n>Add Question</button></div>
           <button mat-raised-button color="accent" type="button" (click)="showPreviewDialog()" i18n>Preview {examType, select, exam {Test} survey {Survey}}</button>
         </div>

--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -12,7 +12,7 @@
       <div class="exam-buttons">
         <div class="button-group">
           <button mat-raised-button color="primary" type="submit" [disabled]="questions.length === 0" i18n>Save</button>
-<button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" [disabled]="questions.length === 0" (click)="onSubmit(true)" i18n>Save & Return</button>
+          <button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" [disabled]="questions.length === 0" (click)="onSubmit(true)" i18n>Save & Return</button>
           <div class="menu-button"><button mat-raised-button color="accent" type="button" [matMenuTriggerFor]="questionMenu" i18n>Add Question</button></div>
           <button mat-raised-button color="accent" type="button" (click)="showPreviewDialog()" i18n>Preview {examType, select, exam {Test} survey {Survey}}</button>
         </div>

--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -12,7 +12,7 @@
       <div class="exam-buttons">
         <div class="button-group">
           <button mat-raised-button color="primary" type="submit" [disabled]="questions.length === 0" i18n>Save</button>
-          <button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" [disabled]="questions.length === 0" [planetSubmit]="examForm.valid" (click)="onSubmit(true)" i18n>Save & Return</button>
+<button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" [disabled]="questions.length === 0" (click)="onSubmit(true)" i18n>Save & Return</button>
           <div class="menu-button"><button mat-raised-button color="accent" type="button" [matMenuTriggerFor]="questionMenu" i18n>Add Question</button></div>
           <button mat-raised-button color="accent" type="button" (click)="showPreviewDialog()" i18n>Preview {examType, select, exam {Test} survey {Survey}}</button>
         </div>


### PR DESCRIPTION
Fixes #9662 
- Surveys must now have question content to be saved
- Disables `Save` and `Save & Return` when there is no content within a survey

# Disabled Save

<img width="2159" height="728" alt="{B0F36AA4-1FC8-4A7A-B12C-AD8EEDF39D95}" src="https://github.com/user-attachments/assets/544b6378-c9c2-4cf8-a722-48251e1c52be" />

# Enabled Save

<img width="1398" height="669" alt="{88EEBF78-C22E-475C-A102-39AB56B9938B}" src="https://github.com/user-attachments/assets/953efd33-2de3-434e-830d-9e39f96e4beb" />
