### PR TITLE
achievements: add certifications to achievements (fixes #8657)

### DIFF
--- a/src/app/users/users-achievements/users-achievements-update.component.html
+++ b/src/app/users/users-achievements/users-achievements-update.component.html
@@ -58,6 +58,10 @@
           <mat-label i18n>Summary of Achievements - Briefly summarize your achievements and add related materials below</mat-label>
           <planet-markdown-textbox class="full-width" [formControl]="editForm.controls.achievementsHeader"></planet-markdown-textbox>
         </mat-form-field>
+        <mat-form-field class="full-width mat-form-field-type-no-underline">
+          <mat-label i18n>Summary of Certifications - Briefly summarize your certifications and add related materials below</mat-label>
+          <planet-markdown-textbox class="full-width" [formControl]="editForm.controls.certificationsHeader"></planet-markdown-textbox>
+        </mat-form-field>
         <div>
           <p class="mat-hint mat-caption" i18n>Add any materials demonstrating your achievements below</p>
           @if (achievements.length > 1) {
@@ -87,6 +91,36 @@
             <p class="warn-text-color mat-caption">{{ sectionError('achievements') }}</p>
           }
           <button type="button" (click)="addAchievement()" mat-stroked-button color="primary" i18n>Enter an Achievement</button>
+        </div>
+        <div>
+          <p class="mat-hint mat-caption" i18n>Add any materials demonstrating your certifications below</p>
+          @if (certifications.length > 1) {
+            <a mat-raised-button color="accent" class="margin-lr-3" (click)="sortCertifications()">
+              <ng-container i18n>Sort by Date</ng-container>
+              @switch (editForm.controls.dateSortOrder.value) {
+                @case ('desc') {
+                  <mat-icon>keyboard_arrow_up</mat-icon>
+                }
+                @case ('asc') {
+                  <mat-icon>keyboard_arrow_down</mat-icon>
+                }
+              }
+            </a>
+          }
+          <planet-step-list [steps]="certifications" [ignoreClick]="true">
+            @for (certification of certifications.controls; track certification; let i = $index) {
+              <planet-step-list-item>
+                <span matListItemTitle>{{certification.value.title || certification.value}}</span>
+                <ng-container matListItemMeta>
+                  <button mat-stroked-button type="button" class="margin-lr-4" (click)="addCertification(i, certification.value)" i18n>Edit</button>
+                </ng-container>
+              </planet-step-list-item>
+            }
+          </planet-step-list>
+          @if (sectionError('certifications')) {
+            <p class="warn-text-color mat-caption">{{ sectionError('certifications') }}</p>
+          }
+          <button type="button" (click)="addCertification()" mat-stroked-button color="primary" i18n>Enter a Certification</button>
         </div>
         <div>
           <p class="mat-hint mat-caption" i18n>Add any references below</p>

--- a/src/app/users/users-achievements/users-achievements-update.component.ts
+++ b/src/app/users/users-achievements/users-achievements-update.component.ts
@@ -52,11 +52,20 @@ interface LinkFormControls {
   url: FormControl<string>;
 }
 
+interface CertificationFormControls {
+  title: FormControl<string>;
+  description: FormControl<string>;
+  link: FormControl<string>;
+  date: FormControl<DateValue>;
+}
+
 interface EditFormControls {
   purpose: FormControl<string>;
   goals: FormControl<string>;
   achievementsHeader: FormControl<string>;
   achievements: FormArray<AchievementFormGroup>;
+  certificationsHeader: FormControl<string>;
+  certifications: FormArray<CertificationFormGroup>;
   references: FormArray<ReferenceFormGroup>;
   links: FormArray<LinkFormGroup>;
   otherInfo: FormArray<FormControl<any>>;
@@ -75,6 +84,7 @@ interface ProfileFormControls {
 type AchievementFormGroup = FormGroup<AchievementFormControls>;
 type ReferenceFormGroup = FormGroup<ReferenceFormControls>;
 type LinkFormGroup = FormGroup<LinkFormControls>;
+type CertificationFormGroup = FormGroup<CertificationFormControls>;
 
 @Component({
   templateUrl: './users-achievements-update.component.html',
@@ -131,6 +141,9 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
   get achievements(): FormArray<AchievementFormGroup> {
     return this.editForm.controls.achievements;
   }
+  get certifications(): FormArray<CertificationFormGroup> {
+    return this.editForm.controls.certifications;
+  }
   get references(): FormArray<ReferenceFormGroup> {
     return this.editForm.controls.references;
   }
@@ -167,10 +180,12 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
           purpose: achievements.purpose,
           goals: achievements.goals,
           achievementsHeader: achievements.achievementsHeader,
+          certificationsHeader: achievements.certificationsHeader,
           sendToNation: achievements.sendToNation,
           dateSortOrder: achievements.dateSortOrder || 'none'
         });
         this.editForm.setControl('achievements', this.buildAchievementsFormArray(achievements.achievements));
+        this.editForm.setControl('certifications', this.buildCertificationsFormArray(achievements.certifications));
         this.editForm.setControl('references', this.buildReferencesFormArray(achievements.references));
         this.editForm.setControl('links', this.buildLinksFormArray(achievements.links));
         // Keeping older otherInfo property so we don't lose this info on database
@@ -221,6 +236,8 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
       goals: this.fb.control(''),
       achievementsHeader: this.fb.control(''),
       achievements: this.fb.array<AchievementFormGroup>([]),
+      certificationsHeader: this.fb.control(''),
+      certifications: this.fb.array<CertificationFormGroup>([]),
       references: this.fb.array<ReferenceFormGroup>([]),
       links: this.fb.array<LinkFormGroup>([]),
       // Keeping older otherInfo property so we don't lose this info on database
@@ -247,6 +264,10 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
     return this.fb.array(achievements.map((achievement) => this.createAchievementGroup(achievement)));
   }
 
+  private buildCertificationsFormArray(certifications: any[] = []) {
+    return this.fb.array(certifications.map((certification) => this.createCertificationGroup(certification)));
+  }
+
   private buildReferencesFormArray(references: any[] = []) {
     return this.fb.array(references.map((reference) => this.createReferenceGroup(reference)));
   }
@@ -268,6 +289,15 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
       description: this.fb.control(achievement.description || ''),
       link: this.fb.control(achievement.link || '', { asyncValidators: CustomValidators.validLink }),
       date: this.fb.control(achievement.date || '', { asyncValidators: ac => this.validatorService.notDateInFuture$(ac) })
+    });
+  }
+
+  private createCertificationGroup(certification: any = { title: '', description: '', link: '', date: '' }): CertificationFormGroup {
+    return this.fb.group<CertificationFormControls>({
+      title: this.fb.control(certification.title || '', { validators: CustomValidators.required }),
+      description: this.fb.control(certification.description || ''),
+      link: this.fb.control(certification.link || '', { asyncValidators: CustomValidators.validLink }),
+      date: this.fb.control(certification.date || '', { asyncValidators: ac => this.validatorService.notDateInFuture$(ac) })
     });
   }
 
@@ -328,6 +358,25 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
     );
   }
 
+  addCertification(index = -1, certification = { title: '', description: '', link: '', date: '' }) {
+    this.dialogsFormService.openDialogsForm(
+      certification.title !== '' ? $localize`Edit Certification` : $localize`Add Certification`,
+      [
+        { 'type': 'textbox', 'name': 'title', 'placeholder': $localize`Title`, required: true },
+        { 'type': 'date', 'name': 'date', 'placeholder': $localize`Date`, 'required': false },
+        { 'type': 'textbox', 'name': 'link', 'placeholder': $localize`Link`, required: false },
+        { 'type': 'textarea', 'name': 'description', 'placeholder': $localize`Description`, 'required': false },
+      ],
+      this.createCertificationGroup(certification),
+      { onSubmit: (formValue, formGroup) => {
+        const certifiedAt = formGroup.controls.date.value instanceof Date ? formGroup.controls.date.value.toISOString() :
+          formGroup.controls.date.value;
+        formGroup.controls.date.setValue(certifiedAt);
+        this.onDialogSubmit(this.certifications, index)(formValue, formGroup);
+      }, closeOnSubmit: true }
+    );
+  }
+
   addReference(index = -1, reference: any = { name: '' }) {
     this.dialogsFormService.openDialogsForm(
       reference.name !== '' ? $localize`Edit Reference` : $localize`Add Reference`,
@@ -378,6 +427,12 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
     const sort = this.editForm.controls.dateSortOrder.value === 'asc' ? 'desc' : 'asc';
     this.editForm.controls.dateSortOrder.setValue(sort);
     this.achievements.setValue(this.sortDate(this.achievements.value, sort));
+  }
+
+  sortCertifications() {
+    const sort = this.editForm.controls.dateSortOrder.value === 'asc' ? 'desc' : 'asc';
+    this.editForm.controls.dateSortOrder.setValue(sort);
+    this.certifications.setValue(this.sortDate(this.certifications.value, sort));
   }
 
   sortDate(achievements: any[], sortOrder: DateSortOrder = 'none') {
@@ -483,7 +538,7 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
     }
   }
 
-  sectionError(section: 'achievements' | 'references' | 'links'): string {
+  sectionError(section: 'achievements' | 'certifications' | 'references' | 'links'): string {
     const index = this.firstInvalidIndex(this.editForm.controls[section]);
     if (index < 0 || !this.submitAttempted) {
       return '';
@@ -492,6 +547,8 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
     switch (section) {
       case 'achievements':
         return $localize`Achievement #${itemNumber} has invalid fields`;
+      case 'certifications':
+        return $localize`Certification #${itemNumber} has invalid fields`;
       case 'references':
         return $localize`Reference #${itemNumber} has invalid fields`;
       case 'links':

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -78,13 +78,50 @@
                   <td-markdown [content]="achievements.goals"></td-markdown>
                 </div>
               }
+              @if (achievements.certificationsHeader || (achievements.certifications?.length ?? 0) > 0) {
+                <div>
+                  <mat-divider></mat-divider>
+                  <h3 i18n>My Certifications</h3>
+                  <td-markdown [content]="achievements.certificationsHeader"></td-markdown>
+                  <mat-list>
+                    @for (certification of achievements.certifications; track certification; let i = $index) {
+                      <mat-list-item class="mat-list-item-word-wrap" [ngClass]="{'cursor-pointer':isClickable(certification)}" (click)="onAchievementClick(certification, i + 1000)">
+                        <span matListItemTitle class="achievement-header">
+                          <span class="achievement-text">{{certification.title || certification}}
+                            @if (isClickable(certification)) {
+                              @if (openAchievementIndex !== i + 1000) {
+                                <mat-icon color="primary">expand_more</mat-icon>
+                              }
+                              @if (openAchievementIndex === i + 1000) {
+                                <mat-icon color="primary">expand_less</mat-icon>
+                              }
+                            }
+                          </span>
+                          <span class="achievement-date">{{certification.date | date: medium}}</span>
+                        </span>
+                        @if (openAchievementIndex === i + 1000) {
+                          <span matListItemLine>
+                            {{certification.description}}
+                            @if (certification.link) {
+                              <a href="{{certification.link}}" target="_blank" class="styled-link">{{certification.link}}</a>
+                            }
+                          </span>
+                        }
+                        @if (openAchievementIndex === i + 1000) {
+                          <span matListItemLine class="achievement-buttons"></span>
+                        }
+                      </mat-list-item>
+                    }
+                  </mat-list>
+                </div>
+              }
               <ng-container *planetBeta>
-                @if (certifications.length > 0) {
+                @if (earnedCertifications.length > 0) {
                   <div>
                     <mat-divider></mat-divider>
-                    <h3 i18n>My Certifications</h3>
+                    <h3 i18n>My Earned Certifications</h3>
                     <mat-list class="certs-list">
-                      @for (certification of certifications; track certification) {
+                      @for (certification of earnedCertifications; track certification) {
                         <mat-list-item>
                           <span matListItemTitle class="cert-item">{{certification.name}}</span>
                         </mat-list-item>

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -61,7 +61,7 @@ export class UsersAchievementsComponent implements OnInit {
   ownAchievements = false;
   urlPrefix = environment.couchAddress + '/_users/org.couchdb.user:' + this.userService.get().name + '/';
   openAchievementIndex = -1;
-  certifications: any[] = [];
+  earnedCertifications: any[] = [];
   publicView = this.route.snapshot.data.requiresAuth === false && !this.userService.get()._id;
   isLoading = true;
 
@@ -102,7 +102,7 @@ export class UsersAchievementsComponent implements OnInit {
     combineLatest([
       this.coursesService.coursesListener$(), this.coursesService.progressListener$(), this.certificationsService.getCertifications()
     ]).pipe(auditTime(500)).subscribe(([ courses, progress, certifications ]) => {
-      this.setCertifications(courses, progress, certifications);
+      this.setEarnedCertifications(courses, progress, certifications);
       this.isLoading = false;
     });
     this.coursesService.requestCourses();
@@ -174,8 +174,8 @@ export class UsersAchievementsComponent implements OnInit {
     return 'assets/image.png';
   }
 
-  setCertifications(courses = [], progress = [], certifications = []) {
-    this.certifications = certifications.filter(certification => {
+  setEarnedCertifications(courses = [], progress = [], certifications = []) {
+    this.earnedCertifications = certifications.filter(certification => {
       const certificateCourses = courses
         .filter(course => certification.courseIds.indexOf(course._id) > -1)
         .map(course => ({ ...course, progress: progress.filter(p => p.courseId === course._id) }));
@@ -225,10 +225,34 @@ export class UsersAchievementsComponent implements OnInit {
       );
     }
 
-    if (this.certifications && this.certifications.length > 0) {
+    if (this.achievements.certificationsHeader) {
       optionals.push(
-        { text: $localize`My Certifications`, style: 'subHeader', alignment: 'center' },
-        ...this.certifications.map((certification) => {
+        { text: $localize`Summary of Certifications`, style: 'subHeader', alignment: 'center' },
+        { text: this.achievements.certificationsHeader, alignment: 'left', margin: [ 20, 5 ] },
+        sectionSpacer
+      );
+    }
+
+    if (this.achievements.certifications && this.achievements.certifications.length > 0) {
+      optionals.push(
+        { text: $localize`My Manual Certifications`, style: 'subHeader', alignment: 'center' },
+        ...this.achievements.certifications.map((certification) => {
+          const formattedDate = certification.date ? formatStringDate(certification.date) : '';
+          return [
+            { text: certification.title, bold: true, margin: [ 20, 5 ] },
+            { text: certification.date ? formattedDate : '', marginLeft: 40 },
+            { text: certification.link, marginLeft: 40 },
+            { text: certification.description, marginLeft: 40 },
+          ];
+        }),
+        sectionSpacer
+      );
+    }
+
+    if (this.earnedCertifications && this.earnedCertifications.length > 0) {
+      optionals.push(
+        { text: $localize`My Earned Certifications`, style: 'subHeader', alignment: 'center' },
+        ...this.earnedCertifications.map((certification) => {
           return [
             { text: certification.name, bold: true, margin: [ 20, 5 ] },
           ];

--- a/src/app/users/users-achievements/users-achievements.service.ts
+++ b/src/app/users/users-achievements/users-achievements.service.ts
@@ -19,7 +19,10 @@ export class UsersAchievementsService {
 
   isEmpty(achievement) {
     return (!achievement.purpose && !achievement.goals && !achievement.achievementsHeader
-            && achievement.achievements.length === 0 && achievement.references.length === 0
+            && !achievement.certificationsHeader
+            && (achievement.achievements?.length ?? 0) === 0
+            && (achievement.certifications?.length ?? 0) === 0
+            && (achievement.references?.length ?? 0) === 0
             && (achievement.links?.length ?? 0) === 0
             && !achievement.resumeFileName && !achievement._attachments?.['resume.pdf']);
   }


### PR DESCRIPTION
Fixes #8657 
Similar to achievements, users can now provide a summary of their certifications and maintain a manual list of certifications.

- Updated UsersAchievementsUpdateComponent with new form controls and dialogs
- Updated UsersAchievementsComponent to display manual certifications
- Renamed existing auto-earned certifications to 'earnedCertifications' to avoid conflict
- Updated PDF generation to include manual certifications and summary
- Fixed manual certification list items to correctly show links by making them identical to achievement list items
- Updated UsersAchievementsService to include new fields in empty-check logic
- Added i18n tags for new labels and headers

<img width="2516" height="703" alt="image" src="https://github.com/user-attachments/assets/6f647438-a992-422c-8681-5479afd242c6" />

<img width="605" height="466" alt="image" src="https://github.com/user-attachments/assets/9497205b-eb1d-4817-a9de-b4c71be381ad" />

<img width="683" height="634" alt="image" src="https://github.com/user-attachments/assets/62f53c38-ba82-498d-884f-9f44286bbdfd" />
