### PR TITLE
courses: smoother draft discarding (fixes #10152)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.71",
   "myplanet": {
     "latest": "v0.61.83",
     "min": "v0.60.60"

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -1,16 +1,19 @@
 <mat-toolbar>
   <a mat-icon-button (click)="navigateBack()"><mat-icon>arrow_back</mat-icon></a>
   @if (pageType) {
-    <span i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</span>
+  <span i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</span>
   }
 </mat-toolbar>
 
 <div class="space-container">
-  <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</mat-toolbar>
+  <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}}
+    Course</mat-toolbar>
   <div class="view-container view-full-height">
     <div class="course-content">
       <mat-accordion>
-        <mat-expansion-panel class="course-details-panel" [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded" (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
+        <mat-expansion-panel class="course-details-panel"
+          [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded"
+          (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
           <mat-expansion-panel-header>
             <mat-panel-title class="course-title-header" i18n>
               Course Details: {{ (courseForm.controls.courseTitle.value || newCourseLabel) | truncateText:50 }}
@@ -21,12 +24,15 @@
               <mat-form-field class="full-width">
                 <mat-label i18n>Course Title</mat-label>
                 <input matInput formControlName="courseTitle" required>
-                <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+                <mat-error><planet-form-error-messages class="km-coursetitle-errormessage"
+                    [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
               </mat-form-field>
               <mat-form-field class="full-width mat-form-field-type-no-underline">
                 <mat-label i18n>Description</mat-label>
-                <planet-markdown-textbox class="full-width" required="true" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-                <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+                <planet-markdown-textbox class="full-width" required="true"
+                  [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+                <mat-error><planet-form-error-messages
+                    [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
               </mat-form-field>
               <div class="collections-field">
                 <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
@@ -37,9 +43,9 @@
                   <input matInput formControlName="languageOfInstruction" [matAutocomplete]="auto">
                   <mat-autocomplete #auto="matAutocomplete">
                     @for (language of languageNames; track language) {
-                      <mat-option [value]="language">
-                        {{ language }}
-                      </mat-option>
+                    <mat-option [value]="language">
+                      {{ language }}
+                    </mat-option>
                     }
                   </mat-autocomplete>
                 </mat-form-field>
@@ -47,7 +53,7 @@
                   <mat-label i18n>Grade Level</mat-label>
                   <mat-select formControlName="gradeLevel" required>
                     @for (grade of gradeLevels; track grade) {
-                      <mat-option [value]="grade.value">{{grade.label}}</mat-option>
+                    <mat-option [value]="grade.value">{{grade.label}}</mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
@@ -55,21 +61,16 @@
                   <mat-label i18n>Subject Level</mat-label>
                   <mat-select formControlName="subjectLevel" required>
                     @for (sub of subjectLevels; track sub) {
-                      <mat-option [value]="sub.value">{{sub.label}}</mat-option>
+                    <mat-option [value]="sub.value">{{sub.label}}</mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
               </div>
               <div class="cover-field">
                 <label class="cover-label" i18n>Cover image</label>
-                <planet-file-upload
-                  accept="image/*"
-                  [imagePreview]="true"
-                  [maxFiles]="1"
-                  [typePills]="['IMG']"
+                <planet-file-upload accept="image/*" [imagePreview]="true" [maxFiles]="1" [typePills]="['IMG']"
                   hint="Recommended: a square image. Covers are cropped to fit." i18n-hint
-                  [existingAttachments]="existingCoverAttachments"
-                  (stateChange)="onCoverStateChange($event)">
+                  [existingAttachments]="existingCoverAttachments" (stateChange)="onCoverStateChange($event)">
                 </planet-file-upload>
               </div>
             </form>
@@ -77,17 +78,20 @@
         </mat-expansion-panel>
       </mat-accordion>
       <div class="steps-container" [hidden]="steps.length === 0">
-        <planet-courses-step [(steps)]="steps" (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
+        <planet-courses-step [(steps)]="steps"
+          (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
       </div>
     </div>
     <div class="actions-container">
-      <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
+      <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary"
+        i18n>Submit</button>
       <button type="button" mat-stroked-button color="primary" (click)="addStep()">
         <mat-icon>add</mat-icon>
         <span i18n>Add Step</span>
       </button>
       @if (draftExists) {
-        <button type="button" mat-stroked-button (click)="deleteDraft()" i18n="@@discardDraftButton">Discard Draft</button>
+      <button type="button" mat-stroked-button color="warn" (click)="deleteDraft()" i18n="@@discardDraftButton">Discard
+        Draft</button>
       }
       <button type="button" mat-stroked-button color="warn" (click)="cancel()" i18n>Cancel</button>
     </div>

--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -1,19 +1,16 @@
 <mat-toolbar>
   <a mat-icon-button (click)="navigateBack()"><mat-icon>arrow_back</mat-icon></a>
   @if (pageType) {
-  <span i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</span>
+    <span i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</span>
   }
 </mat-toolbar>
 
 <div class="space-container">
-  <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}}
-    Course</mat-toolbar>
+  <mat-toolbar class="primary-color font-size-1" i18n>{this.pageType, select, Add {Add} Edit {Edit}} Course</mat-toolbar>
   <div class="view-container view-full-height">
     <div class="course-content">
       <mat-accordion>
-        <mat-expansion-panel class="course-details-panel"
-          [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded"
-          (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
+        <mat-expansion-panel class="course-details-panel" [class.course-details-invalid]="submitAttempted && courseForm.invalid" [expanded]="isFormExpanded" (opened)="openCourseDetails()" (closed)="isFormExpanded = false">
           <mat-expansion-panel-header>
             <mat-panel-title class="course-title-header" i18n>
               Course Details: {{ (courseForm.controls.courseTitle.value || newCourseLabel) | truncateText:50 }}
@@ -24,15 +21,12 @@
               <mat-form-field class="full-width">
                 <mat-label i18n>Course Title</mat-label>
                 <input matInput formControlName="courseTitle" required>
-                <mat-error><planet-form-error-messages class="km-coursetitle-errormessage"
-                    [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+                <mat-error><planet-form-error-messages class="km-coursetitle-errormessage" [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
               </mat-form-field>
               <mat-form-field class="full-width mat-form-field-type-no-underline">
                 <mat-label i18n>Description</mat-label>
-                <planet-markdown-textbox class="full-width" required="true"
-                  [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
-                <mat-error><planet-form-error-messages
-                    [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+                <planet-markdown-textbox class="full-width" required="true" [formControl]="courseForm.controls.description" imageGroup="community"></planet-markdown-textbox>
+                <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
               </mat-form-field>
               <div class="collections-field">
                 <planet-tag-input [formControl]="tags" [db]="dbName" mode="add"></planet-tag-input>
@@ -43,9 +37,9 @@
                   <input matInput formControlName="languageOfInstruction" [matAutocomplete]="auto">
                   <mat-autocomplete #auto="matAutocomplete">
                     @for (language of languageNames; track language) {
-                    <mat-option [value]="language">
-                      {{ language }}
-                    </mat-option>
+                      <mat-option [value]="language">
+                        {{ language }}
+                      </mat-option>
                     }
                   </mat-autocomplete>
                 </mat-form-field>
@@ -53,7 +47,7 @@
                   <mat-label i18n>Grade Level</mat-label>
                   <mat-select formControlName="gradeLevel" required>
                     @for (grade of gradeLevels; track grade) {
-                    <mat-option [value]="grade.value">{{grade.label}}</mat-option>
+                      <mat-option [value]="grade.value">{{grade.label}}</mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
@@ -61,16 +55,21 @@
                   <mat-label i18n>Subject Level</mat-label>
                   <mat-select formControlName="subjectLevel" required>
                     @for (sub of subjectLevels; track sub) {
-                    <mat-option [value]="sub.value">{{sub.label}}</mat-option>
+                      <mat-option [value]="sub.value">{{sub.label}}</mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
               </div>
               <div class="cover-field">
                 <label class="cover-label" i18n>Cover image</label>
-                <planet-file-upload accept="image/*" [imagePreview]="true" [maxFiles]="1" [typePills]="['IMG']"
+                <planet-file-upload
+                  accept="image/*"
+                  [imagePreview]="true"
+                  [maxFiles]="1"
+                  [typePills]="['IMG']"
                   hint="Recommended: a square image. Covers are cropped to fit." i18n-hint
-                  [existingAttachments]="existingCoverAttachments" (stateChange)="onCoverStateChange($event)">
+                  [existingAttachments]="existingCoverAttachments"
+                  (stateChange)="onCoverStateChange($event)">
                 </planet-file-upload>
               </div>
             </form>
@@ -78,20 +77,17 @@
         </mat-expansion-panel>
       </mat-accordion>
       <div class="steps-container" [hidden]="steps.length === 0">
-        <planet-courses-step [(steps)]="steps"
-          (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
+        <planet-courses-step [(steps)]="steps" (stepEditorOpenChange)="onStepEditorOpenChange($event)"></planet-courses-step>
       </div>
     </div>
     <div class="actions-container">
-      <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary"
-        i18n>Submit</button>
+      <button type="submit" (click)="onSubmit()" [planetSubmit]="courseForm.valid" mat-raised-button color="primary" i18n>Submit</button>
       <button type="button" mat-stroked-button color="primary" (click)="addStep()">
         <mat-icon>add</mat-icon>
         <span i18n>Add Step</span>
       </button>
       @if (draftExists) {
-      <button type="button" mat-stroked-button color="warn" (click)="deleteDraft()" i18n="@@discardDraftButton">Discard
-        Draft</button>
+        <button type="button" mat-stroked-button (click)="deleteDraft()" i18n="@@discardDraftButton">Discard Draft</button>
       }
       <button type="button" mat-stroked-button color="warn" (click)="cancel()" i18n>Cancel</button>
     </div>

--- a/src/app/courses/add-courses/courses-add.component.spec.ts
+++ b/src/app/courses/add-courses/courses-add.component.spec.ts
@@ -12,6 +12,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
 
+import { MatDialog } from '@angular/material/dialog';
+import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
+
 describe('CoursesAddComponent', () => {
   let component: CoursesAddComponent;
   let fixture: ComponentFixture<CoursesAddComponent>;
@@ -73,32 +76,29 @@ describe('CoursesAddComponent', () => {
     expect(component.courseForm.controls.courseTitle.hasError('required')).toBe(true);
   });
 
-  // test addCourse()
-  // it('should make a post request to CouchDB', () => {
-  //   postSpy = spyOn(couchService, 'post').and.returnValue(of({ ...testCourseForm }));
-  //   component.addCourse(testCourseForm);
-  //   fixture.detectChanges();
-  //   fixture.whenStable().then(() => {
-  //     expect(postSpy).toHaveBeenCalled();
-  //   });
-  // });
-
   // test cancel()
   it('should cancel', () => {
     expect(component.cancel()).toBe(undefined);
   });
 
-  // test onDayChange()
-  // it('should onDayChange', () => {
-  //   expect(component.onDayChange('Monday', true)).toBe(undefined);
-  // });
+  it('should not open dialog when deleteDraft is called and draftExists is false', () => {
+    const dialog = TestBed.inject(MatDialog);
+    const openSpy = vi.spyOn(dialog, 'open');
+    component.draftExists = false;
+    component.deleteDraft();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
 
-  // test toogleWeekly()
-  // it('should toogleDaily', () => {
-  //   component.toggleDaily(false);
-  //   fixture.whenStable().then(() => {
-  //     fixture.detectChanges();
-  //     expect(component.showDaysCheckBox).toBe(false);
-  //   });
-  // });
+  it('should open confirmation dialog when deleteDraft is called and draftExists is true', () => {
+    const dialog = TestBed.inject(MatDialog);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({ close: vi.fn() } as any);
+    component.draftExists = true;
+    component.deleteDraft();
+    expect(openSpy).toHaveBeenCalledWith(DialogsPromptComponent, expect.objectContaining({
+      data: expect.objectContaining({
+        changeType: 'delete',
+        type: 'course'
+      })
+    }));
+  });
 });

--- a/src/app/courses/add-courses/courses-add.component.spec.ts
+++ b/src/app/courses/add-courses/courses-add.component.spec.ts
@@ -9,19 +9,17 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CouchService } from '../../shared/couchdb.service';
 import { MaterialModule } from '../../shared/material.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { of } from 'rxjs';
+import { Subject } from 'rxjs';
 import { vi } from 'vitest';
 
 import { MatDialog } from '@angular/material/dialog';
 import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
+import { PouchService } from '../../shared/database/pouch.service';
+import { PlanetMessageService } from '../../shared/planet-message.service';
 
 describe('CoursesAddComponent', () => {
   let component: CoursesAddComponent;
   let fixture: ComponentFixture<CoursesAddComponent>;
-  let couchService;
-  let testCourseForm;
-  let de;
-  let postSpy: any;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -54,31 +52,28 @@ describe('CoursesAddComponent', () => {
     });
     fixture = TestBed.createComponent(CoursesAddComponent);
     component = fixture.componentInstance;
-    couchService = fixture.debugElement.injector.get(CouchService);
-    de = fixture.debugElement;
-    postSpy = fixture.debugElement.injector.get(CouchService);
-    testCourseForm = { courseTitle: 'OLE Test 1', description: 'First test for VIs' };
+  });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // test createForm()
-  it('should createForm', () => {
-    expect(component.createForm()).toBe(undefined);
-  });
-
-  // test onSubmit()
-  it('should onSubmit', () => {
+  it('should mark the course title as required when an empty form is submitted', () => {
     component.onSubmit();
     expect(component.courseForm.controls.courseTitle.hasError('required')).toBe(true);
   });
 
-  // test cancel()
-  it('should cancel', () => {
-    expect(component.cancel()).toBe(undefined);
+  it('should navigate back when cancel is clicked', () => {
+    const router = TestBed.inject(Router);
+    component.cancel();
+    expect(router.navigate).toHaveBeenCalledWith(
+      [ '../' ],
+      { relativeTo: TestBed.inject(ActivatedRoute) }
+    );
   });
 
   it('should not open dialog when deleteDraft is called and draftExists is false', () => {
@@ -91,14 +86,116 @@ describe('CoursesAddComponent', () => {
 
   it('should open confirmation dialog when deleteDraft is called and draftExists is true', () => {
     const dialog = TestBed.inject(MatDialog);
-    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({ close: vi.fn() } as any);
+    const pouchService = TestBed.inject(PouchService);
+    const afterClosed$ = new Subject<void>();
+    const dialogRef = { close: vi.fn(), afterClosed: () => afterClosed$ } as any;
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue(dialogRef);
+    const deleteDraftSpy = vi.spyOn(pouchService, 'deleteDocEditing').mockImplementation(() => undefined);
+    component.courseForm.controls.courseTitle.setValue('Test draft');
     component.draftExists = true;
     component.deleteDraft();
     expect(openSpy).toHaveBeenCalledWith(DialogsPromptComponent, expect.objectContaining({
       data: expect.objectContaining({
         changeType: 'delete',
-        type: 'course'
+        type: 'courseDraft',
+        displayName: 'Test draft'
       })
     }));
+    const config = openSpy.mock.calls[0][1];
+    if (config === undefined) {
+      throw new Error('Expected the course draft dialog configuration');
+    }
+    expect(config.data.okClick).toEqual(expect.objectContaining({
+      request: expect.anything(),
+      onNext: expect.any(Function)
+    }));
+    expect(component.deleteDialog).toBe(dialogRef);
+    afterClosed$.next();
+    expect(component.deleteDialog).toBeNull();
+    expect(component.draftExists).toBe(true);
+    expect(deleteDraftSpy).not.toHaveBeenCalled();
+  });
+
+  it('should discard the draft when the confirmation is accepted', () => {
+    const dialog = TestBed.inject(MatDialog);
+    const dialogRef = { close: vi.fn(), afterClosed: () => new Subject<void>() } as any;
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue(dialogRef);
+    const deleteDraftSpy = vi.spyOn(TestBed.inject(PouchService), 'deleteDocEditing').mockImplementation(() => undefined);
+    const showMessageSpy = vi.spyOn(TestBed.inject(PlanetMessageService), 'showMessage');
+    const coverUpload = { clear: vi.fn() };
+    component.coverUploadComponent = coverUpload as any;
+    component.coursesStepComponent = { toList: vi.fn() } as any;
+    component.courseId = 'new-draft';
+    component.existingCoverAttachments = [ {
+      name: 'draft-cover.png',
+      contentType: 'image/png',
+      url: 'draft-cover-url'
+    } ];
+    component.courseForm.patchValue({
+      courseTitle: 'New draft',
+      description: 'Draft description'
+    });
+    component.draftExists = true;
+
+    component.deleteDraft();
+    const config = openSpy.mock.calls[0][1];
+    if (config === undefined) {
+      throw new Error('Expected the course draft dialog configuration');
+    }
+    config.data.okClick.request.subscribe(config.data.okClick.onNext);
+
+    expect(component.draftExists).toBe(false);
+    expect(component.courseForm.controls.courseTitle.value).toBe('');
+    expect(component.courseForm.controls.description.value).toBe('');
+    expect(component.existingCoverAttachments).toEqual([]);
+    expect(coverUpload.clear).toHaveBeenCalled();
+    expect(deleteDraftSpy).toHaveBeenCalledWith('courses', component.courseId);
+    expect(showMessageSpy).toHaveBeenCalledWith('Draft discarded');
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should restore the saved course when an edited draft is discarded', () => {
+    const dialog = TestBed.inject(MatDialog);
+    const dialogRef = { close: vi.fn(), afterClosed: () => new Subject<void>() } as any;
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue(dialogRef);
+    vi.spyOn(TestBed.inject(PouchService), 'deleteDocEditing').mockImplementation(() => undefined);
+    component.coursesStepComponent = { toList: vi.fn() } as any;
+    component.savedCourse = {
+      _id: 'saved-course',
+      courseTitle: 'Saved course',
+      description: 'Saved description',
+      coverFileName: 'saved-cover.png',
+      _attachments: {
+        'saved-cover.png': { content_type: 'image/png' }
+      },
+      steps: [ {
+        stepTitle: 'Saved step',
+        description: 'Saved step description',
+        resources: [],
+        images: []
+      } ],
+      tags: [ 'saved-tag' ]
+    };
+    component.courseForm.patchValue({
+      courseTitle: 'Edited draft',
+      description: 'Edited description'
+    });
+    component.courseForm.markAsDirty();
+    component.draftExists = true;
+
+    component.deleteDraft();
+    const config = openSpy.mock.calls[0][1];
+    if (config === undefined) {
+      throw new Error('Expected the course draft dialog configuration');
+    }
+    config.data.okClick.request.subscribe(config.data.okClick.onNext);
+
+    expect(component.courseForm.controls.courseTitle.value).toBe('Saved course');
+    expect(component.courseForm.controls.description.value).toBe('Saved description');
+    expect(component.steps[0].stepTitle).toBe('Saved step');
+    expect(component.tags.value).toEqual([ 'saved-tag' ]);
+    expect(component.existingCoverAttachments).toHaveLength(1);
+    expect(component.existingCoverAttachments[0].name).toBe('saved-cover.png');
+    expect(component.courseForm.pristine).toBe(true);
   });
 });

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -34,6 +34,8 @@ import { FileUploadComponent, AttachmentInputState, ExistingAttachment } from '.
 import { couchAttachmentUrl, normalizeImage, NormalizedImage } from '../../shared/utils';
 import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
 
 interface CourseFormModel {
   courseTitle: FormControl<string>;
@@ -75,6 +77,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   private coverState: AttachmentInputState = { retained: [], removed: [], added: [] };
   savedCourse: any = null;
   draftExists: boolean;
+  deleteDialog: MatDialogRef<DialogsPromptComponent> | null = null;
   courseForm: FormGroup<CourseFormModel>;
   documentInfo = { '_rev': undefined, '_id': undefined };
   courseId = this.route.snapshot.paramMap.get('id') || undefined;
@@ -98,7 +101,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     this._steps = value.map(step => ({
       ...step,
       description: step.description?.text ?? step.description ?? '',
-      images: [ ...(step.description?.images ?? []), ...(step.images || []) ]
+      images: [...(step.description?.images ?? []), ...(step.images || [])]
     }));
     this.coursesService.course = { form: this.courseForm.value, steps: this._steps };
     this.stepsChange$.next(value);
@@ -116,7 +119,8 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     private stateService: StateService,
     private planetStepListService: PlanetStepListService,
     private pouchService: PouchService,
-    private tagsService: TagsService
+    private tagsService: TagsService,
+    private dialog: MatDialog
   ) {
     this.createForm();
     this.onFormChanges();
@@ -130,7 +134,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       this.pouchService.getDocEditing(this.dbName, this.courseId),
       this.couchService.get('courses/' + this.courseId).pipe(catchError((err) => of(err.error))),
       this.stateService.getCouchState('tags', 'local')
-    ]).subscribe(([ draft, saved, tags ]: [ any, any, any[] ]) => {
+    ]).subscribe(([draft, saved, tags]: [any, any, any[]]) => {
       if (saved.error !== 'not_found') {
         this.setDocumentInfo(saved);
         this.savedCourse = saved;
@@ -157,7 +161,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
         this.setInitialState();
       }
     });
-    const returnRoute = this.router.createUrlTree([ '.', { continue: true } ], { relativeTo: this.route });
+    const returnRoute = this.router.createUrlTree(['.', { continue: true }], { relativeTo: this.route });
     this.coursesService.returnUrl = this.router.serializeUrl(returnRoute);
     if (!continued) {
       this.coursesService.course = { form: this.courseForm.value, steps: this.steps };
@@ -229,7 +233,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     if (this.isDestroyed) {
       return;
     }
-    const courseTags = documentInfo._id ? this.tagsService.attachTagsToDocs(this.dbName, [ documentInfo ], tags)[0].tags : [];
+    const courseTags = documentInfo._id ? this.tagsService.attachTagsToDocs(this.dbName, [documentInfo], tags)[0].tags : [];
     this.coursesService.course = { initialTags: courseTags || [] };
     this.tags.setValue(draft === undefined ? this.coursesService.course.initialTags.map((tag: any) => tag._id) : draft.tags);
   }
@@ -242,7 +246,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     ]).pipe(
       debounce(() => race(interval(200), this.onDestroy$)),
       takeWhile(() => this.isDestroyed === false, true)
-    ).subscribe(([ value, steps, tags ]) => {
+    ).subscribe(([value, steps, tags]) => {
       if (this.isSaved) {
         return;
       }
@@ -280,13 +284,13 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   setExistingCover(course: any) {
     const fileName = course.coverFileName;
     const attachment = course._attachments?.[fileName];
-    this.existingCoverAttachments = fileName && attachment ? [ {
+    this.existingCoverAttachments = fileName && attachment ? [{
       name: fileName,
       contentType: attachment.content_type,
       url: couchAttachmentUrl(environment.couchAddress, this.dbName, course._id, fileName)
-    } ] : [];
+    }] : [];
     // Seed cover state directly so a save can't drop the cover if it fires before the upload child emits.
-    this.setCoverState({ retained: [ ...this.existingCoverAttachments ], removed: [], added: [] });
+    this.setCoverState({ retained: [...this.existingCoverAttachments], removed: [], added: [] });
   }
 
   updateCourse(courseInfo: FormGroup<CourseFormModel>['value'], shouldNavigate: boolean) {
@@ -320,7 +324,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
         }
         return this.saveCourseDocument(newCourse);
       })
-    ).subscribe(([ courseRes ]) => {
+    ).subscribe(([courseRes]) => {
       const message = (this.pageType === 'Edit' ? $localize`Edited course: ` : $localize`Added course: `) + courseInfo.courseTitle;
       this.courseChangeComplete(message, courseRes, shouldNavigate);
       this.preserveCoverStateUntilSubmit = false;
@@ -406,7 +410,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     this.stateService.getCouchState('tags', 'local').subscribe((tags) => this.setInitialTags(tags, this.documentInfo));
     this.coursesService.course = { ...this.documentInfo };
     if (this.pageType === 'Add') {
-      this.router.navigate([ '../update/', this.courseId ], { relativeTo: this.route, replaceUrl: true });
+      this.router.navigate(['../update/', this.courseId], { relativeTo: this.route, replaceUrl: true });
     }
   }
 
@@ -439,6 +443,27 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     if (!this.draftExists) {
       return;
     }
+    const displayName = this.courseForm.value.courseTitle || $localize`Draft`;
+    this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: of(true),
+          onNext: () => {
+            this.executeDeleteDraft();
+            this.deleteDialog?.close();
+          },
+          onError: () => {
+            this.deleteDialog?.close();
+          }
+        },
+        changeType: 'delete',
+        type: 'course',
+        displayName
+      }
+    });
+  }
+
+  private executeDeleteDraft() {
     this.coverUploadComponent?.clear();
     if (this.savedCourse) {
       this.setFormAndSteps({
@@ -467,12 +492,11 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   navigateBack() {
     const relativeRoute = (urlArray: string[]) => {
       const lastIndex = urlArray.length - 1;
-      const endConditions = [ 'update', 'add' ];
-      return `../${
-        (lastIndex === 1 || endConditions.indexOf(urlArray[lastIndex]) > -1) ? '' : relativeRoute(urlArray.slice(0, lastIndex))
+      const endConditions = ['update', 'add'];
+      return `../${(lastIndex === 1 || endConditions.indexOf(urlArray[lastIndex]) > -1) ? '' : relativeRoute(urlArray.slice(0, lastIndex))
       }`;
     };
-    this.router.navigate([ relativeRoute(this.router.url.split('/')) ], { relativeTo: this.route });
+    this.router.navigate([relativeRoute(this.router.url.split('/'))], { relativeTo: this.route });
   }
 
   removeStep(pos) {

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -101,7 +101,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     this._steps = value.map(step => ({
       ...step,
       description: step.description?.text ?? step.description ?? '',
-      images: [...(step.description?.images ?? []), ...(step.images || [])]
+      images: [ ...(step.description?.images ?? []), ...(step.images || []) ]
     }));
     this.coursesService.course = { form: this.courseForm.value, steps: this._steps };
     this.stepsChange$.next(value);
@@ -134,7 +134,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
       this.pouchService.getDocEditing(this.dbName, this.courseId),
       this.couchService.get('courses/' + this.courseId).pipe(catchError((err) => of(err.error))),
       this.stateService.getCouchState('tags', 'local')
-    ]).subscribe(([draft, saved, tags]: [any, any, any[]]) => {
+    ]).subscribe(([ draft, saved, tags ]: [ any, any, any[] ]) => {
       if (saved.error !== 'not_found') {
         this.setDocumentInfo(saved);
         this.savedCourse = saved;
@@ -161,7 +161,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
         this.setInitialState();
       }
     });
-    const returnRoute = this.router.createUrlTree(['.', { continue: true }], { relativeTo: this.route });
+    const returnRoute = this.router.createUrlTree([ '.', { continue: true } ], { relativeTo: this.route });
     this.coursesService.returnUrl = this.router.serializeUrl(returnRoute);
     if (!continued) {
       this.coursesService.course = { form: this.courseForm.value, steps: this.steps };
@@ -233,7 +233,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     if (this.isDestroyed) {
       return;
     }
-    const courseTags = documentInfo._id ? this.tagsService.attachTagsToDocs(this.dbName, [documentInfo], tags)[0].tags : [];
+    const courseTags = documentInfo._id ? this.tagsService.attachTagsToDocs(this.dbName, [ documentInfo ], tags)[0].tags : [];
     this.coursesService.course = { initialTags: courseTags || [] };
     this.tags.setValue(draft === undefined ? this.coursesService.course.initialTags.map((tag: any) => tag._id) : draft.tags);
   }
@@ -246,7 +246,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     ]).pipe(
       debounce(() => race(interval(200), this.onDestroy$)),
       takeWhile(() => this.isDestroyed === false, true)
-    ).subscribe(([value, steps, tags]) => {
+    ).subscribe(([ value, steps, tags ]) => {
       if (this.isSaved) {
         return;
       }
@@ -284,13 +284,13 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   setExistingCover(course: any) {
     const fileName = course.coverFileName;
     const attachment = course._attachments?.[fileName];
-    this.existingCoverAttachments = fileName && attachment ? [{
+    this.existingCoverAttachments = fileName && attachment ? [ {
       name: fileName,
       contentType: attachment.content_type,
       url: couchAttachmentUrl(environment.couchAddress, this.dbName, course._id, fileName)
-    }] : [];
+    } ] : [];
     // Seed cover state directly so a save can't drop the cover if it fires before the upload child emits.
-    this.setCoverState({ retained: [...this.existingCoverAttachments], removed: [], added: [] });
+    this.setCoverState({ retained: [ ...this.existingCoverAttachments ], removed: [], added: [] });
   }
 
   updateCourse(courseInfo: FormGroup<CourseFormModel>['value'], shouldNavigate: boolean) {
@@ -324,7 +324,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
         }
         return this.saveCourseDocument(newCourse);
       })
-    ).subscribe(([courseRes]) => {
+    ).subscribe(([ courseRes ]) => {
       const message = (this.pageType === 'Edit' ? $localize`Edited course: ` : $localize`Added course: `) + courseInfo.courseTitle;
       this.courseChangeComplete(message, courseRes, shouldNavigate);
       this.preserveCoverStateUntilSubmit = false;
@@ -410,7 +410,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     this.stateService.getCouchState('tags', 'local').subscribe((tags) => this.setInitialTags(tags, this.documentInfo));
     this.coursesService.course = { ...this.documentInfo };
     if (this.pageType === 'Add') {
-      this.router.navigate(['../update/', this.courseId], { relativeTo: this.route, replaceUrl: true });
+      this.router.navigate([ '../update/', this.courseId ], { relativeTo: this.route, replaceUrl: true });
     }
   }
 
@@ -443,7 +443,6 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
     if (!this.draftExists) {
       return;
     }
-    const displayName = this.courseForm.value.courseTitle || $localize`Draft`;
     this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
         okClick: {
@@ -451,15 +450,15 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
           onNext: () => {
             this.executeDeleteDraft();
             this.deleteDialog?.close();
-          },
-          onError: () => {
-            this.deleteDialog?.close();
           }
         },
         changeType: 'delete',
-        type: 'course',
-        displayName
+        type: 'courseDraft',
+        displayName: this.courseForm.value.courseTitle
       }
+    });
+    this.deleteDialog.afterClosed().subscribe(() => {
+      this.deleteDialog = null;
     });
   }
 
@@ -492,11 +491,12 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   navigateBack() {
     const relativeRoute = (urlArray: string[]) => {
       const lastIndex = urlArray.length - 1;
-      const endConditions = ['update', 'add'];
-      return `../${(lastIndex === 1 || endConditions.indexOf(urlArray[lastIndex]) > -1) ? '' : relativeRoute(urlArray.slice(0, lastIndex))
+      const endConditions = [ 'update', 'add' ];
+      return `../${
+        (lastIndex === 1 || endConditions.indexOf(urlArray[lastIndex]) > -1) ? '' : relativeRoute(urlArray.slice(0, lastIndex))
       }`;
     };
-    this.router.navigate([relativeRoute(this.router.url.split('/'))], { relativeTo: this.route });
+    this.router.navigate([ relativeRoute(this.router.url.split('/')) ], { relativeTo: this.route });
   }
 
   removeStep(pos) {

--- a/src/app/shared/dialogs/dialogs-prompt.component.html
+++ b/src/app/shared/dialogs/dialogs-prompt.component.html
@@ -10,6 +10,7 @@
         community {community}
         nation {nation}
         course {course}
+        courseDraft {course draft}
         resource {resource}
         document {document}
         meetup {meetup}


### PR DESCRIPTION
Fixes #10152 
- Injected private dialog: MatDialog into CoursesAddComponent.
- Added property deleteDialog: MatDialogRef<DialogsPromptComponent> | null = null;.
- Refactored deleteDraft() to open DialogsPromptComponent

<img width="587" height="225" alt="image" src="https://github.com/user-attachments/assets/07591eba-a961-4c59-9094-9eef3f89f3cf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before deleting a course draft.
  * Extended the prompt options to display “course draft”.
  * Confirmed deletion now clears draft data, attachments, and form state, shows a confirmation message, and closes the dialog.
* **Bug Fixes**
  * Improved handling for discarding edited drafts, restoring related steps, tags, attachments, and returning the form to pristine.
* **Tests**
  * Updated and expanded coverage for navigation and the delete/confirm dialog flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->