### PR TITLE
courses: add start test and survey confirmation dialog (fixes #10159)

### DIFF
--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -299,7 +299,6 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
         },
         changeType: type === 'survey' ? 'take' : (this.attempts > 0 ? 'retake' : 'take'),
         type: type === 'survey' ? 'survey' : 'exam',
-        displayName,
         extraMessage,
       }
     });

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -285,7 +285,9 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
     const formType = type === 'survey' ? $localize`Survey` : $localize`Exam`;
     const extraMessage = $localize`Course: <b>${this.courseTitle}</b>` +
       `<br>Step: <b>${this.stepDetail?.stepTitle}</b>` +
-      `<br>Form Type: <b>${formType}</b>`;
+      `<br>Form Type: <b>${formType}</b>` +
+      '<br/></br>' +
+      '<br>Total Questions: <b>' + (this.stepDetail?.[type]?.questions?.length || 0) + '</b>';
     const dialogRef = this.dialog.open(DialogsPromptComponent, {
       data: {
         okClick: {

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -277,6 +277,11 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
 
   goToExam(type = 'exam', preview = false) {
     const displayName = this.stepDetail[type]?.displayName || type;
+    if (preview) {
+      this.navigateToExam(type, true);
+      this.planetMessageService.showMessage(`Previewing ${displayName}`);
+      return;
+    }
     const formType = type === 'survey' ? $localize`Survey` : $localize`Exam`;
     const extraMessage = $localize`Course: <b>${this.courseTitle}</b>` +
       `<br>Step: <b>${this.stepDetail?.stepTitle}</b>` +
@@ -288,12 +293,13 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
           onNext: () => {
             dialogRef.close();
             this.navigateToExam(type, preview);
-            const message = preview ? `Previewing ${displayName}` : `Starting ${displayName}`;
+            const message = `Starting ${displayName}`;
             this.planetMessageService.showMessage(message);
           },
         },
         changeType: type === 'survey' ? 'take' : (this.attempts > 0 ? 'retake' : 'take'),
         type: type === 'survey' ? 'survey' : 'exam',
+        displayName,
         extraMessage,
       }
     });

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -25,6 +25,9 @@ import { FormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ResourcesViewerComponent } from '../../resources/view-resources/resources-viewer.component';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
+import { PlanetMessageService } from '../../shared/planet-message.service';
+import { of } from 'rxjs';
+import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
 
 @Component({
   templateUrl: './courses-step-view.component.html',
@@ -49,7 +52,8 @@ import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinn
     MatButtonToggle,
     MatTooltip,
     ResourcesViewerComponent,
-    PlanetLoadingSpinnerComponent
+    PlanetLoadingSpinnerComponent,
+    DialogsPromptComponent
   ]
 })
 
@@ -60,6 +64,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   stepDetail: any = { stepTitle: '', description: '', resources: [] };
   conversations: any[] = [];
   courseId: string;
+  courseTitle = '';
   maxStep = 1;
   resourceUrl = '';
   examStart = 1;
@@ -91,6 +96,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private deviceInfoService: DeviceInfoService,
     private challengesService: ChallengesService,
+    private planetMessageService: PlanetMessageService,
   ) {
     this.deviceType = this.deviceInfoService.getDeviceType();
   }
@@ -165,6 +171,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   }
 
   initCourse(course, progress, resources, exams) {
+    this.courseTitle = course?.courseTitle || course?.title || '';
     // To be readable by non-technical people stepNum param will start at 1
     this.stepDetail = course.steps[this.stepNum - 1];
     this.initResources(resources);
@@ -251,7 +258,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
     this.resource = value;
   }
 
-  goToExam(type = 'exam', preview = false) {
+  navigateToExam(type = 'exam', preview = false) {
     this.router.navigate(
       [
         'exam',
@@ -266,6 +273,30 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
       ],
       { relativeTo: this.route }
     );
+  }
+
+  goToExam(type = 'exam', preview = false) {
+    const displayName = this.stepDetail[type]?.displayName || type;
+    const formType = type === 'survey' ? $localize`Survey` : $localize`Exam`;
+    const extraMessage = $localize`Course: <b>${this.courseTitle}</b>` +
+      `<br>Step: <b>${this.stepDetail?.stepTitle}</b>` +
+      `<br>Form Type: <b>${formType}</b>`;
+    const dialogRef = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: of(true),
+          onNext: () => {
+            dialogRef.close();
+            this.navigateToExam(type, preview);
+            const message = preview ? `Previewing ${displayName}` : `Starting ${displayName}`;
+            this.planetMessageService.showMessage(message);
+          },
+        },
+        changeType: type === 'survey' ? 'take' : (this.attempts > 0 ? 'retake' : 'take'),
+        type: type === 'survey' ? 'survey' : 'exam',
+        extraMessage,
+      }
+    });
   }
 
   filterResources(step, resources) {

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -226,7 +226,9 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     const formType = $localize`Survey`;
     const extraMessage = $localize`Course: <b>${courseTitle}</b>` +
       `<br>Step: <b>${stepDetail?.stepTitle || 'Step ' + displayStepNum}</b>` +
-      `<br>Form Type: <b>${formType}</b>`;
+      `<br>Form Type: <b>${formType}</b>` +
+      '<br/></br>' +
+      '<br>Total Questions: <b>' + (stepDetail?.exam?.questions?.length || 0) + '</b>';
 
     const dialogRef = this.dialog.open(DialogsPromptComponent, {
       data: {
@@ -278,7 +280,9 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     const formType = $localize`Exam`;
     const extraMessage = $localize`Course: <b>${courseTitle}</b>` +
       `<br>Step: <b>${stepDetail?.stepTitle || 'Step ' + displayStepNum}</b>` +
-      `<br>Form Type: <b>${formType}</b>`;
+      `<br>Form Type: <b>${formType}</b>` +
+      '<br/></br>' +
+      '<br>Total Questions: <b>' + (stepDetail?.exam?.questions?.length || 0) + '</b>';
 
     const dialogRef = this.dialog.open(DialogsPromptComponent, {
       data: {

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -244,7 +244,6 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
         },
         changeType: 'take',
         type: 'survey',
-        displayName,
         extraMessage,
       }
     });
@@ -297,7 +296,6 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
         },
         changeType: stepDetail?.attempts > 0 ? 'retake' : 'take',
         type: 'exam',
-        displayName,
         extraMessage,
       }
     });

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -26,6 +26,10 @@ import { CoursesIconComponent, courseIcons } from '../courses-icon.component';
 import { PlanetMarkdownComponent } from '../../shared/planet-markdown.component';
 import { ResourcesMenuComponent } from '../../resources/view-resources/resources-menu.component';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
+import { MatDialog } from '@angular/material/dialog';
+import { PlanetMessageService } from '../../shared/planet-message.service';
+import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
+import { of } from 'rxjs';
 
 @Component({
   templateUrl: './courses-view.component.html',
@@ -52,7 +56,8 @@ import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinn
     ResourcesMenuComponent,
     MatAnchor,
     MatMenuItem,
-    PlanetLoadingSpinnerComponent
+    PlanetLoadingSpinnerComponent,
+    DialogsPromptComponent
   ]
 })
 export class CoursesViewComponent implements OnInit, OnDestroy {
@@ -83,7 +88,9 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     private coursesService: CoursesService,
     private submissionsService: SubmissionsService,
     private stateService: StateService,
-    private deviceInfoService: DeviceInfoService
+    private deviceInfoService: DeviceInfoService,
+    private dialog: MatDialog,
+    private planetMessageService: PlanetMessageService
   ) {
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
@@ -169,23 +176,120 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     this.router.navigate([ './step/' + latestStep ], { relativeTo: this.route });
   }
 
-  goToSurvey(stepNum, preview = false) {
+  private resolveStepAndIndex(
+    stepOrIndex: any, indexOrPreview?: any, previewParam = false
+  ): { stepDetail: any, stepIndex: number, preview: boolean } {
+    let stepIndex: number;
+    let preview = previewParam;
+
+    if (typeof stepOrIndex === 'number') {
+      stepIndex = stepOrIndex;
+      if (typeof indexOrPreview === 'boolean') {
+        preview = indexOrPreview;
+      }
+    } else if (typeof indexOrPreview === 'number') {
+      stepIndex = indexOrPreview;
+    } else {
+      stepIndex = 0;
+    }
+
+    if (typeof indexOrPreview === 'boolean') {
+      preview = indexOrPreview;
+    }
+
+    const stepDetail = (typeof stepIndex === 'number' && this.courseDetail?.steps?.[stepIndex])
+      ? this.courseDetail.steps[stepIndex]
+      : (typeof stepOrIndex === 'object' && stepOrIndex ? stepOrIndex : {});
+    return { stepDetail, stepIndex, preview };
+  }
+
+  navigateToSurvey(stepOrIndex: any, indexOrPreview?: any, previewParam = false) {
+    const { stepDetail, stepIndex, preview } = this.resolveStepAndIndex(stepOrIndex, indexOrPreview, previewParam);
+    const stepNum = stepIndex + 1;
+    const examId = stepDetail?.survey?._id;
     this.router.navigate(
-      [ `./step/${stepNum + 1}/exam`, { questionNum: 1, type: 'survey', preview, examId: this.courseDetail.steps[stepNum].survey._id } ],
+      [ `./step/${stepNum}/exam`, { questionNum: 1, type: 'survey', preview, examId } ],
       { relativeTo: this.route }
     );
   }
 
-  goToExam(step, stepIndex, preview = false) {
-    const questionNum = (this.submissionsService.nextQuestion(step.submission, step.submission.answers.length - 1, 'passed') + 1) || 1;
+  goToSurvey(stepOrIndex: any, indexOrPreview?: any, previewParam = false) {
+    const { stepDetail, stepIndex, preview } = this.resolveStepAndIndex(stepOrIndex, indexOrPreview, previewParam);
+    const displayName = stepDetail?.survey?.name || stepDetail?.survey?.displayName || stepDetail?.survey?.title || 'survey';
+    const courseTitle = this.courseDetail?.courseTitle || this.courseDetail?.title || '';
+    const displayStepNum = stepIndex + 1;
+    const formType = $localize`Survey`;
+    const extraMessage = $localize`Course: <b>${courseTitle}</b>` +
+      `<br>Step: <b>${stepDetail?.stepTitle || 'Step ' + displayStepNum}</b>` +
+      `<br>Form Type: <b>${formType}</b>`;
+
+    const dialogRef = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: of(true),
+          onNext: () => {
+            dialogRef.close();
+            this.navigateToSurvey(stepDetail, stepIndex, preview);
+            const message = preview ? `Previewing ${displayName}` : `Starting ${displayName}`;
+            this.planetMessageService.showMessage(message);
+          },
+          onError: () => {
+            dialogRef.close();
+          }
+        },
+        changeType: 'take',
+        type: 'survey',
+        displayName,
+        extraMessage,
+      }
+    });
+  }
+
+  navigateToExam(stepOrIndex: any, indexOrPreview?: any, previewParam = false) {
+    const { stepDetail, stepIndex, preview } = this.resolveStepAndIndex(stepOrIndex, indexOrPreview, previewParam);
+    const submission = stepDetail?.submission;
+    const questionNum = submission?.answers ?
+      (this.submissionsService.nextQuestion(submission, submission.answers.length - 1, 'passed') + 1) || 1 : 1;
     const stepNum = stepIndex + 1;
+    const examId = stepDetail?.exam?._id;
     this.router.navigate(
       [
         `./step/${stepNum}/exam`,
-        { id: this.courseId, stepNum, questionNum, type: 'exam', preview, examId: this.courseDetail.steps[stepIndex].exam._id }
+        { id: this.courseId, stepNum, questionNum, type: 'exam', preview, examId }
       ],
       { relativeTo: this.route }
     );
+  }
+
+  goToExam(stepOrIndex: any, indexOrPreview?: any, previewParam = false) {
+    const { stepDetail, stepIndex, preview } = this.resolveStepAndIndex(stepOrIndex, indexOrPreview, previewParam);
+    const displayName = stepDetail?.exam?.name || stepDetail?.exam?.displayName || stepDetail?.exam?.title || 'exam';
+    const courseTitle = this.courseDetail?.courseTitle || this.courseDetail?.title || '';
+    const displayStepNum = stepIndex + 1;
+    const formType = $localize`Exam`;
+    const extraMessage = $localize`Course: <b>${courseTitle}</b>` +
+      `<br>Step: <b>${stepDetail?.stepTitle || 'Step ' + displayStepNum}</b>` +
+      `<br>Form Type: <b>${formType}</b>`;
+
+    const dialogRef = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: of(true),
+          onNext: () => {
+            dialogRef.close();
+            this.navigateToExam(stepDetail, stepIndex, preview);
+            const message = preview ? `Previewing ${displayName}` : `Starting ${displayName}`;
+            this.planetMessageService.showMessage(message);
+          },
+          onError: () => {
+            dialogRef.close();
+          }
+        },
+        changeType: stepDetail?.attempts > 0 ? 'retake' : 'take',
+        type: 'exam',
+        extraMessage,
+      }
+    });
   }
 
   previewButtonClick(step: any, stepNum: any): void {
@@ -193,7 +297,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     if (stepType === 'both' || stepType === undefined) {
       return;
     }
-    this.previewButton.closeMenu();
+    this.previewButton?.closeMenu();
     if (stepType === 'exam') {
       this.goToExam(step, stepNum, true);
     }

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -216,6 +216,11 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   goToSurvey(stepOrIndex: any, indexOrPreview?: any, previewParam = false) {
     const { stepDetail, stepIndex, preview } = this.resolveStepAndIndex(stepOrIndex, indexOrPreview, previewParam);
     const displayName = stepDetail?.survey?.name || stepDetail?.survey?.displayName || stepDetail?.survey?.title || 'survey';
+    if (preview) {
+      this.navigateToSurvey(stepDetail, stepIndex, true);
+      this.planetMessageService.showMessage(`Previewing ${displayName}`);
+      return;
+    }
     const courseTitle = this.courseDetail?.courseTitle || this.courseDetail?.title || '';
     const displayStepNum = stepIndex + 1;
     const formType = $localize`Survey`;
@@ -230,7 +235,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
           onNext: () => {
             dialogRef.close();
             this.navigateToSurvey(stepDetail, stepIndex, preview);
-            const message = preview ? `Previewing ${displayName}` : `Starting ${displayName}`;
+            const message = `Starting ${displayName}`;
             this.planetMessageService.showMessage(message);
           },
           onError: () => {
@@ -264,6 +269,11 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   goToExam(stepOrIndex: any, indexOrPreview?: any, previewParam = false) {
     const { stepDetail, stepIndex, preview } = this.resolveStepAndIndex(stepOrIndex, indexOrPreview, previewParam);
     const displayName = stepDetail?.exam?.name || stepDetail?.exam?.displayName || stepDetail?.exam?.title || 'exam';
+    if (preview) {
+      this.navigateToExam(stepDetail, stepIndex, true);
+      this.planetMessageService.showMessage(`Previewing ${displayName}`);
+      return;
+    }
     const courseTitle = this.courseDetail?.courseTitle || this.courseDetail?.title || '';
     const displayStepNum = stepIndex + 1;
     const formType = $localize`Exam`;
@@ -278,7 +288,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
           onNext: () => {
             dialogRef.close();
             this.navigateToExam(stepDetail, stepIndex, preview);
-            const message = preview ? `Previewing ${displayName}` : `Starting ${displayName}`;
+            const message = `Starting ${displayName}`;
             this.planetMessageService.showMessage(message);
           },
           onError: () => {
@@ -287,6 +297,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
         },
         changeType: stepDetail?.attempts > 0 ? 'retake' : 'take',
         type: 'exam',
+        displayName,
         extraMessage,
       }
     });

--- a/src/app/shared/dialogs/dialogs-prompt.component.html
+++ b/src/app/shared/dialogs/dialogs-prompt.component.html
@@ -4,7 +4,7 @@
   }
   @if (showMainParagraph) {
     <p i18n>
-    Are you sure you want to {data.changeType, select, accept {accept} archive {archive} reject {reject} delete {delete} leave {leave} remove {remove} leader {give leadership to} exit {leave} reset {reset}}
+    Are you sure you want to {data.changeType, select, accept {accept} archive {archive} reject {reject} take {take} retake {retake} delete {delete} leave {leave} remove {remove} leader {give leadership to} exit {leave} reset {reset}}
       the {data.amount, select, single
       {following {data.type, select,
         community {community}
@@ -22,6 +22,7 @@
         event {event}
         transaction {transaction}
         link {link}
+        exam {exam}
         news {message}
         report {report}
         changes {form}


### PR DESCRIPTION
Fixes #10159 
- Updates Angular ICU message format select expressions for take and retake of exams and surveys
- Creates dialog popup for course members attempting to take a course test or survey, displaying warning, course name, step name, and form type.
- Adds identical logic for attempting to start a test or survey from the step dropdown menu on the course overview page

<img width="481" height="282" alt="image" src="https://github.com/user-attachments/assets/9e88bcb8-b7f5-44df-9a80-8dec0a03a404" />

<img width="481" height="282" alt="image" src="https://github.com/user-attachments/assets/9d482ba5-4bd6-4f8a-841b-a5b8636e6672" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before starting exam and survey flows.
  * Added clearer preview and start messaging that includes course/step context.
  * Improved exam and survey navigation with preview vs start behavior.
  * Extended dialog localization for “take” vs “retake” and added exam option messaging.
* **Bug Fixes**
  * Improved preview menu handling to avoid errors when the preview menu is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->