### PR TITLE
manager: less reports chart button top margin is more (fixes #10131)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.46",
+  "version": "0.23.52",
   "myplanet": {
-    "latest": "v0.60.60",
+    "latest": "v0.61.30",
     "min": "v0.59.59"
   },
   "scripts": {

--- a/src/app/manager-dashboard/reports/reports-detail.scss
+++ b/src/app/manager-dashboard/reports/reports-detail.scss
@@ -41,7 +41,6 @@ mat-toolbar mat-form-field {
 
     .chart-actions {
       position: absolute;
-      top: 0.5rem;
       right: 0.5rem;
       opacity: 0;
       transition: opacity 0.2s;


### PR DESCRIPTION
Fixes #10131 
- Removes a spacing causing the copy and export buttons for reports to clip into the report chart

## Before

<img width="197" height="161" alt="{F8A2FC13-9D34-448E-92A3-E9F94069A7A2}" src="https://github.com/user-attachments/assets/a3730356-0fe4-493c-9551-e1081396472b" />

## After

<img width="316" height="234" alt="{D47F1528-962A-42C0-9683-A723EE95353B}" src="https://github.com/user-attachments/assets/ad673236-abdd-49cc-bf40-b6b080b176be" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted report chart action positioning for a cleaner layout.

* **Chores**
  * Updated application and platform release version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->