### PR TITLE
all: smoother android app promoting (fixes #10221)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.69",
   "myplanet": {
-    "latest": "v0.61.83",
+    "latest": "v0.63.0",
     "min": "v0.60.60"
   },
   "scripts": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
+import { MatDialog } from '@angular/material/dialog';
 import { Router, NavigationStart, NavigationEnd, RouterOutlet } from '@angular/router';
 import { StateService } from './shared/state.service';
+import { DialogsAndroidAppComponent } from './shared/dialogs/dialogs-android-app.component';
 import { Dir } from '@angular/cdk/bidi';
 declare let gtag: (type: string, account: string, params: { 'page_path': string }) => void;
 
@@ -11,12 +13,16 @@ declare let gtag: (type: string, account: string, params: { 'page_path': string 
   template: '<div i18n-dir dir="ltr"><router-outlet></router-outlet></div>',
   imports: [Dir, RouterOutlet]
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
+
+  private androidAppPromptKey = 'planet-android-app-prompt-dismissed';
+
   constructor(
     iconRegistry: MatIconRegistry,
     sanitizer: DomSanitizer,
     public router: Router,
-    private stateService: StateService
+    private stateService: StateService,
+    private dialog: MatDialog
   ) {
     iconRegistry.addSvgIcon(
       'myLibrary',
@@ -87,5 +93,37 @@ export class AppComponent {
         gtag('config', 'UA-118745384-1', { 'page_path': event.urlAfterRedirects });
       }
     });
+  }
+
+  ngOnInit() {
+    this.maybePromptAndroidApp();
+  }
+
+  private maybePromptAndroidApp() {
+    if (!this.isAndroid() || this.isDismissed()) {
+      return;
+    }
+    this.dialog.open(DialogsAndroidAppComponent, { maxWidth: '90vw', width: '400px' })
+      .afterClosed().subscribe(() => this.dismissAndroidPrompt());
+  }
+
+  private isAndroid(): boolean {
+    return typeof navigator !== 'undefined' && /android/i.test(navigator.userAgent);
+  }
+
+  private isDismissed(): boolean {
+    try {
+      return localStorage.getItem(this.androidAppPromptKey) === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  private dismissAndroidPrompt() {
+    try {
+      localStorage.setItem(this.androidAppPromptKey, 'true');
+    } catch {
+      // Ignore storage errors (e.g. private mode); prompt may reappear next visit.
+    }
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
-import { MatDialog } from '@angular/material/dialog';
 import { Router, NavigationStart, NavigationEnd, RouterOutlet } from '@angular/router';
 import { StateService } from './shared/state.service';
-import { DialogsAndroidAppComponent } from './shared/dialogs/dialogs-android-app.component';
 import { Dir } from '@angular/cdk/bidi';
 declare let gtag: (type: string, account: string, params: { 'page_path': string }) => void;
 
@@ -13,16 +11,12 @@ declare let gtag: (type: string, account: string, params: { 'page_path': string 
   template: '<div i18n-dir dir="ltr"><router-outlet></router-outlet></div>',
   imports: [Dir, RouterOutlet]
 })
-export class AppComponent implements OnInit {
-
-  private androidAppPromptKey = 'planet-android-app-prompt-dismissed';
-
+export class AppComponent {
   constructor(
     iconRegistry: MatIconRegistry,
     sanitizer: DomSanitizer,
     public router: Router,
-    private stateService: StateService,
-    private dialog: MatDialog
+    private stateService: StateService
   ) {
     iconRegistry.addSvgIcon(
       'myLibrary',
@@ -93,37 +87,5 @@ export class AppComponent implements OnInit {
         gtag('config', 'UA-118745384-1', { 'page_path': event.urlAfterRedirects });
       }
     });
-  }
-
-  ngOnInit() {
-    this.maybePromptAndroidApp();
-  }
-
-  private maybePromptAndroidApp() {
-    if (!this.isAndroid() || this.isDismissed()) {
-      return;
-    }
-    this.dialog.open(DialogsAndroidAppComponent, { maxWidth: '90vw', width: '400px' })
-      .afterClosed().subscribe(() => this.dismissAndroidPrompt());
-  }
-
-  private isAndroid(): boolean {
-    return typeof navigator !== 'undefined' && /android/i.test(navigator.userAgent);
-  }
-
-  private isDismissed(): boolean {
-    try {
-      return localStorage.getItem(this.androidAppPromptKey) === 'true';
-    } catch {
-      return false;
-    }
-  }
-
-  private dismissAndroidPrompt() {
-    try {
-      localStorage.setItem(this.androidAppPromptKey, 'true');
-    } catch {
-      // Ignore storage errors (e.g. private mode); prompt may reappear next visit.
-    }
   }
 }

--- a/src/app/exams/public-surveys/public-survey.component.ts
+++ b/src/app/exams/public-surveys/public-survey.component.ts
@@ -15,6 +15,7 @@ import { ExamsTakeWidgetComponent } from '../exams-take/exams-take-widget.compon
 import { StoredExamAnswer, ExamAnswerValue, examAnswerValidator } from '../exams-take/exam-answer.helpers';
 import { PublicSurvey, PublicSurveyDemographics, PublicSurveysService } from './public-surveys.service';
 import { LoginDialogComponent } from '../../login/login-dialog.component';
+import { AndroidAppPromptService } from '../../shared/android-app-prompt.service';
 
 @Component({
   selector: 'planet-public-survey',
@@ -63,10 +64,12 @@ export class PublicSurveyComponent implements OnInit {
     private route: ActivatedRoute,
     private publicSurveysService: PublicSurveysService,
     private fb: NonNullableFormBuilder,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private androidAppPromptService: AndroidAppPromptService
   ) {}
 
   ngOnInit() {
+    this.androidAppPromptService.maybePrompt();
     this.route.paramMap.pipe(
       switchMap(params => this.publicSurveysService.getSurvey(params.get('teamId') || '', params.get('surveyId') || ''))
     ).subscribe({

--- a/src/app/exams/public-surveys/public-survey.component.ts
+++ b/src/app/exams/public-surveys/public-survey.component.ts
@@ -69,7 +69,7 @@ export class PublicSurveyComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.androidAppPromptService.maybePrompt();
+    this.androidAppPromptService.openIfEligible();
     this.route.paramMap.pipe(
       switchMap(params => this.publicSurveysService.getSurvey(params.get('teamId') || '', params.get('surveyId') || ''))
     ).subscribe({

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -125,12 +125,22 @@
 
 @if (isAndroid && showBanner) {
   <div class="banner">
-    <p i18n>Check out our Android app</p>
-    <a href="https://play.google.com/store/apps/details?id=org.ole.planet.myplanet" target="_blank">
-      <img src="assets/get_on_playstore.svg" i18n-alt alt="myPlanet on playstore" class="playstore-logo">
-    </a>
+    <p i18n>Check out our Android apps</p>
+    <div class="banner-apps">
+      @for (app of androidApps; track app.url) {
+        <a
+          class="banner-app"
+          [href]="app.url"
+          target="_blank"
+          rel="noopener"
+          [attr.aria-label]="app.installLabel">
+          <span>{{ app.name }}</span>
+          <img src="assets/get_on_playstore.svg" alt="" class="playstore-logo">
+        </a>
+      }
+    </div>
     <div class="spacer"></div>
-    <button class="close-btn" (click)="showBanner = false">✕</button>
+    <button class="close-btn" (click)="showBanner = false" aria-label="Close Android app banner" i18n-aria-label>✕</button>
   </div>
 }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -29,6 +29,7 @@ import { ChangePasswordDirective } from '../shared/dialogs/change-password.direc
 import { MatDivider } from '@angular/material/list';
 import { MatSidenavContainer, MatSidenav, MatSidenavContent } from '@angular/material/sidenav';
 import { PulsateIconDirective } from './pulsate-icon.directive';
+import { ANDROID_APPS } from '../shared/android-apps';
 
 @Component({
   templateUrl: './home.component.html',
@@ -70,6 +71,7 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   isAndroid: boolean;
   isMobile: boolean;
   showBanner = true;
+  readonly androidApps = ANDROID_APPS;
   isLoggedIn = false;
 
   // Sets the margin for the main content to match the sidenav width

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -210,7 +210,9 @@
 
 .banner {
   background-color: v.$primary;
+  box-sizing: border-box;
   color: white;
+  gap: 16px;
   padding: 10px;
   text-align: center;
   position: fixed;
@@ -222,9 +224,25 @@
   align-items: center;
 }
 
+.banner p {
+  margin: 0;
+}
+
 .banner .playstore-logo {
-  margin: 8px;
   height: 30px;
+}
+
+.banner-apps {
+  display: flex;
+  gap: 16px;
+}
+
+.banner-app {
+  align-items: center;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
 }
 
 .spacer {
@@ -238,6 +256,33 @@
   font-size: 20px;
   margin-right: 20px;
   cursor: pointer;
+}
+
+@media (max-width: #{v.$screen-xs}) {
+  .banner {
+    flex-wrap: wrap;
+    padding-right: 48px;
+  }
+
+  .banner p {
+    flex-basis: 100%;
+  }
+
+  .banner-apps {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .spacer {
+    display: none;
+  }
+
+  .close-btn {
+    margin: 0;
+    position: absolute;
+    right: 12px;
+    top: 12px;
+  }
 }
 
 .profile-image-large {

--- a/src/app/shared/android-app-prompt.service.spec.ts
+++ b/src/app/shared/android-app-prompt.service.spec.ts
@@ -1,0 +1,82 @@
+import { MatDialog } from '@angular/material/dialog';
+import { Subject } from 'rxjs';
+import { vi } from 'vitest';
+
+import { AndroidAppPromptService } from './android-app-prompt.service';
+import { DeviceInfoService } from './device-info.service';
+import { DialogsAndroidAppComponent } from './dialogs/dialogs-android-app.component';
+
+describe('AndroidAppPromptService', () => {
+  let afterClosed$: Subject<void>;
+  let deviceInfoService: { isAndroid: ReturnType<typeof vi.fn> };
+  let dialog: { open: ReturnType<typeof vi.fn> };
+  let service: AndroidAppPromptService;
+
+  beforeEach(() => {
+    afterClosed$ = new Subject<void>();
+    deviceInfoService = { isAndroid: vi.fn().mockReturnValue(true) };
+    dialog = {
+      open: vi.fn().mockReturnValue({ afterClosed: () => afterClosed$ })
+    };
+    service = new AndroidAppPromptService(
+      deviceInfoService as unknown as DeviceInfoService,
+      dialog as unknown as MatDialog
+    );
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('does not prompt non-Android devices', () => {
+    deviceInfoService.isAndroid.mockReturnValue(false);
+
+    service.maybePrompt();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt after a prior dismissal', () => {
+    sessionStorage.setItem('planet-android-survey-app-prompt-dismissed', 'true');
+
+    service.maybePrompt();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('prompts first-time Android visitors and persists after close', () => {
+    service.maybePrompt();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      DialogsAndroidAppComponent,
+      { maxWidth: '90vw', width: '400px' }
+    );
+    expect(sessionStorage.getItem('planet-android-survey-app-prompt-dismissed')).toBeNull();
+
+    afterClosed$.next();
+
+    expect(sessionStorage.getItem('planet-android-survey-app-prompt-dismissed')).toBe('true');
+  });
+
+  it('prompts when sessionStorage cannot be read', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    service.maybePrompt();
+
+    expect(dialog.open).toHaveBeenCalled();
+  });
+
+  it('ignores sessionStorage write errors after the dialog closes', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    service.maybePrompt();
+
+    expect(() => afterClosed$.next()).not.toThrow();
+  });
+});

--- a/src/app/shared/android-app-prompt.service.spec.ts
+++ b/src/app/shared/android-app-prompt.service.spec.ts
@@ -33,7 +33,7 @@ describe('AndroidAppPromptService', () => {
   it('does not prompt non-Android devices', () => {
     deviceInfoService.isAndroid.mockReturnValue(false);
 
-    service.maybePrompt();
+    service.openIfEligible();
 
     expect(dialog.open).not.toHaveBeenCalled();
   });
@@ -41,13 +41,13 @@ describe('AndroidAppPromptService', () => {
   it('does not prompt after a prior dismissal', () => {
     sessionStorage.setItem('planet-android-survey-app-prompt-dismissed', 'true');
 
-    service.maybePrompt();
+    service.openIfEligible();
 
     expect(dialog.open).not.toHaveBeenCalled();
   });
 
   it('prompts first-time Android visitors and persists after close', () => {
-    service.maybePrompt();
+    service.openIfEligible();
 
     expect(dialog.open).toHaveBeenCalledWith(
       DialogsAndroidAppComponent,
@@ -65,7 +65,7 @@ describe('AndroidAppPromptService', () => {
       throw new Error('Storage unavailable');
     });
 
-    service.maybePrompt();
+    service.openIfEligible();
 
     expect(dialog.open).toHaveBeenCalled();
   });
@@ -75,7 +75,7 @@ describe('AndroidAppPromptService', () => {
       throw new Error('Storage unavailable');
     });
 
-    service.maybePrompt();
+    service.openIfEligible();
 
     expect(() => afterClosed$.next()).not.toThrow();
   });

--- a/src/app/shared/android-app-prompt.service.ts
+++ b/src/app/shared/android-app-prompt.service.ts
@@ -8,6 +8,7 @@ import { DialogsAndroidAppComponent } from './dialogs/dialogs-android-app.compon
   providedIn: 'root'
 })
 export class AndroidAppPromptService {
+  // Keep the prompt dismissed across reloads and restores for the lifetime of this tab's page session.
   private readonly dismissedSessionStorageKey = 'planet-android-survey-app-prompt-dismissed';
 
   constructor(

--- a/src/app/shared/android-app-prompt.service.ts
+++ b/src/app/shared/android-app-prompt.service.ts
@@ -8,33 +8,33 @@ import { DialogsAndroidAppComponent } from './dialogs/dialogs-android-app.compon
   providedIn: 'root'
 })
 export class AndroidAppPromptService {
-  private readonly promptDismissedKey = 'planet-android-survey-app-prompt-dismissed';
+  private readonly dismissedSessionStorageKey = 'planet-android-survey-app-prompt-dismissed';
 
   constructor(
     private deviceInfoService: DeviceInfoService,
     private dialog: MatDialog
   ) {}
 
-  maybePrompt() {
-    if (!this.deviceInfoService.isAndroid() || this.isDismissed()) {
+  openIfEligible() {
+    if (!this.deviceInfoService.isAndroid() || this.wasDismissedThisSession()) {
       return;
     }
 
     this.dialog.open(DialogsAndroidAppComponent, { maxWidth: '90vw', width: '400px' })
-      .afterClosed().subscribe(() => this.dismissPrompt());
+      .afterClosed().subscribe(() => this.markDismissedForSession());
   }
 
-  private isDismissed(): boolean {
+  private wasDismissedThisSession(): boolean {
     try {
-      return sessionStorage.getItem(this.promptDismissedKey) === 'true';
+      return sessionStorage.getItem(this.dismissedSessionStorageKey) === 'true';
     } catch {
       return false;
     }
   }
 
-  private dismissPrompt() {
+  private markDismissedForSession() {
     try {
-      sessionStorage.setItem(this.promptDismissedKey, 'true');
+      sessionStorage.setItem(this.dismissedSessionStorageKey, 'true');
     } catch {
       // The banner remains available when storage is unavailable.
     }

--- a/src/app/shared/android-app-prompt.service.ts
+++ b/src/app/shared/android-app-prompt.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+import { DeviceInfoService } from './device-info.service';
+import { DialogsAndroidAppComponent } from './dialogs/dialogs-android-app.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AndroidAppPromptService {
+  private readonly promptDismissedKey = 'planet-android-survey-app-prompt-dismissed';
+
+  constructor(
+    private deviceInfoService: DeviceInfoService,
+    private dialog: MatDialog
+  ) {}
+
+  maybePrompt() {
+    if (!this.deviceInfoService.isAndroid() || this.isDismissed()) {
+      return;
+    }
+
+    this.dialog.open(DialogsAndroidAppComponent, { maxWidth: '90vw', width: '400px' })
+      .afterClosed().subscribe(() => this.dismissPrompt());
+  }
+
+  private isDismissed(): boolean {
+    try {
+      return sessionStorage.getItem(this.promptDismissedKey) === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  private dismissPrompt() {
+    try {
+      sessionStorage.setItem(this.promptDismissedKey, 'true');
+    } catch {
+      // The banner remains available when storage is unavailable.
+    }
+  }
+}

--- a/src/app/shared/android-apps.ts
+++ b/src/app/shared/android-apps.ts
@@ -1,0 +1,21 @@
+export interface AndroidApp {
+  name: string;
+  description: string;
+  installLabel: string;
+  url: string;
+}
+
+export const ANDROID_APPS: readonly AndroidApp[] = [
+  {
+    name: $localize`myPlanet`,
+    description: $localize`Full-featured offline learning app`,
+    installLabel: $localize`Install myPlanet`,
+    url: 'https://play.google.com/store/apps/details?id=org.ole.planet.myplanet'
+  },
+  {
+    name: $localize`myPlanet Lite`,
+    description: $localize`Lightweight version that uses less storage`,
+    installLabel: $localize`Install myPlanet Lite`,
+    url: 'https://play.google.com/store/apps/details?id=org.ole.planet.myplanet.lite'
+  }
+];

--- a/src/app/shared/dialogs/dialogs-android-app.component.html
+++ b/src/app/shared/dialogs/dialogs-android-app.component.html
@@ -1,0 +1,19 @@
+<h2 mat-dialog-title class="primary-color" i18n>Get the Planet mobile app</h2>
+<mat-dialog-content>
+  <p i18n>You're browsing on an Android device. Install one of our apps for a faster, offline-capable experience.</p>
+  <div class="app-list">
+    @for (app of apps; track app.url) {
+      <div class="app-item">
+        <mat-icon class="app-icon">android</mat-icon>
+        <div class="app-info">
+          <span class="app-name">{{ app.name }}</span>
+          <span class="app-description">{{ app.description }}</span>
+        </div>
+        <a mat-raised-button color="primary" [href]="app.url" target="_blank" rel="noopener" (click)="close()" i18n>Install</a>
+      </div>
+    }
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close i18n>Not now</button>
+</mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-android-app.component.html
+++ b/src/app/shared/dialogs/dialogs-android-app.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title class="primary-color" i18n>Get the Planet mobile app</h2>
+<h2 mat-dialog-title class="dialog-title primary-color" i18n>Get the Planet mobile app</h2>
 <mat-dialog-content>
   <p i18n>You're browsing on an Android device. Install one of our apps for a faster, offline-capable experience.</p>
   <div class="app-list">
@@ -9,11 +9,20 @@
           <span class="app-name">{{ app.name }}</span>
           <span class="app-description">{{ app.description }}</span>
         </div>
-        <a mat-raised-button color="primary" [href]="app.url" target="_blank" rel="noopener" (click)="close()" i18n>Install</a>
+        <a
+          mat-raised-button
+          color="primary"
+          [href]="app.url"
+          target="_blank"
+          rel="noopener"
+          (click)="close()"
+          [attr.aria-label]="app.installLabel">
+          <ng-container i18n>Install</ng-container>
+        </a>
       </div>
     }
   </div>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close i18n>Not now</button>
+  <button mat-raised-button mat-dialog-close i18n>Not now</button>
 </mat-dialog-actions>

--- a/src/app/shared/dialogs/dialogs-android-app.component.scss
+++ b/src/app/shared/dialogs/dialogs-android-app.component.scss
@@ -1,0 +1,32 @@
+.app-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.app-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-icon {
+  flex-shrink: 0;
+}
+
+.app-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.app-name {
+  font-weight: 500;
+}
+
+.app-description {
+  font-size: 0.85em;
+  opacity: 0.75;
+}

--- a/src/app/shared/dialogs/dialogs-android-app.component.scss
+++ b/src/app/shared/dialogs/dialogs-android-app.component.scss
@@ -1,3 +1,9 @@
+@use '../../variables' as v;
+
+.dialog-title {
+  color: v.$primary-text;
+}
+
 .app-list {
   display: flex;
   flex-direction: column;

--- a/src/app/shared/dialogs/dialogs-android-app.component.spec.ts
+++ b/src/app/shared/dialogs/dialogs-android-app.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MatDialogRef } from '@angular/material/dialog';
+import { vi } from 'vitest';
+
+import { DialogsAndroidAppComponent } from './dialogs-android-app.component';
+
+describe('DialogsAndroidAppComponent', () => {
+  let fixture: ComponentFixture<DialogsAndroidAppComponent>;
+  const dialogRef = { close: vi.fn() };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DialogsAndroidAppComponent],
+      providers: [{ provide: MatDialogRef, useValue: dialogRef }]
+    });
+    fixture = TestBed.createComponent(DialogsAndroidAppComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    dialogRef.close.mockClear();
+  });
+
+  it('renders a uniquely named install link for each Android app', () => {
+    const links = fixture.debugElement.queryAll(By.css('a[mat-raised-button]'));
+
+    expect(links.map(link => link.nativeElement.getAttribute('aria-label'))).toEqual([
+      'Install myPlanet',
+      'Install myPlanet Lite'
+    ]);
+  });
+
+  it('closes after an install link is selected', () => {
+    const link = fixture.debugElement.query(By.css('a[mat-raised-button]'));
+
+    link.triggerEventHandler('click');
+
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/dialogs/dialogs-android-app.component.ts
+++ b/src/app/shared/dialogs/dialogs-android-app.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { MatDialogRef, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
+import { MatAnchor, MatButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+
+interface MobileApp {
+  name: string;
+  description: string;
+  url: string;
+}
+
+@Component({
+  templateUrl: './dialogs-android-app.component.html',
+  styleUrls: ['./dialogs-android-app.component.scss'],
+  imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose, MatAnchor, MatButton, MatIcon]
+})
+export class DialogsAndroidAppComponent {
+
+  apps: MobileApp[] = [
+    {
+      name: $localize`myPlanet`,
+      description: $localize`Full-featured offline learning app`,
+      url: 'https://play.google.com/store/apps/details?id=org.ole.planet.myplanet'
+    },
+    {
+      name: $localize`myPlanet Lite`,
+      description: $localize`Lightweight version that uses less storage`,
+      url: 'https://play.google.com/store/apps/details?id=org.ole.planet.myplanet.lite'
+    }
+  ];
+
+  constructor(public dialogRef: MatDialogRef<DialogsAndroidAppComponent>) {}
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/shared/dialogs/dialogs-android-app.component.ts
+++ b/src/app/shared/dialogs/dialogs-android-app.component.ts
@@ -2,12 +2,7 @@ import { Component } from '@angular/core';
 import { MatDialogRef, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 import { MatAnchor, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-
-interface MobileApp {
-  name: string;
-  description: string;
-  url: string;
-}
+import { ANDROID_APPS } from '../android-apps';
 
 @Component({
   templateUrl: './dialogs-android-app.component.html',
@@ -16,18 +11,7 @@ interface MobileApp {
 })
 export class DialogsAndroidAppComponent {
 
-  apps: MobileApp[] = [
-    {
-      name: $localize`myPlanet`,
-      description: $localize`Full-featured offline learning app`,
-      url: 'https://play.google.com/store/apps/details?id=org.ole.planet.myplanet'
-    },
-    {
-      name: $localize`myPlanet Lite`,
-      description: $localize`Lightweight version that uses less storage`,
-      url: 'https://play.google.com/store/apps/details?id=org.ole.planet.myplanet.lite'
-    }
-  ];
+  readonly apps = ANDROID_APPS;
 
   constructor(public dialogRef: MatDialogRef<DialogsAndroidAppComponent>) {}
 

--- a/src/i18n/messages.spa.xlf
+++ b/src/i18n/messages.spa.xlf
@@ -2492,13 +2492,49 @@ Otras notas</target>
         <source>See All</source>
         <target state="final">Ver todo</target>
       </trans-unit>
-      <trans-unit id="3335034047405167528" datatype="html" approved="yes">
-        <source>Check out our Android app</source>
-        <target state="final">Echa un vistazo a nuestra aplicación Android</target>
+      <trans-unit id="3534984212959071163" datatype="html" approved="yes">
+        <source>Check out our Android apps</source>
+        <target state="final">Echa un vistazo a nuestras aplicaciones para Android</target>
       </trans-unit>
-      <trans-unit id="3947932744068086415" datatype="html">
-        <source>myPlanet on playstore</source>
-        <target state="translated">myPlanet en Google Play</target>
+      <trans-unit id="9065868234082693767" datatype="html" approved="yes">
+        <source>Close Android app banner</source>
+        <target state="final">Cerrar el banner de aplicaciones para Android</target>
+      </trans-unit>
+      <trans-unit id="2866055652148348809" datatype="html" approved="yes">
+        <source>Full-featured offline learning app</source>
+        <target state="final">Aplicación de aprendizaje sin conexión con todas las funciones</target>
+      </trans-unit>
+      <trans-unit id="4159803850116371687" datatype="html" approved="yes">
+        <source>Install myPlanet</source>
+        <target state="final">Instalar myPlanet</target>
+      </trans-unit>
+      <trans-unit id="7608345630430529300" datatype="html" approved="yes">
+        <source>myPlanet Lite</source>
+        <target state="final">myPlanet Lite</target>
+      </trans-unit>
+      <trans-unit id="5853502135183082395" datatype="html" approved="yes">
+        <source>Lightweight version that uses less storage</source>
+        <target state="final">Versión ligera que ocupa menos espacio de almacenamiento</target>
+      </trans-unit>
+      <trans-unit id="689883195141523023" datatype="html" approved="yes">
+        <source>Install myPlanet Lite</source>
+        <target state="final">Instalar myPlanet Lite</target>
+      </trans-unit>
+      <trans-unit id="3158554629807420909" datatype="html" approved="yes">
+        <source>Get the Planet mobile app</source>
+        <target state="final">Obtén la aplicación móvil de Planet</target>
+      </trans-unit>
+      <trans-unit id="4684839318250929517" datatype="html" approved="yes">
+        <source>You&apos;re browsing on an Android device. Install one of our apps for a faster, offline-capable experience.</source>
+        <target state="final">Estás navegando desde un dispositivo Android. Instala una de nuestras aplicaciones para disfrutar de una experiencia más rápida y con acceso sin conexión.</target>
+      </trans-unit>
+      <trans-unit id="6082171864197428613" datatype="html" approved="yes">
+        <source>Install</source>
+        <target state="final">Instalar</target>
+      </trans-unit>
+      <trans-unit id="5161411570094992408" datatype="html" approved="yes">
+        <source>Not now</source>
+        <target state="final">Ahora no</target>
       </trans-unit>
       <trans-unit id="6570363013146073520" datatype="html" approved="yes">
         <source>Dashboard</source>
@@ -5795,6 +5831,10 @@ Otras notas</target>
         <source>Error sending survey requests.</source>
         <target state="final">Error al enviar las solicitudes de encuesta.</target>
       </trans-unit>
+      <trans-unit id="8902217649532050849" datatype="html" approved="yes">
+        <source>There was a problem recording the survey.</source>
+        <target state="final">Hubo un problema al registrar la encuesta.</target>
+      </trans-unit>
       <trans-unit id="1414733139904716677" datatype="html">
         <source>Public link generated for this survey</source>
         <target state="translated">Se generó un enlace público para esta encuesta</target>
@@ -6055,9 +6095,9 @@ Otras notas</target>
         <source>reports</source>
         <target state="translated">reportes</target>
       </trans-unit>
-      <trans-unit id="6825329815737519497" datatype="html" approved="yes">
-        <source>Export as CSV</source>
-        <target state="final">Exportar como CSV</target>
+      <trans-unit id="7926143511350598250" datatype="html" approved="yes">
+        <source>CSV</source>
+        <target state="final">CSV</target>
       </trans-unit>
       <trans-unit id="6864016537810263548" datatype="html" approved="yes">
         <source>Add Report</source>
@@ -6155,6 +6195,22 @@ Otras notas</target>
         <source>Other Expenses</source>
         <target state="final">Otros gastos</target>
       </trans-unit>
+      <trans-unit id="7531506369118512654" datatype="html" approved="yes">
+        <source>Total Credit</source>
+        <target state="final">Crédito total</target>
+      </trans-unit>
+      <trans-unit id="5935363325942095320" datatype="html" approved="yes">
+        <source>Total Debit</source>
+        <target state="final">Débito total</target>
+      </trans-unit>
+      <trans-unit id="6565745869379859165" datatype="html" approved="yes">
+        <source>Net Profit/Loss</source>
+        <target state="final">Ganancia/pérdida neta</target>
+      </trans-unit>
+      <trans-unit id="4579766002080253515" datatype="html" approved="yes">
+        <source>Financial Summary for <x id="PH" equiv-text="titleName"/>.pdf</source>
+        <target state="final">Resumen financiero de <x id="PH" equiv-text="titleName"/>.pdf</target>
+      </trans-unit>
       <trans-unit id="188408324951035066" datatype="html" approved="yes">
         <source>Unnamed</source>
         <target state="final">Sin nombre</target>
@@ -6162,6 +6218,10 @@ Otras notas</target>
       <trans-unit id="6630681340946694789" datatype="html" approved="yes">
         <source>Financial Summary for <x id="PH" equiv-text="titleName"/></source>
         <target state="final">Resumen financiero de <x id="PH" equiv-text="titleName"/></target>
+      </trans-unit>
+      <trans-unit id="2352646517693441633" datatype="html" approved="yes">
+        <source>Receipt images for <x id="PH" equiv-text="fullLabel(report.startDate, this.localeId)"/> - <x id="PH_1" equiv-text="fullLabel(report.endDate, this.localeId)"/></source>
+        <target state="final">Imágenes de recibos de <x id="PH" equiv-text="fullLabel(report.startDate, this.localeId)"/> - <x id="PH_1" equiv-text="fullLabel(report.endDate, this.localeId)"/></target>
       </trans-unit>
       <trans-unit id="7115407436370620649" datatype="html">
         <source>Balance is negative</source>
@@ -6267,9 +6327,21 @@ Otras notas</target>
         <source>balance</source>
         <target state="final">saldo</target>
       </trans-unit>
+      <trans-unit id="7791553364151343531" datatype="html" approved="yes">
+        <source>Financial Transactions for <x id="PH" equiv-text="titleName"/>.pdf</source>
+        <target state="final">Transacciones financieras de <x id="PH" equiv-text="titleName"/>.pdf</target>
+      </trans-unit>
       <trans-unit id="7933600964690636863" datatype="html" approved="yes">
         <source>Financial Transactions for <x id="PH" equiv-text="titleName"/></source>
         <target state="final">Transacciones financieras de<x id="PH" equiv-text="titleName"/></target>
+      </trans-unit>
+      <trans-unit id="5577210405857641325" datatype="html" approved="yes">
+        <source>Beginning</source>
+        <target state="final">Inicio</target>
+      </trans-unit>
+      <trans-unit id="8571274863118609047" datatype="html" approved="yes">
+        <source>Date range: <x id="PH" equiv-text="start"/> - <x id="PH_1" equiv-text="end"/></source>
+        <target state="final">Rango de fechas: <x id="PH" equiv-text="start"/> - <x id="PH_1" equiv-text="end"/></target>
       </trans-unit>
       <trans-unit id="8759370273386874620" datatype="html" approved="yes">
         <source>{VAR_SELECT, select, team {Teams} enterprise {Enterprises}}</source>
@@ -6967,9 +7039,9 @@ Otras notas</target>
         <source>Birthplace: <x id="PH" equiv-text="this.user.birthplace"/></source>
         <target state="final">Lugar de nacimiento: <x id="PH" equiv-text="this.user.birthplace"/></target>
       </trans-unit>
-      <trans-unit id="1569462115651641805" datatype="html">
-        <source><x id="PH" equiv-text="this.user.name"/> achievements</source>
-        <target state="translated">logros de <x id="PH" equiv-text="this.user.name"/></target>
+      <trans-unit id="6914009700103907353" datatype="html" approved="yes">
+        <source><x id="PH" equiv-text="this.user.name"/> achievements.pdf</source>
+        <target state="final">Logros de <x id="PH" equiv-text="this.user.name"/>.pdf</target>
       </trans-unit>
       <trans-unit id="9082581968602742137" datatype="html" approved="yes">
         <source>Request for User Data Deletion</source>

--- a/src/i18n/messages.spa.xlf
+++ b/src/i18n/messages.spa.xlf
@@ -5831,10 +5831,6 @@ Otras notas</target>
         <source>Error sending survey requests.</source>
         <target state="final">Error al enviar las solicitudes de encuesta.</target>
       </trans-unit>
-      <trans-unit id="8902217649532050849" datatype="html" approved="yes">
-        <source>There was a problem recording the survey.</source>
-        <target state="final">Hubo un problema al registrar la encuesta.</target>
-      </trans-unit>
       <trans-unit id="1414733139904716677" datatype="html">
         <source>Public link generated for this survey</source>
         <target state="translated">Se generó un enlace público para esta encuesta</target>
@@ -6095,9 +6091,9 @@ Otras notas</target>
         <source>reports</source>
         <target state="translated">reportes</target>
       </trans-unit>
-      <trans-unit id="7926143511350598250" datatype="html" approved="yes">
-        <source>CSV</source>
-        <target state="final">CSV</target>
+      <trans-unit id="6825329815737519497" datatype="html" approved="yes">
+        <source>Export as CSV</source>
+        <target state="final">Exportar como CSV</target>
       </trans-unit>
       <trans-unit id="6864016537810263548" datatype="html" approved="yes">
         <source>Add Report</source>
@@ -6195,22 +6191,6 @@ Otras notas</target>
         <source>Other Expenses</source>
         <target state="final">Otros gastos</target>
       </trans-unit>
-      <trans-unit id="7531506369118512654" datatype="html" approved="yes">
-        <source>Total Credit</source>
-        <target state="final">Crédito total</target>
-      </trans-unit>
-      <trans-unit id="5935363325942095320" datatype="html" approved="yes">
-        <source>Total Debit</source>
-        <target state="final">Débito total</target>
-      </trans-unit>
-      <trans-unit id="6565745869379859165" datatype="html" approved="yes">
-        <source>Net Profit/Loss</source>
-        <target state="final">Ganancia/pérdida neta</target>
-      </trans-unit>
-      <trans-unit id="4579766002080253515" datatype="html" approved="yes">
-        <source>Financial Summary for <x id="PH" equiv-text="titleName"/>.pdf</source>
-        <target state="final">Resumen financiero de <x id="PH" equiv-text="titleName"/>.pdf</target>
-      </trans-unit>
       <trans-unit id="188408324951035066" datatype="html" approved="yes">
         <source>Unnamed</source>
         <target state="final">Sin nombre</target>
@@ -6218,10 +6198,6 @@ Otras notas</target>
       <trans-unit id="6630681340946694789" datatype="html" approved="yes">
         <source>Financial Summary for <x id="PH" equiv-text="titleName"/></source>
         <target state="final">Resumen financiero de <x id="PH" equiv-text="titleName"/></target>
-      </trans-unit>
-      <trans-unit id="2352646517693441633" datatype="html" approved="yes">
-        <source>Receipt images for <x id="PH" equiv-text="fullLabel(report.startDate, this.localeId)"/> - <x id="PH_1" equiv-text="fullLabel(report.endDate, this.localeId)"/></source>
-        <target state="final">Imágenes de recibos de <x id="PH" equiv-text="fullLabel(report.startDate, this.localeId)"/> - <x id="PH_1" equiv-text="fullLabel(report.endDate, this.localeId)"/></target>
       </trans-unit>
       <trans-unit id="7115407436370620649" datatype="html">
         <source>Balance is negative</source>
@@ -6327,21 +6303,9 @@ Otras notas</target>
         <source>balance</source>
         <target state="final">saldo</target>
       </trans-unit>
-      <trans-unit id="7791553364151343531" datatype="html" approved="yes">
-        <source>Financial Transactions for <x id="PH" equiv-text="titleName"/>.pdf</source>
-        <target state="final">Transacciones financieras de <x id="PH" equiv-text="titleName"/>.pdf</target>
-      </trans-unit>
       <trans-unit id="7933600964690636863" datatype="html" approved="yes">
         <source>Financial Transactions for <x id="PH" equiv-text="titleName"/></source>
         <target state="final">Transacciones financieras de<x id="PH" equiv-text="titleName"/></target>
-      </trans-unit>
-      <trans-unit id="5577210405857641325" datatype="html" approved="yes">
-        <source>Beginning</source>
-        <target state="final">Inicio</target>
-      </trans-unit>
-      <trans-unit id="8571274863118609047" datatype="html" approved="yes">
-        <source>Date range: <x id="PH" equiv-text="start"/> - <x id="PH_1" equiv-text="end"/></source>
-        <target state="final">Rango de fechas: <x id="PH" equiv-text="start"/> - <x id="PH_1" equiv-text="end"/></target>
       </trans-unit>
       <trans-unit id="8759370273386874620" datatype="html" approved="yes">
         <source>{VAR_SELECT, select, team {Teams} enterprise {Enterprises}}</source>
@@ -7039,9 +7003,9 @@ Otras notas</target>
         <source>Birthplace: <x id="PH" equiv-text="this.user.birthplace"/></source>
         <target state="final">Lugar de nacimiento: <x id="PH" equiv-text="this.user.birthplace"/></target>
       </trans-unit>
-      <trans-unit id="6914009700103907353" datatype="html" approved="yes">
-        <source><x id="PH" equiv-text="this.user.name"/> achievements.pdf</source>
-        <target state="final">Logros de <x id="PH" equiv-text="this.user.name"/>.pdf</target>
+      <trans-unit id="1569462115651641805" datatype="html">
+        <source><x id="PH" equiv-text="this.user.name"/> achievements</source>
+        <target state="translated">logros de <x id="PH" equiv-text="this.user.name"/></target>
       </trans-unit>
       <trans-unit id="9082581968602742137" datatype="html" approved="yes">
         <source>Request for User Data Deletion</source>

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -1865,11 +1865,11 @@ Other Notes</source>
       <trans-unit id="6404477247085751415" datatype="html">
         <source>See All</source>
       </trans-unit>
-      <trans-unit id="3335034047405167528" datatype="html">
-        <source>Check out our Android app</source>
+      <trans-unit id="3534984212959071163" datatype="html">
+        <source>Check out our Android apps</source>
       </trans-unit>
-      <trans-unit id="3947932744068086415" datatype="html">
-        <source>myPlanet on playstore</source>
+      <trans-unit id="9065868234082693767" datatype="html">
+        <source>Close Android app banner</source>
       </trans-unit>
       <trans-unit id="6570363013146073520" datatype="html">
         <source>Dashboard</source>
@@ -3546,6 +3546,21 @@ Other Notes</source>
         <source>The following information is a course step from the &quot;<x id="PH" equiv-text="stepTitle"/>&quot; course with a description &quot;<x id="PH_1" equiv-text="stepDescription"/>&quot;.
   Be sure to assist the learner in the best way you can. </source>
       </trans-unit>
+      <trans-unit id="2866055652148348809" datatype="html">
+        <source>Full-featured offline learning app</source>
+      </trans-unit>
+      <trans-unit id="4159803850116371687" datatype="html">
+        <source>Install myPlanet</source>
+      </trans-unit>
+      <trans-unit id="7608345630430529300" datatype="html">
+        <source>myPlanet Lite</source>
+      </trans-unit>
+      <trans-unit id="5853502135183082395" datatype="html">
+        <source>Lightweight version that uses less storage</source>
+      </trans-unit>
+      <trans-unit id="689883195141523023" datatype="html">
+        <source>Install myPlanet Lite</source>
+      </trans-unit>
       <trans-unit id="6048892649018070225" datatype="html">
         <source>Today</source>
       </trans-unit>
@@ -3648,6 +3663,18 @@ Other Notes</source>
       </trans-unit>
       <trans-unit id="5099513225683382398" datatype="html">
         <source>Send to team or enterprise</source>
+      </trans-unit>
+      <trans-unit id="3158554629807420909" datatype="html">
+        <source>Get the Planet mobile app</source>
+      </trans-unit>
+      <trans-unit id="4684839318250929517" datatype="html">
+        <source>You&apos;re browsing on an Android device. Install one of our apps for a faster, offline-capable experience.</source>
+      </trans-unit>
+      <trans-unit id="6082171864197428613" datatype="html">
+        <source>Install</source>
+      </trans-unit>
+      <trans-unit id="5161411570094992408" datatype="html">
+        <source>Not now</source>
       </trans-unit>
       <trans-unit id="4070918274702026114" datatype="html">
         <source>Announcement</source>
@@ -4348,6 +4375,9 @@ Other Notes</source>
       <trans-unit id="1209916426134713754" datatype="html">
         <source>Error sending survey requests.</source>
       </trans-unit>
+      <trans-unit id="8902217649532050849" datatype="html">
+        <source>There was a problem recording the survey.</source>
+      </trans-unit>
       <trans-unit id="1414733139904716677" datatype="html">
         <source>Public link generated for this survey</source>
       </trans-unit>
@@ -4543,8 +4573,8 @@ Other Notes</source>
       <trans-unit id="6590475405017990661" datatype="html">
         <source>reports</source>
       </trans-unit>
-      <trans-unit id="6825329815737519497" datatype="html">
-        <source>Export as CSV</source>
+      <trans-unit id="7926143511350598250" datatype="html">
+        <source>CSV</source>
       </trans-unit>
       <trans-unit id="6864016537810263548" datatype="html">
         <source>Add Report</source>
@@ -4609,20 +4639,35 @@ Other Notes</source>
       <trans-unit id="1232877081534491011" datatype="html">
         <source>There was a problem deleting the report.</source>
       </trans-unit>
-      <trans-unit id="8047377907322802891" datatype="html">
-        <source>Updated Date</source>
-      </trans-unit>
       <trans-unit id="8279659101806790636" datatype="html">
         <source>Wages</source>
       </trans-unit>
       <trans-unit id="1426475745601890846" datatype="html">
         <source>Other Expenses</source>
       </trans-unit>
+      <trans-unit id="7531506369118512654" datatype="html">
+        <source>Total Credit</source>
+      </trans-unit>
+      <trans-unit id="5935363325942095320" datatype="html">
+        <source>Total Debit</source>
+      </trans-unit>
+      <trans-unit id="6565745869379859165" datatype="html">
+        <source>Net Profit/Loss</source>
+      </trans-unit>
+      <trans-unit id="4579766002080253515" datatype="html">
+        <source>Financial Summary for <x id="PH" equiv-text="titleName"/>.pdf</source>
+      </trans-unit>
+      <trans-unit id="8047377907322802891" datatype="html">
+        <source>Updated Date</source>
+      </trans-unit>
       <trans-unit id="188408324951035066" datatype="html">
         <source>Unnamed</source>
       </trans-unit>
       <trans-unit id="6630681340946694789" datatype="html">
         <source>Financial Summary for <x id="PH" equiv-text="titleName"/></source>
+      </trans-unit>
+      <trans-unit id="2352646517693441633" datatype="html">
+        <source>Receipt images for <x id="PH" equiv-text="fullLabel(report.startDate, this.localeId)"/> - <x id="PH_1" equiv-text="fullLabel(report.endDate, this.localeId)"/></source>
       </trans-unit>
       <trans-unit id="7115407436370620649" datatype="html">
         <source>Balance is negative</source>
@@ -4687,9 +4732,6 @@ Other Notes</source>
       <trans-unit id="1783245762876858628" datatype="html">
         <source>There was a problem deleting this transaction.</source>
       </trans-unit>
-      <trans-unit id="3938396793871184620" datatype="html">
-        <source>date</source>
-      </trans-unit>
       <trans-unit id="6777974573583289938" datatype="html">
         <source>description</source>
       </trans-unit>
@@ -4702,8 +4744,20 @@ Other Notes</source>
       <trans-unit id="5452881409775077105" datatype="html">
         <source>balance</source>
       </trans-unit>
+      <trans-unit id="7791553364151343531" datatype="html">
+        <source>Financial Transactions for <x id="PH" equiv-text="titleName"/>.pdf</source>
+      </trans-unit>
+      <trans-unit id="3938396793871184620" datatype="html">
+        <source>date</source>
+      </trans-unit>
       <trans-unit id="7933600964690636863" datatype="html">
         <source>Financial Transactions for <x id="PH" equiv-text="titleName"/></source>
+      </trans-unit>
+      <trans-unit id="5577210405857641325" datatype="html">
+        <source>Beginning</source>
+      </trans-unit>
+      <trans-unit id="8571274863118609047" datatype="html">
+        <source>Date range: <x id="PH" equiv-text="start"/> - <x id="PH_1" equiv-text="end"/></source>
       </trans-unit>
       <trans-unit id="8759370273386874620" datatype="html">
         <source>{VAR_SELECT, select, team {Teams} enterprise {Enterprises}}</source>
@@ -5227,8 +5281,8 @@ Other Notes</source>
       <trans-unit id="7216178614747796846" datatype="html">
         <source>Birthplace: <x id="PH" equiv-text="this.user.birthplace"/></source>
       </trans-unit>
-      <trans-unit id="1569462115651641805" datatype="html">
-        <source><x id="PH" equiv-text="this.user.name"/> achievements</source>
+      <trans-unit id="6914009700103907353" datatype="html">
+        <source><x id="PH" equiv-text="this.user.name"/> achievements.pdf</source>
       </trans-unit>
       <trans-unit id="9082581968602742137" datatype="html">
         <source>Request for User Data Deletion</source>

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -4375,9 +4375,6 @@ Other Notes</source>
       <trans-unit id="1209916426134713754" datatype="html">
         <source>Error sending survey requests.</source>
       </trans-unit>
-      <trans-unit id="8902217649532050849" datatype="html">
-        <source>There was a problem recording the survey.</source>
-      </trans-unit>
       <trans-unit id="1414733139904716677" datatype="html">
         <source>Public link generated for this survey</source>
       </trans-unit>
@@ -4573,8 +4570,8 @@ Other Notes</source>
       <trans-unit id="6590475405017990661" datatype="html">
         <source>reports</source>
       </trans-unit>
-      <trans-unit id="7926143511350598250" datatype="html">
-        <source>CSV</source>
+      <trans-unit id="6825329815737519497" datatype="html">
+        <source>Export as CSV</source>
       </trans-unit>
       <trans-unit id="6864016537810263548" datatype="html">
         <source>Add Report</source>
@@ -4639,35 +4636,20 @@ Other Notes</source>
       <trans-unit id="1232877081534491011" datatype="html">
         <source>There was a problem deleting the report.</source>
       </trans-unit>
+      <trans-unit id="8047377907322802891" datatype="html">
+        <source>Updated Date</source>
+      </trans-unit>
       <trans-unit id="8279659101806790636" datatype="html">
         <source>Wages</source>
       </trans-unit>
       <trans-unit id="1426475745601890846" datatype="html">
         <source>Other Expenses</source>
       </trans-unit>
-      <trans-unit id="7531506369118512654" datatype="html">
-        <source>Total Credit</source>
-      </trans-unit>
-      <trans-unit id="5935363325942095320" datatype="html">
-        <source>Total Debit</source>
-      </trans-unit>
-      <trans-unit id="6565745869379859165" datatype="html">
-        <source>Net Profit/Loss</source>
-      </trans-unit>
-      <trans-unit id="4579766002080253515" datatype="html">
-        <source>Financial Summary for <x id="PH" equiv-text="titleName"/>.pdf</source>
-      </trans-unit>
-      <trans-unit id="8047377907322802891" datatype="html">
-        <source>Updated Date</source>
-      </trans-unit>
       <trans-unit id="188408324951035066" datatype="html">
         <source>Unnamed</source>
       </trans-unit>
       <trans-unit id="6630681340946694789" datatype="html">
         <source>Financial Summary for <x id="PH" equiv-text="titleName"/></source>
-      </trans-unit>
-      <trans-unit id="2352646517693441633" datatype="html">
-        <source>Receipt images for <x id="PH" equiv-text="fullLabel(report.startDate, this.localeId)"/> - <x id="PH_1" equiv-text="fullLabel(report.endDate, this.localeId)"/></source>
       </trans-unit>
       <trans-unit id="7115407436370620649" datatype="html">
         <source>Balance is negative</source>
@@ -4732,6 +4714,9 @@ Other Notes</source>
       <trans-unit id="1783245762876858628" datatype="html">
         <source>There was a problem deleting this transaction.</source>
       </trans-unit>
+      <trans-unit id="3938396793871184620" datatype="html">
+        <source>date</source>
+      </trans-unit>
       <trans-unit id="6777974573583289938" datatype="html">
         <source>description</source>
       </trans-unit>
@@ -4744,20 +4729,8 @@ Other Notes</source>
       <trans-unit id="5452881409775077105" datatype="html">
         <source>balance</source>
       </trans-unit>
-      <trans-unit id="7791553364151343531" datatype="html">
-        <source>Financial Transactions for <x id="PH" equiv-text="titleName"/>.pdf</source>
-      </trans-unit>
-      <trans-unit id="3938396793871184620" datatype="html">
-        <source>date</source>
-      </trans-unit>
       <trans-unit id="7933600964690636863" datatype="html">
         <source>Financial Transactions for <x id="PH" equiv-text="titleName"/></source>
-      </trans-unit>
-      <trans-unit id="5577210405857641325" datatype="html">
-        <source>Beginning</source>
-      </trans-unit>
-      <trans-unit id="8571274863118609047" datatype="html">
-        <source>Date range: <x id="PH" equiv-text="start"/> - <x id="PH_1" equiv-text="end"/></source>
       </trans-unit>
       <trans-unit id="8759370273386874620" datatype="html">
         <source>{VAR_SELECT, select, team {Teams} enterprise {Enterprises}}</source>
@@ -5281,8 +5254,8 @@ Other Notes</source>
       <trans-unit id="7216178614747796846" datatype="html">
         <source>Birthplace: <x id="PH" equiv-text="this.user.birthplace"/></source>
       </trans-unit>
-      <trans-unit id="6914009700103907353" datatype="html">
-        <source><x id="PH" equiv-text="this.user.name"/> achievements.pdf</source>
+      <trans-unit id="1569462115651641805" datatype="html">
+        <source><x id="PH" equiv-text="this.user.name"/> achievements</source>
       </trans-unit>
       <trans-unit id="9082581968602742137" datatype="html">
         <source>Request for User Data Deletion</source>


### PR DESCRIPTION
<img width="391" height="854" alt="image" src="https://github.com/user-attachments/assets/8148048d-217d-4420-b6b9-318d3a3290e8" />


 Adds an extra Android app-install prompt when users open public surveys, while retaining the existing Android banner. Both surfaces offer myPlanet and myPlanet Lite.

  Dismissal of the dialog is stored in `sessionStorage`, so it remains closed after refreshes in the same tab but may reappear in a new session.

  ## Changes

  - Adds a public-survey Android install dialog.
  - Expands the existing banner to include both apps.
  - Centralizes app names, descriptions, and Play Store links.
  - Adds accessibility labels and responsive styling.
  - Adds tests and Spanish translations for all newly extracted strings.

  ## Steps to test

  1. On an Android device or Android user agent, open:
     `/survey/<teamId>/<surveyId>`
  2. Verify the dialog shows both apps and their correct Play Store links.
  3. Close the dialog and refresh; it should not reappear in the same tab.
  4. Clear `sessionStorage` or start a new session; it should appear again.
  5. Use a non-Android user agent; the dialog should not appear.
  6. Open the authenticated Planet interface on Android and verify the existing banner shows both apps and can be closed.
  7. Repeat using the Spanish locale and verify the translated text.

  ## Validation

  - Unit tests
  - Angular lint
  - i18n extraction check
  - Spanish localized build


https://claude.ai/code/session_01JEkpsKj5Erfasi6PTaFXed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an Android app promotion dialog for myPlanet and myPlanet Lite with “Install” and “Not now”.
  * Added a conditional Android app prompt on public surveys that shows once per session after dismissal.
  * Updated the home banner to render multiple Android app links dynamically.

* **Bug Fixes**
  * Improved accessibility with clearer aria-labels for banner close and app install actions.

* **Translations**
  * Updated Android banner and prompt text (including Spanish) for both app variants and related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->