### PR TITLE
all: smoother one var linting (connects #9082)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -232,7 +232,7 @@
         "no-unused-labels": "error",
         // "no-var": "error",
         // "object-shorthand": "error",
-        // "one-var": ["error", "never"],
+        "one-var": ["error", "never"],
         // "prefer-arrow/prefer-arrow-functions": "error",
         // "prefer-const": "error",
         "radix": "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,6 +169,7 @@ export default defineConfig([globalIgnores(["projects/**/*", "gateway/**/*"]), {
         }],
 
         "@typescript-eslint/unified-signatures": "error",
+        "one-var": ["error", "never"],
         complexity: "off",
         "constructor-super": "error",
         "guard-for-in": "error",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "myplanet": {
     "latest": "v0.65.91",
     "min": "v0.64.64"

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -312,9 +312,9 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
 
   deleteSelected() {
     const selected = this.selection.selected.map(courseId => findByIdInArray(this.courses.data, courseId).doc);
-    let amount = 'many',
-      okClick = this.deleteCourses(selected),
-      displayName = '';
+    let amount = 'many';
+    let okClick = this.deleteCourses(selected);
+    let displayName = '';
     if (selected.length === 1) {
       const course = selected[0];
       amount = 'single';

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -40,8 +40,8 @@ describe('Home', () => {
     });
     const router = TestBed.inject(Router);
     Object.defineProperty(router, 'events', { value: routerEvents.asObservable(), configurable: true });
-    const fixture = TestBed.createComponent(HomeComponent),
-      comp = fixture.componentInstance;
+    const fixture = TestBed.createComponent(HomeComponent);
+    const comp = fixture.componentInstance;
     activeFixture = fixture;
     return { fixture, comp, routerEvents };
   };

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -16,8 +16,8 @@ describe('Home', () => {
       imports: [RouterTestingModule, BrowserAnimationsModule, CommonModule, MaterialModule, HomeComponent],
       providers: [CouchService, UserService, provideHttpClient(withInterceptorsFromDi())]
     });
-    const fixture = TestBed.createComponent(HomeComponent),
-      comp = fixture.componentInstance;
+    const fixture = TestBed.createComponent(HomeComponent);
+    const comp = fixture.componentInstance;
     return { fixture, comp };
   };
 

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -17,9 +17,9 @@ describe('Login', () => {
       imports: [RouterTestingModule.withRoutes([]), FormsModule, CommonModule, MaterialModule, BrowserAnimationsModule, LoginComponent],
       providers: [CouchService, provideHttpClient(withInterceptorsFromDi())]
     });
-    const fixture = TestBed.createComponent(LoginComponent),
-      comp = fixture.componentInstance;
-      /*de = fixture.debugElement.query(By.css('#login-status')),
+    const fixture = TestBed.createComponent(LoginComponent);
+    const comp = fixture.componentInstance;
+    /*de = fixture.debugElement.query(By.css('#login-status')),
       statusElement = de.nativeElement,
       couchService = fixture.debugElement.injector.get(CouchService),
       testModel = { name: 'test', password: 'password', repeatPassword: 'password' };*/

--- a/src/app/manager-dashboard/sync.directive.ts
+++ b/src/app/manager-dashboard/sync.directive.ts
@@ -138,8 +138,8 @@ export class SyncDirective {
   createReplicatorUserDoc(users: any[], repUsers: any[]) {
     const planetCode = this.planetConfiguration.code;
     return users.map((user: any) => {
-      const repUser = repUsers.find((rUser: any) => rUser.couchId === user._id) || {},
-        { _id, _rev, ...userProps } = user;
+      const repUser = repUsers.find((rUser: any) => rUser.couchId === user._id) || {};
+      const { _id, _rev, ...userProps } = user;
       return {
         ...repUser,
         ...userProps,

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -314,9 +314,9 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   deleteSelected() {
     const resources = this.selection.selected.map(id => this.resources.data.find((r: any) => r._id === id));
-    let amount = 'many',
-      okClick = this.deleteResources(resources),
-      displayName = '';
+    let amount = 'many';
+    let okClick = this.deleteResources(resources);
+    let displayName = '';
     if (resources.length === 1) {
       const resource: any = resources[0];
       amount = 'single';
@@ -383,8 +383,8 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   shareResource(type, resources) {
-    const msg = (type === 'pull' ? 'fetch' : 'send'),
-      items = resources.map(id => ({ item: this.resources.data.find((resource: any) => resource._id === id), db: this.dbName }));
+    const msg = (type === 'pull' ? 'fetch' : 'send');
+    const items = resources.map(id => ({ item: this.resources.data.find((resource: any) => resource._id === id), db: this.dbName }));
     this.syncService.confirmPasswordAndRunReplicators(this.syncService.createReplicatorsArray(items, type) )
       .subscribe((response: any) => {
         this.planetMessageService.showMessage($localize`${resources.length} ${this.dbName} queued to ${msg}`);

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -315,9 +315,9 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   deleteSelected() {
     const resources = this.selection.selected.map(id => this.resources.data.find((r: any) => r._id === id));
-    let amount = 'many',
-      okClick = this.deleteResources(resources),
-      displayName = '';
+    let amount = 'many';
+    let okClick = this.deleteResources(resources);
+    let displayName = '';
     if (resources.length === 1) {
       const resource: any = resources[0];
       amount = 'single';
@@ -412,8 +412,8 @@ export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   shareResource(type, resources) {
-    const msg = (type === 'pull' ? 'fetch' : 'send'),
-      items = resources.map(id => ({ item: this.resources.data.find((resource: any) => resource._id === id), db: this.dbName }));
+    const msg = (type === 'pull' ? 'fetch' : 'send');
+    const items = resources.map(id => ({ item: this.resources.data.find((resource: any) => resource._id === id), db: this.dbName }));
     this.syncService.confirmPasswordAndRunReplicators(this.syncService.createReplicatorsArray(items, type) )
       .subscribe((response: any) => {
         this.planetMessageService.showMessage($localize`${resources.length} ${this.dbName} queued to ${msg}`);

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -270,9 +270,9 @@ export class PlanetTagInputDialogComponent {
 
   deleteTag(event, tag) {
     event.stopPropagation();
-    const amount = 'single',
-      okClick = this.deleteSelectedTag(tag),
-      displayName = tag.name;
+    const amount = 'single';
+    const okClick = this.deleteSelectedTag(tag);
+    const displayName = tag.name;
     this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
         okClick,

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -209,11 +209,11 @@ export class CustomValidators {
         return null;
       }
 
-      const matchControl = ac.parent.get(matchField),
-        val1 = ac.value,
-        val2 = matchControl?.value,
-        confirmControl: AbstractControl<string | null> | null = confirm ? ac : matchControl,
-        errorType = match ? 'matchPassword' : 'unmatchPassword';
+      const matchControl = ac.parent.get(matchField);
+      const val1 = ac.value;
+      const val2 = matchControl?.value;
+      const confirmControl: AbstractControl<string | null> | null = confirm ? ac : matchControl;
+      const errorType = match ? 'matchPassword' : 'unmatchPassword';
 
       if (!confirmControl || !matchControl) {
         return null;


### PR DESCRIPTION
Now I got my local model working (Qwen3.5: a3b-35b-Q4).

This rule seems to be a bit more of a preference than anything else. It'd be good to keep things consistent, and since the change to switch to the "never" variant is minimal I think we should use this instead of "always".

LLM output:
Added one-var: ["error", "never"] rule and auto-fixed all 8 lint errors.

connects #9082 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized variable declarations across application code and tests.
  * Improved code consistency by requiring each variable declaration to be written separately.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->