### PR TITLE
resources: smoother file type filtering (fixes #10179)

### DIFF
--- a/src/app/resources/resources-constants.ts
+++ b/src/app/resources/resources-constants.ts
@@ -66,3 +66,40 @@ export const resourceFor = [
   { 'label': $localize`Leader`, 'value': 'leader' },
   { 'label': $localize`Learner`, 'value': 'learner' }
 ];
+
+export const mediaTypeList = [
+  { 'label': $localize`PDF`, 'value': 'pdf' },
+  { 'label': $localize`Image`, 'value': 'image' },
+  { 'label': $localize`Audio`, 'value': 'audio' },
+  { 'label': $localize`Video`, 'value': 'video' },
+  { 'label': $localize`ZIP`, 'value': 'zip' },
+  { 'label': $localize`HTML`, 'value': 'HTML' },
+  { 'label': $localize`EPUB`, 'value': 'epub' },
+  { 'label': $localize`CSV`, 'value': 'csv' },
+  { 'label': $localize`Document`, 'value': 'document' },
+  { 'label': $localize`Slides`, 'value': 'slides' },
+  { 'label': $localize`Spreadsheet`, 'value': 'spreadsheet' },
+  { 'label': $localize`Other`, 'value': 'other' }
+];
+
+export const getResourceFileType = (doc: any): string => {
+  if (doc?._attachments && Object.keys(doc._attachments).length > 0) {
+    const filename = doc.openWhichFile || Object.keys(doc._attachments)[0] || '';
+    const ext = filename.includes('.') ? filename.split('.').pop()?.toLowerCase() : '';
+    if (ext) {
+      return ext;
+    }
+  }
+  if (doc?.filename) {
+    const ext = doc.filename.includes('.') ? doc.filename.split('.').pop()?.toLowerCase() : '';
+    if (ext) {
+      return ext;
+    }
+  }
+  if (doc?.mediaType) {
+    return doc.mediaType.toLowerCase();
+  }
+  return '';
+};
+
+

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -23,9 +23,10 @@
 
   @if (showFilters) {
     <mat-toolbar-row class="search-bar">
-      <planet-resources-search [filteredData]="resources.filteredData" [startingSelection]="searchSelection" (searchChange)="onSearchChange($event)"></planet-resources-search>
+      <planet-resources-search [filteredData]="resources.data" [startingSelection]="searchSelection" (searchChange)="onSearchChange($event)"></planet-resources-search>
     </mat-toolbar-row>
   }
+
 </mat-toolbar>
 
 <ng-template #collectionRow>

--- a/src/app/resources/search-resources/resources-search.component.spec.ts
+++ b/src/app/resources/search-resources/resources-search.component.spec.ts
@@ -1,0 +1,87 @@
+import { ResourcesSearchComponent } from './resources-search.component';
+import { getResourceFileType } from '../resources-constants';
+import { filterAdvancedSearch } from '../../shared/table-helpers';
+
+describe('ResourcesSearchComponent and getResourceFileType', () => {
+  let component: ResourcesSearchComponent;
+
+  beforeEach(() => {
+    component = new ResourcesSearchComponent();
+  });
+
+  describe('getResourceFileType edgecases', () => {
+    it('prioritizes exact file extension from attachments or filename over generic mediaType', () => {
+      expect(getResourceFileType({ filename: 'video.mp4', mediaType: 'video' })).toBe('mp4');
+      expect(getResourceFileType({ _attachments: { 'audio.mp3': {} }, mediaType: 'audio' })).toBe('mp3');
+    });
+
+    it('handles uppercase file extensions cleanly', () => {
+      expect(getResourceFileType({ filename: 'DOCUMENT.PDF', mediaType: 'pdf' })).toBe('pdf');
+      expect(getResourceFileType({ _attachments: { 'PHOTO.PNG': {} } })).toBe('png');
+    });
+
+    it('uses openWhichFile over first attachment key when present', () => {
+      expect(getResourceFileType({
+        openWhichFile: 'main.html',
+        _attachments: { 'data.json': {}, 'main.html': {} }
+      })).toBe('html');
+    });
+
+    it('falls back to mediaType if filename or attachments have no extension', () => {
+      expect(getResourceFileType({ filename: 'README', mediaType: 'text' })).toBe('text');
+      expect(getResourceFileType({ mediaType: 'pdf' })).toBe('pdf');
+    });
+
+    it('returns empty string if no file info available', () => {
+      expect(getResourceFileType({})).toBe('');
+      expect(getResourceFileType(null)).toBe('');
+    });
+  });
+
+  describe('createSearchList', () => {
+    it('creates search list for mediaType category with extension labels', () => {
+      const sampleData = [
+        { doc: { filename: 'file1.mp4', mediaType: 'video' } },
+        { doc: { filename: 'file2.mp3', mediaType: 'audio' } },
+        { doc: { _attachments: { 'archive.zip': {} } } }
+      ];
+
+      const category = component.categories.find(c => c.label === 'mediaType');
+      const searchList = component.createSearchList(category, sampleData);
+
+      expect(searchList.category).toBe('mediaType');
+      expect(searchList.items).toEqual([
+        { label: 'MP3', value: 'mp3' },
+        { label: 'MP4', value: 'mp4' },
+        { label: 'ZIP', value: 'zip' }
+      ]);
+    });
+  });
+
+  describe('filterAdvancedSearch integration with mediaType', () => {
+    const docMp4 = { doc: { filename: 'clip.mp4', mediaType: 'video' } };
+    const docPdf = { doc: { filename: 'doc.pdf', mediaType: 'pdf' } };
+    const docZip = { doc: { _attachments: { 'app.zip': {} } } };
+
+    it('matches rows when single file type selected', () => {
+      const filterFn = filterAdvancedSearch({ mediaType: ['mp4'] });
+      expect(filterFn(docMp4, '')).toBe(true);
+      expect(filterFn(docPdf, '')).toBe(false);
+      expect(filterFn(docZip, '')).toBe(false);
+    });
+
+    it('matches rows when multiple file types selected (OR matching)', () => {
+      const filterFn = filterAdvancedSearch({ mediaType: ['mp4', 'zip'] });
+      expect(filterFn(docMp4, '')).toBe(true);
+      expect(filterFn(docPdf, '')).toBe(false);
+      expect(filterFn(docZip, '')).toBe(true);
+    });
+
+    it('matches all rows when no file types selected', () => {
+      const filterFn = filterAdvancedSearch({ mediaType: [] });
+      expect(filterFn(docMp4, '')).toBe(true);
+      expect(filterFn(docPdf, '')).toBe(true);
+      expect(filterFn(docZip, '')).toBe(true);
+    });
+  });
+});

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -114,9 +114,11 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
   createSearchList(category, data) {
     return ({
       category: category.label,
-      items: data.reduce((list, { doc }) => list.concat(doc[category.label]), []).reduce(dedupeShelfReduce, []).filter(item => item)
-        .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1).map(item => category.options.find(opt => opt.value === item))
+      items: data.reduce((list, { doc }) => list.concat(doc[category.label]), [])
+        .reduce(dedupeShelfReduce, [])
         .filter(item => item)
+        .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1)
+        .map(item => category.options.find(opt => opt.value === item) || { label: item, value: item })
     });
   }
 

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -114,11 +114,9 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
   createSearchList(category, data) {
     return ({
       category: category.label,
-      items: data.reduce((list, { doc }) => list.concat(doc[category.label]), [])
-        .reduce(dedupeShelfReduce, [])
+      items: data.reduce((list, { doc }) => list.concat(doc[category.label]), []).reduce(dedupeShelfReduce, []).filter(item => item)
+        .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1).map(item => category.options.find(opt => opt.value === item))
         .filter(item => item)
-        .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1)
-        .map(item => category.options.find(opt => opt.value === item) || { label: item, value: item })
     });
   }
 

--- a/src/app/resources/search-resources/resources-search.component.ts
+++ b/src/app/resources/search-resources/resources-search.component.ts
@@ -14,9 +14,11 @@ import { trackByCategory } from '../../shared/table-helpers';
       subject {Subject}
       language {Language}
       medium {Medium}
+      mediaType {File Type}
       level {Level}
     }
     </span>
+
     <mat-selection-list (selectionChange)="selectionChange($event)">
       @for (item of items; track item) {
         <mat-list-option [value]="item.value" [selected]="isSelected(item)" checkboxPosition="before">
@@ -87,6 +89,7 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
     { 'label': 'subject', 'options': constants.subjectList },
     { 'label': 'language', 'options': languages },
     { 'label': 'medium', 'options': constants.media },
+    { 'label': 'mediaType', 'options': constants.mediaTypeList },
     { 'label': 'level', 'options': constants.levelList }
   ];
 
@@ -112,13 +115,29 @@ export class ResourcesSearchComponent implements OnInit, OnChanges {
   }
 
   createSearchList(category, data) {
+    const rawItems = category.label === 'mediaType'
+      ? data.map(({ doc }) => constants.getResourceFileType(doc))
+      : data.reduce((list, { doc }) => list.concat(doc[category.label]), []);
+
     return ({
       category: category.label,
-      items: data.reduce((list, { doc }) => list.concat(doc[category.label]), []).reduce(dedupeShelfReduce, []).filter(item => item)
-        .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1).map(item => category.options.find(opt => opt.value === item))
+      items: rawItems
+        .reduce(dedupeShelfReduce, [])
         .filter(item => item)
+        .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1)
+        .map(item => {
+          if (category.label === 'mediaType') {
+            return { label: String(item).toUpperCase(), value: item };
+          }
+          const found = category.options?.find(
+            opt => opt.value.toLowerCase() === String(item).toLowerCase()
+          );
+          return found || { label: String(item), value: item };
+        })
     });
   }
+
+
 
   selectChange({ items, category }) {
     this.selected[category] = items;

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -112,27 +112,18 @@ const matchAllItems = (filterItems: string[], propItems: string[]) => {
   return filterItems.every(filter => propSet.has(filter));
 };
 
-const matchAnyItem = (filterItems: string[], propItems: string[]) => {
-  if (!filterItems || filterItems.length === 0) {
-    return true;
-  }
-  const propSet = new Set(propItems);
-  return filterItems.some(filter => propSet.has(filter));
-};
-
 const filterArrayField = (filterField: string, filterItems: string[]) => {
   return (data: unknown, _filter: string) => {
     const raw = getProperty(data, filterField);
     const propItems = Array.isArray(raw) ? raw : raw == null ? [] : [String(raw)];
 
-    return matchAnyItem(filterItems, propItems);
+    return matchAllItems(filterItems, propItems);
   };
 };
 
 export const filterTags = (filterControl: FormControl) => {
-  return (data: any) => {
-    const raw = data.tags ? data.tags.map((tag: any) => tag._id) : [];
-    return matchAllItems(filterControl.value, raw);
+  return (data: any, filter: string) => {
+    return filterArrayField('tags', filterControl.value)({ tags: data.tags.map((tag: any) => tag._id) }, filter);
   };
 };
 

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -1,5 +1,7 @@
 import { FormControl, AbstractControl } from '../../../node_modules/@angular/forms';
 import { FuzzySearchService } from './fuzzy-search.service';
+import { getResourceFileType } from '../resources/resources-constants';
+
 
 // Takes an object and string of dot seperated property keys.  Returns the nested value of the succession of
 // keys or undefined.
@@ -107,25 +109,43 @@ export const filterFieldExists = (filterFields: string[], trueIfExists: boolean)
   };
 };
 
-const matchAllItems = (filterItems: string[], propItems: string[]) => {
-  const propSet = new Set(propItems);
-  return filterItems.every(filter => propSet.has(filter));
+const matchAnyItem = (filterItems: string[], propItems: string[]) => {
+
+  if (!filterItems || filterItems.length === 0) {
+    return true;
+  }
+  const propSet = new Set(propItems.map(p => String(p).toLowerCase()));
+  return filterItems.some(filter => propSet.has(String(filter).toLowerCase()));
 };
 
 const filterArrayField = (filterField: string, filterItems: string[]) => {
   return (data: unknown, _filter: string) => {
-    const raw = getProperty(data, filterField);
+    const raw = filterField === 'mediaType'
+      ? getResourceFileType(data)
+      : getProperty(data, filterField);
     const propItems = Array.isArray(raw) ? raw : raw == null ? [] : [String(raw)];
 
-    return matchAllItems(filterItems, propItems);
+    return matchAnyItem(filterItems, propItems);
   };
+};
+
+
+
+const matchAllItems = (filterItems: string[], propItems: string[]) => {
+  if (!filterItems || filterItems.length === 0) {
+    return true;
+  }
+  const propSet = new Set(propItems);
+  return filterItems.every(filter => propSet.has(filter));
 };
 
 export const filterTags = (filterControl: FormControl) => {
-  return (data: any, filter: string) => {
-    return filterArrayField('tags', filterControl.value)({ tags: data.tags.map((tag: any) => tag._id) }, filter);
+  return (data: any) => {
+    const raw = data.tags ? data.tags.map((tag: any) => tag._id) : [];
+    return matchAllItems(filterControl.value, raw);
   };
 };
+
 
 export const filterAdvancedSearch = (searchObj: any) => {
   return (data: any, filter: string) => {

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -112,18 +112,27 @@ const matchAllItems = (filterItems: string[], propItems: string[]) => {
   return filterItems.every(filter => propSet.has(filter));
 };
 
+const matchAnyItem = (filterItems: string[], propItems: string[]) => {
+  if (!filterItems || filterItems.length === 0) {
+    return true;
+  }
+  const propSet = new Set(propItems);
+  return filterItems.some(filter => propSet.has(filter));
+};
+
 const filterArrayField = (filterField: string, filterItems: string[]) => {
   return (data: unknown, _filter: string) => {
     const raw = getProperty(data, filterField);
     const propItems = Array.isArray(raw) ? raw : raw == null ? [] : [String(raw)];
 
-    return matchAllItems(filterItems, propItems);
+    return matchAnyItem(filterItems, propItems);
   };
 };
 
 export const filterTags = (filterControl: FormControl) => {
-  return (data: any, filter: string) => {
-    return filterArrayField('tags', filterControl.value)({ tags: data.tags.map((tag: any) => tag._id) }, filter);
+  return (data: any) => {
+    const raw = data.tags ? data.tags.map((tag: any) => tag._id) : [];
+    return matchAllItems(filterControl.value, raw);
   };
 };
 


### PR DESCRIPTION
Fixes #10179

- Adds dedicated **File Type** (mediaType) category to resources search sidebar options while keeping Medium untouched
- Dynamically extracts exact file extensions (e.g. MP4, MP3, PDF, EPUB, PNG, ZIP, HTML, DOCX, PPTX, CSV) from attachment metadata and filenames
- Updates ilterArrayField helper to evaluate file types consistently via getResourceFileType and perform case-insensitive matching
- Binds esources.data to search component in esources.component.html to preserve filter options while filtering
- Adds unit tests covering file extension extraction and multi-selection search filtering

<img width="533" height="329" alt="image" src="https://github.com/user-attachments/assets/1ccb22dd-b84f-41a0-8ab5-9aed864cb067" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a media type filter for resource searches, including document, audio, video, and archive formats.
  * File types are now detected from filenames or attachments, with media type fallback support.
  * Search results support matching one or multiple selected media types.

* **Bug Fixes**
  * Improved resource filtering accuracy for file types and tags.
  * Updated search filtering to use the complete resource dataset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->