### PR TITLE
courses: adding waiting for grading indicator (fixes #7900)

### DIFF
--- a/src/app/courses/courses-icon.component.ts
+++ b/src/app/courses/courses-icon.component.ts
@@ -8,7 +8,8 @@ export const courseIcons = {
   attachFile: 'attach_file',
   description: 'description',
   done: 'done',
-  rotateRight: 'rotate_right'
+  rotateRight: 'rotate_right',
+  assignmentPending: 'pending_actions'
 } as const;
 
 export type CourseIcon = typeof courseIcons[keyof typeof courseIcons] | '';
@@ -34,6 +35,9 @@ export type CourseIcon = typeof courseIcons[keyof typeof courseIcons] | '';
         }
         @case (courseIcons.rotateRight) {
           <span i18n-matTooltip matTooltip="This step is in progress."><mat-icon >rotate_right</mat-icon></span>
+        }
+        @case (courseIcons.assignmentPending) {
+        <span i18n-matTooltip matTooltip="Pending grading"><mat-icon>pending_actions</mat-icon></span>
         }
       }
     </div>


### PR DESCRIPTION
Fixes #7900 
- Changes description text to "Pending grading"
- Uses a new icon with a clearer indication of the grading request