### PR TITLE
all: smoother markdown fullscreen handling (fixes #10145)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.70",
   "myplanet": {
     "latest": "v0.61.83",
     "min": "v0.60.60"

--- a/src/app/shared/forms/planet-markdown-textbox.component.spec.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.spec.ts
@@ -1,0 +1,109 @@
+import { vi } from 'vitest';
+import { ElementRef } from '@angular/core';
+import { of } from 'rxjs';
+import { PlanetMarkdownTextboxComponent } from './planet-markdown-textbox.component';
+
+describe('PlanetMarkdownTextboxComponent fullscreen layout', () => {
+  let component: PlanetMarkdownTextboxComponent | undefined;
+
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      disconnect() {}
+    });
+  });
+
+  afterEach(() => {
+    component?.ngOnDestroy();
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  function setupComponent(markup: string) {
+    document.body.innerHTML = markup;
+    document.querySelectorAll<HTMLElement>(
+      '.mat-mdc-dialog-actions, .actions-container, .exam-buttons, .action-buttons, div.action-button'
+    ).forEach(element => vi.spyOn(element, 'getClientRects').mockReturnValue([ {} as DOMRect ]));
+
+    const host = document.querySelector<HTMLElement>('planet-markdown-textbox');
+    return new PlanetMarkdownTextboxComponent(
+      null,
+      {
+        monitor: vi.fn().mockReturnValue(of(null)),
+        stopMonitoring: vi.fn()
+      } as any,
+      new ElementRef(host),
+      {} as any,
+      { runOutsideAngular: (callback: () => void) => callback() } as any
+    );
+  }
+
+  it('pins the owning action row without selecting nested controls', () => {
+    component = setupComponent(`
+      <form>
+        <div class="exam-buttons"></div>
+        <mat-accordion>
+          <planet-markdown-textbox></planet-markdown-textbox>
+        </mat-accordion>
+        <planet-step-list>
+          <div class="action-buttons"></div>
+        </planet-step-list>
+      </form>
+    `);
+    const examActions = document.querySelector<HTMLElement>('.exam-buttons');
+    const stepActions = document.querySelector<HTMLElement>('.action-buttons');
+
+    component.options.onToggleFullScreen(true);
+
+    expect(examActions.classList.contains('planet-markdown-fullscreen-actions')).toBe(true);
+    expect(stepActions.classList.contains('planet-markdown-fullscreen-actions')).toBe(false);
+  });
+
+  it('finds dialog actions through Material wrapper elements', () => {
+    component = setupComponent(`
+      <mat-dialog-container class="mat-mdc-dialog-container">
+        <div class="mat-mdc-dialog-inner-container">
+          <div class="mat-mdc-dialog-surface">
+            <form>
+              <mat-dialog-content>
+                <planet-markdown-textbox></planet-markdown-textbox>
+              </mat-dialog-content>
+              <mat-dialog-actions class="mat-mdc-dialog-actions"></mat-dialog-actions>
+            </form>
+          </div>
+        </div>
+      </mat-dialog-container>
+    `);
+    const dialogActions = document.querySelector<HTMLElement>('.mat-mdc-dialog-actions');
+
+    component.options.onToggleFullScreen(true);
+
+    expect(dialogActions.classList.contains('planet-markdown-fullscreen-actions')).toBe(true);
+  });
+
+  it('restores the marked elements when fullscreen ends', () => {
+    component = setupComponent(`
+      <form>
+        <div class="mat-mdc-form-field">
+          <planet-markdown-textbox></planet-markdown-textbox>
+        </div>
+        <div class="action-buttons"></div>
+      </form>
+    `);
+    const owner = document.querySelector<HTMLElement>('form');
+    const formField = document.querySelector<HTMLElement>('.mat-mdc-form-field');
+    const actions = document.querySelector<HTMLElement>('.action-buttons');
+    const host = document.querySelector<HTMLElement>('planet-markdown-textbox');
+
+    component.options.onToggleFullScreen(true);
+    expect(formField.classList.contains('planet-markdown-fullscreen-field')).toBe(true);
+
+    component.options.onToggleFullScreen(false);
+
+    expect(owner.classList.contains('planet-markdown-fullscreen-owner')).toBe(false);
+    expect(owner.style.getPropertyValue('--fullscreen-actions-height')).toBe('');
+    expect(formField.classList.contains('planet-markdown-fullscreen-field')).toBe(false);
+    expect(actions.classList.contains('planet-markdown-fullscreen-actions')).toBe(false);
+    expect(host.classList.contains('planet-markdown-fullscreen-host')).toBe(false);
+  });
+});

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -245,7 +245,7 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
 
     this.fullscreenState = layout;
     const host = this.elementRef.nativeElement as HTMLElement;
-    layout.formField = host.closest<HTMLElement>('.mat-mdc-form-field');
+    layout.formField = host.closest<HTMLElement>('.mat-mdc-form-field') ?? undefined;
     host.classList.add('planet-markdown-fullscreen-host');
     layout.formField?.classList.add('planet-markdown-fullscreen-field');
     layout.owner.classList.add('planet-markdown-fullscreen-owner');

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -1,5 +1,6 @@
 import {
-  Component, Input, Optional, Self, OnDestroy, HostBinding, EventEmitter, Output, OnInit, ViewEncapsulation, ElementRef, DoCheck, ViewChild
+  Component, Input, Optional, Self, OnDestroy, HostBinding, EventEmitter, Output, OnInit, ViewEncapsulation, ElementRef, DoCheck,
+  ViewChild, NgZone
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -12,6 +13,12 @@ import { NgClass } from '@angular/common';
 
 interface ImageInfo { resourceId: string; filename: string; markdown: string; }
 interface ValueWithImages { text: string; images: ImageInfo[]; }
+interface FullscreenState {
+  owner: HTMLElement;
+  actions: HTMLElement;
+  formField?: HTMLElement;
+  layoutObserver?: ResizeObserver;
+}
 
 @Component({
   'selector': 'planet-markdown-textbox',
@@ -26,6 +33,10 @@ interface ValueWithImages { text: string; images: ImageInfo[]; }
 export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoCheck, OnInit, OnDestroy {
 
   static nextId = 0;
+  // Action-row containers this component knows how to pin during fullscreen; a form whose
+  // action row uses a class not listed here keeps the old behavior (buttons hidden behind the overlay).
+  private static readonly actionSelector =
+    '.mat-mdc-dialog-actions, .actions-container, .exam-buttons, .action-buttons, div.action-button';
 
   @HostBinding() id = `planet-markdown-textbox-${PlanetMarkdownTextboxComponent.nextId++}`;
   @HostBinding('attr.aria-describedby') describedBy = '';
@@ -63,6 +74,7 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
   }
 
   private _placeholder: string;
+  private fullscreenState?: FullscreenState;
   @Input()
   get placeholder() {
     return this._placeholder;
@@ -94,14 +106,16 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
   options: any = {
     autoRefresh: true,
     hideIcons: [ 'image' ],
-    minHeight: 'var(--planet-markdown-textbox-height)'
+    minHeight: 'var(--planet-markdown-textbox-height)',
+    onToggleFullScreen: (isFullscreen: boolean) => this.setFullscreenLayout(isFullscreen)
   };
 
   constructor(
     @Optional() @Self() public ngControl: NgControl,
     private focusMonitor: FocusMonitor,
     private elementRef: ElementRef,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private ngZone: NgZone
   ) {
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
@@ -207,8 +221,86 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
   }
 
   ngOnDestroy() {
-    this.focusMonitor.stopMonitoring(this.elementRef.nativeElement);
-    this.stateChanges.complete();
+    try {
+      if (this.editor?.easyMDE?.isFullscreenActive()) {
+        this.editor.toggleFullScreen();
+      }
+    } finally {
+      this.clearFullscreenLayout();
+      this.focusMonitor.stopMonitoring(this.elementRef.nativeElement);
+      this.stateChanges.complete();
+    }
+  }
+
+  private setFullscreenLayout(isFullscreen: boolean) {
+    this.clearFullscreenLayout();
+    if (!isFullscreen) {
+      return;
+    }
+
+    const layout = this.findFullscreenLayout();
+    if (!layout) {
+      return;
+    }
+
+    this.fullscreenState = layout;
+    const host = this.elementRef.nativeElement as HTMLElement;
+    layout.formField = host.closest<HTMLElement>('.mat-mdc-form-field');
+    host.classList.add('planet-markdown-fullscreen-host');
+    layout.formField?.classList.add('planet-markdown-fullscreen-field');
+    layout.owner.classList.add('planet-markdown-fullscreen-owner');
+    layout.actions.classList.add('planet-markdown-fullscreen-actions');
+
+    this.updateFullscreenLayout();
+    this.ngZone.runOutsideAngular(() => {
+      layout.layoutObserver = new ResizeObserver(() => this.updateFullscreenLayout());
+      layout.layoutObserver.observe(layout.actions);
+    });
+  }
+
+  private findFullscreenLayout(): FullscreenState | undefined {
+    const host = this.elementRef.nativeElement as HTMLElement;
+    let owner = host.parentElement;
+    while (owner && owner !== document.body) {
+      const actions = this.findVisibleActions(owner);
+      if (actions) {
+        return { owner, actions };
+      }
+      owner = owner.parentElement;
+    }
+    return undefined;
+  }
+
+  private findVisibleActions(owner: HTMLElement): HTMLElement | undefined {
+    return Array.from(owner.children)
+      .filter((element): element is HTMLElement => element instanceof HTMLElement)
+      .find(element =>
+        element.matches(PlanetMarkdownTextboxComponent.actionSelector) &&
+        element.getClientRects().length > 0
+      );
+  }
+
+  private updateFullscreenLayout() {
+    const state = this.fullscreenState;
+    if (!state) {
+      return;
+    }
+    const actionsHeight = Math.ceil(state.actions.getBoundingClientRect().height);
+    state.owner.style.setProperty('--fullscreen-actions-height', `${actionsHeight}px`);
+  }
+
+  private clearFullscreenLayout() {
+    const state = this.fullscreenState;
+    if (!state) {
+      return;
+    }
+    state.layoutObserver?.disconnect();
+    state.owner.classList.remove('planet-markdown-fullscreen-owner');
+    state.owner.style.removeProperty('--fullscreen-actions-height');
+    state.actions.classList.remove('planet-markdown-fullscreen-actions');
+    state.formField?.classList.remove('planet-markdown-fullscreen-field');
+    (this.elementRef.nativeElement as HTMLElement).classList.remove('planet-markdown-fullscreen-host');
+    this.fullscreenState = undefined;
   }
 
   writeValue(val: string) {

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -55,14 +55,14 @@ planet-markdown-textbox {
   background: white !important;
 }
 
-.EasyMDEContainer .CodeMirror-fullscreen,
-.EasyMDEContainer .editor-preview-full,
-.EasyMDEContainer .editor-preview-side {
-  bottom: 52px !important;
-}
-
 :has(.CodeMirror-fullscreen),
 :has(.editor-toolbar.fullscreen) {
+  --fullscreen-actions-height: 52px;
+
+  @media (max-width: 600px) {
+    --fullscreen-actions-height: 88px;
+  }
+
   .mat-mdc-dialog-actions,
   mat-dialog-actions,
   .action-buttons {
@@ -71,6 +71,7 @@ planet-markdown-textbox {
     left: 0 !important;
     right: 0 !important;
     width: 100% !important;
+    min-height: var(--fullscreen-actions-height) !important;
     margin: 0 !important;
     padding: 8px 16px !important;
     box-sizing: border-box !important;
@@ -80,7 +81,15 @@ planet-markdown-textbox {
     display: flex !important;
     justify-content: flex-end !important;
     align-items: center !important;
+    flex-wrap: wrap !important;
     gap: 8px !important;
   }
 }
+
+.EasyMDEContainer .CodeMirror-fullscreen,
+.EasyMDEContainer .editor-preview-full,
+.EasyMDEContainer .editor-preview-side {
+  bottom: var(--fullscreen-actions-height, 52px) !important;
+}
+
 

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -63,10 +63,12 @@ planet-markdown-textbox {
   .planet-markdown-fullscreen-actions {
     position: fixed;
     inset: auto 0 0;
+
     // Rows styled `width: 100%` would over-constrain the fixed box and drop `right`.
     width: auto;
     margin: 0;
     padding: 8px 16px;
+
     // EasyMDE uses z-index 7-9 for its fullscreen surfaces.
     z-index: 10;
     background: v.$white;
@@ -121,6 +123,7 @@ planet-markdown-textbox {
   &:has(planet-markdown-textbox.is-invalid) .mat-mdc-form-field-subscript-wrapper {
     position: fixed;
     inset: auto 0 var(--fullscreen-actions-height, 0px);
+
     // Material sets width: 100%; with left and right set it must yield or `right` is ignored.
     width: auto;
     padding: 4px 0;

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -54,3 +54,33 @@ planet-markdown-textbox {
 .editor-preview-full, .editor-toolbar.fullscreen {
   background: white !important;
 }
+
+.EasyMDEContainer .CodeMirror-fullscreen,
+.EasyMDEContainer .editor-preview-full,
+.EasyMDEContainer .editor-preview-side {
+  bottom: 52px !important;
+}
+
+:has(.CodeMirror-fullscreen),
+:has(.editor-toolbar.fullscreen) {
+  .mat-mdc-dialog-actions,
+  mat-dialog-actions,
+  .action-buttons {
+    position: fixed !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    width: 100% !important;
+    margin: 0 !important;
+    padding: 8px 16px !important;
+    box-sizing: border-box !important;
+    z-index: 1001 !important;
+    background: #fff !important;
+    border-top: 1px solid #ddd !important;
+    display: flex !important;
+    justify-content: flex-end !important;
+    align-items: center !important;
+    gap: 8px !important;
+  }
+}
+

--- a/src/app/shared/forms/planet-markdown-textbox.scss
+++ b/src/app/shared/forms/planet-markdown-textbox.scss
@@ -51,45 +51,93 @@ planet-markdown-textbox {
 // EasyMDE fullscreen surfaces need an explicit background after the MDC form migration;
 // otherwise the app chrome shows through the fixed preview/editor layer.
 .EasyMDEContainer .CodeMirror-fullscreen,
+.planet-markdown-fullscreen-host .editor-preview-side,
 .editor-preview-full, .editor-toolbar.fullscreen {
-  background: white !important;
+  background: v.$white !important;
 }
 
-:has(.CodeMirror-fullscreen),
-:has(.editor-toolbar.fullscreen) {
-  --fullscreen-actions-height: 52px;
-
-  @media (max-width: 600px) {
-    --fullscreen-actions-height: 88px;
+// The component marks only the nearest owner/action pair and measures the row's rendered
+// height, so wrapped button rows still fit; when no action row is found it adds no classes
+// and fullscreen behaves as before.
+.planet-markdown-fullscreen-owner {
+  .planet-markdown-fullscreen-actions {
+    position: fixed;
+    inset: auto 0 0;
+    // Rows styled `width: 100%` would over-constrain the fixed box and drop `right`.
+    width: auto;
+    margin: 0;
+    padding: 8px 16px;
+    // EasyMDE uses z-index 7-9 for its fullscreen surfaces.
+    z-index: 10;
+    background: v.$white;
+    border-top: 1px solid v.$medium-grey;
   }
 
-  .mat-mdc-dialog-actions,
-  mat-dialog-actions,
-  .action-buttons {
-    position: fixed !important;
-    bottom: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    width: 100% !important;
-    min-height: var(--fullscreen-actions-height) !important;
-    margin: 0 !important;
-    padding: 8px 16px !important;
-    box-sizing: border-box !important;
-    z-index: 1001 !important;
-    background: #fff !important;
-    border-top: 1px solid #ddd !important;
-    display: flex !important;
-    justify-content: flex-end !important;
-    align-items: center !important;
-    flex-wrap: wrap !important;
-    gap: 8px !important;
+  &:has(.planet-markdown-fullscreen-host .CodeMirror-sided) .planet-markdown-fullscreen-actions {
+    right: 50%;
   }
 }
 
-.EasyMDEContainer .CodeMirror-fullscreen,
-.EasyMDEContainer .editor-preview-full,
-.EasyMDEContainer .editor-preview-side {
-  bottom: var(--fullscreen-actions-height, 52px) !important;
+.planet-markdown-fullscreen-host {
+  position: relative;
+  z-index: 2;
+
+  .EasyMDEContainer {
+    .CodeMirror-fullscreen,
+    .editor-preview-full,
+    .editor-preview-side {
+      bottom: var(--fullscreen-actions-height, 0px) !important;
+    }
+  }
+
+  // In side-by-side the preview keeps its full half; only the editor column and the
+  // rows pinned below it shift up for the action bar.
+  &:has(.CodeMirror-sided) {
+    // Covalent's side preview paints no background of its own until EasyMDE renders
+    // into it; keep an opaque canvas behind the right half so the page never shows
+    // through. The fullscreen toolbar and preview sit at z-index 9 and stay above it.
+    &::after {
+      content: '';
+      position: fixed;
+      inset: 0 0 0 50%;
+      z-index: 8;
+      background: v.$white;
+    }
+
+    .EasyMDEContainer .editor-preview-side {
+      bottom: 0 !important;
+    }
+  }
 }
 
+.planet-markdown-fullscreen-field {
+  // Sibling Material form fields create their own paint layers that would otherwise
+  // sit above the fullscreen editor; lift the field that contains it.
+  position: relative;
+  z-index: 2;
 
+  // This component only reports an error while the editor is empty (see setErrorState),
+  // so the pinned message can overlay the editor's bottom edge without reserving space.
+  &:has(planet-markdown-textbox.is-invalid) .mat-mdc-form-field-subscript-wrapper {
+    position: fixed;
+    inset: auto 0 var(--fullscreen-actions-height, 0px);
+    // Material sets width: 100%; with left and right set it must yield or `right` is ignored.
+    width: auto;
+    padding: 4px 0;
+    z-index: 10;
+    background: v.$white;
+
+    &::before {
+      display: none;
+    }
+
+    .mat-mdc-form-field-error-wrapper {
+      // Grow the strip with wrapped or localized messages instead of overflowing it.
+      position: static;
+    }
+  }
+
+  &:has(.CodeMirror-sided):has(planet-markdown-textbox.is-invalid) .mat-mdc-form-field-subscript-wrapper {
+    right: 50%;
+  }
+}


### PR DESCRIPTION
Fixes #10145 
- Repositions markdown text box action buttons to be placed at the bottom of the panel when in fullscreen mode.

<img width="1829" height="1061" alt="image" src="https://github.com/user-attachments/assets/39d88b37-65df-40cc-8eaf-2c38fe85534e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen markdown editor visuals so preview and editing surfaces keep a clean white background and stay correctly offset from the page chrome.
  * Refined fullscreen action controls to use a consistent fixed bottom bar with correct stacking, padding, and split-editor alignment.
  * Improved fullscreen form validation presentation so field errors/subscripts remain readable and properly positioned.
* **Tests**
  * Added automated tests covering fullscreen class styling, fullscreen start/stop cleanup, and CSS variable resets for consistent layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->