### PR TITLE
resources: smoother viewer fullscreen button handling (fixes #10166)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.73",
   "myplanet": {
     "latest": "v0.61.83",
     "min": "v0.60.60"

--- a/src/app/resources/view-resources/resources-viewer.component.html
+++ b/src/app/resources/view-resources/resources-viewer.component.html
@@ -16,7 +16,7 @@
     @case ('pdf') {
       <div style="position: relative;">
         <div class="pdf-toolbar">
-          <button mat-icon-button style="color: white" (click)="openFullscreen()">
+          <button mat-icon-button class="fullscreen-button" (click)="openFullscreen()">
             <mat-icon>fullscreen</mat-icon>
           </button>
         </div>

--- a/src/app/resources/view-resources/resources-viewer.scss
+++ b/src/app/resources/view-resources/resources-viewer.scss
@@ -64,6 +64,10 @@ $full-height: calc(#{v.$view-container-height} - 2rem);
     bottom: 10px;
     right: 10px;
     background-color: rgba(0, 0, 0, 0.5);
+
+    .fullscreen-button {
+      color: v.$white;
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #10166 
- Removes `style="color: white"` inline attribute from the fullscreen toggle button in `resources-viewer.component.html`
- Adds `.fullscreen-button` CSS class in `resources-viewer.scss` using `$white` design token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved PDF viewer fullscreen button styling to ensure its icon and text remain clearly visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->