### PR TITLE
teams: less submissions service import is more (fixes #10038)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.24",
+  "version": "0.23.31",
   "myplanet": {
     "latest": "v0.58.93",
     "min": "v0.54.94"

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -14,7 +14,6 @@ import { PlanetMessageService } from '../shared/planet-message.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { ManagerService } from '../manager-dashboard/manager.service';
 import { attachNamesToPlanets, codeToPlanetName, fullLabel } from '../manager-dashboard/reports/reports.utils';
-import { TeamsService } from '../teams/teams.service';
 import { ChatService } from '../shared/chat.service';
 import { surveyAnalysisPrompt } from '../shared/ai-prompts.constants';
 import { loadChart, createChartCanvas, renderNoDataPlaceholder, CHART_COLORS } from '../shared/chart-utils';
@@ -47,7 +46,6 @@ export class SubmissionsService {
     private planetMessageService: PlanetMessageService,
     private dialogsLoadingService: DialogsLoadingService,
     private managerService: ManagerService,
-    private teamsService: TeamsService,
     private chatService: ChatService
   ) { }
 


### PR DESCRIPTION
Fixes #10038

## Summary
Removes an unused import and dependency injection of `TeamsService` from the `SubmissionsService` class.

## Changes
- Removed `TeamsService` import from the service imports
- Removed `TeamsService` from the constructor dependency injection

## Notes
This is a cleanup change that removes dead code. The `TeamsService` was imported and injected but never used within the `SubmissionsService`, so removing it reduces unnecessary coupling and improves code clarity.

https://claude.ai/code/session_01AqiGYPfinHTvaYrHEVZAQG