### PR TITLE
courses: smoother deleting (fixes #9418)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.24",
+  "version": "0.23.27",
   "myplanet": {
     "latest": "v0.58.93",
     "min": "v0.54.94"

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -349,6 +349,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
         this.selection.deselect(course._id);
         // It's safer to remove the item from the array based on its id than to splice based on the index
         this.courses.data = this.courses.data.filter((c: any) => data.id !== c._id);
+        this.getCourses();
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`Course deleted: ${course.courseTitle}`);
       },


### PR DESCRIPTION
Fixes #9418

- After single-course deletion, trigger a full state refresh via getCourses() to keep the CoursesService cache in sync with the locally patched table data.
- Align single-delete behavior with existing bulk-delete behavior (which already calls getCourses() on success).