### PR TITLE
teams: smoother join request canceling (fixes #10138)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.46",
+  "version": "0.23.67",
   "myplanet": {
     "latest": "v0.60.60",
     "min": "v0.59.59"

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -77,6 +77,7 @@
       }
       @case ('requesting') {
         <mat-chip-set aria-label="Request status" i18n-aria-label><mat-chip color="accent" highlighted i18n>Request pending</mat-chip></mat-chip-set>
+        <button mat-raised-button color="warn" class="toolbar-button margin-lr-3" (click)="cancelRequest()" i18n>Cancel Request</button>
       }
     }
   }

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -77,7 +77,7 @@
       }
       @case ('requesting') {
         <mat-chip-set aria-label="Request status" i18n-aria-label><mat-chip color="accent" highlighted i18n>Request pending</mat-chip></mat-chip-set>
-        <button mat-raised-button color="warn" class="toolbar-button margin-lr-3" (click)="openCancelRequestDialog()" i18n>Cancel Request</button>
+        <button mat-raised-button color="warn" class="toolbar-button margin-lr-3" (click)="openCancelJoinRequestDialog()" i18n>Cancel Join Request</button>
       }
     }
   }

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -77,7 +77,7 @@
       }
       @case ('requesting') {
         <mat-chip-set aria-label="Request status" i18n-aria-label><mat-chip color="accent" highlighted i18n>Request pending</mat-chip></mat-chip-set>
-        <button mat-raised-button color="warn" class="toolbar-button margin-lr-3" (click)="cancelRequest()" i18n>Cancel Request</button>
+        <button mat-raised-button color="warn" class="toolbar-button margin-lr-3" (click)="openCancelRequestDialog()" i18n>Cancel Request</button>
       }
     }
   }

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -439,9 +439,9 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     });
   }
 
-  cancelRequest() {
+  cancelJoinRequest() {
     return {
-      request: this.teamsService.removeFromRequests(this.team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+      request: this.teamsService.cancelJoinRequest(this.team).pipe(
         switchMap(() => this.getMembers())
       ),
       onNext: () => {
@@ -460,10 +460,10 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     };
   }
 
-  openCancelRequestDialog() {
+  openCancelJoinRequestDialog() {
     this.cancelDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
-        okClick: this.cancelRequest(),
+        okClick: this.cancelJoinRequest(),
         showMainParagraph: false,
         extraMessage: this.mode === 'enterprise'
           ? $localize`Are you sure you want to cancel the request to join the following enterprise?`

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -123,6 +123,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   mode: 'team' | 'enterprise' | 'services' = this.route.snapshot.data.mode || 'team';
   readonly dbName = 'teams';
   leaderDialog: any;
+  cancelDialog: any;
   finances: any[] = [];
   teamDataLoading = true;
   reports: any[] = [];
@@ -435,6 +436,33 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     this.changeMembershipRequest(type, memberDoc)().subscribe((message) => {
       this.setStatus(this.team, this.leader, this.userService.get());
       this.planetMessageService.showMessage(message);
+    });
+  }
+
+  cancelRequest() {
+    this.cancelDialog = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: this.teamsService.removeFromRequests(this.team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+            switchMap(() => this.teamsService.getTeamMembers(this.team)),
+            switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team: this.team, url: this.router.url })),
+            switchMap(() => this.getMembers())
+          ),
+          onNext: () => {
+            this.cancelDialog.close();
+            this.setStatus(this.team, this.leader, this.userService.get());
+            const msg = this.mode === 'enterprise'
+              ? $localize`Cancelled request to join enterprise` + ' ' + this.team.name
+              : $localize`Cancelled request to join team` + ' ' + this.team.name;
+            this.planetMessageService.showMessage(msg);
+          }
+        },
+        showMainParagraph: false,
+        extraMessage: this.mode === 'enterprise'
+          ? $localize`Are you sure you want to cancel the request to join the following enterprise?`
+          : $localize`Are you sure you want to cancel the request to join the following team?`,
+        displayName: this.team.name
+      }
     });
   }
 

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -332,7 +332,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   isUserInMemberDocs(memberDocs, user) {
-    return memberDocs.some((memberDoc: any) => memberDoc.userId === user._id && memberDoc.userPlanetCode === user.planetCode);
+    return memberDocs.some((memberDoc: any) => memberDoc.userId === user._id && memberDoc.userPlanetCode === this.planetCode);
   }
 
   toggleMembership(team, leaveTeam) {
@@ -441,11 +441,13 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   cancelJoinRequest() {
     return {
-      request: this.teamsService.cancelJoinRequest(this.team).pipe(
-        switchMap(() => this.getMembers())
-      ),
+      request: this.teamsService.cancelJoinRequest(this.team),
       onNext: () => {
         this.cancelDialog.close();
+        this.requests = this.requests.filter(request =>
+          request.userId !== this.user._id || request.userPlanetCode !== this.planetCode
+        );
+        this.setStatus(this.team, this.leader, this.userService.get());
         const msg = this.mode === 'enterprise'
           ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + this.team.name
           : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + this.team.name;

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -440,23 +440,30 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   cancelRequest() {
+    return {
+      request: this.teamsService.removeFromRequests(this.team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+        switchMap(() => this.getMembers())
+      ),
+      onNext: () => {
+        this.cancelDialog.close();
+        const msg = this.mode === 'enterprise'
+          ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + this.team.name
+          : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + this.team.name;
+        this.planetMessageService.showMessage(msg);
+      },
+      onError: () => {
+        const msg = this.mode === 'enterprise'
+          ? $localize`There was a problem cancelling your request to join this enterprise.`
+          : $localize`There was a problem cancelling your request to join this team.`;
+        this.planetMessageService.showAlert(msg);
+      }
+    };
+  }
+
+  openCancelRequestDialog() {
     this.cancelDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
-        okClick: {
-          request: this.teamsService.removeFromRequests(this.team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
-            switchMap(() => this.teamsService.getTeamMembers(this.team)),
-            switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team: this.team, url: this.router.url })),
-            switchMap(() => this.getMembers())
-          ),
-          onNext: () => {
-            this.cancelDialog.close();
-            this.setStatus(this.team, this.leader, this.userService.get());
-            const msg = this.mode === 'enterprise'
-              ? $localize`Cancelled request to join enterprise` + ' ' + this.team.name
-              : $localize`Cancelled request to join team` + ' ' + this.team.name;
-            this.planetMessageService.showMessage(msg);
-          }
-        },
+        okClick: this.cancelRequest(),
         showMainParagraph: false,
         extraMessage: this.mode === 'enterprise'
           ? $localize`Are you sure you want to cancel the request to join the following enterprise?`

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -145,11 +145,11 @@
                   </button>
                 }
                 @case ('requesting') {
-                  <button mat-raised-button color="warn" aria-label="Cancel Request" i18n-aria-label
-                    (click)="openCancelRequestDialog(element.doc); $event.stopPropagation()">
+                  <button mat-raised-button color="warn" aria-label="Cancel Join Request" i18n-aria-label
+                    (click)="openCancelJoinRequestDialog(element.doc); $event.stopPropagation()">
                     <mat-icon>cancel</mat-icon>
                     @if (!isMobile) {
-                      <label i18n> Cancel Request </label>
+                      <label i18n> Cancel Join Request </label>
                     }
                   </button>
                 }

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -145,7 +145,8 @@
                   </button>
                 }
                 @case ('requesting') {
-                  <button mat-raised-button color="warn" (click)="cancelRequest(element.doc); $event.stopPropagation()">
+                  <button mat-raised-button color="warn" aria-label="Cancel Request" i18n-aria-label
+                    (click)="openCancelRequestDialog(element.doc); $event.stopPropagation()">
                     <mat-icon>cancel</mat-icon>
                     @if (!isMobile) {
                       <label i18n> Cancel Request </label>

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -145,10 +145,10 @@
                   </button>
                 }
                 @case ('requesting') {
-                  <button mat-raised-button color="primary" disabled>
-                    <mat-icon>hourglass_empty</mat-icon>
+                  <button mat-raised-button color="warn" (click)="cancelRequest(element.doc); $event.stopPropagation()">
+                    <mat-icon>cancel</mat-icon>
                     @if (!isMobile) {
-                      <label i18n> Request pending </label>
+                      <label i18n> Cancel Request </label>
                     }
                   </button>
                 }

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -86,6 +86,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   leaveDialog: any;
   message = '';
   deleteDialog: any;
+  cancelDialog: any;
   isLoading = true;
   readonly myTeamsFilter = this.route.snapshot.data.myTeams ? 'on' : 'off';
   private _mode: 'team' | 'enterprise' = this.route.snapshot.data.mode || 'team';
@@ -363,18 +364,29 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   }
 
   cancelRequest(team) {
-    this.dialogsLoadingService.start();
-    this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
-      switchMap(() => this.teamsService.getTeamMembers(team)),
-      switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team, url: this.router.url + '/view/' + team._id })),
-      switchMap(() => this.getMembershipStatus()),
-      finalize(() => this.dialogsLoadingService.stop())
-    ).subscribe(() => {
-      this.teams.data = this.teamList(this.teams.data);
-      const msg = this.mode === 'enterprise'
-        ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name
-        : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + team.name;
-      this.planetMessageService.showMessage(msg);
+    this.cancelDialog = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+            switchMap(() => this.teamsService.getTeamMembers(team)),
+            switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team, url: this.router.url + '/view/' + team._id })),
+            switchMap(() => this.getMembershipStatus())
+          ),
+          onNext: () => {
+            this.cancelDialog.close();
+            this.teams.data = this.teamList(this.teams.data);
+            const msg = this.mode === 'enterprise'
+              ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name
+              : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + team.name;
+            this.planetMessageService.showMessage(msg);
+          }
+        },
+        showMainParagraph: false,
+        extraMessage: this.mode === 'enterprise'
+          ? $localize`Are you sure you want to cancel the request to join the following enterprise?`
+          : $localize`Are you sure you want to cancel the request to join the following team?`,
+        displayName: team.name
+      }
     });
   }
 

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -364,23 +364,31 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   }
 
   cancelRequest(team) {
+    return {
+      request: this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+        switchMap(() => this.getMembershipStatus())
+      ),
+      onNext: () => {
+        this.cancelDialog.close();
+        this.teams.data = this.teamList(this.teams.data);
+        const msg = this.mode === 'enterprise'
+          ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name
+          : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + team.name;
+        this.planetMessageService.showMessage(msg);
+      },
+      onError: () => {
+        const msg = this.mode === 'enterprise'
+          ? $localize`There was a problem cancelling your request to join this enterprise.`
+          : $localize`There was a problem cancelling your request to join this team.`;
+        this.planetMessageService.showAlert(msg);
+      }
+    };
+  }
+
+  openCancelRequestDialog(team) {
     this.cancelDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
-        okClick: {
-          request: this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
-            switchMap(() => this.teamsService.getTeamMembers(team)),
-            switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team, url: this.router.url + '/view/' + team._id })),
-            switchMap(() => this.getMembershipStatus())
-          ),
-          onNext: () => {
-            this.cancelDialog.close();
-            this.teams.data = this.teamList(this.teams.data);
-            const msg = this.mode === 'enterprise'
-              ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name
-              : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + team.name;
-            this.planetMessageService.showMessage(msg);
-          }
-        },
+        okClick: this.cancelRequest(team),
         showMainParagraph: false,
         extraMessage: this.mode === 'enterprise'
           ? $localize`Are you sure you want to cancel the request to join the following enterprise?`
@@ -389,7 +397,6 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       }
     });
   }
-
 
   resetSearch() {
     this.teams.filter = this.myTeamsFilter ? ' ' : '';

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -363,9 +363,9 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     });
   }
 
-  cancelRequest(team) {
+  cancelJoinRequest(team) {
     return {
-      request: this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+      request: this.teamsService.cancelJoinRequest(team).pipe(
         switchMap(() => this.getMembershipStatus())
       ),
       onNext: () => {
@@ -385,10 +385,10 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     };
   }
 
-  openCancelRequestDialog(team) {
+  openCancelJoinRequestDialog(team) {
     this.cancelDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
-        okClick: this.cancelRequest(team),
+        okClick: this.cancelJoinRequest(team),
         showMainParagraph: false,
         extraMessage: this.mode === 'enterprise'
           ? $localize`Are you sure you want to cancel the request to join the following enterprise?`

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -196,7 +196,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
 
   getMembershipStatus() {
     return forkJoin([
-      this.couchService.findAll(this.dbName, { 'selector': { 'userId': this.user._id, 'userPlanetCode': this.user.planetCode } }),
+      this.couchService.findAll(this.dbName, { 'selector': { 'userId': this.user._id, 'userPlanetCode': this.planetCode } }),
       this.couchService.get('shelf/' + this.user._id)
     ]).pipe(
       map(([ membershipDocs, shelf ]) => this.userMembership = [
@@ -365,11 +365,13 @@ export class TeamsComponent implements OnInit, AfterViewInit {
 
   cancelJoinRequest(team) {
     return {
-      request: this.teamsService.cancelJoinRequest(team).pipe(
-        switchMap(() => this.getMembershipStatus())
-      ),
+      request: this.teamsService.cancelJoinRequest(team),
       onNext: () => {
         this.cancelDialog.close();
+        this.userMembership = this.userMembership.filter(membership =>
+          membership.docType !== 'request' || membership.teamId !== team._id ||
+          membership.teamPlanetCode !== team.teamPlanetCode
+        );
         this.teams.data = this.teamList(this.teams.data);
         const msg = this.mode === 'enterprise'
           ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -362,6 +362,23 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     });
   }
 
+  cancelRequest(team) {
+    this.dialogsLoadingService.start();
+    this.teamsService.removeFromRequests(team, { userId: this.user._id, userPlanetCode: this.user.planetCode }).pipe(
+      switchMap(() => this.teamsService.getTeamMembers(team)),
+      switchMap((docs) => this.teamsService.sendNotifications('request', docs, { team, url: this.router.url + '/view/' + team._id })),
+      switchMap(() => this.getMembershipStatus()),
+      finalize(() => this.dialogsLoadingService.stop())
+    ).subscribe(() => {
+      this.teams.data = this.teamList(this.teams.data);
+      const msg = this.mode === 'enterprise'
+        ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + team.name
+        : $localize`:@@team-join-request-cancelled:Cancelled request to join team` + ' ' + team.name;
+      this.planetMessageService.showMessage(msg);
+    });
+  }
+
+
   resetSearch() {
     this.teams.filter = this.myTeamsFilter ? ' ' : '';
     this.filter = '';

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -149,6 +149,11 @@ export class TeamsService {
     );
   }
 
+  cancelJoinRequest(team) {
+    const user = this.userService.get();
+    return this.removeFromRequests(team, { userId: user._id, userPlanetCode: user.planetCode });
+  }
+
   toggleTeamMembership(team, leaveTeam, memberInfo) {
     return (memberInfo.fromShelf === true && leaveTeam === true ?
       this.updateShelf(memberInfo) :

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -151,7 +151,7 @@ export class TeamsService {
 
   cancelJoinRequest(team) {
     const user = this.userService.get();
-    return this.removeFromRequests(team, { userId: user._id, userPlanetCode: user.planetCode });
+    return this.removeFromRequests(team, { userId: user._id, userPlanetCode: this.stateService.configuration.code });
   }
 
   toggleTeamMembership(team, leaveTeam, memberInfo) {


### PR DESCRIPTION
Fixes #10138 
This is the second proposed solution to implement the cancel join request feature
- Changes `Request Pending` button to `Cancel Request` button
- Updates button onclick response to run `cancelRequest`
- Implements button response logic in `teams.component.ts`

<img width="224" height="155" alt="{999FAAA5-0657-413B-BF27-2B36CDE55CC9}" src="https://github.com/user-attachments/assets/56981ef6-5601-42df-abc8-d5a3a15f3b09" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Cancel Join Request” actions for teams where the user’s join request is pending (replacing the prior “Request pending” indicator).
  * Users now see a confirmation prompt before cancelling.
  * After cancellation, the teams list refreshes and localized success/error messages are shown (enterprise vs team mode).
* **Bug Fixes**
  * Corrected how membership/request status is matched using the active planet code, improving pending/member doc detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->