### PR TITLE
teams: smoother finances reports buttons hovering (fixes #10190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.68",
+  "version": "0.23.77",
   "myplanet": {
     "latest": "v0.61.83",
     "min": "v0.60.60"

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -85,9 +85,9 @@
             <mat-card-actions class="report-card-actions">
               @if (editable) {
                 <button mat-icon-button (click)="$event.stopPropagation(); openAddReportDialog(card.report, true)"
-                  i18n-aria-label aria-label="Edit"><mat-icon>edit</mat-icon></button>
+                  i18n-aria-label aria-label="Edit" matTooltip="Edit" i18n-matTooltip><mat-icon>edit</mat-icon></button>
                   <button mat-icon-button (click)="$event.stopPropagation(); openDeleteReportDialog(card.report)"
-                    i18n-aria-label aria-label="Delete"><mat-icon>delete_outline</mat-icon></button>
+                    i18n-aria-label aria-label="Delete" matTooltip="Delete" i18n-matTooltip><mat-icon>delete_outline</mat-icon></button>
                   }
                   <span class="spacer"></span>
                   <button mat-raised-button color="primary" (click)="$event.stopPropagation(); openReportDialog(card.report)">

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -19,6 +19,7 @@ import { AttachmentInputState } from '../shared/forms/file-upload.component';
 import { TeamsAttachmentsService } from './teams-attachments.service';
 import { formatDate, NgClass, DatePipe, CurrencyPipe } from '@angular/common';
 import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatTooltip } from '@angular/material/tooltip';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { MatCard, MatCardContent, MatCardActions } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
@@ -48,6 +49,7 @@ interface NewReportForm {
     MatButton,
     MatIconButton,
     MatIcon,
+    MatTooltip,
     PlanetLoadingSpinnerComponent,
     MatCard,
     MatCardContent,

--- a/src/app/teams/teams-view-finances.component.html
+++ b/src/app/teams/teams-view-finances.component.html
@@ -93,8 +93,8 @@
           <ng-container matColumnDef="action">
             <mat-header-cell *matHeaderCellDef class="actions"></mat-header-cell>
             <mat-cell *matCellDef="let element" class="actions">
-              <button mat-icon-button (click)="openEditTransactionDialog(element); $event.stopPropagation()" i18n-aria-label aria-label="Edit"><mat-icon>edit</mat-icon></button>
-              <button mat-icon-button (click)="openArchiveTransactionDialog(element); $event.stopPropagation()" i18n-aria-label aria-label="Delete"><mat-icon>delete_outline</mat-icon></button>
+              <button mat-icon-button (click)="openEditTransactionDialog(element); $event.stopPropagation()" i18n-aria-label aria-label="Edit" matTooltip="Edit" i18n-matTooltip><mat-icon>edit</mat-icon></button>
+              <button mat-icon-button (click)="openArchiveTransactionDialog(element); $event.stopPropagation()" i18n-aria-label aria-label="Delete" matTooltip="Delete" i18n-matTooltip><mat-icon>delete_outline</mat-icon></button>
             </mat-cell>
           </ng-container>
           <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -17,6 +17,7 @@ import { CsvService } from '../shared/csv.service';
 import { endOfDay, fullLabel } from '../manager-dashboard/reports/reports.utils';
 import { NgClass, CurrencyPipe, DatePipe } from '@angular/common';
 import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatTooltip } from '@angular/material/tooltip';
 import { MatFormField, MatLabel, MatSuffix, MatError } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
@@ -65,6 +66,7 @@ interface TransactionForm {
     MatCell,
     NgClass,
     MatIconButton,
+    MatTooltip,
     MatHeaderRowDef,
     MatHeaderRow,
     MatRowDef,


### PR DESCRIPTION
Fixes #10190 
- Imports mattooltips to required files
- Adds mattooltips to finances action buttons
- Adds mattooltips to reports action buttons

<img width="198" height="414" alt="image" src="https://github.com/user-attachments/assets/f0caff51-1fe1-4542-95c9-0d976350ea35" />

<img width="472" height="400" alt="image" src="https://github.com/user-attachments/assets/eb99fee1-f861-4bb5-8e97-d6ddbc91b38b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added localized tooltips to edit and delete actions in team reports.
  * Added localized tooltips to edit and delete transaction actions in team finances.
  * Existing accessibility labels and action behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->