### PR TITLE
teams: smoother surveys handling (fixes #10172)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.75",
   "myplanet": {
     "latest": "v0.61.83",
     "min": "v0.60.60"

--- a/src/app/_mixins.scss
+++ b/src/app/_mixins.scss
@@ -7,3 +7,14 @@
     grid-area: rt;
   }
 }
+
+// One column absorbs leftover width; the rest shrink from a content-sized basis.
+@mixin table-column-grow($min-width: 10rem) {
+  flex: 1 1 0;
+  min-width: $min-width;
+}
+
+@mixin table-column-fixed($basis) {
+  flex: 0 1 $basis;
+  min-width: 0;
+}

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -13,7 +13,7 @@
   </mat-toolbar>
 }
 
-<div class="primary-link-hover" [class.space-container]="!teamSurveyMode">
+<div class="primary-link-hover" [class.space-container]="!teamId">
   @if (!teamId) {
     <mat-toolbar class="primary-color font-size-1">
       @if (isAuthorized) {
@@ -38,7 +38,7 @@
       </ng-container>
     </mat-toolbar>
   }
-  <div class="view-container view-table" [class.view-full-height]="!teamSurveyMode" [class.in-tab]="teamSurveyMode">
+  <div class="view-container view-full-height view-table" [class.fill-parent]="teamId">
     @if (isLoading && !useDialogLoading) {
       <planet-loading-spinner text="Loading surveys..." i18n-text></planet-loading-spinner>
     }

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -13,7 +13,7 @@
   </mat-toolbar>
 }
 
-<div class="primary-link-hover" [class.space-container]="!teamId">
+<div class="primary-link-hover" [class.space-container]="!teamSurveyMode">
   @if (!teamId) {
     <mat-toolbar class="primary-color font-size-1">
       @if (isAuthorized) {
@@ -38,7 +38,7 @@
       </ng-container>
     </mat-toolbar>
   }
-  <div class="view-container view-table" [class.view-full-height]="!teamId" [class.in-tab]="teamId">
+  <div class="view-container view-table" [class.view-full-height]="!teamSurveyMode" [class.in-tab]="teamSurveyMode">
     @if (isLoading && !useDialogLoading) {
       <planet-loading-spinner text="Loading surveys..." i18n-text></planet-loading-spinner>
     }

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -13,7 +13,7 @@
   </mat-toolbar>
 }
 
-<div class="space-container primary-link-hover">
+<div class="primary-link-hover" [class.space-container]="!teamId">
   @if (!teamId) {
     <mat-toolbar class="primary-color font-size-1">
       @if (isAuthorized) {
@@ -38,7 +38,7 @@
       </ng-container>
     </mat-toolbar>
   }
-  <div class="view-container view-full-height view-table">
+  <div class="view-container view-table" [class.view-full-height]="!teamId" [class.in-tab]="teamId">
     @if (isLoading && !useDialogLoading) {
       <planet-loading-spinner text="Loading surveys..." i18n-text></planet-loading-spinner>
     }

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -1,3 +1,5 @@
+@use "../mixins" as m;
+
 :host {
   display: block;
 }
@@ -7,13 +9,8 @@
   height: 100%;
 }
 
-.mat-column-select {
-  flex: 0 0 auto;
-}
-
 .mat-column-name {
-  flex: 1 1 0;
-  min-width: 10rem;
+  @include m.table-column-grow;
 }
 
 .mat-column-name span,
@@ -26,15 +23,8 @@
 }
 
 .mat-column-taken,
-.mat-column-courseTitle,
-.mat-column-createdDate,
-.mat-column-action {
-  min-width: 0;
-}
-
-.mat-column-taken,
 .mat-column-createdDate {
-  flex: 0 1 16rem;
+  @include m.table-column-fixed(16rem);
 }
 
 .mat-column-taken {
@@ -43,7 +33,7 @@
 }
 
 .mat-column-courseTitle {
-  flex: 0 1 15rem;
+  @include m.table-column-fixed(15rem);
 }
 
 .mat-column-createdDate {
@@ -51,6 +41,5 @@
 }
 
 .mat-column-action {
-  flex: 0 1 18rem;
-  justify-content: flex-start;
+  @include m.table-column-fixed(18rem);
 }

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -1,5 +1,20 @@
 @use "../variables" as v;
 
+:host {
+  display: block;
+  height: 100%;
+}
+
+.view-full-height {
+  height: calc(#{v.$view-container-height} - 64px);
+  overflow: hidden;
+}
+
+.in-tab {
+  height: 100%;
+  overflow: hidden;
+}
+
 .mat-column-taken {
   max-width: 250px;
   display: flex;
@@ -15,11 +30,11 @@
   padding: 0 20px;
 }
 
-.mat-column-name, .mat-column-courseTitle {
+.mat-column-courseTitle {
   max-width: 250px;
 }
 
-.course-title, .mat-column-name span {
+.course-title {
   max-width: 250px;
   white-space: nowrap;
   overflow: hidden;
@@ -27,22 +42,21 @@
   display: block;
 }
 
-.mat-column-action {
-  justify-content: flex-start;
+.mat-column-name {
   flex: 1 1 auto;
   min-width: 0;
-}
 
-/* Targeting tablet screens */
-@media (max-width: v.$screen-md) {
-  .mat-column-name {
-    max-width: 175px;
+  span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+    max-width: 100%;
   }
 }
 
-/* Targeting mobile screens */
-@media (max-width: v.$screen-sm) {
-  .mat-column-name {
-    max-width: 80px;
-  }
+.mat-column-action {
+  justify-content: flex-start;
+  flex: 0 0 auto;
 }
+

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -1,73 +1,56 @@
-@use "../variables" as v;
-
 :host {
   display: block;
-  height: 100%;
 }
 
-.view-full-height {
-  height: calc(#{v.$view-container-height} - 64px);
-  overflow: hidden;
-}
-
-.in-tab {
+:host(.embedded),
+:host(.embedded) > .primary-link-hover {
   height: 100%;
-  overflow: hidden;
 }
 
 .mat-column-select {
-  flex: 0 0 50px;
-  max-width: 50px;
+  flex: 0 0 auto;
 }
 
 .mat-column-name {
-  flex: 1 1 auto;
-  min-width: 150px;
+  flex: 1 1 0;
+  min-width: 10rem;
+}
 
-  span {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: block;
-    max-width: 100%;
-  }
+.mat-column-name span,
+.mat-column-courseTitle .course-title {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mat-column-taken,
+.mat-column-courseTitle,
+.mat-column-createdDate,
+.mat-column-action {
+  min-width: 0;
+}
+
+.mat-column-taken,
+.mat-column-createdDate {
+  flex: 0 1 16rem;
 }
 
 .mat-column-taken {
-  flex: 0 0 220px;
-  max-width: 220px;
   justify-content: center;
   text-align: center;
-
-  ::ng-deep .mat-sort-header-container {
-    justify-content: center;
-  }
 }
 
 .mat-column-courseTitle {
-  flex: 0 0 240px;
-  max-width: 240px;
-
-  .course-title {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: block;
-    max-width: 100%;
-  }
+  flex: 0 1 15rem;
 }
 
 .mat-column-createdDate {
-  flex: 0 0 220px;
-  max-width: 220px;
-  justify-content: flex-start;
-  text-align: left;
+  text-align: start;
 }
 
 .mat-column-action {
-  flex: 0 0 240px;
-  min-width: 240px;
-  max-width: 240px;
+  flex: 0 1 18rem;
   justify-content: flex-start;
 }
-

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -34,8 +34,8 @@
 }
 
 .mat-column-taken {
-  flex: 0 0 180px;
-  max-width: 180px;
+  flex: 0 0 220px;
+  max-width: 220px;
   justify-content: center;
   text-align: center;
 
@@ -45,8 +45,8 @@
 }
 
 .mat-column-courseTitle {
-  flex: 0 0 200px;
-  max-width: 200px;
+  flex: 0 0 240px;
+  max-width: 240px;
 
   .course-title {
     white-space: nowrap;
@@ -58,16 +58,16 @@
 }
 
 .mat-column-createdDate {
-  flex: 0 0 180px;
-  max-width: 180px;
+  flex: 0 0 220px;
+  max-width: 220px;
   justify-content: flex-start;
   text-align: left;
 }
 
 .mat-column-action {
-  flex: 0 0 200px;
-  min-width: 200px;
-  max-width: 200px;
+  flex: 0 0 240px;
+  min-width: 240px;
+  max-width: 240px;
   justify-content: flex-start;
 }
 

--- a/src/app/surveys/surveys.component.scss
+++ b/src/app/surveys/surveys.component.scss
@@ -15,36 +15,14 @@
   overflow: hidden;
 }
 
-.mat-column-taken {
-  max-width: 250px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  padding: 0 32px;
-}
-
-.mat-column-createdDate {
-  max-width: 200px;
-  text-align: left;
-  padding: 0 20px;
-}
-
-.mat-column-courseTitle {
-  max-width: 250px;
-}
-
-.course-title {
-  max-width: 250px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
+.mat-column-select {
+  flex: 0 0 50px;
+  max-width: 50px;
 }
 
 .mat-column-name {
   flex: 1 1 auto;
-  min-width: 0;
+  min-width: 150px;
 
   span {
     white-space: nowrap;
@@ -55,8 +33,41 @@
   }
 }
 
-.mat-column-action {
+.mat-column-taken {
+  flex: 0 0 180px;
+  max-width: 180px;
+  justify-content: center;
+  text-align: center;
+
+  ::ng-deep .mat-sort-header-container {
+    justify-content: center;
+  }
+}
+
+.mat-column-courseTitle {
+  flex: 0 0 200px;
+  max-width: 200px;
+
+  .course-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+    max-width: 100%;
+  }
+}
+
+.mat-column-createdDate {
+  flex: 0 0 180px;
+  max-width: 180px;
   justify-content: flex-start;
-  flex: 0 0 auto;
+  text-align: left;
+}
+
+.mat-column-action {
+  flex: 0 0 200px;
+  min-width: 200px;
+  max-width: 200px;
+  justify-content: flex-start;
 }
 

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -50,6 +50,9 @@ interface SurveyFilterForm {
   selector: 'planet-surveys',
   templateUrl: './surveys.component.html',
   styleUrls: ['./surveys.component.scss'],
+  host: {
+    '[class.embedded]': 'teamId'
+  },
   imports: [
     MatToolbar,
     MatIconButton,

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -1,22 +1,36 @@
 @use "../variables" as v;
+@use "../mixins" as m;
 
 :host {
-  .mat-column-doc-teamType {
-    max-width: 150px;
-    padding-right: 0.5rem;
+  .mat-column-doc-name {
+    @include m.table-column-grow;
+  }
+
+  .mat-column-visitLog-lastVisit {
+    @include m.table-column-fixed(14rem);
   }
 
   .mat-column-visitLog-visitCount {
+    @include m.table-column-fixed(18rem);
     justify-content: center;
-    max-width: 175px;
     padding-right: 1rem;
+  }
+
+  .mat-column-doc-teamType {
+    @include m.table-column-fixed(8rem);
+    padding-right: 0.5rem;
+  }
+
+  .mat-column-action {
+    @include m.table-column-fixed(18rem);
   }
 
   mat-row {
     cursor: pointer;
   }
 
-  .team-name{
+  // Keep joined/type metadata visible by allowing long names to wrap.
+  .team-name {
     max-width: 95%;
     overflow: hidden;
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -424,6 +424,11 @@ body {
     height: v.$view-container-height;
     overflow-y: auto;
     box-sizing: border-box;
+
+    // Use the parent's bounds when the view is inside an already-sized container.
+    &.fill-parent {
+      height: 100%;
+    }
   }
 
   .view-container.view-full-height.view-table {


### PR DESCRIPTION
Fixes #10172 

## What changed

  - Preserved the Survey table's internal scrolling, sticky header, and paginator in every view.
  - Made embedded Surveys fill the available Team tab height instead of using a viewport-based height, removing the nested scrollbar.
  - Kept `/teams/view/:teamId/surveys` as a standalone routed page with its own toolbars, spacing, and viewport-based height.
  - Introduced shared Sass mixins for the table-column layout:
    - one primary column absorbs available space;
    - supporting columns use shrinkable, content-appropriate bases.
  - Applied the shared column layout to Surveys and Teams/Enterprises.
  - Kept long Survey and course titles on one line with ellipsis while allowing Team names and their membership/type metadata to wrap.

  ## Why

  The previous Survey layout allowed the Action column to absorb unused width, producing a large empty gap and unnecessarily wrapped headers. The viewport-based table height also did not fit
  correctly when Surveys was embedded inside a Team tab, resulting in nested scrollbars.

<img width="2558" height="1132" alt="image" src="https://github.com/user-attachments/assets/8f0b782c-2576-4cad-965a-496aa9b88574" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the surveys view layout when embedded in a tab, including more reliable full-height sizing.
* **Bug Fixes**
  * Refined survey table column sizing and alignment for a more consistent, stable layout.
  * Improved truncation/ellipsis behavior for long survey and course titles to keep rows readable.
  * Enhanced “fill available space” behavior for embedded views to maintain proper scrolling and height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->