### PR TITLE
fix: prevent Add Courses dialog overflow with expanded filters

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -306,10 +306,10 @@
         }</td>
       </tr>
     </mat-table>
-    <mat-paginator #paginator
-      [pageSize]="50"
-      [pageSizeOptions]="[5, 10, 20, 50, 100, 200]"
-      (page)="onPaginateChange($event)">
-    </mat-paginator>
   </div>
+    <mat-paginator #paginator
+    [pageSize]="50"
+    [pageSizeOptions]="[5, 10, 20, 50, 100, 200]"
+    (page)="onPaginateChange($event)">
+  </mat-paginator>
 </div>

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -1,4 +1,15 @@
-@if (!isForm) {
+<ng-template #filterOptions>
+  <span class="font-size-1 margin-lr-4" i18n>Search by:</span>
+  <button mat-stroked-button i18n (click)="this.showFilters = !this.showFilters">Filter</button>
+  <mat-form-field class="font-size-1 margin-lr-4 mdc-toolbar-input">
+    <mat-label i18n>Title</mat-label>
+    <input matInput [(ngModel)]="titleSearch">
+  </mat-form-field>
+  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection._empty"><span i18n>Clear</span></button>
+</ng-template>
+
+<div [ngClass]="{ 'space-container': !isForm }" class="primary-link-hover course-table-container">
+  @if (!isForm) {
   <mat-toolbar>
     @if (deviceType === deviceTypes.TABLET || deviceType === deviceTypes.DESKTOP) {
       <mat-toolbar-row>
@@ -36,19 +47,7 @@
       </mat-toolbar-row>
     }
   </mat-toolbar>
-}
-
-<ng-template #filterOptions>
-  <span class="font-size-1 margin-lr-4" i18n>Search by:</span>
-  <button mat-stroked-button i18n (click)="this.showFilters = !this.showFilters">Filter</button>
-  <mat-form-field class="font-size-1 margin-lr-4 mdc-toolbar-input">
-    <mat-label i18n>Title</mat-label>
-    <input matInput [(ngModel)]="titleSearch">
-  </mat-form-field>
-  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection._empty"><span i18n>Clear</span></button>
-</ng-template>
-
-<div [ngClass]="{ 'space-container': !isForm }" class="primary-link-hover">
+  }
   @if (!isDialog && !isForm) {
     <mat-toolbar class="primary-color font-size-1">
       @if (isAuthorized) {

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -130,7 +130,7 @@
     }
   </ng-template>
 
-  <div class="card-table" [ngClass]="{ 'view-container view-full-height view-table': !isForm }">
+  <div class="card-table" [ngClass]="{ 'view-container view-full-height view-table': !isForm && !isDialog, 'view-with-search': showFilters && !isDialog }">
     <mat-table #table [dataSource]="courses" matSort [matSortDisableClear]="true" [trackBy]="trackById">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -36,6 +36,10 @@ planet-courses {
     word-break: break-word;
   }
 
+  .view-full-height.view-with-search {
+    height: calc(#{v.$view-container-height} - #{c.$toolbar-height});
+  }
+
   @media(max-width: v.$screen-md) {
     .mat-column-createdDate {
       max-width: 70px;

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -45,9 +45,8 @@ planet-courses {
       max-width: 70px;
     }
   }
-}
 
-.course-table-container {
+  .course-table-container {
   display: flex;
   flex-direction: column;
   height: v.$view-container-height;
@@ -59,3 +58,6 @@ planet-courses {
   min-height: 0;
   overflow: auto;
 }
+
+}
+

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -46,3 +46,16 @@ planet-courses {
     }
   }
 }
+
+.course-table-container {
+  display: flex;
+  flex-direction: column;
+  height: v.$view-container-height;
+  overflow: hidden;
+}
+
+.card-table {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -143,7 +143,7 @@
     </mat-menu>
   </ng-template>
 
-  <div class="view-container view-full-height view-table card-table" [ngClass]="{'view-with-search':showFilters}">
+  <div class="card-table" [ngClass]="{'view-container view-full-height view-table': !isDialog, 'view-with-search':showFilters && !isDialog}">
     <mat-table #table [dataSource]="resources" [matSortActive]="initialSort" matSortDirection="desc" matSort [matSortDisableClear]="true" [trackBy]="trackById">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -143,7 +143,7 @@
     </mat-menu>
   </ng-template>
 
-  <div class="card-table" [ngClass]="{'view-container view-full-height view-table': !isDialog, 'view-with-search':showFilters && !isDialog}">
+  <div class="view-container view-full-height view-table card-table" [ngClass]="{'view-with-search':showFilters}">
     <mat-table #table [dataSource]="resources" [matSortActive]="initialSort" matSortDirection="desc" matSort [matSortDisableClear]="true" [trackBy]="trackById">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>


### PR DESCRIPTION
This addresses issue #10107 where the "Add Courses" dialog in teams would overflow when search filters were expanded.

The behavior now mirrors the "Add Resources" dialog. Fixed by ensuring the \`view-full-height\`, \`view-table\`, \`view-container\`, and \`view-with-search\` classes (which calculate height dynamically up to 100vh of the window) are conditionally omitted from the table layout when the component is being rendered inside a dialog (\`isDialog=true\`). Missing sizing rules for \`view-with-search\` class calculations were also appropriately added for the course search layout.

---
*PR created automatically by Jules for task [15002612364531840396](https://jules.google.com/task/15002612364531840396) started by @RyanS4*