### PR TITLE
dashboard: refactor styling to scss file (fixes #10084)

### DIFF
--- a/ng_serve.log
+++ b/ng_serve.log
@@ -1,0 +1,62 @@
+
+> planet@0.23.33 start
+> ng serve
+
+
+Warning: This is a simple server for use in testing or debugging Angular applications
+locally. It hasn't been reviewed for security issues.
+
+Binding this server to an open connection can result in compromising your application or
+computer. Using a different host than the one passed to the "--host" flag might result in
+websocket connection issues. You might need to use "--disable-host-check" if that's the
+case.
+
+❯ Building...
+One or more browsers which are configured in the project's Browserslist configuration will be ignored as ES5 output is not supported by the Angular CLI.
+Ignored browsers:
+kaios 2.5, op_mini all
+One or more browsers which are configured in the project's Browserslist configuration fall outside Angular's browser support for this version.
+Unsupported browsers:
+and_qq 14.9, and_uc 15.5, android 149, ios_saf 26.5, kaios 3.0-3.1, op_mob 80, opera 131, opera 127, safari 26.5, samsung 30, samsung 29
+✔ Building...
+Initial chunk files                  | Names                    |  Raw size
+chunk-QMU4YQX7.js                    | -                        |   1.01 MB |
+styles.css                           | styles                   | 513.61 kB |
+chunk-477QWWN4.js                    | -                        |  95.61 kB |
+chunk-V5L7YISW.js                    | -                        |  89.36 kB |
+main.js                              | main                     |  13.77 kB |
+chunk-7EAWSCEA.js                    | -                        |   1.68 kB |
+polyfills.js                         | polyfills                | 192 bytes |
+
+                                     | Initial total            |   1.73 MB
+
+Lazy chunk files                     | Names                    |  Raw size
+manager-dashboard.module-SFA6L7JI.js | manager-dashboard-module | 663.53 kB |
+chunk-E2PVZEDT.js                    | -                        | 494.06 kB |
+chunk-CIGX4RYR.js                    | -                        | 445.54 kB |
+chunk-T3KPIRI5.js                    | -                        | 319.57 kB |
+home.module-5GZXBRX6.js              | home-module              | 264.99 kB |
+chunk-VS6YPRA5.js                    | -                        | 255.55 kB |
+chunk-JLF4QFOT.js                    | -                        | 219.27 kB |
+health.module-ROCPNIQ3.js            | health-module            | 157.11 kB |
+chunk-OGEOX5GC.js                    | -                        | 141.88 kB |
+chunk-BLA3Q7CD.js                    | -                        | 117.28 kB |
+chunk-OAWFUIRZ.js                    | -                        | 105.42 kB |
+feedback.module-SLIVNZKV.js          | feedback-module          | 102.50 kB |
+chunk-XTTV4CNV.js                    | -                        |  92.73 kB |
+chunk-WXHVWPVG.js                    | -                        |  72.61 kB |
+certifications.module-O4LKIPIW.js    | certifications-module    |  66.13 kB |
+...and 18 more lazy chunks files. Use "--verbose" to show all the files.
+
+Application bundle generation complete. [26.788 seconds] - 2026-07-07T18:54:31.427Z
+
+Watch mode enabled. Watching for file changes...
+NOTE: Raw file sizes do not reflect development server per-request transformations.
+One or more browsers which are configured in the project's Browserslist configuration will be ignored as ES5 output is not supported by the Angular CLI.
+Ignored browsers:
+kaios 2.5, op_mini all
+One or more browsers which are configured in the project's Browserslist configuration fall outside Angular's browser support for this version.
+Unsupported browsers:
+and_qq 14.9, and_uc 15.5, android 149, ios_saf 26.5, kaios 3.0-3.1, op_mob 80, opera 131, opera 127, safari 26.5, samsung 30, samsung 29
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: http://192.168.0.2:3000/

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -6,12 +6,12 @@
     <span class="closebtn" (click)="closeBanner()">&times;</span>
   </div>
 }
-<mat-card class="horizontal" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-start;">
-  <div style="display: flex; align-items: flex-start;">
+<mat-card class="horizontal profile-card">
+  <div class="profile-main-content">
     <a [routerLink]="['/users/profile', user.name]" class="profile-link">
       <img [src]="profileImg" class="profile-avatar">
     </a>
-    <div class="dashboard-name" style="margin-left: 16px;">
+    <div class="dashboard-name">
       <a [routerLink]="['/users/profile', user.name]" class="profile-link">
         <h1 class="mat-headline-6">{{displayName | truncateText:(isMobile ? 20 : 40)}} @if (!isLoading) {
           <span> ({{visits | number}})</span>
@@ -28,13 +28,13 @@
     </h1>
   </div>
 </div>
-<div style="display: flex; flex-direction: column; align-items: flex-end;">
-  <div class="date" style="text-align: right;">
+<div class="profile-side-content">
+  <div class="date">
     <p>{{dateNow | date:'longDate'}}</p>
   </div>
-  <div class="badges" style="display: flex; flex-wrap: wrap; justify-content: flex-end; max-width: 100%; margin-top: 8px;">
+  <div class="badges">
     @for (badgeGroup of badgeGroups; track badgeGroup) {
-      <div style="margin-right: 4px;">
+      <div class="badge-group">
         @for (course of badgesCourses[badgeGroup]; track course) {
           <span class="cursor-pointer" (click)="openCourseView(course)" [matTooltip]="course.doc.courseTitle">
             <mat-icon

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -22,30 +22,43 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
   }
 
   mat-card {
-
     grid-area: hcard;
-    display: grid;
-    grid-template-areas:
-      "img info . date"
-      "img info badge badge";
-    grid-template-columns: calc(#{v.$dashboard-tile-width} - 0.5rem) max-content auto 1fr;
-    grid-template-rows: auto calc(#{$top-row-height} - 2.5rem);
-    grid-column-gap: 1rem;
     padding: 0.5rem;
     margin: 0 2px;
+
+    &.profile-card {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: flex-start;
+    }
+
+    .profile-main-content {
+      display: flex;
+      align-items: flex-start;
+    }
+
+    .profile-side-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+    }
+
+    .badge-group {
+      margin-right: 4px;
+    }
+
     img {
-      grid-area: img;
       width: calc(#{v.$dashboard-tile-width} - 0.5rem);
       max-width: 15vh;
       max-height: 15vh;
       border-radius: 50%;
-      justify-self: end;
-      align-self: center;
     }
+
     .dashboard-name {
-      grid-area: info;
       display: flex;
       flex-direction: column;
+      margin-left: 16px;
       h1 {
         display: flex;
         align-items: center;
@@ -58,27 +71,17 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
       }
     }
 
-    .date, .badges {
-      justify-self: end;
-    }
-
     .date {
-      grid-area: date;
+      text-align: right;
     }
 
     .badges {
-      grid-area: badge;
       width: 100%;
       display: flex;
       justify-content: flex-end;
-
-      & > div {
-        margin-right: 0.5rem;
-      }
-
-      & > div:last-child {
-        margin: 0;
-      }
+      flex-wrap: wrap;
+      max-width: 100%;
+      margin-top: 8px;
 
       & mat-icon.fa {
         font-size: 20px;
@@ -142,20 +145,18 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
     mat-card {
       display: flex;
       flex-direction: column;
-      grid-template-areas: unset;
-      grid-template-columns: unset;
-      grid-template-rows: unset;
 
-      &.horizontal {
-        flex-direction: column !important;
+      &.profile-card {
+        flex-direction: column;
         align-items: center;
-        div[style*="display: flex; align-items: flex-start;"] {
+
+        .profile-main-content {
           flex-direction: column;
-          align-items: center !important;
+          align-items: center;
           width: 100%;
 
           .dashboard-name {
-            margin-left: 0 !important;
+            margin-left: 0;
             margin-top: 8px;
             text-align: center;
 
@@ -165,11 +166,11 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
           }
         }
 
-        div[style*="flex-direction: column; align-items: flex-end;"] {
+        .profile-side-content {
           order: 2;
           width: 100%;
           margin-top: 12px;
-          align-items: center !important;
+          align-items: center;
 
           .date {
             text-align: center;
@@ -177,7 +178,7 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
           }
 
           .badges {
-            justify-content: center !important;
+            justify-content: center;
           }
         }
       }


### PR DESCRIPTION
This PR refactors the profile card layout in the Dashboard to improve maintainability and follow project styling conventions. Inline styles have been moved to the component's SCSS file and replaced with descriptive classes. Brittle CSS selectors in media queries have also been updated to use these new classes.

---
*PR created automatically by Jules for task [9696092958945182601](https://jules.google.com/task/9696092958945182601) started by @RyanS4*