### PR TITLE
teams: smoother surveys question options spacing (fixes #10049)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.24",
+  "version": "0.23.34",
   "myplanet": {
-    "latest": "v0.58.93",
-    "min": "v0.54.94"
+    "latest": "v0.60.48",
+    "min": "v0.59.59"
   },
   "scripts": {
     "ng": "ng",

--- a/src/app/exams/exams-question.scss
+++ b/src/app/exams/exams-question.scss
@@ -4,19 +4,18 @@
 
   form {
     display: grid;
-    grid-template-rows: 56px auto 56px;
+    grid-template-rows: auto auto auto;
     grid-row-gap: 1rem;
   }
 
   .question-choices {
     display: flex;
-    align-items: baseline;
+    align-items: flex-start;
     flex-wrap: wrap;
   }
 
   .question-choices > div {
-    margin-right: 0.5rem;
-    max-height: 56px;
+    margin: 0 .5rem .75rem 0;
   }
 
   .type-title-container {


### PR DESCRIPTION
Fixes #10049

In survey creation mode, fix the options spacing

<img width="1919" height="1070" alt="image" src="https://github.com/user-attachments/assets/924db418-ea8b-4fe8-9f39-a6ed34f1ac1a" />
