### PR TITLE
resources: smoother downloading (fixes #10043)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.24",
+  "version": "0.23.32",
   "myplanet": {
     "latest": "v0.58.93",
     "min": "v0.54.94"

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -59,9 +59,11 @@
       </button>
       }
     }
-    <a href={{resourceSrc}} mat-icon-button download [disabled]="!resource?.doc?.isDownloadable">
-      <mat-icon>file_download</mat-icon>
-    </a>
+    @if (resource?.doc?.isDownloadable) {
+      <a href={{resourceSrc}} mat-icon-button download [disabled]="!resource?.doc?.isDownloadable">
+        <mat-icon>file_download</mat-icon>
+      </a>
+    }
   </ng-template>
 
   <div class="view-container view-full-height" [ngClass]="{'full-view-container':fullView==='on'}">

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -60,7 +60,7 @@
       }
     }
     @if (resource?.doc?.isDownloadable) {
-      <a href={{resourceSrc}} mat-icon-button download [disabled]="!resource?.doc?.isDownloadable">
+      <a mat-icon-button [href]="resourceSrc" download>
         <mat-icon>file_download</mat-icon>
       </a>
     }


### PR DESCRIPTION
Fixes #10043

- Adds check which evaluates if a resource is downloadable
- If a resource is not downloadable then the download button for that resource is hidden

# Download Enabled

<img width="542" height="113" alt="image" src="https://github.com/user-attachments/assets/b7381edd-c532-4333-9c46-f03e4d4c4ed1" />

# Download Disabled

<img width="419" height="63" alt="image" src="https://github.com/user-attachments/assets/1880c7af-6cb1-4a45-8631-4f8fba6dfb17" />
