### PR TITLE
Fix circular dependencies and Angular/Sass build errors

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -66,7 +66,12 @@
             "sourceMap": true,
             "optimization": false,
             "namedChunks": true,
-            "browser": "src/main.ts"
+            "browser": "src/main.ts",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "node_modules"
+              ]
+            }
           },
           "configurations": {
             "production": {

--- a/src/app/chat/chat-window/chat-window.component.ts
+++ b/src/app/chat/chat-window/chat-window.component.ts
@@ -9,7 +9,7 @@ import { showFormErrors, trackByIdVal } from '../../shared/table-helpers';
 import { UserService } from '../../shared/user.service';
 import { StateService } from '../../shared/state.service';
 import { NgClass } from '@angular/common';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatFormField, MatLabel, MatSuffix } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatIconButton } from '@angular/material/button';
@@ -24,7 +24,7 @@ type PromptFormGroup = FormGroup<{ prompt: FormControl<string> }>;
   templateUrl: './chat-window.component.html',
   styleUrls: ['./chat-window.scss'],
   imports: [
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     NgClass,
     FormsModule,
     ReactiveFormsModule,

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -19,7 +19,7 @@ import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatIconButton, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { PlanetMarkdownTextboxComponent } from '../shared/forms/planet-markdown-textbox.component';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
@@ -44,7 +44,7 @@ interface ExamViewForm {
     MatMenuTrigger,
     MatMenu,
     MatMenuItem,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatFormField,
     MatLabel,
     FormsModule,

--- a/src/app/exams/public-surveys/public-survey.component.ts
+++ b/src/app/exams/public-surveys/public-survey.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl, NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { switchMap } from 'rxjs/operators';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
@@ -21,7 +21,7 @@ import { LoginDialogComponent } from '../../login/login-dialog.component';
   templateUrl: './public-survey.component.html',
   styleUrls: ['./public-survey.component.scss'],
   imports: [
-    MatIcon, TdFlavoredMarkdownComponent, ExamsQuestionFrameComponent, ExamsTakeWidgetComponent, MatButton,
+    MatIcon, CovalentFlavoredMarkdownModule, ExamsQuestionFrameComponent, ExamsTakeWidgetComponent, MatButton,
     ReactiveFormsModule, MatFormField, MatLabel, MatHint, MatError, MatInput, MatRadioGroup, MatRadioButton
   ]
 })

--- a/src/app/health/health-event-dialog.component.ts
+++ b/src/app/health/health-event-dialog.component.ts
@@ -11,13 +11,13 @@ import pdfMake from 'pdfmake/build/pdfmake';
 import pdfFonts from 'pdfmake/build/vfs_fonts';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { DatePipe } from '@angular/common';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatButton } from '@angular/material/button';
 
 @Component({
   templateUrl: './health-event-dialog.component.html',
   imports: [
-    MatDialogTitle, CdkScrollable, MatDialogContent, TdFlavoredMarkdownComponent,
+    MatDialogTitle, CdkScrollable, MatDialogContent, CovalentFlavoredMarkdownModule,
     MatDialogActions, MatButton, MatDialogClose, DatePipe
   ]
 })

--- a/src/app/health/health.component.ts
+++ b/src/app/health/health.component.ts
@@ -20,7 +20,7 @@ import { MatIcon } from '@angular/material/icon';
 import { NgClass, DatePipe } from '@angular/common';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { MatDivider } from '@angular/material/list';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatTooltip } from '@angular/material/tooltip';
 import { LabelComponent } from '../shared/label.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
@@ -36,7 +36,7 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     RouterLink,
     PlanetLoadingSpinnerComponent,
     MatDivider,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatTable,
     MatColumnDef,
     MatHeaderCellDef,

--- a/src/app/meetups/meetups.component.ts
+++ b/src/app/meetups/meetups.component.ts
@@ -24,7 +24,7 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { NgClass, TitleCasePipe, DatePipe } from '@angular/common';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { FeedbackDirective } from '../feedback/feedback.directive';
 
@@ -68,7 +68,7 @@ import { FeedbackDirective } from '../feedback/feedback.directive';
     MatCellDef,
     MatCell,
     MatSortHeader,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatMenuTrigger,
     MatMenu,
     MatMenuItem,

--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -19,7 +19,7 @@ import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 
 @Component({
@@ -34,7 +34,7 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
     MatButton,
     MatTooltip,
     NgClass,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     CdkScrollable,
     MatDialogContent,
     NgTemplateOutlet,

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -20,7 +20,7 @@ import { MatIcon } from '@angular/material/icon';
 import { LabelComponent } from '../shared/label.component';
 import { MatTooltip } from '@angular/material/tooltip';
 import { PlanetMarkdownComponent } from '../shared/planet-markdown.component';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatIconButton, MatButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { TimeAgoPipe } from '../shared/time-ago.pipe';
@@ -41,7 +41,7 @@ import { TimeAgoPipe } from '../shared/time-ago.pipe';
     MatTooltip,
     MatCardContent,
     PlanetMarkdownComponent,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     NgClass,
     MatIconButton,
     MatCardActions,

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -16,7 +16,7 @@ import { MatIcon } from '@angular/material/icon';
 import { NgTemplateOutlet, NgClass } from '@angular/common';
 import { MatMenuTrigger, MatMenu } from '@angular/material/menu';
 import { PlanetRatingComponent } from '../../shared/forms/planet-rating.component';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { LanguageLabelComponent } from '../../shared/language-label.component';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
 import { ResourcesViewerComponent } from './resources-viewer.component';
@@ -36,7 +36,7 @@ import { ResourcesViewerComponent } from './resources-viewer.component';
     MatAnchor,
     NgClass,
     PlanetRatingComponent,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     LanguageLabelComponent,
     PlanetLoadingSpinnerComponent,
     ResourcesViewerComponent

--- a/src/app/shared/dialogs/planet-dialogs.module.ts
+++ b/src/app/shared/dialogs/planet-dialogs.module.ts
@@ -4,7 +4,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PlanetFormsModule } from '../forms/planet-forms.module';
-import { SharedComponentsModule } from '../shared-components.module';
 import { DialogsFormComponent } from './dialogs-form.component';
 import { DialogsPromptComponent } from './dialogs-prompt.component';
 import { DialogsViewComponent } from './dialogs-view.component';
@@ -25,7 +24,6 @@ import { DialogsRatingsComponent, DialogsRatingsDirective } from './dialogs-rati
     FormsModule,
     ReactiveFormsModule,
     PlanetFormsModule,
-    SharedComponentsModule,
     DialogsFormComponent,
     DialogsViewComponent,
     DialogsPromptComponent,

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -14,7 +14,6 @@ import { PlanetStepListComponent, PlanetStepListFormDirective, PlanetStepListIte
   PlanetStepListActionsDirective, PlanetStepListNumberDirective } from './planet-step-list.component';
 import { PlanetMarkdownTextboxComponent } from './planet-markdown-textbox.component';
 import { PlanetTagInputDialogComponent, PlanetTagInputToggleIconComponent } from './planet-tag-input-dialog.component';
-import { SharedComponentsModule } from '../shared-components.module';
 import { PlanetTimeMaskDirective } from './planet-time-mask.directive';
 import { PlanetSelectorComponent } from './planet-selector.component';
 import { PlanetNumberValidatorDirective } from './planet-number-validator.directive';
@@ -28,7 +27,6 @@ import { PlanetRoundDirective } from './planet-round.directive';
     MaterialModule,
     CovalentTextEditorModule,
     CovalentFlavoredMarkdownModule,
-    SharedComponentsModule,
     FormErrorMessagesComponent,
     PlanetRatingComponent,
     PlanetRatingStarsComponent,

--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -5,7 +5,7 @@ import { calculateMdAdjustedLimit, extractMarkdownImageUrls, getMarkdownPreviewT
   markdownImageRegex, normalizeMarkdownWhitespace, truncateText
 } from './utils';
 
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 
 @Component({
   selector: 'planet-markdown',
@@ -25,7 +25,7 @@ import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
     `,
   styleUrls: ['./planet-markdown.scss'],
   encapsulation: ViewEncapsulation.None,
-  imports: [TdFlavoredMarkdownComponent]
+  imports: [CovalentFlavoredMarkdownModule]
 })
 export class PlanetMarkdownComponent implements OnChanges {
 

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -13,10 +13,7 @@ import { ResourcesMenuComponent } from '../resources/view-resources/resources-me
 import { AuthorizedRolesDirective } from './authorized-roles.directive';
 import { PlanetBetaDirective } from './beta.directive';
 import { FilteredAmountComponent } from './planet-filtered-amount.component';
-import { TasksComponent, FilterAssigneePipe, AssigneeNamePipe } from '../tasks/tasks.component';
 import { PlanetRoleComponent } from './planet-role.component';
-import { PlanetMarkdownComponent } from './planet-markdown.component';
-import { CommunityListComponent } from '../community/community-list.component';
 import { LabelComponent } from './label.component';
 import { TimePipe } from '../manager-dashboard/reports/time.pipe';
 import { AvatarComponent } from './avatar.component';
@@ -39,12 +36,7 @@ import { PreviewOverflowDirective } from './preview-overflow.directive';
     AuthorizedRolesDirective,
     PlanetBetaDirective,
     FilteredAmountComponent,
-    TasksComponent,
-    FilterAssigneePipe,
-    AssigneeNamePipe,
     PlanetRoleComponent,
-    PlanetMarkdownComponent,
-    CommunityListComponent,
     LabelComponent,
     LanguageLabelComponent,
     TimePipe,
@@ -64,12 +56,7 @@ import { PreviewOverflowDirective } from './preview-overflow.directive';
     AuthorizedRolesDirective,
     PlanetBetaDirective,
     FilteredAmountComponent,
-    TasksComponent,
-    FilterAssigneePipe,
-    AssigneeNamePipe,
     PlanetRoleComponent,
-    PlanetMarkdownComponent,
-    CommunityListComponent,
     LabelComponent,
     LanguageLabelComponent,
     TimePipe,

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -35,7 +35,7 @@ import { MatChipSet, MatChip } from '@angular/material/chips';
 import { AuthorizedRolesDirective } from '../shared/authorized-roles.directive';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { NewsListComponent } from '../news/news-list.component';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import {
   MatCard, MatCardHeader, MatCardAvatar, MatCardTitle, MatCardSubtitle, MatCardActions, MatCardContent
 } from '@angular/material/card';
@@ -73,7 +73,7 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     PlanetLoadingSpinnerComponent,
     NewsListComponent,
     MatTabLabel,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatCard,
     MatCardHeader,
     MatCardAvatar,

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -21,7 +21,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
 import { MatDivider, MatList, MatListItem, MatListItemTitle, MatListItemMeta, MatListItemLine } from '@angular/material/list';
-import { TdFlavoredMarkdownComponent } from '@covalent/flavored-markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { PlanetBetaDirective } from '../../shared/beta.directive';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 
@@ -40,7 +40,7 @@ pdfMake.addVirtualFileSystem(pdfFonts);
     MatTooltip,
     PlanetLoadingSpinnerComponent,
     MatDivider,
-    TdFlavoredMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     PlanetBetaDirective,
     MatList,
     MatListItem,


### PR DESCRIPTION
This PR resolves a series of build-breaking errors related to circular dependencies, Angular module recognition, and Sass stylesheet resolution.

Key changes:
1. **Broken Circular Dependencies**: Extracted `TasksComponent`, `PlanetMarkdownComponent`, and `CommunityListComponent` from `SharedComponentsModule`. These are standalone components and should be imported directly by their consumers.
2. **Module Decoupling**: Removed `SharedComponentsModule` from `PlanetFormsModule` and `PlanetDialogsModule` to simplify the dependency graph.
3. **Covalent Fixes**: Migrated several standalone components to import `CovalentFlavoredMarkdownModule` from `@covalent/flavored-markdown`. This ensures the Angular compiler can statically resolve the flavored markdown component.
4. **Sass Resolution**: Added `node_modules` to `stylePreprocessorOptions` in `angular.json` to allow the Sass compiler to correctly resolve `@use` and `@import` statements for library stylesheets.
5. **Import Audit**: Conducted an exhaustive audit of the codebase to ensure all templates still have access to the necessary components and pipes.

The application now builds successfully in both production and development configurations and passes all unit tests and linting.

---
*PR created automatically by Jules for task [10904181191151369789](https://jules.google.com/task/10904181191151369789) started by @RyanS4*