### PR TITLE
teams: smoother surveys table style handling (fixes #10095)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.46",
+  "version": "0.23.55",
   "myplanet": {
     "latest": "v0.60.60",
     "min": "v0.59.59"

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -80,7 +80,7 @@
       </ng-container>
       <ng-container matColumnDef="action">
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
-        <mat-cell *matCellDef="let element">
+        <mat-cell *matCellDef="let element" class="survey-action-cell">
           <div class="table-action-buttons">
           @if (element.parent !== true && currentFilter.viewMode !== 'adopt') {
             @if (!teamId) {

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -42,7 +42,7 @@
     @if (isLoading && !useDialogLoading) {
       <planet-loading-spinner text="Loading surveys..." i18n-text></planet-loading-spinner>
     }
-    <mat-table #table class="responsive-table surveys-table" [dataSource]="surveys" matSort matSortActive="createdDate" matSortDirection="desc" [matSortDisableClear]="true" [class.hidden]="isLoading && !useDialogLoading">
+    <mat-table #table class="responsive-table min-width-table" [dataSource]="surveys" matSort matSortActive="createdDate" matSortDirection="desc" [matSortDisableClear]="true" [class.hidden]="isLoading && !useDialogLoading">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>
           <mat-checkbox (change)="$event ? masterToggle() : null"
@@ -80,7 +80,8 @@
       </ng-container>
       <ng-container matColumnDef="action">
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
-        <mat-cell *matCellDef="let element" class="survey-action-cell">
+        <mat-cell *matCellDef="let element">
+          <div class="table-action-buttons">
           @if (element.parent !== true && currentFilter.viewMode !== 'adopt') {
             @if (!teamId) {
               <div [matTooltip]="getActionTooltip(element, 'edit')">
@@ -184,6 +185,7 @@
               </mat-menu>
             </div>
           }
+          </div>
         </mat-cell>
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns" [class.hidden]="!surveys.data || surveys.data.length === 0"></mat-header-row>

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -27,78 +27,22 @@
   display: block;
 }
 
-.surveys-table {
-  min-width: 1120px;
-  width: 100%;
-}
-
-.survey-action-cell {
-  display: inline-grid;
-  grid-template-columns: minmax(150px, max-content);
-  gap: 8px;
-  padding: 5px 0;
-  align-items: stretch;
-  justify-content: flex-start;
-  width: max-content;
-  max-width: 100%;
-}
-
 .mat-column-action {
   justify-content: flex-start;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-.survey-action-cell button[mat-raised-button] {
-  width: 100%;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 0 12px;
-  white-space: nowrap;
-}
-
 /* Targeting tablet screens */
 @media (max-width: v.$screen-md) {
-
   .mat-column-name {
     max-width: 175px;
-  }
-
-  .survey-action-cell {
-    gap: 6px;
-  }
-
-  .survey-action-cell button[mat-raised-button] {
-    width: 44px;
-    min-width: 44px;
-    padding: 0;
-  }
-
-  .survey-action-cell button[mat-raised-button] mat-icon {
-    margin: 0;
-  }
-
-  .survey-action-cell label {
-    display: none;
   }
 }
 
 /* Targeting mobile screens */
 @media (max-width: v.$screen-sm) {
-
   .mat-column-name {
     max-width: 80px;
-  }
-
-  .survey-action-cell {
-    gap: 6px;
-  }
-
-  .survey-action-cell button[mat-raised-button] {
-    width: 40px;
-    min-width: 40px;
   }
 }

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -33,6 +33,10 @@
   min-width: 0;
 }
 
+.survey-action-cell {
+  padding: 5px 0;
+}
+
 /* Targeting tablet screens */
 @media (max-width: v.$screen-md) {
   .mat-column-name {

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -56,7 +56,7 @@
   }
 
   <div class="primary-link-hover" [ngClass]="{'view-container view-table view-full-height':!isDialog}">
-    <mat-table #table class="responsive-table" [dataSource]="teams" matSort [matSortDisableClear]="true">
+    <mat-table #table class="responsive-table" [class.min-width-table]="!isDialog" [dataSource]="teams" matSort [matSortDisableClear]="true">
       <ng-container matColumnDef="doc.name">
         <mat-header-cell *matHeaderCellDef mat-sort-header="doc.name" i18n>Name</mat-header-cell>
         <mat-cell *matCellDef="let element">
@@ -115,7 +115,7 @@
       <ng-container matColumnDef="action">
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
         <mat-cell *matCellDef="let element">
-          <div class="button-container" [ngClass]="{'horizontal-align': isMobile}">
+          <div class="table-action-buttons" [ngClass]="{'horizontal-align': isMobile}">
             @if (user.isUserAdmin || user.roles.length) {
               @switch (element.userStatus) {
                 @case ('member') {

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -16,28 +16,9 @@
     cursor: pointer;
   }
 
-  .button-container {
-    display: inline-grid;
-    grid-template-columns: minmax(150px, max-content);
-    align-items: stretch;
-    gap: 0.5rem;
-    width: max-content;
-    max-width: 100%;
-  }
-  .horizontal-align {
-    justify-items: center;
-  }
-
   .team-name{
     max-width: 95%;
     overflow: hidden;
-  }
-
-  .button-container button[mat-raised-button] {
-    width: 100%;
-    text-align: center;
-    padding: 8px 12px;
-    white-space: nowrap;
   }
 
   .highlighted {
@@ -47,31 +28,5 @@
   .team-type-label {
     font-size: 12px;
     color: #666;
-  }
-
-  @media (max-width: v.$screen-md) {
-    .button-container {
-      gap: 0.75rem;
-    }
-  }
-
-  @media (max-width: v.$screen-sm) {
-    mat-cell button {
-      min-width: 0;
-      padding: 0 3px;
-    }
-
-    .button-container {
-      grid-template-columns: minmax(120px, max-content);
-      align-items: stretch;
-      gap: 0.5rem;
-    }
-  }
-
-  @media (max-width: v.$screen-xs) {
-    .button-container button[mat-raised-button] {
-      min-width: 0;
-      white-space: normal;
-    }
   }
 }

--- a/src/app/users/users-table.component.html
+++ b/src/app/users/users-table.component.html
@@ -2,7 +2,7 @@
   @if (isLoading) {
     <planet-loading-spinner text="Loading users..." i18n-text></planet-loading-spinner>
   }
-  <mat-table #table class="responsive-table" [dataSource]="usersTable" [trackBy]="trackById" matSort [matSortActive]="matSortActive" matSortDirection="desc" [class.hidden]="isLoading">
+  <mat-table #table class="responsive-table" [dataSource]="usersTable" [trackBy]="trackById" matSort [matSortActive]="matSortActive" matSortDirection="desc" [class.hidden]="isLoading" [class.min-width-table]="displayedColumns.includes('action')">
     <ng-container matColumnDef="select">
       <mat-header-cell *matHeaderCellDef>
         <mat-checkbox (change)="$event ? masterToggle() : null"
@@ -132,55 +132,49 @@
     <ng-container matColumnDef="action">
       <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
       <mat-cell *matCellDef="let element">
-        <div [ngClass]="{'horizontal-align button-container': isMobile}">
+        <div class="table-action-buttons" [ngClass]="{'horizontal-align': isMobile}">
           @if (isUserAdmin && filterType === 'local' && !isDialog) {
-            <span>
-              @if (!element.doc.isUserAdmin) {
-                <span>
-                  @if (element.doc.roles.length === 0) {
-                    <button mat-raised-button color="primary" (click)="setRoles(element.doc, element.doc.oldRoles || ['learner'], $event)">
-                      <mat-icon>lock_open</mat-icon>
-                      @if (!isMobile) {
-                        <label i18n>Activate</label>
-                      }
-                    </button>
-                  }
-                  @if (element.doc.roles.length > 0) {
-                    <button mat-raised-button color="primary" (click)="setRoles(element.doc, [], $event)">
-                      <mat-icon>lock</mat-icon>
-                      @if (!isMobile) {
-                        <label i18n>Deactivate</label>
-                      }
-                    </button>
-                  }
-                </span>
-              }
-              @if (!element.doc.isUserAdmin || element.doc.roles.length > 0) {
-                <button mat-raised-button color="primary" (click)="deleteClick(element.doc, $event)">
-                  <mat-icon>delete</mat-icon>
-                  @if (!isMobile) {
-                    <label i18n> Delete </label>
-                  }
-                </button>
-              }
-              @if (!element.doc.isUserAdmin && filterType === 'local') {
-                <button (click)="toggleStatus($event, element.doc, 'admin', false)" mat-raised-button color="primary">
-              <mat-icon>vertical_align_top</mat-icon>
-              @if (!isMobile) {
-<label i18n> Promote </label>
-}
-            </button>
-              }
-              @if (element.doc.isUserAdmin && filterType === 'local' && (element.doc.name + '@' + configuration.code) !== configuration.adminName) {
-                <button
-                  (click)="toggleStatus($event, element.doc, element.doc.roles.length === 0 ? 'admin' : 'manager', true)" mat-raised-button color="primary">
-              <mat-icon>vertical_align_bottom</mat-icon>
-              @if (!isMobile) {
-<label i18n> Demote </label>
-}
-            </button>
-              }
-            </span>
+            @if (!element.doc.isUserAdmin && element.doc.roles.length === 0) {
+              <button mat-raised-button color="primary" (click)="setRoles(element.doc, element.doc.oldRoles || ['learner'], $event)">
+                <mat-icon>lock_open</mat-icon>
+                @if (!isMobile) {
+                  <label i18n>Activate</label>
+                }
+              </button>
+            }
+            @if (!element.doc.isUserAdmin && element.doc.roles.length > 0) {
+              <button mat-raised-button color="primary" (click)="setRoles(element.doc, [], $event)">
+                <mat-icon>lock</mat-icon>
+                @if (!isMobile) {
+                  <label i18n>Deactivate</label>
+                }
+              </button>
+            }
+            @if (!element.doc.isUserAdmin || element.doc.roles.length > 0) {
+              <button mat-raised-button color="primary" (click)="deleteClick(element.doc, $event)">
+                <mat-icon>delete</mat-icon>
+                @if (!isMobile) {
+                  <label i18n> Delete </label>
+                }
+              </button>
+            }
+            @if (!element.doc.isUserAdmin && filterType === 'local') {
+              <button (click)="toggleStatus($event, element.doc, 'admin', false)" mat-raised-button color="primary">
+                <mat-icon>vertical_align_top</mat-icon>
+                @if (!isMobile) {
+                  <label i18n> Promote </label>
+                }
+              </button>
+            }
+            @if (element.doc.isUserAdmin && filterType === 'local' && (element.doc.name + '@' + configuration.code) !== configuration.adminName) {
+              <button
+                (click)="toggleStatus($event, element.doc, element.doc.roles.length === 0 ? 'admin' : 'manager', true)" mat-raised-button color="primary">
+                <mat-icon>vertical_align_bottom</mat-icon>
+                @if (!isMobile) {
+                  <label i18n> Demote </label>
+                }
+              </button>
+            }
           }
           <button (click)="gotoProfileView(element.doc.name)" mat-raised-button color="primary">
             <mat-icon>visibility</mat-icon>

--- a/src/app/users/users-table.scss
+++ b/src/app/users/users-table.scss
@@ -16,34 +16,8 @@
 mat-cell p {
   margin: 0;
 }
-
-button-container {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.horizontal-align {
-  justify-content: center;
-}
-
-.mat-mdc-cell button, .mat-mdc-cell div button[mat-raised-button] {
-  width: 150px;
-  text-align: center;
-  padding: 8px 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 @media(max-width: v.$screen-md) {
   .mat-column-visitCount, .mat-column-joinDate, .mat-column-lastLogin {
     max-width: 70px;
-  }
-}
-
-@media (max-width: v.$screen-sm) {
-  .mat-mdc-cell button, .mat-mdc-cell div button[mat-raised-button] {
-    width: 50px;
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -449,6 +449,56 @@ body {
     }
   }
 
+  // Opt-in addition to .responsive-table for tables whose columns (e.g. stacked action buttons)
+  // should never squish: holds a usable min-width at all viewport widths so the surrounding
+  // view-table container scrolls horizontally instead. Override via --responsive-table-min-width.
+  mat-table.responsive-table.min-width-table,
+  table.mat-mdc-table.responsive-table.min-width-table {
+    min-width: var(--responsive-table-min-width, 1000px);
+    width: 100%;
+  }
+
+  // Shared opt-in styling for the button container in a table's action column.
+  // Apply to a div wrapping the buttons inside the action mat-cell; add .horizontal-align to center buttons.
+  .table-action-buttons {
+    display: inline-grid;
+    grid-template-columns: minmax(150px, max-content);
+    align-items: stretch;
+    gap: 0.5rem;
+    width: max-content;
+    max-width: 100%;
+
+    &.horizontal-align {
+      justify-items: center;
+    }
+
+    button[mat-raised-button] {
+      width: 100%;
+      text-align: center;
+      padding: 8px 12px;
+      white-space: nowrap;
+    }
+
+    @media (max-width: v.$screen-md) {
+      gap: 0.75rem;
+    }
+
+    @media (max-width: v.$screen-sm) {
+      grid-template-columns: minmax(120px, max-content);
+
+      button[mat-raised-button] {
+        min-width: 0;
+        padding: 0 3px;
+      }
+    }
+
+    @media (max-width: v.$screen-xs) {
+      button[mat-raised-button] {
+        white-space: normal;
+      }
+    }
+  }
+
   // Shared opt-in card-stack table styling to collapse tables rows into stacked cards on smaller screens.
   .card-table {
     .mat-mdc-row {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -427,6 +427,15 @@ body {
     margin: 0 8px;
   }
 
+  // Tables using an explicit min-width should scroll inside their view container
+  // throughout the tablet range instead of overflowing the page.
+  @media (max-width: v.$screen-md) {
+    .view-container.view-table {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+  }
+
   // Opt-in shared pattern for tables that can't reasonably collapse to a card layout.
   // Can be applied either directly to a mat-table element, or to a wrapper div around one (dialogs, tabs, inline tables).
   // Courses/resources use a separate pattern


### PR DESCRIPTION
Fixes #10095

Centralize the table action-cell styling that is shared between the teams, surveys & users tables. 
- Improve tables responsiveness with horizontal scrollbar under 1000px breakpoint
- Consistent table styling