### PR TITLE
Enable and force resource downloads

### DIFF
--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -221,7 +221,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
       openWhichFile: this.fb.control({ value: '', disabled: true }, {
         validators: (ac) => CustomValidators.fileMatch(ac, this.attachedZipFiles)
       }),
-      isDownloadable: this.fb.control(false),
+      isDownloadable: this.fb.control(true),
       sourcePlanet: this.fb.control(this.stateService.configuration.code),
       resideOn: this.fb.control(this.stateService.configuration.code),
       createdDate: this.fb.control<number | DatePlaceholderType>(this.couchService.datePlaceholder),
@@ -263,7 +263,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
       resourceType: doc.resourceType ?? '',
       addedBy: doc.addedBy ?? this.currentUsername,
       openWhichFile: doc.openWhichFile ?? '',
-      isDownloadable: doc.isDownloadable ?? false,
+      isDownloadable: doc.isDownloadable ?? true,
       sourcePlanet: doc.sourcePlanet ?? this.stateService.configuration.code,
       resideOn: doc.resideOn ?? this.stateService.configuration.code,
       createdDate: doc.createdDate ?? this.couchService.datePlaceholder,
@@ -374,7 +374,7 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
     this.resourceFilename = '';
     this.disableDelete = true;
     this.showDownloadCheckbox = false;
-    this.resourceForm.patchValue({ isDownloadable: false });
+    this.resourceForm.patchValue({ isDownloadable: true });
     this.hasUnsavedChanges = true;
   }
 

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -250,7 +250,7 @@
               <mat-icon>star</mat-icon>
               <span i18n>View Ratings</span>
             </button>
-            <a href="{{urlPrefix + element._id + '/' + element.doc.filename}}" mat-menu-item download [disabled]="!(myView === 'myPersonals') && !element.doc.isDownloadable">
+            <a href="{{urlPrefix + element._id + '/' + element.doc.filename}}" mat-menu-item download [disabled]="!(myView === 'myPersonals') && !element.doc.isDownloadable && !element.libraryInfo">
               <mat-icon>file_download</mat-icon>
               <span i18n>Download file</span>
             </a>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -250,10 +250,10 @@
               <mat-icon>star</mat-icon>
               <span i18n>View Ratings</span>
             </button>
-            <a href="{{urlPrefix + element._id + '/' + element.doc.filename}}" mat-menu-item download [disabled]="!(myView === 'myPersonals') && !element.doc.isDownloadable && !element.libraryInfo">
+            <button mat-menu-item [disabled]="!(myView === 'myPersonals') && !element.doc.isDownloadable && !element.libraryInfo" (click)="downloadClick(element)">
               <mat-icon>file_download</mat-icon>
               <span i18n>Download file</span>
-            </a>
+            </button>
           </mat-menu>
         </mat-cell>
       </ng-container>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -514,4 +514,9 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
     this.previewOverflow.set(this.getPreviewKey(element), hasOverflow);
   }
 
+  downloadClick(element: any) {
+    const url = this.urlPrefix + element._id + '/' + element.doc.filename;
+    this.resourcesService.downloadResource(url, element.doc.filename);
+  }
+
 }

--- a/src/app/resources/resources.service.ts
+++ b/src/app/resources/resources.service.ts
@@ -169,4 +169,16 @@ export class ResourcesService {
     };
   }
 
+  downloadResource(url: string, filename: string) {
+    this.couchService.getAttachment(url).subscribe((blob: Blob) => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, () => {
+      this.planetMessageService.showAlert($localize`There was an error downloading this resource.`);
+    });
+  }
+
 }

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -59,7 +59,7 @@
       </button>
       }
     }
-    <a href={{resourceSrc}} mat-icon-button download [disabled]="!resource?.doc?.isDownloadable">
+    <a href={{resourceSrc}} mat-icon-button download [disabled]="!resource?.doc?.isDownloadable && !isUserEnrolled && !canManage">
       <mat-icon>file_download</mat-icon>
     </a>
   </ng-template>

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -59,9 +59,9 @@
       </button>
       }
     }
-    <a href={{resourceSrc}} mat-icon-button download [disabled]="!resource?.doc?.isDownloadable && !isUserEnrolled && !canManage">
+    <button mat-icon-button [disabled]="!resource?.doc?.isDownloadable && !isUserEnrolled && !canManage" (click)="downloadClick()">
       <mat-icon>file_download</mat-icon>
-    </a>
+    </button>
   </ng-template>
 
   <div class="view-container view-full-height" [ngClass]="{'full-view-container':fullView==='on'}">

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -152,4 +152,9 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
     }
     this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
+
+  downloadClick() {
+    const filename = this.resource.doc.filename || Object.keys(this.resource.doc._attachments)[0];
+    this.resourcesService.downloadResource(this.resourceSrc, filename);
+  }
 }


### PR DESCRIPTION
This PR addresses the issue where the resource download button was frequently inactive and, when active, often opened the file in a new tab instead of downloading it.

Key changes:
1.  **Enabling the button:** The `disabled` condition now checks if the resource is in the user's library (`libraryInfo` or `isUserEnrolled`), ensuring the button is active for relevant resources even if the global `isDownloadable` flag is false.
2.  **Forcing download:** Introduced `ResourcesService.downloadResource`, which fetches the resource as a Blob and triggers a download. This ensures that files like PDFs and images are downloaded directly rather than opened in a new tab.
3.  **Default behavior:** New resources now default to `isDownloadable: true`.
4.  **Consistency:** Applied these changes to both the resource list and the resource detail view.

---
*PR created automatically by Jules for task [17570375376118917603](https://jules.google.com/task/17570375376118917603) started by @RyanS4*