### PR TITLE
all: smoother eqeqeq less underscore linting (connects #9082)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -155,7 +155,7 @@
         "@typescript-eslint/unified-signatures": "error",
         "complexity": "off",
         "constructor-super": "error",
-        // "eqeqeq": ["error", "smart"],
+        "eqeqeq": ["error", "smart"],
         "guard-for-in": "error",
         "id-match": "error",
         "import/no-deprecated": "warn",
@@ -211,23 +211,23 @@
         ],
         "no-throw-literal": "error",
         "no-undef-init": "error",
-        // "no-underscore-dangle": [
-        //   "error",
-        //   {
-        //     "allow": [
-        //       "_attachments",
-        //       "_filter",
-        //       "_id",
-        //       "_placeholder",
-        //       "_required",
-        //       "_rev",
-        //       "_tableState",
-        //       "_textValue",
-        //       "_value",
-        //       "__karma__"
-        //     ]
-        //   }
-        // ],
+        "no-underscore-dangle": [
+          "error",
+          {
+            "allow": [
+              "_attachments",
+              "_filter",
+              "_id",
+              "_placeholder",
+              "_required",
+              "_rev",
+              "_tableState",
+              "_textValue",
+              "_value",
+              "__karma__"
+            ]
+          }
+        ],
         "no-unsafe-finally": "error",
         "no-unused-labels": "error",
         // "no-var": "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -171,6 +171,7 @@ export default defineConfig([globalIgnores(["projects/**/*", "gateway/**/*"]), {
         "@typescript-eslint/unified-signatures": "error",
         complexity: "off",
         "constructor-super": "error",
+        "eqeqeq": ["error", "smart"],
         "guard-for-in": "error",
         "id-match": "error",
         "import/no-deprecated": "warn",
@@ -222,6 +223,26 @@ export default defineConfig([globalIgnores(["projects/**/*", "gateway/**/*"]), {
 
         "no-throw-literal": "error",
         "no-undef-init": "error",
+        "no-underscore-dangle": [
+          "error",
+          {
+            "allow": [
+              "_attachments",
+              "_filter",
+              "_id",
+              "_placeholder",
+              "_required",
+              "_rev",
+              "_tableState",
+              "_textValue",
+              "_value",
+              "_deleted",
+              "_replication_state",
+              "_changeDetectorRef",
+              "__karma__"
+            ]
+          }
+        ],
         "no-unsafe-finally": "error",
         "no-unused-labels": "error",
         radix: "error",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "myplanet": {
     "latest": "v0.65.55",
     "min": "v0.64.64"

--- a/src/app/chat/chat-sidebar/chat-sidebar.component.ts
+++ b/src/app/chat/chat-sidebar/chat-sidebar.component.ts
@@ -64,12 +64,12 @@ interface TitleForm {
 export class ChatSidebarComponent implements OnInit, OnDestroy {
   readonly dbName = 'chat_history';
   private onDestroy$ = new Subject<void>();
-  private _titleSearch = '';
+  #titleSearch = '';
   get titleSearch(): string {
-    return this._titleSearch.trim();
+    return this.#titleSearch.trim();
   }
   set titleSearch(value: string) {
-    this._titleSearch = value;
+    this.#titleSearch = value;
     this.recordSearch();
     this.filterConversations();
   }

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -71,7 +71,7 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   private isSaved = false;
   private stepsChange$ = new Subject<any[]>();
   private initialState = '';
-  private _steps = [];
+  #steps = [];
   private preserveCoverStateUntilSubmit = false;
   existingCoverAttachments: ExistingAttachment[] = [];
   private coverState: AttachmentInputState = { retained: [], removed: [], added: [] };
@@ -95,15 +95,15 @@ export class CoursesAddComponent implements OnInit, OnDestroy {
   @ViewChild(CoursesStepComponent) coursesStepComponent: CoursesStepComponent;
   @ViewChild(FileUploadComponent) coverUploadComponent?: FileUploadComponent;
   get steps() {
-    return this._steps;
+    return this.#steps;
   }
   set steps(value: any[]) {
-    this._steps = value.map(step => ({
+    this.#steps = value.map(step => ({
       ...step,
       description: step.description?.text ?? step.description ?? '',
       images: [ ...(step.description?.images ?? []), ...(step.images || []) ]
     }));
-    this.coursesService.course = { form: this.courseForm.value, steps: this._steps };
+    this.coursesService.course = { form: this.courseForm.value, steps: this.#steps };
     this.stepsChange$.next(value);
   }
 

--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -45,7 +45,7 @@
     <mat-label i18n>Title</mat-label>
     <input matInput [(ngModel)]="titleSearch">
   </mat-form-field>
-  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection._empty"><span i18n>Clear</span></button>
+  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection.isEmpty"><span i18n>Clear</span></button>
 </ng-template>
 
 <div [ngClass]="{ 'space-container': !isForm }" class="primary-link-hover">

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -153,14 +153,14 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   };
   filterIds = { ids: [] };
   readonly myCoursesFilter: { value: 'on' | 'off' } = { value: this.route.snapshot.data.myCourses === true ? 'on' : 'off' };
-  private _titleSearch = '';
+  #titleSearch = '';
   get titleSearch(): string {
-    return this._titleSearch;
+    return this.#titleSearch;
   }
   set titleSearch(value: string) {
     // When setting the titleSearch, also set the courses filter
     this.courses.filter = value ? value : this.dropdownsFill();
-    this._titleSearch = value;
+    this.#titleSearch = value;
     this.recordSearch();
     this.removeFilteredFromSelection();
   }
@@ -171,7 +171,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   isAuthorized = false;
   tagFilter = new FormControl<string[]>([], { nonNullable: true });
   tagFilterValue: string[] = [];
-  searchSelection: any = { _empty: true };
+  searchSelection: any = { isEmpty: true };
   filterPredicate = composeFilterFunctions([
     filterAdvancedSearch(this.searchSelection),
     filterTags(this.tagFilter),
@@ -428,7 +428,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
 
   onSearchChange({ items, category }) {
     this.searchSelection[category] = items;
-    this.searchSelection._empty = Object.entries(this.searchSelection).every(
+    this.searchSelection.isEmpty = Object.entries(this.searchSelection).every(
       ([ field, val ]: any[]) => !Array.isArray(val) || val.length === 0
     );
     this.titleSearch = this.titleSearch;
@@ -448,7 +448,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   recordSearch(complete = false) {
     if (this.courses.filter !== '') {
       this.searchService.recordSearch({
-        text: this._titleSearch,
+        text: this.titleSearch,
         type: this.dbName,
         filter: { ...this.searchSelection, tags: this.tagFilter.value }
       }, complete);

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -153,14 +153,14 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   };
   filterIds = { ids: [] };
   readonly myCoursesFilter: { value: 'on' | 'off' } = { value: this.route.snapshot.data.myCourses === true ? 'on' : 'off' };
-  private _titleSearch = '';
+  #titleSearch = '';
   get titleSearch(): string {
-    return this._titleSearch;
+    return this.#titleSearch;
   }
   set titleSearch(value: string) {
     // When setting the titleSearch, also set the courses filter
     this.courses.filter = value ? value : this.dropdownsFill();
-    this._titleSearch = value;
+    this.#titleSearch = value;
     this.recordSearch();
     this.removeFilteredFromSelection();
   }
@@ -171,7 +171,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   isAuthorized = false;
   tagFilter = new FormControl<string[]>([], { nonNullable: true });
   tagFilterValue: string[] = [];
-  searchSelection: any = { _empty: true };
+  searchSelection: any = { isEmpty: true };
   filterPredicate = composeFilterFunctions([
     filterAdvancedSearch(this.searchSelection),
     filterTags(this.tagFilter),
@@ -459,7 +459,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
 
   onSearchChange({ items, category }) {
     this.searchSelection[category] = items;
-    this.searchSelection._empty = Object.entries(this.searchSelection).every(
+    this.searchSelection.isEmpty = Object.entries(this.searchSelection).every(
       ([ field, val ]: any[]) => !Array.isArray(val) || val.length === 0
     );
     this.titleSearch = this.titleSearch;
@@ -479,7 +479,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   recordSearch(complete = false) {
     if (this.courses.filter !== '') {
       this.searchService.recordSearch({
-        text: this._titleSearch,
+        text: this.titleSearch,
         type: this.dbName,
         filter: { ...this.searchSelection, tags: this.tagFilter.value }
       }, complete);

--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -19,12 +19,12 @@ import { UsersService } from '../users/users.service';
 export class CoursesService {
   private dbName = 'courses';
   private progressDb = 'courses_progress';
-  private _course: any = {};
+  #course: any = {};
   get course() {
-    return this._course;
+    return this.#course;
   }
   set course(newCourse: any) {
-    this._course = { ...this._course, ...newCourse };
+    this.#course = { ...this.#course, ...newCourse };
   }
   progress: any;
   private courseUpdated = new Subject<{ progress: any, course: any }>();
@@ -133,7 +133,7 @@ export class CoursesService {
   }
 
   reset() {
-    this._course = {};
+    this.#course = {};
     this.stepIndex = -1;
     this.returnUrl = '';
   }

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -67,15 +67,15 @@ export class DashboardTileTitleComponent {
 export class DashboardTileComponent implements AfterViewChecked, OnInit {
   private readonly destroyRef = inject(DestroyRef);
   @Input() cardTitle: string;
-  private _cardType: string;
+  #cardType: string;
   @Input() set cardType(value: string) {
-    this._cardType = value;
+    this.#cardType = value;
     if (value === 'myLife' && this.deviceType === DeviceType.MOBILE) {
       this.isExpanded = true;
     }
   }
   get cardType(): string {
-    return this._cardType;
+    return this.#cardType;
   }
   @Input() color: string;
   @Input() itemData;

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -65,15 +65,15 @@ export class DashboardTileTitleComponent {
 export class DashboardTileComponent implements AfterViewChecked, OnInit {
   private readonly destroyRef = inject(DestroyRef);
   @Input() cardTitle: string;
-  private _cardType: string;
+  #cardType: string;
   @Input() set cardType(value: string) {
-    this._cardType = value;
+    this.#cardType = value;
     if (value === 'myLife' && this.deviceType === DeviceType.MOBILE) {
       this.isExpanded = true;
     }
   }
   get cardType(): string {
-    return this._cardType;
+    return this.#cardType;
   }
   @Input() color: string;
   @Input() itemData;

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -123,14 +123,14 @@ export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
   activeQuestionIndex = -1;
   isManagerRoute = this.router.url.startsWith('/manager/surveys');
   isQuestionsActive = false;
-  private _question!: QuestionFormGroup;
+  #question!: QuestionFormGroup;
   get question(): QuestionFormGroup {
-    return this._question;
+    return this.#question;
   }
   set question(newQuestion: QuestionFormGroup) {
     const question = this.questions.at(this.activeQuestionIndex);
     this.examsService.updateQuestion(question, newQuestion);
-    this._question = newQuestion;
+    this.#question = newQuestion;
     this.examForm.controls.questions.updateValueAndValidity();
   }
   get questions(): FormArray<QuestionFormGroup> {

--- a/src/app/feedback/feedback.component.ts
+++ b/src/app/feedback/feedback.component.ts
@@ -113,14 +113,14 @@ export class FeedbackComponent implements OnInit, AfterViewInit, OnDestroy {
     'type': '',
     'status': ''
   };
-  private _titleSearch = '';
+  #titleSearch = '';
   get titleSearch(): string {
-    return this._titleSearch;
+    return this.#titleSearch;
   }
   set titleSearch(value: string) {
     // When setting the titleSearch, also set the feedback filter
     this.feedback.filter = value ? value : this.dropdownsFill();
-    this._titleSearch = value;
+    this.#titleSearch = value;
   }
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;

--- a/src/app/manager-dashboard/reports/reports-detail-data.ts
+++ b/src/app/manager-dashboard/reports/reports-detail-data.ts
@@ -9,12 +9,12 @@ export interface ReportDetailFilter {
 
 export class ReportsDetailData {
 
-  _data: any[] = [];
+  #data: any[] = [];
   get data() {
-    return this._data;
+    return this.#data;
   }
   set data(newData: any[]) {
-    this._data = newData;
+    this.#data = newData;
     this.filteredData = newData;
   }
   filteredData: any[] = [];

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -115,12 +115,12 @@ export class ResourcesAddComponent implements OnInit, CanComponentDeactivate {
   resourceFilename = '';
   languages = languages;
   tags = this.fb.control<string[]>([]);
-  _existingResource: any = {};
+  #existingResource: any = {};
   get existingResource(): any {
-    return this._existingResource;
+    return this.#existingResource;
   }
   @Input() set existingResource(resource) {
-    this._existingResource = resource;
+    this.#existingResource = resource;
     if (this.resourceForm) {
       this.setFormValues(resource);
     }

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -49,7 +49,7 @@
     <mat-label i18n>Title</mat-label>
     <input matInput [(ngModel)]="titleSearch">
   </mat-form-field>
-  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="resources.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection._empty"><span i18n>Clear</span></button>
+  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="resources.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection.isEmpty"><span i18n>Clear</span></button>
 </ng-template>
 
 <div class="space-container primary-link-hover">

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -138,14 +138,14 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   tagFilterValue = [];
   // As of v0.1.13 ResourcesComponent does not have download link available on parent view
   urlPrefix = environment.couchAddress + '/' + this.dbName + '/';
-  private _titleSearch = '';
+  #titleSearch = '';
   get titleSearch(): string {
-    return this._titleSearch.trim();
+    return this.#titleSearch.trim();
   }
   set titleSearch(value: string) {
     // When setting the titleSearch, also set the resource filter
     this.resources.filter = value ? value : this.dropdownsFill();
-    this._titleSearch = value;
+    this.#titleSearch = value;
     this.recordSearch();
     this.removeFilteredFromSelection();
   }
@@ -155,7 +155,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   selectedSync = [];
   isAuthorized = false;
   showFilters = false;
-  searchSelection: any = { _empty: true };
+  searchSelection: any = { isEmpty: true };
   filterPredicate = composeFilterFunctions(
     [
       filterAdvancedSearch(this.searchSelection),
@@ -400,7 +400,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onSearchChange({ items, category }) {
     this.searchSelection[category] = items;
-    this.searchSelection._empty = Object.entries(this.searchSelection).every(
+    this.searchSelection.isEmpty = Object.entries(this.searchSelection).every(
       ([ field, val ]: any[]) => !Array.isArray(val) || val.length === 0
     );
     this.titleSearch = this.titleSearch;
@@ -420,7 +420,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   recordSearch(complete = false) {
     if (this.resources.filter !== '') {
       this.searchService.recordSearch({
-        text: this._titleSearch,
+        text: this.titleSearch,
         type: this.dbName,
         filter: { ...this.searchSelection, tags: this.tagFilter.value }
       }, complete);

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -139,14 +139,14 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   tagFilterValue = [];
   // As of v0.1.13 ResourcesComponent does not have download link available on parent view
   urlPrefix = environment.couchAddress + '/' + this.dbName + '/';
-  private _titleSearch = '';
+  #titleSearch = '';
   get titleSearch(): string {
-    return this._titleSearch.trim();
+    return this.#titleSearch.trim();
   }
   set titleSearch(value: string) {
     // When setting the titleSearch, also set the resource filter
     this.resources.filter = value ? value : this.dropdownsFill();
-    this._titleSearch = value;
+    this.#titleSearch = value;
     this.recordSearch();
     this.removeFilteredFromSelection();
   }
@@ -156,7 +156,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   selectedSync = [];
   isAuthorized = false;
   showFilters = false;
-  searchSelection: any = { _empty: true };
+  searchSelection: any = { isEmpty: true };
   filterPredicate = composeFilterFunctions(
     [
       filterAdvancedSearch(this.searchSelection),
@@ -429,7 +429,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onSearchChange({ items, category }) {
     this.searchSelection[category] = items;
-    this.searchSelection._empty = Object.entries(this.searchSelection).every(
+    this.searchSelection.isEmpty = Object.entries(this.searchSelection).every(
       ([ field, val ]: any[]) => !Array.isArray(val) || val.length === 0
     );
     this.titleSearch = this.titleSearch;
@@ -449,7 +449,7 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   recordSearch(complete = false) {
     if (this.resources.filter !== '') {
       this.searchService.recordSearch({
-        text: this._titleSearch,
+        text: this.titleSearch,
         type: this.dbName,
         filter: { ...this.searchSelection, tags: this.tagFilter.value }
       }, complete);

--- a/src/app/shared/beta.directive.ts
+++ b/src/app/shared/beta.directive.ts
@@ -10,13 +10,13 @@ export class PlanetBetaDirective implements OnInit {
     private viewContainer: ViewContainerRef
   ) {}
 
-  _planetBeta = true;
+  #planetBeta = true;
   @Input() set planetBeta(value: boolean) {
-    this._planetBeta = value === null ? true : value;
+    this.#planetBeta = value === null ? true : value;
   }
 
   ngOnInit() {
-    if (this._planetBeta === this.isBetaEnabled()) {
+    if (this.#planetBeta === this.isBetaEnabled()) {
       this.viewContainer.createEmbeddedView(this.templateRef);
     } else {
       this.viewContainer.clear();

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -55,7 +55,6 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
   @Input() buttonText?: any = {
     today: $localize`Today`
   };
-  @Input() _events: any[] = [ {} ];
   // Initializing events with blank object as first array value ensures calendar renders even if there are no events found
   events: any[] = [ {} ];
   calendarPlugins = [ dayGridPlugin, interactionPlugin ];
@@ -124,7 +123,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     this.calendarOptions.headerToolbar = this.header;
     this.calendarOptions.buttonText = this.buttonText;
     this.calendarOptions.customButtons = this.buttons;
-    this.calendarOptions.events = [ ...this.events, ...this._events ];
+    this.calendarOptions.events = [ ...this.events ];
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -132,7 +131,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
       this.calendar.getApi().updateSize();
       this.resizeCalendar = false;
     }
-    this.calendarOptions.events = [ ...this.events, ...this._events ];
+    this.calendarOptions.events = [ ...this.events ];
   }
 
   getMeetups() {

--- a/src/app/shared/calendar.component.ts
+++ b/src/app/shared/calendar.component.ts
@@ -68,7 +68,6 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
   @Input() buttonText?: any = {
     today: $localize`Today`
   };
-  @Input() _events: any[] = [ {} ];
   // Initializing events with blank object as first array value ensures calendar renders even if there are no events found
   events: any[] = [ {} ];
   calendarPlugins = [ dayGridPlugin, interactionPlugin ];
@@ -138,7 +137,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
     this.calendarOptions.headerToolbar = this.header;
     this.calendarOptions.buttonText = this.buttonText;
     this.calendarOptions.customButtons = this.buttons;
-    this.calendarOptions.events = [ ...this.events, ...this._events ];
+    this.calendarOptions.events = [ ...this.events ];
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -146,7 +145,7 @@ export class PlanetCalendarComponent implements OnInit, OnChanges {
       this.calendar.getApi().updateSize();
       this.resizeCalendar = false;
     }
-    this.calendarOptions.events = [ ...this.events, ...this._events ];
+    this.calendarOptions.events = [ ...this.events ];
   }
 
   getMeetups() {

--- a/src/app/shared/dialogs/change-password.directive.ts
+++ b/src/app/shared/dialogs/change-password.directive.ts
@@ -41,9 +41,12 @@ const resetPasswordFields = [
 @Directive({ selector: '[planetChangePassword]' })
 export class ChangePasswordDirective implements OnChanges {
 
-  _userDetail: any = undefined;
+  #userDetail: any = undefined;
   @Input('planetChangePassword') set userDetail(value: any) {
-    this._userDetail = value._id === undefined ? undefined : value;
+    this.#userDetail = value._id === undefined ? undefined : value;
+  }
+  get userDetail() {
+    return this.#userDetail;
   }
   isLoggedInUser: boolean;
   dbName = '_users';
@@ -98,7 +101,7 @@ export class ChangePasswordDirective implements OnChanges {
   ) {}
 
   ngOnChanges() {
-    this.isLoggedInUser = this._userDetail === undefined || this._userDetail._id === this.userService.get()._id;
+    this.isLoggedInUser = this.userDetail === undefined || this.userDetail._id === this.userService.get()._id;
   }
 
   @HostListener('click')
@@ -114,7 +117,7 @@ export class ChangePasswordDirective implements OnChanges {
   }
 
   onPasswordSubmit(credentialData) {
-    const user = this._userDetail || this.userService.get();
+    const user = this.userDetail || this.userService.get();
     const obs = this.isLoggedInUser
       ? this.couchService.post('_session', { 'name': user.name, 'password': credentialData.oldPassword })
       : of(true);

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -57,12 +57,12 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
     this.onChange(this._value);
     this.stateChanges.next();
   }
-  private _textValue: string;
+  #textValue: string;
   get textValue(): string {
-    return this._textValue;
+    return this.#textValue;
   }
   set textValue(newText: string) {
-    this._textValue = newText;
+    this.#textValue = newText;
     if (newText !== (typeof this._value === 'string' ? this._value : this._value.text)) {
       this.value = typeof this._value === 'string' ? newText : { ...this._value, text: newText };
     }
@@ -73,26 +73,26 @@ export class PlanetMarkdownTextboxComponent implements ControlValueAccessor, DoC
     return (typeof this._value === 'string' ? this._value : this._value.text).length === 0;
   }
 
-  private _placeholder: string;
   private fullscreenState?: FullscreenState;
+  #placeholder: string;
   @Input()
   get placeholder() {
-    return this._placeholder;
+    return this.#placeholder;
   }
   set placeholder(text: string) {
-    this._placeholder = text;
+    this.#placeholder = text;
     this.stateChanges.next();
   }
 
   @Input()
   get required(): boolean {
-    return this._required;
+    return this.#required;
   }
   set required(value: boolean) {
-    this._required = value;
+    this.#required = value;
     this.stateChanges.next();
   }
-  private _required = false;
+  #required = false;
 
   get shouldLabelFloat() {
     return true;

--- a/src/app/shared/forms/planet-rating-stars.component.ts
+++ b/src/app/shared/forms/planet-rating-stars.component.ts
@@ -30,9 +30,9 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
   @HostBinding() id = `planet-rating-stars-${PlanetRatingStarsComponent.nextId++}`;
   @HostBinding('attr.aria-describedby') describedBy = '';
 
-  private _required = false;
-  private _placeholder: string;
-  private _disabled = false;
+  #required = false;
+  #placeholder: string;
+  #disabled = false;
 
   starActiveWidth = '0%';
   stateChanges = new Subject<void>();
@@ -47,10 +47,10 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
 
   @Input()
   get value() {
-    return this._value;
+    return this.#value;
   }
   set value(rating: number) {
-    this._value = rating;
+    this.#value = rating;
     this.starActiveWidth = rating * 20 + '%';
     this.onChange(rating);
     this.stateChanges.next();
@@ -58,7 +58,7 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
   @Input() isEnrolled: (id: any, type: any) => boolean;
   @Input() itemId: (id: any) => void;
   @Input() type: string;
-  private _value = 0;
+  #value = 0;
 
   onChange(_: any) {}
 
@@ -82,28 +82,28 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
 
   @Input()
   get required() {
-    return this._required;
+    return this.#required;
   }
   set required(req) {
-    this._required = coerceBooleanProperty(req);
+    this.#required = coerceBooleanProperty(req);
     this.stateChanges.next();
   }
 
   @Input()
   get placeholder() {
-    return this._placeholder;
+    return this.#placeholder;
   }
   set placeholder(plh) {
-    this._placeholder = plh;
+    this.#placeholder = plh;
     this.stateChanges.next();
   }
 
   @Input()
   get disabled() {
-    return this._disabled;
+    return this.#disabled;
   }
   set disabled(dis) {
-    this._disabled = coerceBooleanProperty(dis);
+    this.#disabled = coerceBooleanProperty(dis);
     this.stateChanges.next();
   }
 
@@ -117,7 +117,7 @@ export class PlanetRatingStarsComponent implements MatFormFieldControl<number>, 
   }
 
   mouseOverStar(starNumber: number): void {
-    if (!this.disabled) {
+    if (!this.#disabled) {
       this.starActiveWidth = starNumber * 20 + '%';
     }
   }

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -109,12 +109,12 @@ export class PlanetTagInputDialogComponent {
   indeterminate: Map<string, boolean> = new Map(this.data.tags.map((value: any) => [ value._id, false ] as [ string, boolean ]));
   filterValue = '';
   mode = 'filter';
-  _selectMany = true;
+  #selectMany = true;
   get selectMany() {
-    return this._selectMany;
+    return this.#selectMany;
   }
   set selectMany(value: boolean) {
-    this._selectMany = value;
+    this.#selectMany = value;
     this.data.reset(value);
   }
   addTagForm: TagFormGroup;
@@ -180,7 +180,7 @@ export class PlanetTagInputDialogComponent {
   resetSelection() {
     this.data.tagUpdate('', false, true);
     this.selected.clear();
-    this.data.reset(this._selectMany);
+    this.data.reset(this.selectMany);
   }
 
   tagChange(tagId, { tagOne = false, parentTag }: { tagOne?, parentTag? } = {}) {

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -64,23 +64,23 @@ export class PlanetTagInputComponent implements ControlValueAccessor, OnInit, On
   }
   @Output() valueChanges = new EventEmitter<string[]>();
 
-  private _placeholder: string;
+  #placeholder: string;
   @Input()
   get placeholder() {
-    return this._placeholder;
+    return this.#placeholder;
   }
   set placeholder(text: string) {
-    this._placeholder = text;
+    this.#placeholder = text;
     this.stateChanges.next();
   }
 
-  private _disabled = false;
+  #disabled = false;
   @Input()
   get disabled() {
-    return this._disabled;
+    return this.#disabled;
   }
   set disabled(dis) {
-    this._disabled = coerceBooleanProperty(dis);
+    this.#disabled = coerceBooleanProperty(dis);
     this.stateChanges.next();
   }
   @Input() mode: string;

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -130,7 +130,9 @@ export const filterTags = (filterControl: FormControl) => {
 export const filterAdvancedSearch = (searchObj: any) => {
   return (data: any, filter: string) => {
     return Object.entries(searchObj).reduce(
-      (isMatch, [ field, val ]: any[]) => isMatch && (field.indexOf('_') > -1 || filterArrayField(field, val)(data.doc, filter)),
+      (isMatch, [ field, val ]: any[]) => (
+        isMatch && (field.indexOf('_') > -1 || field === 'isEmpty' || filterArrayField(field, val)(data.doc, filter))
+      ),
       true
     );
   };

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -20,7 +20,7 @@ export class UserService {
   private user: any = { name: '', roles: [] };
   private usersDb = '_users';
   private logsDb = 'login_activities';
-  private #shelf: any = { };
+  #shelf: any = { };
   skipNextShelfRefresh = false;
 
   get shelf(): any {

--- a/src/app/shared/user.service.ts
+++ b/src/app/shared/user.service.ts
@@ -20,14 +20,14 @@ export class UserService {
   private user: any = { name: '', roles: [] };
   private usersDb = '_users';
   private logsDb = 'login_activities';
-  private _shelf: any = { };
+  private #shelf: any = { };
   skipNextShelfRefresh = false;
 
   get shelf(): any {
-    return this._shelf;
+    return this.#shelf;
   }
   set shelf(shelf: any) {
-    this._shelf = shelf;
+    this.#shelf = shelf;
     if (Object.keys(shelf).length > 0 && !this.skipNextShelfRefresh) {
       this.shelfChange.next(shelf);
     }

--- a/src/app/tasks/tasks.component.ts
+++ b/src/app/tasks/tasks.component.ts
@@ -74,7 +74,7 @@ export class TasksComponent implements OnInit {
   @Input() link: any;
   @Input() sync: { type: 'local' | 'sync', planetCode: string };
   @Input() editable = true;
-  private #assigness: any[];
+  #assigness: any[];
   @Input()
   get assignees() {
     return this.#assigness;

--- a/src/app/tasks/tasks.component.ts
+++ b/src/app/tasks/tasks.component.ts
@@ -74,13 +74,13 @@ export class TasksComponent implements OnInit {
   @Input() link: any;
   @Input() sync: { type: 'local' | 'sync', planetCode: string };
   @Input() editable = true;
-  private _assigness: any[];
+  private #assigness: any[];
   @Input()
   get assignees() {
-    return this._assigness;
+    return this.#assigness;
   }
   set assignees(newAssignees: any[]) {
-    this._assigness = [ ...newAssignees ].sort((a, b) => a.name.localeCompare(b.name));
+    this.#assigness = [ ...newAssignees ].sort((a, b) => a.name.localeCompare(b.name));
   }
   dbName = 'tasks';
   deleteDialog: any;

--- a/src/app/tasks/tasks.component.ts
+++ b/src/app/tasks/tasks.component.ts
@@ -80,15 +80,15 @@ export class TasksComponent implements OnInit {
   @Input() link: any;
   @Input() sync: { type: 'local' | 'sync', planetCode: string };
   @Input() editable = true;
-  private _assignees: any[] = [];
+  #assignees: any[] = [];
   private currentAssignees = new Map<string, any>();
   private failedAvatarSources = new Map<string, string>();
   @Input()
   get assignees() {
-    return this._assignees;
+    return this.#assignees;
   }
   set assignees(newAssignees: any[]) {
-    this._assignees = [ ...(newAssignees || []) ].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+    this.#assignees = [ ...(newAssignees || []) ].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
     this.setCurrentAssignees();
     this.setTaskViews();
     this.filterTasks();
@@ -125,7 +125,7 @@ export class TasksComponent implements OnInit {
   }
 
   private setCurrentAssignees() {
-    this.currentAssignees = new Map(this._assignees
+    this.currentAssignees = new Map(this.#assignees
       .filter(assignee => assigneeKey(assignee))
       .map(assignee => [ assigneeKey(assignee), assignee ]));
   }

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -89,14 +89,14 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   cancelDialog: any;
   isLoading = true;
   readonly myTeamsFilter = this.route.snapshot.data.myTeams ? 'on' : 'off';
-  private _mode: 'team' | 'enterprise' = this.route.snapshot.data.mode || 'team';
+  #mode: 'team' | 'enterprise' = this.route.snapshot.data.mode || 'team';
   @Input()
   get mode(): 'team' | 'enterprise' {
-    return this._mode;
+    return this.#mode;
   }
   set mode(newMode: 'team' | 'enterprise') {
-    if (newMode !== this._mode) {
-      this._mode = newMode;
+    if (newMode !== this.#mode) {
+      this.#mode = newMode;
       this.getTeams();
     }
   }

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -90,14 +90,14 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   cancelDialog: any;
   isLoading = true;
   readonly myTeamsFilter = this.route.snapshot.data.myTeams ? 'on' : 'off';
-  private _mode: 'team' | 'enterprise' = this.route.snapshot.data.mode || 'team';
+  #mode: 'team' | 'enterprise' = this.route.snapshot.data.mode || 'team';
   @Input()
   get mode(): 'team' | 'enterprise' {
-    return this._mode;
+    return this.#mode;
   }
   set mode(newMode: 'team' | 'enterprise') {
-    if (newMode !== this._mode) {
-      this._mode = newMode;
+    if (newMode !== this.#mode) {
+      this.#mode = newMode;
       this.getTeams();
     }
   }

--- a/src/app/users/users-table.component.ts
+++ b/src/app/users/users-table.component.ts
@@ -83,26 +83,26 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
   set search(newSearch: string) {
     this.usersTable.filter = newSearch || ' ';
   }
-  private _filter: { 'doc.roles': string, 'doc.planetCode': string } = { 'doc.roles' : '', 'doc.planetCode': '' };
+  #filter: { 'doc.roles': string, 'doc.planetCode': string } = { 'doc.roles' : '', 'doc.planetCode': '' };
   @Input()
   get filter() {
-    return this._filter;
+    return this.#filter;
   }
   set filter(newFilter) {
     // Trigger filter changes in the Material table
     this.usersTable.filter = this.usersTable.filter;
-    this._filter = newFilter;
+    this.#filter = newFilter;
   }
-  private _tableState: TableState;
+  #tableState: TableState;
   @Input()
   get tableState(): TableState {
-    return this._tableState;
+    return this.#tableState;
   }
   set tableState(newState: TableState) {
     this.filter['doc.planetCode'] = newState.selectedChild.code ||
       (newState.filterType === 'associated' ? undefined : this.configuration.code);
     this.filterType = newState.filterType;
-    this._tableState = newState;
+    this.#tableState = newState;
   }
   get tableData() {
     return this.usersTable;


### PR DESCRIPTION
Adds the eqeqeq and no underscore dangle lint rules back in. Eqeqeq didn't need any changes to fix.

We've used leading underscores for private methods (either explicitly with the `private` keyword or otherwise). There is now a "#" decorator that can be used in most cases which makes the method private at compile time and at runtime. I went through and switched to that or in the few cases where the variable was not private just removed the underscore.

I also tried to make sure the getter/setter pattern used the getter instead of the private method throughout the component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search-selection handling so Clear buttons correctly reflect whether filters are empty.
  * Improved advanced filtering for empty search criteria.
  * Preserved calendar event display behavior with consistent event handling.

* **Refactor**
  * Strengthened internal data encapsulation across courses, resources, forms, dashboards, and other components without changing their public behavior.
  * Standardized linting rules to catch unsafe equality checks and disallowed private-field naming patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->