### PR TITLE
teams: smoother button size handlng (fixes #10065)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.33",
+  "version": "0.23.35",
   "myplanet": {
     "latest": "v0.59.59",
     "min": "v0.59.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0",
   "version": "0.23.35",
   "myplanet": {
-    "latest": "v0.59.59",
+    "latest": "v0.60.50",
     "min": "v0.59.0"
   },
   "scripts": {

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -17,13 +17,15 @@
   }
 
   .button-container {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
+    display: inline-grid;
+    grid-template-columns: minmax(150px, max-content);
+    align-items: stretch;
     gap: 0.5rem;
+    width: max-content;
+    max-width: 100%;
   }
   .horizontal-align {
-    justify-content: center;
+    justify-items: center;
   }
 
   .team-name{
@@ -32,12 +34,10 @@
   }
 
   .button-container button[mat-raised-button] {
-    width: 150px;
+    width: 100%;
     text-align: center;
     padding: 8px 12px;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .highlighted {
@@ -62,15 +62,16 @@
     }
 
     .button-container {
-      flex-direction: column;
-      align-items: flex-start;
+      grid-template-columns: minmax(120px, max-content);
+      align-items: stretch;
       gap: 0.5rem;
     }
   }
 
   @media (max-width: v.$screen-xs) {
     .button-container button[mat-raised-button] {
-      width: 50px;
+      min-width: 0;
+      white-space: normal;
     }
   }
 }


### PR DESCRIPTION
Fixes #10065 
- Buttons should now fit to the button with the largest text size

<img width="287" height="312" alt="{16431BE1-0236-49F3-B8BE-C2C69E0778AA}" src="https://github.com/user-attachments/assets/d826673a-9364-490e-8515-47fe82e8760e" />
