### PR TITLE
all: smoother profile picture uploading (fixes #10136)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.46",
+  "version": "0.23.68",
   "myplanet": {
     "latest": "v0.60.60",
     "min": "v0.59.59"

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -156,7 +156,10 @@
         <img class="profile-image-update" [src]="previewSrc">
         }<br>
         <planet-file-upload #profileUpload accept="image/*" i18n-hint hint="JPG, PNG, GIF or WEBP" [typePills]="['JPG','PNG','GIF','WEBP']" (fileSelected)="openImageEditDialog($event)"></planet-file-upload>
-        <div class="action-buttons">
+        <div class="action-buttons image-action-buttons">
+          <span>
+            <label class="image-action-label" i18n>GIFs will be converted to static images</label>
+          </span>
           @if (imageFile || attachmentDeleted) {
             <button mat-raised-button color="accent" (click)="resetSelection()"><span i18n>Reset Selection</span></button>
           }

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -155,11 +155,8 @@
       @if (showImagePreview) {
         <img class="profile-image-update" [src]="previewSrc">
         }<br>
-        <planet-file-upload #profileUpload accept="image/*" i18n-hint hint="JPG, PNG, GIF or WEBP" [typePills]="['JPG','PNG','GIF','WEBP']" (fileSelected)="openImageEditDialog($event)"></planet-file-upload>
-        <div class="action-buttons image-action-buttons">
-          <span>
-            <label class="image-action-label" i18n>GIFs will be converted to static images</label>
-          </span>
+        <planet-file-upload #profileUpload accept="image/*" i18n-hint hint="Animated GIFs will be saved as static images." [typePills]="['JPG','PNG','GIF','WEBP']" (fileSelected)="openImageEditDialog($event)"></planet-file-upload>
+        <div class="action-buttons">
           @if (imageFile || attachmentDeleted) {
             <button mat-raised-button color="accent" (click)="resetSelection()"><span i18n>Reset Selection</span></button>
           }

--- a/src/app/users/users-update/users-update.scss
+++ b/src/app/users/users-update/users-update.scss
@@ -62,6 +62,18 @@
   justify-content: center;
 }
 
+.image-action-buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.image-action-label {
+  font-size: 0.8rem;
+  color: v.$grey-text;
+}
+
 .profile-image-column {
   flex: 1;
   justify-content: center;

--- a/src/app/users/users-update/users-update.scss
+++ b/src/app/users/users-update/users-update.scss
@@ -62,18 +62,6 @@
   justify-content: center;
 }
 
-.image-action-buttons {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.image-action-label {
-  font-size: 0.8rem;
-  color: v.$grey-text;
-}
-
 .profile-image-column {
   flex: 1;
   justify-content: center;


### PR DESCRIPTION
Fixes #10136 
This solution is 1 of 3 proposed solutions to #10136. This solution maintains simplicity by adding a text label stating that GIFs will be converted to static images. This solution does not modify file type limitations or attempt to implement GIFs as a form of working profile picture.

- Creates disclaimer label under image uploader
- Updates flex style and disclaimer label style

<img width="518" height="369" alt="{27895C97-0BEB-4393-A536-2A686977F9C7}" src="https://github.com/user-attachments/assets/6148bcba-3e17-4638-b398-7780ee495372" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the profile image upload guidance to clarify that animated GIFs are saved as static images.
  * Updated the displayed supported image formats to JPG, PNG, GIF, and WEBP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->