### PR TITLE
fix: resolve padding behavior in markdown textbox

### DIFF
--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, Input, Optional, Self, OnDestroy, HostBinding, EventEmitter, Output, OnInit, ViewEncapsulation, ElementRef, DoCheck, ViewChild
+  Component, Input, Optional, Self, OnDestroy, HostBinding, EventEmitter, Output, OnInit, ViewEncapsulation, ElementRef, DoCheck, ViewChild, AfterViewInit
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -23,7 +23,7 @@ interface ValueWithImages { text: string; images: ImageInfo[]; }
   'encapsulation': ViewEncapsulation.None,
   imports: [TdTextEditorComponent, NgClass, FormsModule]
 })
-export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoCheck, OnInit, OnDestroy {
+export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoCheck, OnInit, OnDestroy, AfterViewInit {
 
   static nextId = 0;
 
@@ -212,7 +212,7 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
   ngAfterViewInit() {
     setTimeout(() => {
       this.editor?.easyMDE?.codemirror?.refresh();
-    }); 
+    });
   }
 
   writeValue(val: string) {

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -2,9 +2,10 @@
 
 @mixin editor-border($color) {
   .EasyMDEContainer .editor-toolbar {
-    border-color: $color;
     border-bottom: 1px solid $color;
+    border-color: $color;
   }
+
   .EasyMDEContainer .CodeMirror {
     border-color: $color;
   }
@@ -20,42 +21,40 @@ planet-markdown-textbox.is-focused:not(.is-invalid) {
 
 planet-markdown-textbox {
   .CodeMirror {
-    height: inherit;
-    min-height: 15vh;
-    max-height: 15vh;
     box-sizing: border-box;
-    overflow: hidden;
-    padding-bottom: 30px;
+    height: inherit;
+    max-height: 15vh;
+    min-height: 15vh;
 
     .CodeMirror-lines {
-      padding-bottom: 15px;
+      padding-bottom: 30px !important;
     }
   }
 
   .CodeMirror-scroll {
     height: 100%;
-    padding-bottom: 30px;
-    margin-bottom: -30px;
   }
 
   .CodeMirror.CodeMirror-fullscreen {
     box-sizing: border-box;
   }
 
-  .CodeMirror.CodeMirror-fullscreen, .CodeMirror-fullscreen .CodeMirror-scroll {
+  .CodeMirror.CodeMirror-fullscreen,
+  .CodeMirror-fullscreen .CodeMirror-scroll {
     height: 100%;
     max-height: 100%;
   }
 
   .editor-statusbar {
-    opacity: 0;
     margin-bottom: -2.75em;
+    opacity: 0;
   }
 
-  .editor-preview, .editor-preview-side {
+  .editor-preview,
+  .editor-preview-side {
     img {
-      width: 100%;
       max-width: 40vw;
+      width: 100%;
     }
   }
 }
@@ -63,6 +62,7 @@ planet-markdown-textbox {
 // EasyMDE fullscreen surfaces need an explicit background after the MDC form migration;
 // otherwise the app chrome shows through the fixed preview/editor layer.
 .EasyMDEContainer .CodeMirror-fullscreen,
-.editor-preview-full, .editor-toolbar.fullscreen {
+.editor-preview-full,
+.editor-toolbar.fullscreen {
   background: white !important;
 }


### PR DESCRIPTION
This PR resolves the issue where the padding at the bottom of the `planet-markdown-textbox` was not clickable or interactive, creating a 'dead zone'. By moving the `padding-bottom` from the outer `.CodeMirror` container to the inner `.CodeMirror-lines` element, we ensure the space is both part of the scrollable content and interactive for the user. 

Additionally, this PR:
- Cleans up redundant `overflow: hidden` and negative margin hacks that were contributing to the layout issues.
- Implements the `AfterViewInit` lifecycle hook in the component to trigger a CodeMirror refresh, ensuring consistent layout on load.
- Fixes existing linting errors in the component file.

---
*PR created automatically by Jules for task [4493119836181558289](https://jules.google.com/task/4493119836181558289) started by @RyanS4*