### PR TITLE
all: smoother delete buttons styling (fixes #10170)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.74",
   "myplanet": {
     "latest": "v0.61.83",
     "min": "v0.60.60"

--- a/src/app/manager-dashboard/certifications/certifications.component.html
+++ b/src/app/manager-dashboard/certifications/certifications.component.html
@@ -51,7 +51,7 @@
           <a mat-raised-button color="primary" class="margin-lr-3 action-button" [routerLink]="['update/' + element._id]" (click)="$event.stopPropagation()" i18n>
             <mat-icon>edit</mat-icon>Edit
           </a>
-          <button mat-raised-button color="primary" class="margin-lr-3 action-button" (click)="$event.stopPropagation(); deleteClick(element)" i18n>
+          <button mat-raised-button color="warn" class="margin-lr-3 action-button" (click)="$event.stopPropagation(); deleteClick(element)" i18n>
             <mat-icon>delete_forever</mat-icon>Delete
           </button>
         </mat-cell>

--- a/src/app/manager-dashboard/reports/pending-table.component.html
+++ b/src/app/manager-dashboard/reports/pending-table.component.html
@@ -17,7 +17,7 @@
   <ng-container matColumnDef="actions">
     <mat-header-cell *matHeaderCellDef i18n>Action</mat-header-cell>
     <mat-cell *matCellDef="let element">
-      <button mat-raised-button color="primary" (click)="deleteItem(element)"><mat-icon>delete</mat-icon><ng-container i18n>Delete</ng-container></button>
+      <button mat-raised-button color="warn" (click)="deleteItem(element)"><mat-icon>delete</mat-icon><ng-container i18n>Delete</ng-container></button>
     </mat-cell>
   </ng-container>
   <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/shared/forms/planet-step-list.component.html
+++ b/src/app/shared/forms/planet-step-list.component.html
@@ -13,7 +13,7 @@
       <button class="back-button" (click)="toList()" mat-stroked-button type="button" i18n><mat-icon>keyboard_arrow_left</mat-icon>Return to List</button>
       <button mat-stroked-button [disabled]="this.openIndex === 0" (click)="changeStep(-1)" type="button" i18n>Previous</button>
       <button mat-stroked-button [disabled]="this.openIndex >= (this.stepListItems.length - 1)" (click)="changeStep(1)" type="button" i18n>Next</button>
-      <button mat-stroked-button (click)="removeStep()" type="button" i18n>Delete</button>
+      <button mat-stroked-button color="warn" (click)="removeStep()" type="button" i18n>Delete</button>
       <ng-content select="[planetStepListNumber]"></ng-content>
     </div>
     <ng-content select="[planetStepListForm]"></ng-content>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -56,7 +56,7 @@
             }
             <span i18n-matTooltip matTooltip="You may only delete a collection with no subcollections" [matTooltipDisabled]="tag.subTags.length === 0">
               @if (isUserAdmin) {
-                <button mat-stroked-button [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
+                <button mat-stroked-button color="warn" [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
               }
             </span>
           </ng-container>
@@ -74,7 +74,7 @@
                   <button mat-stroked-button (click)="editTagClick($event, subTag)" i18n class="button-spacing">Edit</button>
                 }
                 @if (isUserAdmin) {
-                  <button mat-stroked-button (click)="deleteTag($event, subTag)" i18n>Delete</button>
+                  <button mat-stroked-button color="warn" (click)="deleteTag($event, subTag)" i18n>Delete</button>
                 }
               </ng-container>
             </mat-list-item>
@@ -104,7 +104,7 @@
             }
             <span i18n-matTooltip matTooltip="You may only delete a collection with no subcollections" [matTooltipDisabled]="tag.subTags.length === 0">
               @if (isUserAdmin) {
-                <button mat-stroked-button [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
+                <button mat-stroked-button color="warn" [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
               }
             </span>
           </ng-container>
@@ -124,7 +124,7 @@
                   <button mat-stroked-button (click)="editTagClick($event,subTag)" i18n>Edit</button>
                 }
                 @if (isUserAdmin) {
-                  <button mat-stroked-button (click)="deleteTag($event,subTag)" i18n>Delete</button>
+                  <button mat-stroked-button color="warn" (click)="deleteTag($event,subTag)" i18n>Delete</button>
                 }
               </ng-container>
             </mat-list-item>

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -82,7 +82,7 @@
     }
   }
   @if (mode!=='services') {
-    <button *planetAuthorizedRoles="''" mat-raised-button color="accent" class=" toolbar-button margin-lr-3" (click)="openDialogPrompt(team, 'archive', { changeType: 'delete', type: 'team' })" i18n>Delete</button>
+    <button *planetAuthorizedRoles="''" mat-raised-button color="warn" class=" toolbar-button margin-lr-3" (click)="openDialogPrompt(team, 'archive', { changeType: 'delete', type: 'team' })" i18n>Delete</button>
   }
 </ng-template>
 

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -163,7 +163,7 @@
                 <label i18n> Feedback </label>
               }
             </button>
-            <button *planetAuthorizedRoles="''" mat-raised-button color="primary" (click)="archiveClick(element.doc); $event.stopPropagation()">
+            <button *planetAuthorizedRoles="''" mat-raised-button color="warn" (click)="archiveClick(element.doc); $event.stopPropagation()">
               <mat-icon>delete_forever</mat-icon>
               @if (!isMobile) {
                 <label i18n> Delete </label>

--- a/src/app/users/users-table.component.html
+++ b/src/app/users/users-table.component.html
@@ -151,7 +151,7 @@
               </button>
             }
             @if (!element.doc.isUserAdmin || element.doc.roles.length > 0) {
-              <button mat-raised-button color="primary" (click)="deleteClick(element.doc, $event)">
+              <button mat-raised-button color="warn" (click)="deleteClick(element.doc, $event)">
                 <mat-icon>delete</mat-icon>
                 @if (!isMobile) {
                   <label i18n> Delete </label>

--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -161,7 +161,7 @@
             <button mat-raised-button color="accent" (click)="resetSelection()"><span i18n>Reset Selection</span></button>
           }
           @if (uploadImage && currentImgKey && !imageFile && !attachmentDeleted) {
-            <button mat-raised-button color="accent" (click)="deleteImageAttachment()"><span i18n>Remove</span></button>
+            <button mat-raised-button color="warn" (click)="deleteImageAttachment()"><span i18n>Remove</span></button>
           }
         </div>
       </div>


### PR DESCRIPTION
Fixes #10170

Updates full text/raised/stroked destructive action buttons across user management, team views, certifications, pending reports, tag input dialogs, and step forms to use Angular Material's warning color (`color="warn"` / red) in compliance with the project style guide conventions.

<img width="193" height="151" alt="{88F4A550-44F3-41CC-B6E7-7793F06CA028}" src="https://github.com/user-attachments/assets/d1b043f0-733a-442d-8f2f-820bc5ddb514" />

<img width="637" height="88" alt="{3D0FE13D-1EDC-4528-B8C7-30EB8884BA0D}" src="https://github.com/user-attachments/assets/325b0618-f128-486a-8ec4-71839743fd69" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated delete and remove actions across certifications, reports, forms, teams, and user management to use the warning color theme.
  - Improved visual consistency and made potentially destructive actions more clearly identifiable.
  - No action behavior, labels, permissions, or related functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->