### PR TITLE
teams: cancel join request (fixes #10138)

### DIFF
--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -151,6 +151,12 @@
                       <label i18n> Request pending </label>
                     }
                   </button>
+                  <button mat-raised-button color="warn" (click)="cancelRequest(element.doc); $event.stopPropagation()">
+                    <mat-icon>cancel</mat-icon>
+                    @if (!isMobile) {
+                      <label i18n> Cancel Request </label>
+                    }
+                  </button>
                 }
               }
             }

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -362,6 +362,22 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     });
   }
 
+  cancelRequest(team) {
+    this.dialogsLoadingService.start();
+    this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+      switchMap(() => this.teamsService.getTeamMembers(team)),
+      switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team, url: this.router.url + '/view/' + team._id })),
+      switchMap(() => this.getMembershipStatus()),
+      finalize(() => this.dialogsLoadingService.stop())
+    ).subscribe(() => {
+      this.teams.data = this.teamList(this.teams.data);
+      const msg = this.mode === 'enterprise'
+        ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name
+        : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + team.name;
+      this.planetMessageService.showMessage(msg);
+    });
+  }
+
   resetSearch() {
     this.teams.filter = this.myTeamsFilter ? ' ' : '';
     this.filter = '';


### PR DESCRIPTION
Fixes #10138 
This is the first proposed solution for the cancel join request feature
- Adds `Cancel Request` component under teams action buttons for users with `requesting` membership status in a team
- Implements request retraction logic in `teams.component.ts`

<img width="304" height="288" alt="{42227F1C-0BF8-48F8-A4DE-2FEC08F82374}" src="https://github.com/user-attachments/assets/3c341fcf-4f9b-436d-a2b4-5d744c6e3178" />