### PR TITLE
all: upgrade to covalent flavored markdown (fixes #7686)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "planet",
-  "version": "0.23.38",
+  "version": "0.23.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "planet",
-      "version": "0.23.38",
+      "version": "0.23.46",
       "license": "AGPL-3.0",
       "dependencies": {
         "@angular/animations": "20.3.21",
@@ -22,6 +22,7 @@
         "@angular/platform-server": "20.3.21",
         "@angular/router": "20.3.21",
         "@angular/service-worker": "20.3.21",
+        "@covalent/flavored-markdown": "^11.19.8",
         "@covalent/markdown": "^11.19.5",
         "@covalent/text-editor": "^11.19.5",
         "@fullcalendar/angular": "^6.1.10",
@@ -4390,6 +4391,61 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@covalent/core": {
+      "version": "11.19.8",
+      "resolved": "https://registry.npmjs.org/@covalent/core/-/core-11.19.8.tgz",
+      "integrity": "sha512-5ussxmazCJU2XgsLFSxtvVxzcDgA+aEOmZcNfpAqCjHvwanHnFiU7cadv4jTXtaIgm5mtX2Y3wP9XfjFvXd2WA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "20.x.x",
+        "@angular/common": "20.x.x",
+        "@angular/core": "20.x.x",
+        "@angular/forms": "20.x.x",
+        "@angular/material": "20.x.x",
+        "@angular/router": "20.x.x",
+        "@covalent/core": "11.19.8"
+      }
+    },
+    "node_modules/@covalent/flavored-markdown": {
+      "version": "11.19.8",
+      "resolved": "https://registry.npmjs.org/@covalent/flavored-markdown/-/flavored-markdown-11.19.8.tgz",
+      "integrity": "sha512-nRzdx0fW6gHHNwNWAQp5ORTqfHHMR/oNpqj9SP94RPqbQhVkgmPNGkDb747DYfAPKnNrclrCP6mwmAryOU2m/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "20.x.x",
+        "@angular/common": "20.x.x",
+        "@angular/core": "20.x.x",
+        "@angular/material": "20.x.x",
+        "@covalent/core": "11.19.8",
+        "@covalent/highlight": "11.19.8",
+        "@covalent/markdown": "11.19.8"
+      }
+    },
+    "node_modules/@covalent/highlight": {
+      "version": "11.19.8",
+      "resolved": "https://registry.npmjs.org/@covalent/highlight/-/highlight-11.19.8.tgz",
+      "integrity": "sha512-HLIp0b50Auy/SfBo+xP3cG9/56zkQjcPlB8BXNEHsWUfB4pZN4aWBCdHl27ekRCUUu3t490p7io1ijeyjwAlrg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "20.x.x",
+        "@angular/common": "20.x.x",
+        "@angular/core": "20.x.x",
+        "@angular/material": "20.x.x",
+        "@angular/platform-browser": "20.x.x",
+        "highlight.js": "^11.9.0"
       }
     },
     "node_modules/@covalent/markdown": {
@@ -14316,6 +14372,16 @@
       },
       "engines": {
         "node": ">=4.5.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoek": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@angular/platform-server": "20.3.21",
     "@angular/router": "20.3.21",
     "@angular/service-worker": "20.3.21",
+    "@covalent/flavored-markdown": "^11.19.8",
     "@covalent/markdown": "^11.19.5",
     "@covalent/text-editor": "^11.19.5",
     "@fullcalendar/angular": "^6.1.10",

--- a/src/app/exams/exams-view.component.html
+++ b/src/app/exams/exams-view.component.html
@@ -45,7 +45,7 @@
       </button>
     }
   </mat-menu>
-  <td-markdown class="question-body" [content]="question?.body"></td-markdown>
+  <td-flavored-markdown class="question-body" [content]="question?.body"></td-flavored-markdown>
   <div>
     @switch (mode) {
       @case ('take') {
@@ -58,7 +58,7 @@
       }
       @case ('grade') {
         <p><b i18n>Submitted answer:</b></p>
-        <td-markdown [content]="answer?.value?.text || answer?.value"></td-markdown>
+        <td-flavored-markdown [content]="answer?.value?.text || answer?.value"></td-flavored-markdown>
         <mat-radio-group [(ngModel)]="grade" [disabled]="question?.type === 'select' || question?.type === 'selectMultiple'">
           <mat-radio-button [value]="1" class="planet-radio-button" i18n>Correct</mat-radio-button>
           <mat-radio-button [value]="0" class="planet-radio-button" i18n>Incorrect</mat-radio-button>
@@ -70,7 +70,7 @@
       }
       @case ('view') {
         <p><b i18n>Response:</b></p>
-        <td-markdown [content]="answer?.value?.text || answer?.value"></td-markdown>
+        <td-flavored-markdown [content]="answer?.value?.text || answer?.value"></td-flavored-markdown>
         @if (grade>=0) {
           <p><b i18n>Grade:</b></p>
           @if (grade===1) {
@@ -82,7 +82,7 @@
         }
         @if (comment) {
           <p><b i18n>Feedback:</b></p>
-          <td-markdown [content]="comment"></td-markdown>
+          <td-flavored-markdown [content]="comment"></td-flavored-markdown>
         }
       }
     }

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -19,7 +19,7 @@ import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatIconButton, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { PlanetMarkdownTextboxComponent } from '../shared/forms/planet-markdown-textbox.component';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
@@ -44,7 +44,7 @@ interface ExamViewForm {
     MatMenuTrigger,
     MatMenu,
     MatMenuItem,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatFormField,
     MatLabel,
     FormsModule,

--- a/src/app/exams/public-surveys/public-survey.component.html
+++ b/src/app/exams/public-surveys/public-survey.component.html
@@ -15,7 +15,7 @@
     [disableNext]="isLoading || questionNum === maxQuestions"
     (previous)="moveQuestion(-1)"
     (next)="moveQuestion(1)">
-    <td-markdown class="question-body" [content]="question?.body"></td-markdown>
+    <td-flavored-markdown class="question-body" [content]="question?.body"></td-flavored-markdown>
     <planet-exams-take-widget [question]="question" [answer]="answer" [storedAnswerValue]="currentAnswer"></planet-exams-take-widget>
     <div class="action-buttons action-buttons--split">
       <div class="action-buttons__left">

--- a/src/app/exams/public-surveys/public-survey.component.ts
+++ b/src/app/exams/public-surveys/public-survey.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl, NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { switchMap } from 'rxjs/operators';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
@@ -21,7 +21,7 @@ import { LoginDialogComponent } from '../../login/login-dialog.component';
   templateUrl: './public-survey.component.html',
   styleUrls: ['./public-survey.component.scss'],
   imports: [
-    MatIcon, TdMarkdownComponent, ExamsQuestionFrameComponent, ExamsTakeWidgetComponent, MatButton,
+    MatIcon, CovalentFlavoredMarkdownModule, ExamsQuestionFrameComponent, ExamsTakeWidgetComponent, MatButton,
     ReactiveFormsModule, MatFormField, MatLabel, MatHint, MatError, MatInput, MatRadioGroup, MatRadioButton
   ]
 })

--- a/src/app/health/health-event-dialog.component.html
+++ b/src/app/health/health-event-dialog.component.html
@@ -36,35 +36,35 @@
   }
   @if (event.notes) {
     <p><b i18n>Observations & Notes: </b></p>
-    <td-markdown [content]="event.notes"></td-markdown>
+    <td-flavored-markdown [content]="event.notes"></td-flavored-markdown>
   }
   @if (event.diagnosis) {
     <p><b i18n>Diagnosis: </b></p>
-    <td-markdown [content]="event.diagnosis"></td-markdown>
+    <td-flavored-markdown [content]="event.diagnosis"></td-flavored-markdown>
   }
   @if (event.treatments) {
     <p><b i18n>Treatments: </b></p>
-    <td-markdown [content]="event.treatments"></td-markdown>
+    <td-flavored-markdown [content]="event.treatments"></td-flavored-markdown>
   }
   @if (event.medications) {
     <p><b i18n>Medications: </b></p>
-    <td-markdown [content]="event.medications"></td-markdown>
+    <td-flavored-markdown [content]="event.medications"></td-flavored-markdown>
   }
   @if (event.immunizations) {
     <p><b i18n>Immunizations: </b></p>
-    <td-markdown [content]="event.immunizations"></td-markdown>
+    <td-flavored-markdown [content]="event.immunizations"></td-flavored-markdown>
   }
   @if (event.xrays) {
     <p><b i18n>X-rays: </b></p>
-    <td-markdown [content]="event.xrays"></td-markdown>
+    <td-flavored-markdown [content]="event.xrays"></td-flavored-markdown>
   }
   @if (event.tests) {
     <p><b i18n>Lab Tests: </b></p>
-    <td-markdown [content]="event.tests"></td-markdown>
+    <td-flavored-markdown [content]="event.tests"></td-flavored-markdown>
   }
   @if (event.referrals) {
     <p><b i18n>Referrals: </b></p>
-    <td-markdown [content]="event.referrals"></td-markdown>
+    <td-flavored-markdown [content]="event.referrals"></td-flavored-markdown>
   }
 </mat-dialog-content>
 <mat-dialog-actions>

--- a/src/app/health/health-event-dialog.component.ts
+++ b/src/app/health/health-event-dialog.component.ts
@@ -10,13 +10,13 @@ import { UserService } from '../shared/user.service';
 import { PdfService } from '../shared/pdf.service';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { DatePipe, formatDate } from '@angular/common';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatButton } from '@angular/material/button';
 
 @Component({
   templateUrl: './health-event-dialog.component.html',
   imports: [
-    MatDialogTitle, CdkScrollable, MatDialogContent, TdMarkdownComponent,
+    MatDialogTitle, CdkScrollable, MatDialogContent, CovalentFlavoredMarkdownModule,
     MatDialogActions, MatButton, MatDialogClose, DatePipe
   ]
 })

--- a/src/app/health/health.component.html
+++ b/src/app/health/health.component.html
@@ -79,28 +79,28 @@
           <div class="full-width">
             <div>
               <h4 class="primary-text-color" i18n>Allergies</h4>
-              <td-markdown [content]="healthDetail?.allergies || 'N/A'"></td-markdown>
+              <td-flavored-markdown [content]="healthDetail?.allergies || 'N/A'"></td-flavored-markdown>
             </div>
             <mat-divider></mat-divider>
           </div>
           <div class="full-width">
             <div>
               <h4 class="primary-text-color" i18n>Immunization Dates</h4>
-              <td-markdown [content]="healthDetail?.immunizations || 'N/A'"></td-markdown>
+              <td-flavored-markdown [content]="healthDetail?.immunizations || 'N/A'"></td-flavored-markdown>
             </div>
             <mat-divider></mat-divider>
           </div>
           <div class="full-width">
             <div>
               <h4 class="primary-text-color" i18n>Special Needs</h4>
-              <td-markdown [content]="healthDetail?.specialNeeds || 'N/A'"></td-markdown>
+              <td-flavored-markdown [content]="healthDetail?.specialNeeds || 'N/A'"></td-flavored-markdown>
             </div>
             <mat-divider></mat-divider>
           </div>
           <div class="full-width">
             <div>
               <h4 class="primary-text-color" i18n>Notes</h4>
-              <td-markdown [content]="healthDetail?.notes || 'N/A'"></td-markdown>
+              <td-flavored-markdown [content]="healthDetail?.notes || 'N/A'"></td-flavored-markdown>
             </div>
             <mat-divider></mat-divider>
           </div>

--- a/src/app/health/health.component.ts
+++ b/src/app/health/health.component.ts
@@ -20,7 +20,7 @@ import { MatIcon } from '@angular/material/icon';
 import { NgClass, DatePipe } from '@angular/common';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { MatDivider } from '@angular/material/list';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatTooltip } from '@angular/material/tooltip';
 import { LabelComponent } from '../shared/label.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
@@ -36,7 +36,7 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     RouterLink,
     PlanetLoadingSpinnerComponent,
     MatDivider,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatTable,
     MatColumnDef,
     MatHeaderCellDef,

--- a/src/app/meetups/meetups.component.html
+++ b/src/app/meetups/meetups.component.html
@@ -65,7 +65,7 @@
             }
           </h3>
           <div class="content">
-            <td-markdown [content]="element.description"></td-markdown>
+            <td-flavored-markdown [content]="element.description"></td-flavored-markdown>
           </div>
           @if (!parent) {
             <button class="menu" mat-icon-button [matMenuTriggerFor]="meetupMenu">

--- a/src/app/meetups/meetups.component.ts
+++ b/src/app/meetups/meetups.component.ts
@@ -24,7 +24,7 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { NgClass, TitleCasePipe, DatePipe } from '@angular/common';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { FeedbackDirective } from '../feedback/feedback.directive';
 
@@ -68,7 +68,7 @@ import { FeedbackDirective } from '../feedback/feedback.directive';
     MatCellDef,
     MatCell,
     MatSortHeader,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatMenuTrigger,
     MatMenu,
     MatMenuItem,

--- a/src/app/meetups/view-meetups/meetups-view.component.html
+++ b/src/app/meetups/view-meetups/meetups-view.component.html
@@ -81,7 +81,7 @@
       }
       @if (meetupDetail?.description) {
         <b i18n>Description:</b>
-        }<td-markdown [content]="meetupDetail?.description"></td-markdown>
+        }<td-flavored-markdown [content]="meetupDetail?.description"></td-flavored-markdown>
       </div>
       @if (!isDialog) {
         <div class="right-tile">

--- a/src/app/meetups/view-meetups/meetups-view.component.ts
+++ b/src/app/meetups/view-meetups/meetups-view.component.ts
@@ -19,7 +19,7 @@ import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 
 @Component({
@@ -34,7 +34,7 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
     MatButton,
     MatTooltip,
     NgClass,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     CdkScrollable,
     MatDialogContent,
     NgTemplateOutlet,

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -69,7 +69,7 @@
   <div class="view-container view-full-height" [ngClass]="{'full-view-container':fullView==='on'}">
     <div class="resource-detail bg-light-grey" [ngClass]="{'invisible':fullView==='on'}">
       <planet-rating [rating]="resource?.rating" [item]="resource.doc" [parent]="parent" [ratingType]="'resource'"></planet-rating>
-      <p><b i18n>Description:</b><td-markdown [content]="resource?.doc?.description"></td-markdown></p>
+      <p><b i18n>Description:</b><td-flavored-markdown [content]="resource?.doc?.description"></td-flavored-markdown></p>
       @if (resource?.doc?.author) {
         <p><b i18n>Author:</b><i>{{' ' + resource?.doc?.author}}</i></p>
       }

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -16,7 +16,7 @@ import { MatIcon } from '@angular/material/icon';
 import { NgTemplateOutlet, NgClass } from '@angular/common';
 import { MatMenuTrigger, MatMenu } from '@angular/material/menu';
 import { PlanetRatingComponent } from '../../shared/forms/planet-rating.component';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { LanguageLabelComponent } from '../../shared/language-label.component';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
 import { ResourcesViewerComponent } from './resources-viewer.component';
@@ -36,7 +36,7 @@ import { ResourcesViewerComponent } from './resources-viewer.component';
     MatAnchor,
     NgClass,
     PlanetRatingComponent,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     LanguageLabelComponent,
     PlanetLoadingSpinnerComponent,
     ResourcesViewerComponent

--- a/src/app/shared/forms/planet-forms.module.ts
+++ b/src/app/shared/forms/planet-forms.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CovalentTextEditorModule } from '@covalent/text-editor';
-import { CovalentMarkdownModule } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MaterialModule } from '../material.module';
 import { FormErrorMessagesComponent } from './form-error-messages.component';
 import { PlanetRatingComponent } from './planet-rating.component';
@@ -55,7 +55,7 @@ import { PlanetRoundDirective } from './planet-round.directive';
     PlanetTagInputComponent,
     PlanetTagSelectedInputComponent,
     CovalentTextEditorModule,
-    CovalentMarkdownModule,
+    CovalentFlavoredMarkdownModule,
     PlanetSelectorComponent,
     PlanetStepListComponent,
     PlanetStepListFormDirective,

--- a/src/app/shared/planet-markdown.component.ts
+++ b/src/app/shared/planet-markdown.component.ts
@@ -5,13 +5,13 @@ import { calculateMdAdjustedLimit, extractMarkdownImageUrls, getMarkdownPreviewT
   markdownImageRegex, normalizeMarkdownWhitespace, truncateText
 } from './utils';
 
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 
 @Component({
   selector: 'planet-markdown',
   template: `
     @if (previewMode) {
-      <td-markdown [content]="limitedContent"></td-markdown>
+      <td-flavored-markdown [content]="limitedContent"></td-flavored-markdown>
       @if (images?.length) {
         <div class="image-gallery">
           @for (image of images; track image) {
@@ -20,12 +20,12 @@ import { TdMarkdownComponent } from '@covalent/markdown';
         </div>
       }
     } @else {
-      <td-markdown [content]="content" [hostedUrl]="couchAddress"></td-markdown>
+      <td-flavored-markdown [content]="content" [hostedUrl]="couchAddress"></td-flavored-markdown>
     }
     `,
   styleUrls: ['./planet-markdown.scss'],
   encapsulation: ViewEncapsulation.None,
-  imports: [TdMarkdownComponent]
+  imports: [CovalentFlavoredMarkdownModule]
 })
 export class PlanetMarkdownComponent implements OnChanges {
 

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { RouterModule } from '@angular/router';
-import { CovalentMarkdownModule } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 
 import { PlanetLocalStatusComponent } from './planet-local-status.component';
 import { MaterialModule } from './material.module';
@@ -30,7 +30,7 @@ import { PreviewOverflowDirective } from './preview-overflow.directive';
 
 @NgModule({
   imports: [
-    CommonModule, MaterialModule, CovalentMarkdownModule, RouterModule,
+    CommonModule, MaterialModule, CovalentFlavoredMarkdownModule, RouterModule,
     PlanetLoadingSpinnerComponent,
     PlanetLocalStatusComponent,
     SubmitDirective,

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -1,6 +1,17 @@
 import * as showdown from 'showdown';
 import mime from 'mime';
-export const converter = new showdown.Converter();
+
+showdown.setOption('strikethrough', true);
+showdown.setOption('tables', true);
+showdown.setOption('tasklists', true);
+showdown.setOption('ghCodeBlocks', true);
+
+export const converter = new showdown.Converter({
+  tasklists: true,
+  strikethrough: true,
+  tables: true,
+  ghCodeBlocks: true
+});
 
 // File.type can be empty for some browsers / file sources; fall back to the
 // filename extension via the mime package so callers don't reject valid files.

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -110,15 +110,15 @@
         @if (team?.description && mode === 'enterprise') {
           <div class="mat-headline-6" i18n>What is your enterprise's Mission?</div>
         }
-        <td-markdown [content]="team.description"></td-markdown>
+        <td-flavored-markdown [content]="team.description"></td-flavored-markdown>
         @if (team?.services) {
           <div class="mat-headline-6" i18n>What are the Services your enterprise provides?</div>
         }
-        <td-markdown [content]="team.services"></td-markdown>
+        <td-flavored-markdown [content]="team.services"></td-flavored-markdown>
         @if (team?.rules) {
           <div class="mat-headline-6" i18n>What are the Rules of your enterprise?</div>
         }
-        <td-markdown [content]="team.rules"></td-markdown>
+        <td-flavored-markdown [content]="team.rules"></td-flavored-markdown>
       } @else {
         <p i18n>The { mode, select, team {team} enterprise {enterprise} services {services directory} } has no { mode, select, team {plan} enterprise {mission & services} services {services} }.</p>
         @if (isUserLeader || mode === 'services') {

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -35,7 +35,7 @@ import { MatChipSet, MatChip } from '@angular/material/chips';
 import { AuthorizedRolesDirective } from '../shared/authorized-roles.directive';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { NewsListComponent } from '../news/news-list.component';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import {
   MatCard, MatCardHeader, MatCardAvatar, MatCardTitle, MatCardSubtitle, MatCardActions, MatCardContent
 } from '@angular/material/card';
@@ -73,7 +73,7 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     PlanetLoadingSpinnerComponent,
     NewsListComponent,
     MatTabLabel,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     MatCard,
     MatCardHeader,
     MatCardAvatar,

--- a/src/app/teams/teams.module.ts
+++ b/src/app/teams/teams.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { TeamsRouterModule } from './teams-router.module';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '../shared/material.module';
-import { CovalentMarkdownModule } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { TeamsComponent } from './teams.component';
 import { TeamsViewComponent } from './teams-view.component';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
@@ -29,7 +29,7 @@ import { SurveysModule } from '../surveys/surveys.module';
     NewsModule,
     DialogsAddResourcesModule,
     DialogsResourcesViewerModule,
-    CovalentMarkdownModule,
+    CovalentFlavoredMarkdownModule,
     SharedComponentsModule,
     PlanetCalendarModule,
     FormsModule,

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -68,14 +68,14 @@
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Purpose</h3>
-                  <td-markdown [content]="achievements.purpose"></td-markdown>
+                  <td-flavored-markdown [content]="achievements.purpose"></td-flavored-markdown>
                 </div>
               }
               @if (achievements.goals) {
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Goals</h3>
-                  <td-markdown [content]="achievements.goals"></td-markdown>
+                  <td-flavored-markdown [content]="achievements.goals"></td-flavored-markdown>
                 </div>
               }
               <ng-container *planetBeta>
@@ -111,7 +111,7 @@
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Achievements</h3>
-                  <td-markdown [content]="achievements.achievementsHeader"></td-markdown>
+                  <td-flavored-markdown [content]="achievements.achievementsHeader"></td-flavored-markdown>
                   <mat-list>
                     @for (achievement of achievements.achievements; track achievement; let i = $index) {
                       <mat-list-item class="mat-list-item-word-wrap" [ngClass]="{'cursor-pointer':isClickable(achievement)}" (click)="onAchievementClick(achievement, i)">

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -19,7 +19,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
 import { MatDivider, MatList, MatListItem, MatListItemTitle, MatListItemMeta, MatListItemLine } from '@angular/material/list';
-import { TdMarkdownComponent } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { PlanetBetaDirective } from '../../shared/beta.directive';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 
@@ -36,7 +36,7 @@ import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
     MatTooltip,
     PlanetLoadingSpinnerComponent,
     MatDivider,
-    TdMarkdownComponent,
+    CovalentFlavoredMarkdownModule,
     PlanetBetaDirective,
     MatList,
     MatListItem,


### PR DESCRIPTION
Fixes #7686 
- Updates markdown to flavored Covalent markdown, enabling the editor to pick up on checkboxes

<img width="608" height="372" alt="{78E1EFCD-001C-4FA6-85F7-BE01EF9EA120}" src="https://github.com/user-attachments/assets/596e8251-faf6-4d10-8d6e-2f188864aabc" />

<img width="458" height="199" alt="{7C126388-19FA-48EB-A87E-A62D87C2CFE7}" src="https://github.com/user-attachments/assets/331b7013-e4b7-4837-bba7-3e5928cb2c8c" />