### PR TITLE
manager: add health exams by month chart (fixes #8772)

### DIFF
--- a/src/app/manager-dashboard/reports/reports-detail.component.html
+++ b/src/app/manager-dashboard/reports/reports-detail.component.html
@@ -157,7 +157,7 @@
         @if (progress?.steps) {
           <button mat-menu-item (click)="openExportDialog('stepCompletions')" i18n>Course Progress Report</button>
         }
-        @if (healthComponent?.examinations?.length > 0) {
+        @if (healthExams?.data?.length > 0) {
           <button mat-menu-item (click)="openExportDialog('health')" i18n>Health Report</button>
         }
         @if (chatActivities?.filteredData?.length) {
@@ -179,6 +179,7 @@
         <ng-container *ngTemplateOutlet="chartWithActions; context: { chartId: 'stepCompletedChart' }"></ng-container>
         <ng-container *ngTemplateOutlet="chartWithActions; context: { chartId: 'chatUsageChart' }"></ng-container>
         <ng-container *ngTemplateOutlet="chartWithActions; context: { chartId: 'voicesCreatedChart' }"></ng-container>
+        <ng-container *ngTemplateOutlet="chartWithActions; context: { chartId: 'healthExamsCreatedChart' }"></ng-container>
         <div class="reports-table-container">
           <div>
             <h1 class="mat-headline-6" i18n>Members</h1>
@@ -398,6 +399,7 @@
         <div [hidden]="healthLoading || healthNoData">
           <planet-reports-health
             [planetCode]="planetCode"
+            [examinations]="healthExams.data"
             [dateRange]="dateFilterForm?.value"
             [isActive]="healthTab.isActive"
             (changeDateRange)="resetDateFilter($event)"

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -26,6 +26,7 @@ import { ReportsDetailData, ReportDetailFilter } from './reports-detail-data';
 import { UsersService } from '../../users/users.service';
 import { CoursesViewDetailDialogComponent } from '../../courses/view-courses/courses-view-detail.component';
 import { ReportsHealthComponent } from './reports-health.component';
+import { HealthService } from '../../health/health.service';
 import { UserProfileDialogComponent } from '../../users/users-profile/users-profile-dialog.component';
 import { findDocuments } from '../../shared/mangoQueries';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
@@ -127,6 +128,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
   };
   chatActivities = new ReportsDetailData('createdDate');
   voicesActivities = new ReportsDetailData('time');
+  healthExams = new ReportsDetailData('date');
   today: Date;
   minDate: Date;
   ratings = { total: new ReportsDetailData('time'), resources: [], courses: [] };
@@ -181,6 +183,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     private fb: NonNullableFormBuilder,
     private deviceInfoService: DeviceInfoService,
     private planetMessageService: PlanetMessageService,
+    private healthService: HealthService,
     @Inject(LOCALE_ID) private localeId: string
   ) {
     this.initDateFilterForm();
@@ -263,6 +266,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       this.getTeams();
       this.getChatUsage();
       this.getVoicesUsage();
+      this.getHealthExams();
       this.dialogsLoadingService.stop();
     });
   }
@@ -326,6 +330,8 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     this.setChatUsage();
     this.voicesActivities.filter(this.filter);
     this.setVoicesUsage();
+    this.healthExams.filter(this.filter);
+    this.setHealthExamsUsage();
   }
 
   getLoginActivities() {
@@ -487,6 +493,21 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
   setVoicesUsage() {
     const { byMonth } = this.activityService.groupVoicesCreated(this.voicesActivities.filteredData);
     this.setChart({ ...this.setGenderDatasets(byMonth), chartName: 'voicesCreatedChart' });
+  }
+
+  getHealthExams() {
+    this.healthService.getExaminations(this.planetCode).pipe(
+      finalize(() => this.healthLoading = false)
+    ).subscribe((data) => {
+      this.healthExams.data = data;
+      this.healthExams.filter(this.filter);
+      this.setHealthExamsUsage();
+    });
+  }
+
+  setHealthExamsUsage() {
+    const byMonth = this.activityService.groupByMonth(this.healthExams.filteredData, 'date', 'profileId');
+    this.setChart({ ...this.setGenderDatasets(byMonth), chartName: 'healthExamsCreatedChart' });
   }
 
   getTeamMembers(team: any) {
@@ -834,12 +855,13 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     const progressData = filterByMember(filterByDate(this.progress?.steps?.data, 'time', dateRange), members);
     const chatData = filterByMember(filterByDate(this.chatActivities?.data, 'createdDate', dateRange), members);
     const voicesData = filterByMember(filterByDate(this.voicesActivities?.data, 'time', dateRange), members);
+    const healthData = filterByMember(filterByDate(this.healthExams?.data, 'date', dateRange), members);
 
     if (sortBy) {
       const order = sortBy.endsWith('Asc') ? 1 : -1;
       const sortFunction = (a, b) => {
-        const aDate = new Date(a.time || a.loginTime);
-        const bDate = new Date(b.time || b.loginTime);
+        const aDate = new Date(a.time || a.loginTime || a.date);
+        const bDate = new Date(b.time || b.loginTime || b.date);
         const comparison =
           (aDate.getFullYear() - bDate.getFullYear()) ||
           (aDate.getMonth() - bDate.getMonth());
@@ -851,6 +873,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       progressData.sort(sortFunction);
       chatData.sort(sortFunction);
       voicesData.sort(sortFunction);
+      healthData.sort(sortFunction);
     }
 
     this.csvService.exportSummaryCSV(
@@ -860,6 +883,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       progressData,
       chatData,
       voicesData,
+      healthData,
       this.planetName,
       dateRange.startDate,
       dateRange.endDate
@@ -881,7 +905,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       'resourceViews': this.resourceActivities.total.data,
       'courseViews': this.courseActivities.total.data,
       'stepCompletions': this.progress.steps.data,
-      'health': this.healthComponent && this.healthComponent.examinations
+      'health': this.healthExams.data
     }[reportType];
     const title = {
       'resourceViews': $localize`Resource Views`,

--- a/src/app/manager-dashboard/reports/reports-health.component.ts
+++ b/src/app/manager-dashboard/reports/reports-health.component.ts
@@ -49,7 +49,7 @@ export class ReportsHealthComponent implements OnChanges {
   @ViewChild('diagnosesChart') diagnosesChart;
   charts: any[] = [];
   showChart: boolean;
-  examinations;
+  @Input() examinations;
   weeklyHealthData = [];
   headlineData: { total: number, unique: string[], conditions: any };
   conditions = conditions;
@@ -65,21 +65,7 @@ export class ReportsHealthComponent implements OnChanges {
 
   ngOnChanges(changes) {
     const weeks = generateWeeksArray(this.dateRange);
-    if (this.planetCode && changes.planetCode && changes.planetCode.previousValue !== changes.planetCode.currentValue) {
-      this.headlineData = null;
-      this.healthLoadingChange.emit(true);
-      this.healthService.getExaminations(this.planetCode).subscribe(examinations => {
-        this.examinations = examinations;
-        this.setHealthData(weeks);
-      });
-    } else if (changes.isActive && changes.isActive.currentValue === true && !this.examinations) {
-      this.headlineData = null;
-      this.healthLoadingChange.emit(true);
-      this.healthService.getExaminations(this.planetCode).subscribe(examinations => {
-        this.examinations = examinations;
-        this.setHealthData(weeks);
-      });
-    } else if (this.examinations) {
+    if (this.examinations) {
       this.setHealthData(weeks);
     }
   }

--- a/src/app/manager-dashboard/reports/reports.utils.ts
+++ b/src/app/manager-dashboard/reports/reports.utils.ts
@@ -115,6 +115,7 @@ export const titleOfChartName = (chartName: string) => {
     stepCompletedChart: $localize`Steps Completed by Month`,
     chatUsageChart: $localize`Chats Created by Month`,
     voicesCreatedChart: $localize`Voices Created by Month`,
+    healthExamsCreatedChart: $localize`Health Exams Created by Month`
   };
   return chartNames[chartName];
 };
@@ -174,6 +175,12 @@ export const sortingOptionsMap = {
     { name: $localize`Date (Newest first)`, value: 'createdDateDesc' },
     { name: $localize`AI Provider (A-Z)`, value: 'aiProviderAsc' },
     { name: $localize`AI Provider (Z-A)`, value: 'aiProviderDesc' }
+  ],
+  'healthExams': [
+    { name: $localize`User (A-Z)`, value: 'userAsc' },
+    { name: $localize`User (Z-A)`, value: 'userDesc' },
+    { name: $localize`Date (Oldest first)`, value: 'createdDateAsc' },
+    { name: $localize`Date (Newest first)`, value: 'createdDateDesc' }
   ]
 };
 

--- a/src/app/shared/csv.service.ts
+++ b/src/app/shared/csv.service.ts
@@ -46,7 +46,7 @@ export class CsvService {
 
   exportSummaryCSV(
     logins: any[], resourceViews: any[], courseViews: any[], stepCompletions: any[],
-    chatActivities: any[], voicesActivities: any[], planetName: string, startDate: Date, endDate: Date
+    chatActivities: any[], voicesActivities: any[], healthExams: any[], planetName: string, startDate: Date, endDate: Date
   ) {
     const options = {
       title: $localize`Summary report for ${planetName}\n${formatDate(startDate)} - ${formatDate(endDate)}`,
@@ -61,6 +61,7 @@ export class CsvService {
     const groupedStepCompletions = this.reportsService.groupStepCompletion(stepCompletions).byMonth;
     const groupedChatData = this.reportsService.groupChatUsage(chatActivities).byMonth;
     const groupedVoicesData = this.reportsService.groupVoicesCreated(voicesActivities).byMonth;
+    const groupedHealthExams = this.reportsService.groupByMonth(healthExams, 'date', 'profileId');
     const formattedData = this.buildSummaryTable([
       { title: $localize`Unique Member Visits`, data: groupedLogins, countUnique: true },
       { title: $localize`Total Member Visits`, data: groupedLogins, countUnique: false },
@@ -68,7 +69,8 @@ export class CsvService {
       { title: $localize`Course Views`, data: groupedCourseViews, countUnique: false },
       { title: $localize`Steps Completed`, data: groupedStepCompletions, countUnique: false },
       { title: $localize`Chats Created`, data: groupedChatData, countUnique: false },
-      { title: $localize`Voices Created`, data: groupedVoicesData, countUnique: false }
+      { title: $localize`Voices Created`, data: groupedVoicesData, countUnique: false },
+      { title: $localize`Health Exams Created`, data: groupedHealthExams, countUnique: false }
     ]);
     this.generate(formattedData, options);
   }


### PR DESCRIPTION
Fixes #8772 

This PR completes the implementation of the "Health Exams Created by Month" chart on the manager reports dashboard, hooks up its date/member filtering, and integrates health examinations into both the health report export and the summary CSV export.

Additionally, it optimizes database traffic by moving the CouchDB fetch for health exams to the parent component (ReportsDetailComponent) and passing the list down to the child component (ReportsHealthComponent) as an @Input(), eliminating duplicate requests.

<img width="2469" height="465" alt="{EA63D3CE-EBFD-4C32-B6D5-F8939846D026}" src="https://github.com/user-attachments/assets/f94d87c0-55e8-46dd-b991-f54a35f01e43" />
