### PR TITLE
Fix floating-point precision in currency calculations

### DIFF
--- a/src/app/teams/teams-reports-detail.component.ts
+++ b/src/app/teams/teams-reports-detail.component.ts
@@ -4,6 +4,7 @@ import { MatDivider } from '@angular/material/list';
 import { NgClass, CurrencyPipe, DatePipe } from '@angular/common';
 import { PlanetMarkdownComponent } from '../shared/planet-markdown.component';
 import { TeamsAttachmentsService } from './teams-attachments.service';
+import { roundCurrency, sumCurrency } from './teams.utils';
 
 @Component({
   selector: 'planet-teams-reports-detail',
@@ -28,10 +29,10 @@ export class TeamsReportsDetailComponent implements OnChanges {
   ) {}
 
   ngOnChanges() {
-    this.expenses = this.report.wages + this.report.otherExpenses;
-    this.income = this.report.sales + this.report.otherIncome;
-    this.net = this.income - this.expenses;
-    this.endingBalance = this.net + this.report.beginningBalance;
+    this.expenses = sumCurrency([ this.report.wages, this.report.otherExpenses ]);
+    this.income = sumCurrency([ this.report.sales, this.report.otherIncome ]);
+    this.net = roundCurrency(this.income - this.expenses);
+    this.endingBalance = sumCurrency([ this.net, this.report.beginningBalance ]);
     this.receiptImages = this.teamsAttachmentsService.receiptAttachments(this.report);
   }
 

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -10,7 +10,7 @@ import { TeamsReportsDialogComponent } from './teams-reports-dialog.component';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { finalize, map, switchMap, tap } from 'rxjs/operators';
 import { forkJoin, of } from 'rxjs';
-import { convertUtcDate } from './teams.utils';
+import { convertUtcDate, roundCurrency, sumCurrency } from './teams.utils';
 import { CsvService } from '../shared/csv.service';
 import { StateService } from '../shared/state.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
@@ -74,16 +74,16 @@ export class TeamsReportsComponent implements OnChanges {
     this.reportCards = (this.reports || [])
       .filter(report => report.status !== 'archived')
       .map(report => {
-        const income = (+report.sales || 0) + (+report.otherIncome || 0);
-        const expenses = (+report.wages || 0) + (+report.otherExpenses || 0);
-        const net = income - expenses;
+        const income = sumCurrency([ report.sales, report.otherIncome ]);
+        const expenses = sumCurrency([ report.wages, report.otherExpenses ]);
+        const net = roundCurrency(income - expenses);
         return {
           report,
           receiptImageCount: this.teamsAttachmentsService.receiptAttachments(report).length,
           income,
           expenses,
           net,
-          endingBalance: net + (+report.beginningBalance || 0),
+          endingBalance: sumCurrency([ net, report.beginningBalance ]),
           isLoss: net < 0
         };
       });
@@ -280,8 +280,8 @@ export class TeamsReportsComponent implements OnChanges {
 
   exportReportsPdf() {
     const { data, title, titleName } = this.reportsExportData();
-    const totalIncome = this.reportCards.reduce((sum, card) => sum + card.income, 0);
-    const totalExpenses = this.reportCards.reduce((sum, card) => sum + card.expenses, 0);
+    const totalIncome = sumCurrency(this.reportCards.map(card => card.income));
+    const totalExpenses = sumCurrency(this.reportCards.map(card => card.expenses));
     this.dialogsLoadingService.start();
     this.receiptImageSections()
       .pipe(finalize(() => this.dialogsLoadingService.stop()))
@@ -303,7 +303,7 @@ export class TeamsReportsComponent implements OnChanges {
           { label: $localize`Reports`, value: this.reportCards.length },
           { label: $localize`Total Credit`, value: totalIncome, format: 'currency' },
           { label: $localize`Total Debit`, value: totalExpenses, format: 'currency' },
-          { label: $localize`Net Profit/Loss`, value: totalIncome - totalExpenses, format: 'currency' }
+          { label: $localize`Net Profit/Loss`, value: roundCurrency(totalIncome - totalExpenses), format: 'currency' }
         ],
         imageSections,
         filename: $localize`Financial Summary for ${titleName}.pdf`

--- a/src/app/teams/teams-view-finances.component.ts
+++ b/src/app/teams/teams-view-finances.component.ts
@@ -15,6 +15,7 @@ import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.compone
 import { StateService } from '../shared/state.service';
 import { CsvService } from '../shared/csv.service';
 import { endOfDay, fullLabel } from '../manager-dashboard/reports/reports.utils';
+import { fromMinorUnits, roundCurrency, sumCurrency, toMinorUnits } from './teams.utils';
 import { NgClass, CurrencyPipe, DatePipe } from '@angular/common';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatFormField, MatLabel, MatSuffix, MatError } from '@angular/material/form-field';
@@ -152,10 +153,11 @@ export class TeamsViewFinancesComponent implements OnChanges {
   }
 
   private combineTransactionData(newArray: any[], transaction: any, index: number) {
-    const previousBalance = index !== 0 ? newArray[index - 1].balance : 0;
+    const previousBalance = index !== 0 ? toMinorUnits(newArray[index - 1].balance) : 0;
+    const balance = previousBalance + toMinorUnits(transaction.credit) - toMinorUnits(transaction.debit);
     return [
       ...newArray,
-      { ...transaction, balance: previousBalance + (transaction.credit || 0) - (transaction.debit || 0) }
+      { ...transaction, balance: fromMinorUnits(balance) }
     ];
   }
 
@@ -282,9 +284,9 @@ export class TeamsViewFinancesComponent implements OnChanges {
 
   private updateTotals() {
     const rows = this.table.data || [];
-    const credit = rows.reduce((sum, r) => sum + (r.credit || 0), 0);
-    const debit = rows.reduce((sum, r) => sum + (r.debit || 0), 0);
-    const balance = credit - debit;
+    const credit = sumCurrency(rows.map(row => row.credit));
+    const debit = sumCurrency(rows.map(row => row.debit));
+    const balance = roundCurrency(credit - debit);
     this.totals = { credit, debit, balance };
     this.emptyTable = rows.length === 0;
   }

--- a/src/app/teams/teams.utils.spec.ts
+++ b/src/app/teams/teams.utils.spec.ts
@@ -1,0 +1,69 @@
+import { fromMinorUnits, roundCurrency, sumCurrency, toMinorUnits } from './teams.utils';
+
+describe('teams currency utils', () => {
+
+  describe('toMinorUnits', () => {
+
+    it('converts decimal amounts to whole cents', () => {
+      expect(toMinorUnits(0.3)).toBe(30);
+      expect(toMinorUnits(1234.56)).toBe(123456);
+      expect(toMinorUnits('12.34')).toBe(1234);
+    });
+
+    it('rounds half away from zero without floating point drift', () => {
+      expect(toMinorUnits(1.005)).toBe(101);
+      expect(toMinorUnits(-1.005)).toBe(-101);
+    });
+
+    it('treats missing and non-numeric amounts as zero', () => {
+      expect(toMinorUnits(undefined)).toBe(0);
+      expect(toMinorUnits(null)).toBe(0);
+      expect(toMinorUnits('')).toBe(0);
+      expect(toMinorUnits('abc')).toBe(0);
+    });
+
+  });
+
+  describe('sumCurrency', () => {
+
+    it('adds amounts that drift when summed as floats', () => {
+      expect(0.1 + 0.2).not.toBe(0.3);
+      expect(sumCurrency([ 0.1, 0.2 ])).toBe(0.3);
+      expect(sumCurrency([ 0.7, 0.1 ])).toBe(0.8);
+    });
+
+    it('stays exact over a long list of two decimal amounts', () => {
+      expect(sumCurrency(new Array(1000).fill(0.01))).toBe(10);
+    });
+
+    it('skips amounts that are missing', () => {
+      expect(sumCurrency([ 1.5, undefined, null, 2.25 ])).toBe(3.75);
+    });
+
+  });
+
+  describe('roundCurrency', () => {
+
+    it('resolves a difference that should be zero to exactly zero', () => {
+      const balance = 0.3 - (0.1 + 0.2);
+      expect(balance).toBeLessThan(0);
+      expect(roundCurrency(balance)).toBe(0);
+      expect(roundCurrency(balance) < 0).toBe(false);
+    });
+
+    it('leaves genuinely negative balances negative', () => {
+      expect(roundCurrency(0.3 - 0.4)).toBe(-0.1);
+    });
+
+  });
+
+  describe('fromMinorUnits', () => {
+
+    it('converts cents back to a decimal amount', () => {
+      expect(fromMinorUnits(30)).toBe(0.3);
+      expect(fromMinorUnits(-105)).toBe(-1.05);
+    });
+
+  });
+
+});

--- a/src/app/teams/teams.utils.ts
+++ b/src/app/teams/teams.utils.ts
@@ -19,3 +19,28 @@ export const convertUtcDate = (date) => {
   const dateObj = new Date(date);
   return date ? new Date(dateObj.getUTCFullYear(), dateObj.getUTCMonth(), dateObj.getUTCDate()) : undefined;
 };
+
+// Monetary amounts are stored as decimal numbers, which cannot be represented exactly in binary floating point, so
+// accumulating them directly compounds drift. Totals rounded to two decimals still display correctly, but the raw
+// value also drives sign comparisons, where a drifted zero reads as negative. Converting to integer minor units
+// (cents) keeps the accumulation exact, so finance figures are added and subtracted through the helpers below.
+const minorUnitFactor = 100;
+
+export const toMinorUnits = (amount) => {
+  const value = +amount;
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  // toFixed pulls values such as 1.005 * 100 = 100.49999999999999 back to the decimal they were entered as before
+  // rounding, and rounding the magnitude keeps negative amounts symmetrical with positive ones.
+  const scaled = +(value * minorUnitFactor).toFixed(4);
+  const magnitude = Math.round(Math.abs(scaled));
+  return scaled < 0 ? -magnitude : magnitude;
+};
+
+export const fromMinorUnits = (minorUnits: number) => minorUnits / minorUnitFactor;
+
+export const roundCurrency = (amount) => fromMinorUnits(toMinorUnits(amount));
+
+export const sumCurrency = (amounts: any[]) =>
+  fromMinorUnits(amounts.reduce((total: number, amount) => total + toMinorUnits(amount), 0));


### PR DESCRIPTION
## Summary

Adds utility functions to handle currency arithmetic using integer minor units (cents) instead of decimal floating-point, eliminating precision drift in financial calculations across the teams module.

## Changes

- **New utility functions** in `teams.utils.ts`:
  - `toMinorUnits()` — converts decimal amounts to integer cents, handling edge cases (undefined, null, non-numeric) and rounding symmetrically
  - `fromMinorUnits()` — converts cents back to decimal amounts
  - `roundCurrency()` — rounds a decimal amount through the minor-units conversion to eliminate floating-point drift
  - `sumCurrency()` — accumulates amounts via minor units to maintain precision over long lists

- **Updated components** to use the new utilities:
  - `teams-reports.component.ts` — uses `sumCurrency()` for income/expenses/balance calculations and `roundCurrency()` for net profit/loss
  - `teams-view-finances.component.ts` — uses minor-unit conversion in transaction balance tracking and `sumCurrency()` for totals
  - `teams-reports-detail.component.ts` — uses `sumCurrency()` and `roundCurrency()` for report calculations

- **Comprehensive test suite** (`teams.utils.spec.ts`) covering:
  - Decimal-to-cents conversion with rounding
  - Floating-point drift elimination (e.g., `0.1 + 0.2 !== 0.3`)
  - Handling of missing/invalid amounts
  - Precision over long accumulations
  - Sign preservation for negative balances

## Implementation Details

The core issue: JavaScript's binary floating-point representation cannot exactly represent decimal values like `0.1` or `0.2`. Accumulating these directly compounds drift, causing balances that should be zero to read as slightly negative, breaking sign comparisons in financial logic.

The solution converts to integer cents before arithmetic, keeping all operations exact. The `toMinorUnits()` function uses `toFixed(4)` to pull back values like `1.005 * 100 = 100.49999999999999` to their intended decimal before rounding, ensuring symmetric handling of positive and negative amounts.

https://claude.ai/code/session_01ReAdsgqQi4N6rPTNpbkTwF