### PR TITLE
Fix courses progress bar segment completion display

### DIFF
--- a/src/app/courses/progress-courses/courses-progress-bar.component.html
+++ b/src/app/courses/progress-courses/courses-progress-bar.component.html
@@ -1,4 +1,4 @@
-@for (step of steps; track step; let i = $index) {
+@for (step of steps; track $index; let i = $index) {
   <div
     i18n-matTooltip
     [matTooltip]="step.stepTitle || 'Step ' + (i+1)"

--- a/src/app/courses/progress-courses/courses-progress-bar.component.spec.ts
+++ b/src/app/courses/progress-courses/courses-progress-bar.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CoursesProgressBarComponent } from './courses-progress-bar.component';
+import { Router } from '@angular/router';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
+
+describe('CoursesProgressBarComponent', () => {
+  let component: CoursesProgressBarComponent;
+  let fixture: ComponentFixture<CoursesProgressBarComponent>;
+  let mockRouter: any;
+
+  beforeEach(async () => {
+    mockRouter = {
+      navigate: vi.fn()
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [MatTooltipModule, CoursesProgressBarComponent],
+      providers: [
+        { provide: Router, useValue: mockRouter }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CoursesProgressBarComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should correctly identify completed steps when they are out of order', () => {
+    component.course = {
+      steps: [
+        { stepTitle: 'Step 1' },
+        { stepTitle: 'Step 2' },
+        { stepTitle: 'Step 3' }
+      ]
+    };
+    component.courseProgress = [
+      { stepNum: 3, passed: true }
+    ];
+
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(component.steps.length).toBe(3);
+    expect(component.steps[0].status).toBe('not started');
+    expect(component.steps[1].status).toBe('not started');
+    expect(component.steps[2].status).toBe('completed');
+
+    const debugElements = fixture.debugElement.queryAll(By.css('div'));
+
+    expect(debugElements.length).toBe(3);
+    expect(debugElements[0].nativeElement.classList.contains('completed')).toBe(false);
+    expect(debugElements[1].nativeElement.classList.contains('completed')).toBe(false);
+    expect(debugElements[2].nativeElement.classList.contains('completed')).toBe(true);
+
+    expect(debugElements[0].nativeElement.classList.contains('not-started')).toBe(true);
+    expect(debugElements[1].nativeElement.classList.contains('not-started')).toBe(true);
+  });
+
+  it('should handle pending status correctly', () => {
+    component.course = {
+      steps: [
+        { stepTitle: 'Step 1' }
+      ]
+    };
+    component.courseProgress = [
+      { stepNum: 1, passed: false }
+    ];
+
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(component.steps[0].status).toBe('pending');
+    const debugElements = fixture.debugElement.queryAll(By.css('div'));
+    expect(debugElements[0].nativeElement.classList.contains('completed')).toBe(false);
+    expect(debugElements[0].nativeElement.classList.contains('not-started')).toBe(false);
+  });
+});

--- a/src/app/courses/progress-courses/courses-progress-bar.component.ts
+++ b/src/app/courses/progress-courses/courses-progress-bar.component.ts
@@ -20,11 +20,13 @@ export class CoursesProgressBarComponent implements OnChanges {
   ) { }
 
   ngOnChanges() {
-    this.steps = this.course.steps.map((step: any, index: number) => {
-      const progress = this.courseProgress.find((p: any) => p.stepNum === (index + 1));
-      const status = this.progressStatus(progress);
-      return { stepTitle: step.stepTitle, status };
-    });
+    if (this.course?.steps && this.courseProgress) {
+      this.steps = this.course.steps.map((step: any, index: number) => {
+        const progress = this.courseProgress.find((p: any) => Number(p.stepNum) === (index + 1));
+        const status = this.progressStatus(progress);
+        return { stepTitle: step.stepTitle, status };
+      });
+    }
   }
 
   routing(status, i) {

--- a/src/app/courses/progress-courses/courses-progress-bar.scss
+++ b/src/app/courses/progress-courses/courses-progress-bar.scss
@@ -5,9 +5,12 @@
   grid-auto-columns: 1fr;
   grid-column-gap: 3px;
   grid-auto-flow: column;
+  width: 100%;
+  min-height: 10px;
 
   div {
     background-color: v.$accent;
+    height: 10px;
   }
 
   div.completed {


### PR DESCRIPTION
This PR fixes the issue where the courses progress bar would only fill segments sequentially from the left, regardless of which step was actually completed. It now correctly fills the specific segment corresponding to the completed step. Additionally, it ensures the progress bar has a visible height and responsive width.

---
*PR created automatically by Jules for task [1810505903158907665](https://jules.google.com/task/1810505903158907665) started by @RyanS4*