### PR TITLE
teams: smoother list action buttons padding (fixes #10126)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.60",
+  "version": "0.23.66",
   "myplanet": {
     "latest": "v0.61.41",
     "min": "v0.59.59"

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -80,7 +80,7 @@
       </ng-container>
       <ng-container matColumnDef="action">
         <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
-        <mat-cell *matCellDef="let element" class="survey-action-cell">
+        <mat-cell *matCellDef="let element">
           <div class="table-action-buttons">
           @if (element.parent !== true && currentFilter.viewMode !== 'adopt') {
             @if (!teamId) {

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -33,10 +33,6 @@
   min-width: 0;
 }
 
-.survey-action-cell {
-  padding: 5px 0;
-}
-
 /* Targeting tablet screens */
 @media (max-width: v.$screen-md) {
   .mat-column-name {

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -20,7 +20,6 @@
     display: inline-grid;
     grid-template-columns: minmax(150px, max-content);
     align-items: stretch;
-    gap: 0.5rem;
     width: max-content;
     max-width: 100%;
   }
@@ -34,10 +33,13 @@
   }
 
   .button-container button[mat-raised-button] {
+    display: flex;
     width: 100%;
     text-align: center;
     padding: 8px 12px;
     white-space: nowrap;
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
   }
 
   .highlighted {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -498,7 +498,7 @@ body {
     grid-template-columns: minmax(150px, max-content);
     align-items: stretch;
     gap: 0.5rem;
-    padding: 0.25rem 0;
+    padding: 5px 0;
     width: max-content;
     max-width: 100%;
 


### PR DESCRIPTION
Fixes #10126
- Expands the top and bottom teams' action button container margins to prevent packed and awkward component placement

## Before

<img width="355" height="639" alt="{2200C41D-5801-492F-9108-7F13A0B82DF0}" src="https://github.com/user-attachments/assets/170e2c81-9061-404f-a33a-8d5abaff8de1" />

## After

<img width="337" height="727" alt="{801AE867-442B-42A2-9FCE-284B698A851D}" src="https://github.com/user-attachments/assets/f8a95b97-f5f3-4ea4-b45d-1e1f1aa5efbd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around survey table action buttons for a cleaner, more consistent layout.
  * Removed redundant action-cell styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->