### PR TITLE
actions: smoother workflow automerging (fixes #10312)

### DIFF
--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -27,6 +27,9 @@ DRY_RUN="${DRY_RUN:-true}"
 MAX_MERGES="${MAX_MERGES:-0}"
 WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
 USING_PAT="${USING_PAT:-false}"
+# Already normalized and checked against myplanet's releases by the workflow.
+MYPLANET_LATEST="${MYPLANET_LATEST:-}"
+MYPLANET_MIN="${MYPLANET_MIN:-}"
 
 RUN_APPEAR_TIMEOUT_SEC=300
 POLL_INTERVAL_SEC=20
@@ -196,9 +199,13 @@ base_already_failed() {
     return 0
 }
 
-# Guard against a broken version.sh.
+# Guard against a broken version.sh. Only the version line may move, plus the
+# myplanet pins when this run was asked to set them.
 verify_version_only_diff() {
-    local from=$1 to=$2 files bad
+    local from=$1 to=$2 files bad allowed='"version"'
+
+    [ -z "$MYPLANET_LATEST" ] || allowed="$allowed|\"latest\""
+    [ -z "$MYPLANET_MIN" ]    || allowed="$allowed|\"min\""
 
     files=$(git diff --name-only "$from" "$to")
     if [ "$files" != "$PKG_FILE" ]; then
@@ -209,7 +216,7 @@ verify_version_only_diff() {
     bad=$(git diff --unified=0 "$from" "$to" -- "$PKG_FILE" \
           | grep -E '^[+-]' \
           | grep -vE '^(\+\+\+|---)' \
-          | grep -vcE '^[+-][[:space:]]*"version"[[:space:]]*:' || true)
+          | grep -vcE "^[+-][[:space:]]*($allowed)[[:space:]]*:" || true)
     if [ "${bad:-0}" -ne 0 ]; then
         log "  bump changed $bad non-version line(s)"
         return 1
@@ -234,6 +241,15 @@ push_with_retry() {
 log "draining '$LABEL' into $BASE (dry_run=$DRY_RUN)"
 summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
 summary ""
+
+# The pins ride along in the first merge's bump commit, so an empty queue
+# leaves them unset -- there is no merge to carry them.
+if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
+    log "myplanet pins: latest -> ${MYPLANET_LATEST:-unchanged}, min -> ${MYPLANET_MIN:-unchanged}"
+    summary "myplanet pins: latest → \`${MYPLANET_LATEST:-unchanged}\`, min → \`${MYPLANET_MIN:-unchanged}\` (set by the first merge)"
+    summary ""
+fi
+
 summary "| PR | version | result |"
 summary "|---|---|---|"
 
@@ -309,6 +325,9 @@ while :; do
         git checkout --quiet --detach "origin/$HEAD"
         if git merge --quiet --no-edit "origin/$BASE"; then
             log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
+            if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
+                log "           pin myplanet latest=${MYPLANET_LATEST:-unchanged} min=${MYPLANET_MIN:-unchanged},"
+            fi
             log "           wait for ${REQUIRED_WORKFLOWS:-the triggered workflows}, then squash merge #$NUMBER"
             summary "| #$NUMBER | → \`$new_name\` | dry run: would merge |"
         else
@@ -336,12 +355,28 @@ while :; do
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$PKG_FILE" "$new_name"
 
+    # The myplanet pins go in the same commit. Rewriting them for every PR is
+    # a no-op after the first one has landed them on $BASE, so this needs no
+    # memory of which PR carried them.
+    bump_msg="version: bump to $new_name"
+    if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
+        mp_before=$(git show "HEAD:$PKG_FILE" | jq -r '[.myplanet.latest, .myplanet.min] | join(" ")')
+        "$VERSION_SH" myplanet "$PKG_FILE" "$MYPLANET_LATEST" "$MYPLANET_MIN"
+        mp_after=$(jq -r '[.myplanet.latest, .myplanet.min] | join(" ")' "$PKG_FILE")
+        if [ "$mp_before" != "$mp_after" ]; then
+            log "  myplanet pins: $mp_before -> $mp_after"
+            bump_msg="$bump_msg, myplanet ${mp_after% *} (min ${mp_after#* })"
+        else
+            log "  myplanet pins already at $mp_after"
+        fi
+    fi
+
     merge_sha="$pre_bump_sha"
     if git diff --quiet -- "$PKG_FILE"; then
         log "  $PKG_FILE already at $new_name, nothing to commit"
     else
         git add "$PKG_FILE"
-        git commit --quiet -m "version: bump to $new_name"
+        git commit --quiet -m "$bump_msg"
         merge_sha=$(git rev-parse HEAD)
         verify_version_only_diff "$pre_bump_sha" "$merge_sha" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -53,9 +53,6 @@ MAX_REPREPARES=2
 reprep_pr=""
 reprep_n=0
 
-mp_pins_moved=false
-defaults_synced=false
-
 # ---------------------------------------------------------------- helpers
 
 pick_pr() {
@@ -202,78 +199,40 @@ base_already_failed() {
     return 0
 }
 
-changed_lines() {
-    git diff --unified=0 "$1" "$2" -- "$3" \
-        | grep -E '^[+-]' \
-        | grep -vE '^(\+\+\+|---)' || true
-}
+# Guard against a broken version.sh. Only the version line may move, plus the
+# myplanet pins when this run was asked to set them.
+verify_version_only_diff() {
+    local from=$1 to=$2 files bad allowed='"version"'
 
-# Guard against a broken version.sh. In $PKG_FILE only the version line may
-# move, plus the myplanet pins when this bump actually moved them; in the
-# workflow file only the two prefilled dispatch defaults.
-verify_bump_diff() {
-    local from=$1 to=$2 file bad ok keys='"version"'
+    [ -z "$MYPLANET_LATEST" ] || allowed="$allowed|\"latest\""
+    [ -z "$MYPLANET_MIN" ]    || allowed="$allowed|\"min\""
 
-    if [ "$mp_pins_moved" = 'true' ]; then
-        keys='"version"|"latest"|"min"'
-    fi
-
-    while IFS= read -r file; do
-        [ -n "$file" ] || continue
-        ok=false
-        [ "$file" = "$PKG_FILE" ] && ok=true
-        if [ "$defaults_synced" = 'true' ] && [ "$file" = "$SELF_WORKFLOW_PATH" ]; then
-            ok=true
-        fi
-        if [ "$ok" != 'true' ]; then
-            log "  bump touched an unexpected file: $file"
-            return 1
-        fi
-    done < <(git diff --name-only "$from" "$to")
-
-    bad=$(changed_lines "$from" "$to" "$PKG_FILE" \
-          | grep -vcE "^[+-][[:space:]]*($keys)[[:space:]]*:" || true)
-    if [ "${bad:-0}" -ne 0 ]; then
-        log "  bump changed $bad unexpected line(s) in $PKG_FILE"
+    files=$(git diff --name-only "$from" "$to")
+    if [ "$files" != "$PKG_FILE" ]; then
+        log "  bump touched unexpected files: ${files//$'\n'/, }"
         return 1
     fi
 
-    if [ "$defaults_synced" = 'true' ]; then
-        bad=$(changed_lines "$from" "$to" "$SELF_WORKFLOW_PATH" \
-              | grep -vcE "^[+-][[:space:]]*default: 'v?[0-9.]*'$" || true)
-        if [ "${bad:-0}" -ne 0 ]; then
-            log "  defaults sync changed $bad unexpected line(s) in $SELF_WORKFLOW_PATH"
-            return 1
-        fi
+    bad=$(git diff --unified=0 "$from" "$to" -- "$PKG_FILE" \
+          | grep -E '^[+-]' \
+          | grep -vE '^(\+\+\+|---)' \
+          | grep -vcE "^[+-][[:space:]]*($allowed)[[:space:]]*:" || true)
+    if [ "${bad:-0}" -ne 0 ]; then
+        log "  bump changed $bad non-version line(s)"
+        return 1
     fi
-
     log "  bump is version-only ($from -> $to)"
 }
 
-push_out=''
 push_with_retry() {
     local ref=$1
-    push_out=''
     for delay in 0 2 4 8 16; do
         [ "$delay" -eq 0 ] || sleep "$delay"
-        if push_out=$(git push origin "$ref" 2>&1); then
+        if git push origin "$ref"; then
             return 0
         fi
-        # Retrying a refusal only wastes the wait.
-        if workflow_scope_refusal "$push_out"; then
-            break
-        fi
     done
-    printf '%s\n' "$push_out" | sed 's/^/    /'
-    log "  push of $ref failed"
-    return 1
-}
-
-# A token without the workflow scope may push anything but .github/workflows.
-workflow_scope_refusal() {
-    case "$1" in
-        *'workflow` scope'*|*'workflows` permission'*|*'refusing to allow'*) return 0 ;;
-    esac
+    log "  push of $ref failed after retries"
     return 1
 }
 
@@ -284,10 +243,10 @@ summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
 summary ""
 
 # The pins ride along in the first merge's bump commit, so an empty queue
-# leaves them alone -- there is no merge to carry them.
+# leaves them unset -- there is no merge to carry them.
 if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
-    log "myplanet pins asked for: latest=${MYPLANET_LATEST:-unchanged}, min=${MYPLANET_MIN:-unchanged}"
-    summary "myplanet pins: latest \`${MYPLANET_LATEST:-unchanged}\`, min \`${MYPLANET_MIN:-unchanged}\`"
+    log "myplanet pins: latest -> ${MYPLANET_LATEST:-unchanged}, min -> ${MYPLANET_MIN:-unchanged}"
+    summary "myplanet pins: latest → \`${MYPLANET_LATEST:-unchanged}\`, min → \`${MYPLANET_MIN:-unchanged}\` (set by the first merge)"
     summary ""
 fi
 
@@ -367,8 +326,7 @@ while :; do
         if git merge --quiet --no-edit "origin/$BASE"; then
             log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
             if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
-                log "           pin myplanet latest=${MYPLANET_LATEST:-unchanged} min=${MYPLANET_MIN:-unchanged}"
-                log "           (and copy those into this workflow's dispatch defaults),"
+                log "           pin myplanet latest=${MYPLANET_LATEST:-unchanged} min=${MYPLANET_MIN:-unchanged},"
             fi
             log "           wait for ${REQUIRED_WORKFLOWS:-the triggered workflows}, then squash merge #$NUMBER"
             summary "| #$NUMBER | → \`$new_name\` | dry run: would merge |"
@@ -401,13 +359,11 @@ while :; do
     # a no-op after the first one has landed them on $BASE, so this needs no
     # memory of which PR carried them.
     bump_msg="version: bump to $new_name"
-    mp_pins_moved=false
     if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
         mp_before=$(git show "HEAD:$PKG_FILE" | jq -r '[.myplanet.latest, .myplanet.min] | join(" ")')
         "$VERSION_SH" myplanet "$PKG_FILE" "$MYPLANET_LATEST" "$MYPLANET_MIN"
         mp_after=$(jq -r '[.myplanet.latest, .myplanet.min] | join(" ")' "$PKG_FILE")
         if [ "$mp_before" != "$mp_after" ]; then
-            mp_pins_moved=true
             log "  myplanet pins: $mp_before -> $mp_after"
             bump_msg="$bump_msg, myplanet ${mp_after% *} (min ${mp_after#* })"
         else
@@ -415,54 +371,21 @@ while :; do
         fi
     fi
 
-    # Copy whatever package.json now pins into this workflow's own dispatch
-    # defaults, so the next manual start opens with the base's numbers already
-    # in the form instead of asking for them blind.
-    defaults_synced=false
-    if [ -f "$SELF_WORKFLOW_PATH" ]; then
-        "$VERSION_SH" myplanet-defaults "$SELF_WORKFLOW_PATH" "$PKG_FILE"
-        if ! git diff --quiet -- "$SELF_WORKFLOW_PATH"; then
-            defaults_synced=true
-            log "  dispatch form defaults re-synced in $SELF_WORKFLOW_PATH"
-        fi
-    fi
-
     merge_sha="$pre_bump_sha"
-    if git diff --quiet -- "$PKG_FILE" "$SELF_WORKFLOW_PATH"; then
+    if git diff --quiet -- "$PKG_FILE"; then
         log "  $PKG_FILE already at $new_name, nothing to commit"
     else
         git add "$PKG_FILE"
-        if [ "$defaults_synced" = 'true' ]; then
-            git add "$SELF_WORKFLOW_PATH"
-        fi
         git commit --quiet -m "$bump_msg"
         merge_sha=$(git rev-parse HEAD)
-        verify_bump_diff "$pre_bump_sha" "$merge_sha" \
+        verify_version_only_diff "$pre_bump_sha" "$merge_sha" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
     fi
 
     # 3. Push and let CI judge the prepared commit.
     if [ "$merge_sha" != "$SHA" ]; then
-        if ! push_with_retry "$HEAD"; then
-            # The version bump matters; the form prefill does not. Drop it and
-            # keep draining rather than stopping over a token scope.
-            if [ "$defaults_synced" = 'true' ] && workflow_scope_refusal "$push_out"; then
-                log "  this token may not push $SELF_WORKFLOW_PATH -- dropping the defaults sync"
-                log "  give AUTOMERGE_TOKEN the workflow scope to keep the dispatch form in step"
-                summary "| | | note: token cannot update \`$SELF_WORKFLOW_PATH\`, form defaults left alone |"
-                git checkout --quiet "$pre_bump_sha" -- "$SELF_WORKFLOW_PATH"
-                git commit --quiet --amend --no-edit
-                merge_sha=$(git rev-parse HEAD)
-                defaults_synced=false
-                verify_bump_diff "$pre_bump_sha" "$merge_sha" \
-                    || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
-                push_with_retry "$HEAD" \
-                    || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
-            else
-                summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"
-                exit 1
-            fi
-        fi
+        push_with_retry "$HEAD" \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
     else
         log "  branch already merged and bumped, head unchanged at ${SHA:0:7}"
     fi

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -53,6 +53,9 @@ MAX_REPREPARES=2
 reprep_pr=""
 reprep_n=0
 
+mp_pins_moved=false
+defaults_synced=false
+
 # ---------------------------------------------------------------- helpers
 
 pick_pr() {
@@ -199,40 +202,78 @@ base_already_failed() {
     return 0
 }
 
-# Guard against a broken version.sh. Only the version line may move, plus the
-# myplanet pins when this run was asked to set them.
-verify_version_only_diff() {
-    local from=$1 to=$2 files bad allowed='"version"'
+changed_lines() {
+    git diff --unified=0 "$1" "$2" -- "$3" \
+        | grep -E '^[+-]' \
+        | grep -vE '^(\+\+\+|---)' || true
+}
 
-    [ -z "$MYPLANET_LATEST" ] || allowed="$allowed|\"latest\""
-    [ -z "$MYPLANET_MIN" ]    || allowed="$allowed|\"min\""
+# Guard against a broken version.sh. In $PKG_FILE only the version line may
+# move, plus the myplanet pins when this bump actually moved them; in the
+# workflow file only the two prefilled dispatch defaults.
+verify_bump_diff() {
+    local from=$1 to=$2 file bad ok keys='"version"'
 
-    files=$(git diff --name-only "$from" "$to")
-    if [ "$files" != "$PKG_FILE" ]; then
-        log "  bump touched unexpected files: ${files//$'\n'/, }"
-        return 1
+    if [ "$mp_pins_moved" = 'true' ]; then
+        keys='"version"|"latest"|"min"'
     fi
 
-    bad=$(git diff --unified=0 "$from" "$to" -- "$PKG_FILE" \
-          | grep -E '^[+-]' \
-          | grep -vE '^(\+\+\+|---)' \
-          | grep -vcE "^[+-][[:space:]]*($allowed)[[:space:]]*:" || true)
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        ok=false
+        [ "$file" = "$PKG_FILE" ] && ok=true
+        if [ "$defaults_synced" = 'true' ] && [ "$file" = "$SELF_WORKFLOW_PATH" ]; then
+            ok=true
+        fi
+        if [ "$ok" != 'true' ]; then
+            log "  bump touched an unexpected file: $file"
+            return 1
+        fi
+    done < <(git diff --name-only "$from" "$to")
+
+    bad=$(changed_lines "$from" "$to" "$PKG_FILE" \
+          | grep -vcE "^[+-][[:space:]]*($keys)[[:space:]]*:" || true)
     if [ "${bad:-0}" -ne 0 ]; then
-        log "  bump changed $bad non-version line(s)"
+        log "  bump changed $bad unexpected line(s) in $PKG_FILE"
         return 1
     fi
+
+    if [ "$defaults_synced" = 'true' ]; then
+        bad=$(changed_lines "$from" "$to" "$SELF_WORKFLOW_PATH" \
+              | grep -vcE "^[+-][[:space:]]*default: 'v?[0-9.]*'$" || true)
+        if [ "${bad:-0}" -ne 0 ]; then
+            log "  defaults sync changed $bad unexpected line(s) in $SELF_WORKFLOW_PATH"
+            return 1
+        fi
+    fi
+
     log "  bump is version-only ($from -> $to)"
 }
 
+push_out=''
 push_with_retry() {
     local ref=$1
+    push_out=''
     for delay in 0 2 4 8 16; do
         [ "$delay" -eq 0 ] || sleep "$delay"
-        if git push origin "$ref"; then
+        if push_out=$(git push origin "$ref" 2>&1); then
             return 0
         fi
+        # Retrying a refusal only wastes the wait.
+        if workflow_scope_refusal "$push_out"; then
+            break
+        fi
     done
-    log "  push of $ref failed after retries"
+    printf '%s\n' "$push_out" | sed 's/^/    /'
+    log "  push of $ref failed"
+    return 1
+}
+
+# A token without the workflow scope may push anything but .github/workflows.
+workflow_scope_refusal() {
+    case "$1" in
+        *'workflow` scope'*|*'workflows` permission'*|*'refusing to allow'*) return 0 ;;
+    esac
     return 1
 }
 
@@ -243,10 +284,10 @@ summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
 summary ""
 
 # The pins ride along in the first merge's bump commit, so an empty queue
-# leaves them unset -- there is no merge to carry them.
+# leaves them alone -- there is no merge to carry them.
 if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
-    log "myplanet pins: latest -> ${MYPLANET_LATEST:-unchanged}, min -> ${MYPLANET_MIN:-unchanged}"
-    summary "myplanet pins: latest → \`${MYPLANET_LATEST:-unchanged}\`, min → \`${MYPLANET_MIN:-unchanged}\` (set by the first merge)"
+    log "myplanet pins asked for: latest=${MYPLANET_LATEST:-unchanged}, min=${MYPLANET_MIN:-unchanged}"
+    summary "myplanet pins: latest \`${MYPLANET_LATEST:-unchanged}\`, min \`${MYPLANET_MIN:-unchanged}\`"
     summary ""
 fi
 
@@ -326,7 +367,8 @@ while :; do
         if git merge --quiet --no-edit "origin/$BASE"; then
             log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
             if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
-                log "           pin myplanet latest=${MYPLANET_LATEST:-unchanged} min=${MYPLANET_MIN:-unchanged},"
+                log "           pin myplanet latest=${MYPLANET_LATEST:-unchanged} min=${MYPLANET_MIN:-unchanged}"
+                log "           (and copy those into this workflow's dispatch defaults),"
             fi
             log "           wait for ${REQUIRED_WORKFLOWS:-the triggered workflows}, then squash merge #$NUMBER"
             summary "| #$NUMBER | → \`$new_name\` | dry run: would merge |"
@@ -359,11 +401,13 @@ while :; do
     # a no-op after the first one has landed them on $BASE, so this needs no
     # memory of which PR carried them.
     bump_msg="version: bump to $new_name"
+    mp_pins_moved=false
     if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
         mp_before=$(git show "HEAD:$PKG_FILE" | jq -r '[.myplanet.latest, .myplanet.min] | join(" ")')
         "$VERSION_SH" myplanet "$PKG_FILE" "$MYPLANET_LATEST" "$MYPLANET_MIN"
         mp_after=$(jq -r '[.myplanet.latest, .myplanet.min] | join(" ")' "$PKG_FILE")
         if [ "$mp_before" != "$mp_after" ]; then
+            mp_pins_moved=true
             log "  myplanet pins: $mp_before -> $mp_after"
             bump_msg="$bump_msg, myplanet ${mp_after% *} (min ${mp_after#* })"
         else
@@ -371,21 +415,54 @@ while :; do
         fi
     fi
 
+    # Copy whatever package.json now pins into this workflow's own dispatch
+    # defaults, so the next manual start opens with the base's numbers already
+    # in the form instead of asking for them blind.
+    defaults_synced=false
+    if [ -f "$SELF_WORKFLOW_PATH" ]; then
+        "$VERSION_SH" myplanet-defaults "$SELF_WORKFLOW_PATH" "$PKG_FILE"
+        if ! git diff --quiet -- "$SELF_WORKFLOW_PATH"; then
+            defaults_synced=true
+            log "  dispatch form defaults re-synced in $SELF_WORKFLOW_PATH"
+        fi
+    fi
+
     merge_sha="$pre_bump_sha"
-    if git diff --quiet -- "$PKG_FILE"; then
+    if git diff --quiet -- "$PKG_FILE" "$SELF_WORKFLOW_PATH"; then
         log "  $PKG_FILE already at $new_name, nothing to commit"
     else
         git add "$PKG_FILE"
+        if [ "$defaults_synced" = 'true' ]; then
+            git add "$SELF_WORKFLOW_PATH"
+        fi
         git commit --quiet -m "$bump_msg"
         merge_sha=$(git rev-parse HEAD)
-        verify_version_only_diff "$pre_bump_sha" "$merge_sha" \
+        verify_bump_diff "$pre_bump_sha" "$merge_sha" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
     fi
 
     # 3. Push and let CI judge the prepared commit.
     if [ "$merge_sha" != "$SHA" ]; then
-        push_with_retry "$HEAD" \
-            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
+        if ! push_with_retry "$HEAD"; then
+            # The version bump matters; the form prefill does not. Drop it and
+            # keep draining rather than stopping over a token scope.
+            if [ "$defaults_synced" = 'true' ] && workflow_scope_refusal "$push_out"; then
+                log "  this token may not push $SELF_WORKFLOW_PATH -- dropping the defaults sync"
+                log "  give AUTOMERGE_TOKEN the workflow scope to keep the dispatch form in step"
+                summary "| | | note: token cannot update \`$SELF_WORKFLOW_PATH\`, form defaults left alone |"
+                git checkout --quiet "$pre_bump_sha" -- "$SELF_WORKFLOW_PATH"
+                git commit --quiet --amend --no-edit
+                merge_sha=$(git rev-parse HEAD)
+                defaults_synced=false
+                verify_bump_diff "$pre_bump_sha" "$merge_sha" \
+                    || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
+                push_with_retry "$HEAD" \
+                    || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
+            else
+                summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"
+                exit 1
+            fi
+        fi
     else
         log "  branch already merged and bumped, head unchanged at ${SHA:0:7}"
     fi

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -11,8 +11,6 @@
 # Stop on the first failure. Both waits sit in front of step 4 so they
 # overlap: $BASE releases the previous merge while this PR builds.
 #
-# Runs from a copy outside the work tree -- it checks out PR branches.
-#
 set -euo pipefail
 
 REPO="${REPO:?}"
@@ -29,7 +27,6 @@ DRY_RUN="${DRY_RUN:-true}"
 MAX_MERGES="${MAX_MERGES:-0}"
 WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
 USING_PAT="${USING_PAT:-false}"
-# Already normalized and checked against myplanet's releases by the workflow.
 MYPLANET_LATEST="${MYPLANET_LATEST:-}"
 MYPLANET_MIN="${MYPLANET_MIN:-}"
 
@@ -54,8 +51,6 @@ last_base_sha=""
 MAX_REPREPARES=2
 reprep_pr=""
 reprep_n=0
-
-# ---------------------------------------------------------------- helpers
 
 pick_pr() {
     gh pr list \
@@ -116,7 +111,6 @@ runs_for() {
 runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
 runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
 
-# Names in $2 with no successful run yet; blank $2 = none.
 runs_missing() {
     jq -r --arg req "$2" '
         [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
@@ -126,8 +120,6 @@ runs_missing() {
     ' <<<"$1"
 }
 
-# Green: nothing failed, nothing running, every workflow in $need passed.
-# $absent = what no runs at all means: 'fail' (we pushed it), 'pass' ($BASE).
 wait_for_runs() {
     local sha=$1 need=$2 absent=$3
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
@@ -190,7 +182,6 @@ wait_for_runs() {
     done
 }
 
-# Non-blocking peek; step 4 does the blocking version.
 base_already_failed() {
     local sha=$1 runs bad
     runs=$(runs_for "$sha")
@@ -201,8 +192,6 @@ base_already_failed() {
     return 0
 }
 
-# Guard against a broken version.sh. Only the version line may move, plus the
-# myplanet pins when this run was asked to set them.
 verify_version_only_diff() {
     local from=$1 to=$2 files bad allowed='"version"'
 
@@ -238,14 +227,10 @@ push_with_retry() {
     return 1
 }
 
-# ------------------------------------------------------------------- main
-
 log "draining '$LABEL' into $BASE (dry_run=$DRY_RUN)"
 summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
 summary ""
 
-# The pins ride along in the first merge's bump commit, so an empty queue
-# leaves them unset -- there is no merge to carry them.
 if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
     log "myplanet pins: latest -> ${MYPLANET_LATEST:-unchanged}, min -> ${MYPLANET_MIN:-unchanged}"
     summary "myplanet pins: latest → \`${MYPLANET_LATEST:-unchanged}\`, min → \`${MYPLANET_MIN:-unchanged}\` (set by the first merge)"
@@ -302,8 +287,6 @@ while :; do
         continue
     fi
 
-    # A branch policy needing an approval refuses the merge in step 4, after a
-    # full build. Skip rather than stop, so approved PRs behind it still drain.
     review=$(pr_review "$NUMBER")
     case "$review" in
         REVIEW_REQUIRED|CHANGES_REQUIRED|CHANGES_REQUESTED)
@@ -315,7 +298,6 @@ while :; do
 
     check_mergeable "$NUMBER" || { summary "| #$NUMBER | | **stopped**: conflicts with \`$BASE\` |"; exit 1; }
 
-    # "Next" comes off the base -- it is what the merge lands on.
     base_pkg="${RUNNER_TEMP:-/tmp}/base-package.json"
     git show "origin/$BASE:$PKG_FILE" > "$base_pkg"
     eval "$("$VERSION_SH" next "$base_pkg" | sed 's/^/new_/')"
@@ -346,8 +328,6 @@ while :; do
 
     git checkout --quiet -B "$HEAD" "origin/$HEAD"
 
-    # 1. Base first: a branch cut earlier collides on the exact version line
-    #    step 2 rewrites, and this makes step 3 test what actually lands.
     if ! git merge --quiet --no-edit "origin/$BASE"; then
         git merge --abort || true
         log "  #$NUMBER conflicts with $BASE -- needs a human"
@@ -355,14 +335,9 @@ while :; do
         exit 1
     fi
 
-    # 2. Bump. Every merge is tagged v<version> for a release, so each needs
-    #    its own number; writing it here puts it in the squash.
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$PKG_FILE" "$new_name"
 
-    # The myplanet pins go in the same commit. Rewriting them for every PR is
-    # a no-op after the first one has landed them on $BASE, so this needs no
-    # memory of which PR carried them.
     bump_msg="version: bump to $new_name"
     if [ -n "$MYPLANET_LATEST$MYPLANET_MIN" ]; then
         mp_before=$(git show "HEAD:$PKG_FILE" | jq -r '[.myplanet.latest, .myplanet.min] | join(" ")')
@@ -386,8 +361,6 @@ while :; do
         verify_version_only_diff "$pre_bump_sha" "$merge_sha" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
     fi
-
-    # 3. Push and let CI judge the prepared commit.
     if [ "$merge_sha" != "$SHA" ]; then
         push_with_retry "$HEAD" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
@@ -402,7 +375,6 @@ while :; do
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
     fi
 
-    # 4. Merge, but only onto a settled green base.
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
         git fetch --quiet origin "$BASE"
         wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
@@ -478,12 +450,6 @@ while :; do
     git fetch --quiet origin "$BASE"
     last_base_sha=$(git rev-parse "origin/$BASE")
 
-    # 5. Tag the merge and publish the release. The bumped version only means
-    #    something once it is tagged, and it is the release event -- not the
-    #    push -- that builds the versioned images. Lightweight tag and
-    #    generated notes, the way every earlier version on $BASE was cut.
-    #    Those builder runs sit on $BASE's head, so the next PR's green-base
-    #    wait covers them without any extra plumbing here.
     release_note=""
     if [ "$CREATE_RELEASE" = 'true' ]; then
         target=$(gh pr view "$NUMBER" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null || echo '')

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -6,6 +6,7 @@
 #   2. bump the version on the PR branch
 #   3. push, and wait for the builders on that prepared commit
 #   4. wait for $BASE to be settled and green, then squash merge
+#   5. tag the merge and publish its release
 #
 # Stop on the first failure. Both waits sit in front of step 4 so they
 # overlap: $BASE releases the previous merge while this PR builds.
@@ -23,6 +24,7 @@ COAUTHORS_SH="${COAUTHORS_SH:?}"
 REQUIRE_CHECKS="${REQUIRE_CHECKS:-true}"
 REQUIRED_WORKFLOWS="${REQUIRED_WORKFLOWS:-}"
 DELETE_BRANCH="${DELETE_BRANCH:-true}"
+CREATE_RELEASE="${CREATE_RELEASE:-true}"
 DRY_RUN="${DRY_RUN:-true}"
 MAX_MERGES="${MAX_MERGES:-0}"
 WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
@@ -329,6 +331,9 @@ while :; do
                 log "           pin myplanet latest=${MYPLANET_LATEST:-unchanged} min=${MYPLANET_MIN:-unchanged},"
             fi
             log "           wait for ${REQUIRED_WORKFLOWS:-the triggered workflows}, then squash merge #$NUMBER"
+            if [ "$CREATE_RELEASE" = 'true' ]; then
+                log "           and cut v$new_name from the merge"
+            fi
             summary "| #$NUMBER | → \`$new_name\` | dry run: would merge |"
         else
             git merge --abort || true
@@ -473,10 +478,37 @@ while :; do
     git fetch --quiet origin "$BASE"
     last_base_sha=$(git rev-parse "origin/$BASE")
 
+    # 5. Tag the merge and publish the release. The bumped version only means
+    #    something once it is tagged, and it is the release event -- not the
+    #    push -- that builds the versioned images. Lightweight tag and
+    #    generated notes, the way every earlier version on $BASE was cut.
+    #    Those builder runs sit on $BASE's head, so the next PR's green-base
+    #    wait covers them without any extra plumbing here.
+    release_note=""
+    if [ "$CREATE_RELEASE" = 'true' ]; then
+        target=$(gh pr view "$NUMBER" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null || echo '')
+        target="${target:-$last_base_sha}"
+        if release_out=$(gh release create "v$new_name" \
+                            --repo "$REPO" \
+                            --target "$target" \
+                            --title "Version $new_name" \
+                            --generate-notes 2>&1); then
+            log "  released v$new_name at ${target:0:7}"
+            release_note=", released \`v$new_name\`"
+        else
+            printf '%s\n' "$release_out" | sed 's/^/    /'
+            log "  #$NUMBER merged, but cutting v$new_name failed"
+            log "  stopping here: an unreleased version builds no images, and every"
+            log "  later bump would inherit the gap without anyone noticing"
+            summary "| #$NUMBER | → \`$new_name\` | merged as \`${last_base_sha:0:7}\`, **release failed** |"
+            exit 1
+        fi
+    fi
+
     merged_count=$((merged_count + 1))
     merged_list="$merged_list #$NUMBER"
     skip_numbers="$skip_numbers $NUMBER"
-    summary "| #$NUMBER | → \`$new_name\` | merged as \`${last_base_sha:0:7}\` |"
+    summary "| #$NUMBER | → \`$new_name\` | merged as \`${last_base_sha:0:7}\`$release_note |"
 done
 
 log "done: merged $merged_count PR(s):${merged_list:- none}"

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+#
+# Drain the automerge queue. Per PR labelled $LABEL, lowest number first:
+#
+#   1. merge $BASE into the PR branch          (a conflict stops the drain)
+#   2. bump the version on the PR branch
+#   3. push, and wait for the builders on that prepared commit
+#   4. wait for $BASE to be settled and green, then squash merge
+#
+# Stop on the first failure. Both waits sit in front of step 4 so they
+# overlap: $BASE releases the previous merge while this PR builds.
+#
+# Runs from a copy outside the work tree -- it checks out PR branches.
+#
+set -euo pipefail
+
+REPO="${REPO:?}"
+BASE="${BASE:?}"
+LABEL="${LABEL:?}"
+PKG_FILE="${PKG_FILE:?}"
+VERSION_SH="${VERSION_SH:?}"
+COAUTHORS_SH="${COAUTHORS_SH:?}"
+REQUIRE_CHECKS="${REQUIRE_CHECKS:-true}"
+REQUIRED_WORKFLOWS="${REQUIRED_WORKFLOWS:-}"
+DELETE_BRANCH="${DELETE_BRANCH:-true}"
+DRY_RUN="${DRY_RUN:-true}"
+MAX_MERGES="${MAX_MERGES:-0}"
+WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
+USING_PAT="${USING_PAT:-false}"
+
+RUN_APPEAR_TIMEOUT_SEC=300
+POLL_INTERVAL_SEC=20
+PR_SETTLE_TIMEOUT_SEC=120
+
+self_ref="${GITHUB_WORKFLOW_REF:-}"
+self_ref="${self_ref%@*}"
+SELF_WORKFLOW_PATH="${self_ref#*/*/}"
+SELF_WORKFLOW_PATH="${SELF_WORKFLOW_PATH:-.github/workflows/automerge.yml}"
+SELF_RUN_ID="${GITHUB_RUN_ID:-}"
+
+log()     { printf '%s | %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"; return 0; }
+
+merged_count=0
+merged_list=""
+skip_numbers=""
+last_base_sha=""
+
+MAX_REPREPARES=2
+reprep_pr=""
+reprep_n=0
+
+# ---------------------------------------------------------------- helpers
+
+pick_pr() {
+    gh pr list \
+        --repo "$REPO" \
+        --state open \
+        --base "$BASE" \
+        --label "$LABEL" \
+        --limit 100 \
+        --json number,title,isDraft,headRefName,headRefOid,headRepositoryOwner \
+      | jq -c --arg skip "$skip_numbers" '
+            [ $skip | split(" ")[] | select(length > 0) | tonumber ] as $done
+            | map(select(.isDraft | not))
+            | map(select(.number as $n | $done | index($n) | not))
+            | sort_by(.number) | first'
+}
+
+pr_state()  { gh pr view "$1" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo ''; }
+pr_review() { gh pr view "$1" --repo "$REPO" --json reviewDecision --jq '.reviewDecision' 2>/dev/null || echo ''; }
+
+check_mergeable() {
+    local pr=$1 state=""
+    for _ in 1 2 3 4 5; do
+        state=$(gh pr view "$pr" --repo "$REPO" --json mergeable --jq '.mergeable' 2>/dev/null || echo '')
+        case "$state" in MERGEABLE|CONFLICTING) break ;; esac
+        sleep 5
+    done
+    case "$state" in
+        MERGEABLE) ;;
+        CONFLICTING)
+            log "  #$pr conflicts with $BASE -- needs a human"
+            return 1 ;;
+        *)
+            log "  #$pr mergeability is ${state:-unavailable} -- letting step 1 decide" ;;
+    esac
+}
+
+wait_pr_merged() {
+    local pr=$1 state="" deadline=$(( SECONDS + PR_SETTLE_TIMEOUT_SEC ))
+    while :; do
+        state=$(pr_state "$pr")
+        [ "$state" = "OPEN" ] || break
+        [ "$SECONDS" -lt "$deadline" ] || { log "  #$pr still reads as open after ${PR_SETTLE_TIMEOUT_SEC}s"; break; }
+        sleep 5
+    done
+}
+
+runs_for() {
+    local raw
+    raw=$(gh api "repos/$REPO/actions/runs?head_sha=$1&per_page=100" 2>/dev/null) \
+        || { echo '[]'; return 0; }
+    jq -c --arg self "$SELF_WORKFLOW_PATH" --arg run "$SELF_RUN_ID" '
+        [ .workflow_runs[]?
+          | select(.path != $self)
+          | select(($run | length == 0) or ((.id | tostring) != $run))
+          | {name, status, conclusion} ]' <<<"$raw" 2>/dev/null || echo '[]'
+}
+
+runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
+runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
+
+# Names in $2 with no successful run yet; blank $2 = none.
+runs_missing() {
+    jq -r --arg req "$2" '
+        [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
+        | ([ .[] | select(.status == "completed" and .conclusion == "success") | .name ] | unique) as $green
+        | [ $need[] | select(. as $n | $green | index($n) | not) ]
+        | join(", ")
+    ' <<<"$1"
+}
+
+# Green: nothing failed, nothing running, every workflow in $need passed.
+# $absent = what no runs at all means: 'fail' (we pushed it), 'pass' ($BASE).
+wait_for_runs() {
+    local sha=$1 need=$2 absent=$3
+    local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
+    local appear_deadline=$(( SECONDS + RUN_APPEAR_TIMEOUT_SEC ))
+    local runs total pending failed missing announced=0
+
+    log "  waiting for workflows on ${sha:0:7} (timeout ${WAIT_TIMEOUT_MIN}m)"
+    while :; do
+        runs=$(runs_for "$sha")
+        total=$(jq 'length' <<<"$runs")
+
+        if [ "$total" -gt 0 ]; then
+            failed=$(runs_failed "$runs")
+            if [ "$failed" -ne 0 ]; then
+                jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "    \(.conclusion)\t\(.name)"' <<<"$runs"
+                log "  $failed workflow(s) failed on ${sha:0:7}"
+                return 1
+            fi
+
+            pending=$(runs_pending "$runs")
+            missing=$(runs_missing "$runs" "$need")
+
+            if [ "$pending" -eq 0 ] && [ -z "$missing" ]; then
+                jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$runs"
+                log "  all $total workflow(s) green on ${sha:0:7}"
+                return 0
+            fi
+
+            if [ "$pending" -ne 0 ] && [ "$announced" -eq 0 ]; then
+                log "  $pending workflow(s) still running on ${sha:0:7}"
+                announced=1
+            fi
+        fi
+
+        if [ "$total" -eq 0 ] || { [ "${pending:-0}" -eq 0 ] && [ -n "${missing:-}" ]; }; then
+            if [ "$SECONDS" -ge "$appear_deadline" ]; then
+                if [ "$total" -eq 0 ]; then
+                    if [ "$absent" = 'pass' ]; then
+                        log "  no workflow runs for ${sha:0:7} -- nothing to wait for"
+                        return 0
+                    fi
+                    log "  no workflow runs exist for ${sha:0:7} -- refusing to merge blind"
+                else
+                    log "  required workflow(s) never ran on ${sha:0:7}: $missing"
+                fi
+                if [ "$USING_PAT" != 'true' ]; then
+                    log "  a push made with GITHUB_TOKEN deliberately does not trigger workflows."
+                    log "  Set the AUTOMERGE_TOKEN secret to a PAT or GitHub App token so the"
+                    log "  prepared commit gets its own builder runs."
+                fi
+                return 1
+            fi
+        fi
+
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            log "  timed out after ${WAIT_TIMEOUT_MIN}m waiting on ${sha:0:7}"
+            return 1
+        fi
+        sleep "$POLL_INTERVAL_SEC"
+    done
+}
+
+# Non-blocking peek; step 4 does the blocking version.
+base_already_failed() {
+    local sha=$1 runs bad
+    runs=$(runs_for "$sha")
+    bad=$(jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.conclusion)\t\(.name)"' <<<"$runs")
+    [ -n "$bad" ] || return 1
+    printf '%s\n' "$bad" | sed 's/^/    /'
+    log "the last merge has already failed on $BASE (${sha:0:7})"
+    return 0
+}
+
+# Guard against a broken version.sh.
+verify_version_only_diff() {
+    local from=$1 to=$2 files bad
+
+    files=$(git diff --name-only "$from" "$to")
+    if [ "$files" != "$PKG_FILE" ]; then
+        log "  bump touched unexpected files: ${files//$'\n'/, }"
+        return 1
+    fi
+
+    bad=$(git diff --unified=0 "$from" "$to" -- "$PKG_FILE" \
+          | grep -E '^[+-]' \
+          | grep -vE '^(\+\+\+|---)' \
+          | grep -vcE '^[+-][[:space:]]*"version"[[:space:]]*:' || true)
+    if [ "${bad:-0}" -ne 0 ]; then
+        log "  bump changed $bad non-version line(s)"
+        return 1
+    fi
+    log "  bump is version-only ($from -> $to)"
+}
+
+push_with_retry() {
+    local ref=$1
+    for delay in 0 2 4 8 16; do
+        [ "$delay" -eq 0 ] || sleep "$delay"
+        if git push origin "$ref"; then
+            return 0
+        fi
+    done
+    log "  push of $ref failed after retries"
+    return 1
+}
+
+# ------------------------------------------------------------------- main
+
+log "draining '$LABEL' into $BASE (dry_run=$DRY_RUN)"
+summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
+summary ""
+summary "| PR | version | result |"
+summary "|---|---|---|"
+
+git config user.name  'github-actions[bot]'
+git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+while :; do
+    if [ "$MAX_MERGES" -gt 0 ] && [ "$merged_count" -ge "$MAX_MERGES" ]; then
+        log "reached max_merges=$MAX_MERGES, stopping"
+        summary "| | | stopped at max_merges=$MAX_MERGES |"
+        break
+    fi
+
+    if [ -n "$last_base_sha" ] && base_already_failed "$last_base_sha"; then
+        summary "| | | **stopped**: \`$BASE\` red after the last merge |"
+        exit 1
+    fi
+
+    git fetch --quiet origin "$BASE"
+    base_at_prepare=$(git rev-parse "origin/$BASE")
+
+    pr_json=$(pick_pr)
+    if [ "$pr_json" = "null" ] || [ -z "$pr_json" ]; then
+        log "no open non-draft PR labelled '$LABEL' targets $BASE -- queue empty"
+        summary "| | | queue empty |"
+        break
+    fi
+
+    NUMBER=$(jq -r '.number'                    <<<"$pr_json")
+    TITLE=$(jq  -r '.title'                     <<<"$pr_json")
+    HEAD=$(jq   -r '.headRefName'               <<<"$pr_json")
+    SHA=$(jq    -r '.headRefOid'                <<<"$pr_json")
+    OWNER=$(jq  -r '.headRepositoryOwner.login' <<<"$pr_json")
+
+    log "picked #$NUMBER ($HEAD @ ${SHA:0:7}): $TITLE"
+
+    if [ "$OWNER" != "${REPO%%/*}" ]; then
+        log "  #$NUMBER comes from fork $OWNER -- cannot push a version bump to it"
+        summary "| #$NUMBER | | **stopped**: fork, cannot bump |"
+        exit 1
+    fi
+
+    # The list index can be stale; ask about this PR directly before working it.
+    state=$(pr_state "$NUMBER")
+    if [ -n "$state" ] && [ "$state" != "OPEN" ]; then
+        log "  #$NUMBER is no longer open (state: $state) -- skipping"
+        skip_numbers="$skip_numbers $NUMBER"
+        continue
+    fi
+
+    # A branch policy needing an approval refuses the merge in step 4, after a
+    # full build. Skip rather than stop, so approved PRs behind it still drain.
+    review=$(pr_review "$NUMBER")
+    case "$review" in
+        REVIEW_REQUIRED|CHANGES_REQUIRED|CHANGES_REQUESTED)
+            log "  #$NUMBER needs a review ($review) -- skipping, $BASE would refuse it"
+            summary "| #$NUMBER | | skipped: needs a review (\`$review\`) |"
+            skip_numbers="$skip_numbers $NUMBER"
+            continue ;;
+    esac
+
+    check_mergeable "$NUMBER" || { summary "| #$NUMBER | | **stopped**: conflicts with \`$BASE\` |"; exit 1; }
+
+    # "Next" comes off the base -- it is what the merge lands on.
+    base_pkg="${RUNNER_TEMP:-/tmp}/base-package.json"
+    git show "origin/$BASE:$PKG_FILE" > "$base_pkg"
+    eval "$("$VERSION_SH" next "$base_pkg" | sed 's/^/new_/')"
+    log "  version -> $new_name"
+
+    git fetch --quiet origin "$HEAD"
+
+    if [ "$DRY_RUN" = 'true' ]; then
+        git checkout --quiet --detach "origin/$HEAD"
+        if git merge --quiet --no-edit "origin/$BASE"; then
+            log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
+            log "           wait for ${REQUIRED_WORKFLOWS:-the triggered workflows}, then squash merge #$NUMBER"
+            summary "| #$NUMBER | → \`$new_name\` | dry run: would merge |"
+        else
+            git merge --abort || true
+            log "  dry run: #$NUMBER conflicts with $BASE -- needs a human"
+            summary "| #$NUMBER | | dry run: **conflicts** with \`$BASE\` |"
+        fi
+        log "dry run stops after one PR (nothing advances)"
+        break
+    fi
+
+    git checkout --quiet -B "$HEAD" "origin/$HEAD"
+
+    # 1. Base first: a branch cut earlier collides on the exact version line
+    #    step 2 rewrites, and this makes step 3 test what actually lands.
+    if ! git merge --quiet --no-edit "origin/$BASE"; then
+        git merge --abort || true
+        log "  #$NUMBER conflicts with $BASE -- needs a human"
+        summary "| #$NUMBER | | **stopped**: conflicts with \`$BASE\` |"
+        exit 1
+    fi
+
+    # 2. Bump. Every merge is tagged v<version> for a release, so each needs
+    #    its own number; writing it here puts it in the squash.
+    pre_bump_sha=$(git rev-parse HEAD)
+    "$VERSION_SH" apply "$PKG_FILE" "$new_name"
+
+    merge_sha="$pre_bump_sha"
+    if git diff --quiet -- "$PKG_FILE"; then
+        log "  $PKG_FILE already at $new_name, nothing to commit"
+    else
+        git add "$PKG_FILE"
+        git commit --quiet -m "version: bump to $new_name"
+        merge_sha=$(git rev-parse HEAD)
+        verify_version_only_diff "$pre_bump_sha" "$merge_sha" \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
+    fi
+
+    # 3. Push and let CI judge the prepared commit.
+    if [ "$merge_sha" != "$SHA" ]; then
+        push_with_retry "$HEAD" \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
+    else
+        log "  branch already merged and bumped, head unchanged at ${SHA:0:7}"
+    fi
+
+    if [ "$REQUIRE_CHECKS" = 'true' ]; then
+        wait_for_runs "$merge_sha" "$REQUIRED_WORKFLOWS" fail \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: prepared commit not green |"; exit 1; }
+    else
+        log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
+    fi
+
+    # 4. Merge, but only onto a settled green base.
+    if [ "$REQUIRE_CHECKS" = 'true' ]; then
+        git fetch --quiet origin "$BASE"
+        wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` is red |"; exit 1; }
+
+        # Prepared against a base that no longer exists; prepare again.
+        git fetch --quiet origin "$BASE"
+        base_now=$(git rev-parse "origin/$BASE")
+        if [ "$base_now" != "$base_at_prepare" ]; then
+            if [ "$NUMBER" = "$reprep_pr" ]; then
+                reprep_n=$((reprep_n + 1))
+            else
+                reprep_pr="$NUMBER"; reprep_n=1
+            fi
+            if [ "$reprep_n" -gt "$MAX_REPREPARES" ]; then
+                log "  $BASE keeps moving under #$NUMBER -- giving up after $MAX_REPREPARES re-preparations"
+                summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` moving under it |"
+                exit 1
+            fi
+            log "  $BASE moved to ${base_now:0:7} while #$NUMBER was building -- re-preparing it"
+            continue
+        fi
+    fi
+
+    commit_body=$(REPO="$REPO" PR="$NUMBER" "$COAUTHORS_SH")
+    if [ -n "$commit_body" ]; then
+        log "  co-authors:"
+        printf '%s\n' "$commit_body" | sed 's/^/    /'
+    else
+        log "  no co-authors to credit"
+    fi
+
+    ARGS=(--repo "$REPO" --squash --match-head-commit "$merge_sha"
+          --subject "$TITLE (#$NUMBER)" --body "$commit_body")
+    if [ "$DELETE_BRANCH" = 'true' ]; then
+        ARGS+=(--delete-branch)
+    fi
+    if ! merge_out=$(gh pr merge "$NUMBER" "${ARGS[@]}" 2>&1); then
+        printf '%s\n' "$merge_out" | sed 's/^/    /'
+        log "  merge of #$NUMBER refused"
+        reason="merge refused"
+        case "$merge_out" in
+            *"not authorized to push"*|*"Protected branch"*|*"Resource not accessible"*)
+                reason="**stopped**: token may not merge into \`$BASE\`"
+                log "  $BASE is protected and this token may not merge into it."
+                if [ "$USING_PAT" = 'true' ]; then
+                    log "  AUTOMERGE_TOKEN is set, so that account still lacks merge rights on $BASE."
+                else
+                    log "  Running on GITHUB_TOKEN. Set the AUTOMERGE_TOKEN secret to a PAT or"
+                    log "  GitHub App token belonging to someone allowed to merge into $BASE."
+                fi
+                ;;
+            *"base branch policy prohibits"*)
+                reason="**stopped**: \`$BASE\` policy refused the merge (review? codeowner?)"
+                log "  $BASE's branch protection refused this merge. The prepared commit is"
+                log "  green, so the unmet requirement is a policy one -- most often a missing"
+                log "  approving review, a codeowner review, or an unresolved conversation."
+                log "  --auto is deliberately not used: it returns before the merge happens,"
+                log "  and the drain must know the merge landed to bump the next version."
+                ;;
+            *"is not mergeable"*|*"required status check"*)
+                reason="**stopped**: base requires checks the prepared commit has not passed"
+                log "  the prepared commit has not satisfied the base's required checks."
+                log "  Make sure required_workflows covers every check $BASE requires."
+                ;;
+        esac
+        summary "| #$NUMBER | → \`$new_name\` | $reason |"
+        exit 1
+    fi
+    log "  merged #$NUMBER"
+    wait_pr_merged "$NUMBER"
+
+    git fetch --quiet origin "$BASE"
+    last_base_sha=$(git rev-parse "origin/$BASE")
+
+    merged_count=$((merged_count + 1))
+    merged_list="$merged_list #$NUMBER"
+    skip_numbers="$skip_numbers $NUMBER"
+    summary "| #$NUMBER | → \`$new_name\` | merged as \`${last_base_sha:0:7}\` |"
+done
+
+log "done: merged $merged_count PR(s):${merged_list:- none}"
+summary ""
+summary "**merged $merged_count PR(s)**:${merged_list:- none}"

--- a/.github/scripts/coauthors.sh
+++ b/.github/scripts/coauthors.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Build the squash commit body: one Co-authored-by per collaborator who
+# worked on the PR, then $OWNER_LOGIN if they did not author it. The PR
+# description is discarded. Coding agents fall out for free -- they commit as
+# Bot accounts or leave trailers that tie back to no GitHub account.
+#
+# Usage: REPO=owner/name PR=123 coauthors.sh   (empty output is legitimate)
+#
+set -euo pipefail
+
+REPO="${REPO:?}"
+PR="${PR:?}"
+OWNER_LOGIN="${OWNER_LOGIN:-dogi}"
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+noreply_for() { printf '%s <%s@users.noreply.github.com>' "$1" "$1"; }
+
+# Needs push access; failing here beats crediting nobody.
+collaborators=$(
+    gh api "repos/$REPO/collaborators?per_page=100" --paginate \
+        --jq '.[] | select(.type == "User") | .login' | tr '[:upper:]' '[:lower:]' | sort -u
+)
+
+pr_json=$(gh pr view "$PR" --repo "$REPO" --json author,body)
+author_login=$(jq -r '.author.login // ""' <<<"$pr_json")
+pr_body=$(jq -r '.body // ""' <<<"$pr_json")
+
+commits=$(gh api "repos/$REPO/pulls/$PR/commits?per_page=100" --paginate)
+
+candidates=""
+
+while IFS= read -r login; do
+    if [ -n "$login" ]; then
+        candidates+="$login"$'\n'
+    fi
+done < <(jq -r '.[] | select(.author != null) | select(.author.type == "User") | .author.login' <<<"$commits")
+
+trailers=$(
+    { jq -r '.[].commit.message' <<<"$commits"; printf '%s\n' "$pr_body"; } \
+    | grep -iE '^[[:space:]]*co-authored-by:[[:space:]]*' || true
+)
+
+while IFS= read -r line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+    email=$(sed -nE 's/.*<([^>]+)>.*/\1/p' <<<"$line")
+    case "$email" in
+        *@users.noreply.github.com)
+            login=${email%@users.noreply.github.com}
+            login=${login#*+}   # drop the numeric id prefix, if any
+            candidates+="$login"$'\n'
+            ;;
+        *)
+            # Not a GitHub address -- this is what drops the coding agents.
+            ;;
+    esac
+done <<<"$trailers"
+
+author_l=$(lower "$author_login")
+owner_l=$(lower "$OWNER_LOGIN")
+
+body=""
+seen=""
+
+while IFS= read -r login; do
+    if [ -z "$login" ]; then
+        continue
+    fi
+    l=$(lower "$login")
+
+    case "$l" in
+        *'[bot]') continue ;;
+    esac
+    if [ "$l" = "$author_l" ]; then
+        continue                       # already the commit author
+    fi
+    if [ "$l" = "$owner_l" ]; then
+        continue                       # appended at the end instead
+    fi
+    if printf '%s' "$seen" | grep -qxF "$l"; then
+        continue
+    fi
+    if ! printf '%s' "$collaborators" | grep -qxF "$l"; then
+        continue
+    fi
+
+    seen+="$l"$'\n'
+    body+="Co-authored-by: $(noreply_for "$login")"$'\n'
+done <<<"$candidates"
+
+if [ -n "$author_l" ] && [ "$author_l" != "$owner_l" ]; then
+    body+="Co-authored-by: $(noreply_for "$OWNER_LOGIN")"$'\n'
+fi
+
+printf '%s' "$body"

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -12,7 +12,6 @@
 #   version.sh apply <package-file> <name>
 #   version.sh myplanet <package-file> <latest> <min>   (blank = leave as is)
 #   version.sh check-myplanet <version>                 (prints it normalized)
-#   version.sh myplanet-defaults <workflow-file> <package-file>
 #
 # The myplanet subcommands need jq; the rest is sed only.
 #
@@ -114,50 +113,6 @@ apply_myplanet() {
     [ -z "$min" ]    || [ "$mp_min"    = "$min" ]    || die "failed to write myplanet.min $min into $file"
 }
 
-# A workflow_dispatch default has to be literal text -- GitHub does not
-# evaluate expressions in the `on:` block -- so the dispatch form can only
-# show the current pins if they are written into the file. Each bump re-syncs
-# them, which is what keeps the form honest.
-set_input_default() {
-    local wf=$1 input=$2 val=$3
-    # Scoped to one input block, which ends at its `type:` line.
-    sed -i -E \
-        "/^[[:space:]]*${input}:[[:space:]]*$/,/^[[:space:]]*type:/ s/^([[:space:]]*default:[[:space:]]*).*/\1'${val}'/" \
-        "$wf"
-}
-
-input_default() {
-    sed -nE \
-        "/^[[:space:]]*$2:[[:space:]]*$/,/^[[:space:]]*type:/ s/^[[:space:]]*default:[[:space:]]*'?([^']*)'?[[:space:]]*$/\1/p" \
-        "$1" | head -1
-}
-
-has_input() { grep -qE "^[[:space:]]*$2:[[:space:]]*$" "$1"; }
-
-sync_myplanet_defaults() {
-    local wf=$1 file=$2 got_latest got_min
-    [ -f "$wf" ] || die "no such file: $wf"
-
-    read_myplanet "$file"
-    [ -n "$mp_latest" ] && [ -n "$mp_min" ] || die "no myplanet pins to copy out of $file"
-
-    # A branch whose copy of the workflow predates these inputs has nothing to
-    # fill in. Prefilling the form is a convenience; never fail a merge over
-    # it -- the pins in package.json are what actually ship.
-    if ! has_input "$wf" myplanet_latest || ! has_input "$wf" myplanet_min; then
-        echo "version.sh: $wf has no myplanet_* dispatch inputs, leaving it alone" >&2
-        return 0
-    fi
-
-    set_input_default "$wf" myplanet_latest "$mp_latest"
-    set_input_default "$wf" myplanet_min    "$mp_min"
-
-    got_latest=$(input_default "$wf" myplanet_latest)
-    got_min=$(input_default "$wf" myplanet_min)
-    [ "$got_latest" = "$mp_latest" ] || die "failed to write the myplanet_latest default into $wf (got '$got_latest')"
-    [ "$got_min" = "$mp_min" ]       || die "failed to write the myplanet_min default into $wf (got '$got_min')"
-}
-
 case "${1:-}" in
     read)
         read_version "${2:?package file required}"
@@ -177,10 +132,7 @@ case "${1:-}" in
         normalize_myplanet "${2:?version required}"
         echo
         ;;
-    myplanet-defaults)
-        sync_myplanet_defaults "${2:?workflow file required}" "${3:?package file required}"
-        ;;
     *)
-        die "usage: version.sh {read|next|apply|myplanet|check-myplanet|myplanet-defaults} <package-file|version|workflow-file> [args]"
+        die "usage: version.sh {read|next|apply|myplanet|check-myplanet} <package-file|version> [args]"
         ;;
 esac

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# planet version helper. package.json carries one semver <major>.<minor>.<patch>
+# and every merge bumps the patch, with each block rolling over at 99:
+# 0.22.99 -> 0.23.0. Releases are tagged v<version>, so each merge needs its
+# own number.
+#
+#   version.sh {read|next} <package-file>
+#   version.sh apply <package-file> <name>
+#
+set -euo pipefail
+
+die() { echo "version.sh: $*" >&2; exit 1; }
+
+read_version() {
+    local file=$1
+    [ -f "$file" ] || die "no such file: $file"
+
+    # head -1 keeps this on the top-level version, not a nested one.
+    cur_name=$(sed -nE 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$file" | head -1)
+
+    [ -n "$cur_name" ] || die "could not find \"version\" in $file"
+}
+
+next_version() {
+    local file=$1
+    read_version "$file"
+
+    # major is left wider so this is not the thing that breaks at 1.0.0.
+    [[ "$cur_name" =~ ^([0-9]{1,3})\.([0-9]{1,2})\.([0-9]{1,2})$ ]] \
+        || die "version '$cur_name' is not <major>.<minor>.<patch> with 1-2 digits in the minor and patch blocks"
+
+    local major=$((10#${BASH_REMATCH[1]}))
+    local minor=$((10#${BASH_REMATCH[2]}))
+    local patch=$((10#${BASH_REMATCH[3]}))
+
+    patch=$((patch + 1))
+    if [ "$patch" -gt 99 ]; then
+        patch=0
+        minor=$((minor + 1))
+    fi
+    if [ "$minor" -gt 99 ]; then
+        minor=0
+        major=$((major + 1))
+    fi
+
+    new_name="${major}.${minor}.${patch}"
+}
+
+apply_version() {
+    local file=$1 name=$2
+    [ -f "$file" ] || die "no such file: $file"
+
+    # 0,/re/ stops at the first match, so a nested "version" stays untouched.
+    sed -i -E \
+        "0,/^[[:space:]]*\"version\"[[:space:]]*:/s/^([[:space:]]*\"version\"[[:space:]]*:[[:space:]]*\")[^\"]+\"/\1${name}\"/" \
+        "$file"
+
+    read_version "$file"
+    [ "$cur_name" = "$name" ] || die "failed to write version $name into $file"
+}
+
+case "${1:-}" in
+    read)
+        read_version "${2:?package file required}"
+        echo "name=$cur_name"
+        ;;
+    next)
+        next_version "${2:?package file required}"
+        echo "name=$new_name"
+        ;;
+    apply)
+        apply_version "${2:?package file required}" "${3:?name required}"
+        ;;
+    *)
+        die "usage: version.sh {read|next|apply} <package-file> [name]"
+        ;;
+esac

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -132,12 +132,22 @@ input_default() {
         "$1" | head -1
 }
 
+has_input() { grep -qE "^[[:space:]]*$2:[[:space:]]*$" "$1"; }
+
 sync_myplanet_defaults() {
     local wf=$1 file=$2 got_latest got_min
     [ -f "$wf" ] || die "no such file: $wf"
 
     read_myplanet "$file"
     [ -n "$mp_latest" ] && [ -n "$mp_min" ] || die "no myplanet pins to copy out of $file"
+
+    # A branch whose copy of the workflow predates these inputs has nothing to
+    # fill in. Prefilling the form is a convenience; never fail a merge over
+    # it -- the pins in package.json are what actually ship.
+    if ! has_input "$wf" myplanet_latest || ! has_input "$wf" myplanet_min; then
+        echo "version.sh: $wf has no myplanet_* dispatch inputs, leaving it alone" >&2
+        return 0
+    fi
 
     set_input_default "$wf" myplanet_latest "$mp_latest"
     set_input_default "$wf" myplanet_min    "$mp_min"

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -12,6 +12,7 @@
 #   version.sh apply <package-file> <name>
 #   version.sh myplanet <package-file> <latest> <min>   (blank = leave as is)
 #   version.sh check-myplanet <version>                 (prints it normalized)
+#   version.sh myplanet-defaults <workflow-file> <package-file>
 #
 # The myplanet subcommands need jq; the rest is sed only.
 #
@@ -113,6 +114,40 @@ apply_myplanet() {
     [ -z "$min" ]    || [ "$mp_min"    = "$min" ]    || die "failed to write myplanet.min $min into $file"
 }
 
+# A workflow_dispatch default has to be literal text -- GitHub does not
+# evaluate expressions in the `on:` block -- so the dispatch form can only
+# show the current pins if they are written into the file. Each bump re-syncs
+# them, which is what keeps the form honest.
+set_input_default() {
+    local wf=$1 input=$2 val=$3
+    # Scoped to one input block, which ends at its `type:` line.
+    sed -i -E \
+        "/^[[:space:]]*${input}:[[:space:]]*$/,/^[[:space:]]*type:/ s/^([[:space:]]*default:[[:space:]]*).*/\1'${val}'/" \
+        "$wf"
+}
+
+input_default() {
+    sed -nE \
+        "/^[[:space:]]*$2:[[:space:]]*$/,/^[[:space:]]*type:/ s/^[[:space:]]*default:[[:space:]]*'?([^']*)'?[[:space:]]*$/\1/p" \
+        "$1" | head -1
+}
+
+sync_myplanet_defaults() {
+    local wf=$1 file=$2 got_latest got_min
+    [ -f "$wf" ] || die "no such file: $wf"
+
+    read_myplanet "$file"
+    [ -n "$mp_latest" ] && [ -n "$mp_min" ] || die "no myplanet pins to copy out of $file"
+
+    set_input_default "$wf" myplanet_latest "$mp_latest"
+    set_input_default "$wf" myplanet_min    "$mp_min"
+
+    got_latest=$(input_default "$wf" myplanet_latest)
+    got_min=$(input_default "$wf" myplanet_min)
+    [ "$got_latest" = "$mp_latest" ] || die "failed to write the myplanet_latest default into $wf (got '$got_latest')"
+    [ "$got_min" = "$mp_min" ]       || die "failed to write the myplanet_min default into $wf (got '$got_min')"
+}
+
 case "${1:-}" in
     read)
         read_version "${2:?package file required}"
@@ -132,7 +167,10 @@ case "${1:-}" in
         normalize_myplanet "${2:?version required}"
         echo
         ;;
+    myplanet-defaults)
+        sync_myplanet_defaults "${2:?workflow file required}" "${3:?package file required}"
+        ;;
     *)
-        die "usage: version.sh {read|next|apply|myplanet|check-myplanet} <package-file|version> [args]"
+        die "usage: version.sh {read|next|apply|myplanet|check-myplanet|myplanet-defaults} <package-file|version|workflow-file> [args]"
         ;;
 esac

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -5,8 +5,15 @@
 # 0.22.99 -> 0.23.0. Releases are tagged v<version>, so each merge needs its
 # own number.
 #
+# It also owns the two myplanet pins in the same file, which name the apk
+# planets offer and the oldest one they still accept.
+#
 #   version.sh {read|next} <package-file>
 #   version.sh apply <package-file> <name>
+#   version.sh myplanet <package-file> <latest> <min>   (blank = leave as is)
+#   version.sh check-myplanet <version>                 (prints it normalized)
+#
+# The myplanet subcommands need jq; the rest is sed only.
 #
 set -euo pipefail
 
@@ -60,6 +67,52 @@ apply_version() {
     [ "$cur_name" = "$name" ] || die "failed to write version $name into $file"
 }
 
+normalize_myplanet() {
+    local v=$1
+    [[ "$v" =~ ^v?([0-9]{1,3})\.([0-9]{1,2})\.([0-9]{1,2})$ ]] \
+        || die "myplanet version '$v' is not v<major>.<minor>.<patch> with 1-2 digits in the minor and patch blocks"
+
+    # docker/planet/scripts/create_version_json.sh splits on [v.] to derive the
+    # apk version code and pastes the value straight into the release download
+    # URL, so the leading v is load-bearing rather than decoration.
+    printf 'v%s.%s.%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+}
+
+read_myplanet() {
+    local file=$1
+    command -v jq >/dev/null || die "jq is required to read the myplanet pins"
+    mp_latest=$(jq -r '.myplanet.latest // ""' "$file")
+    mp_min=$(jq -r '.myplanet.min // ""'       "$file")
+}
+
+# Scoped to the "myplanet" object, so a same-named key elsewhere is safe.
+set_in_myplanet() {
+    local file=$1 key=$2 val=$3
+    sed -i -E \
+        "/^[[:space:]]*\"myplanet\"[[:space:]]*:[[:space:]]*\{/,/^[[:space:]]*\}/ s/^([[:space:]]*\"${key}\"[[:space:]]*:[[:space:]]*\")[^\"]*\"/\1${val}\"/" \
+        "$file"
+}
+
+apply_myplanet() {
+    local file=$1 latest=$2 min=$3
+    [ -f "$file" ] || die "no such file: $file"
+    [ -n "$latest$min" ] || return 0
+
+    if [ -n "$latest" ]; then
+        latest=$(normalize_myplanet "$latest")
+        set_in_myplanet "$file" latest "$latest"
+    fi
+    if [ -n "$min" ]; then
+        min=$(normalize_myplanet "$min")
+        set_in_myplanet "$file" min "$min"
+    fi
+
+    # A key the sed range never found leaves the file untouched; catch that.
+    read_myplanet "$file"
+    [ -z "$latest" ] || [ "$mp_latest" = "$latest" ] || die "failed to write myplanet.latest $latest into $file"
+    [ -z "$min" ]    || [ "$mp_min"    = "$min" ]    || die "failed to write myplanet.min $min into $file"
+}
+
 case "${1:-}" in
     read)
         read_version "${2:?package file required}"
@@ -72,7 +125,14 @@ case "${1:-}" in
     apply)
         apply_version "${2:?package file required}" "${3:?name required}"
         ;;
+    myplanet)
+        apply_myplanet "${2:?package file required}" "${3-}" "${4-}"
+        ;;
+    check-myplanet)
+        normalize_myplanet "${2:?version required}"
+        echo
+        ;;
     *)
-        die "usage: version.sh {read|next|apply} <package-file> [name]"
+        die "usage: version.sh {read|next|apply|myplanet|check-myplanet} <package-file|version> [args]"
         ;;
 esac

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,6 +4,10 @@ name: planet automerge
 # base in, bump the version, wait for the builders, squash merge. The label is
 # the safety rail. Logic in .github/scripts/automerge.sh.
 #
+# The myplanet_* inputs re-pin package.json's myplanet block in the same bump
+# commit, so they land with the first merge -- an empty queue leaves them
+# alone, since there is no merge to carry them.
+#
 # Needs AUTOMERGE_TOKEN. GITHUB_TOKEN cannot merge into a protected branch,
 # and its pushes do not trigger the workflow runs the drain waits for.
 
@@ -24,6 +28,16 @@ on:
         description: 'credited as co-author on every PR they did not author'
         required: false
         default: 'dogi'
+        type: string
+      myplanet_latest:
+        description: 'myplanet version planets offer as the latest apk (blank = leave as is)'
+        required: false
+        default: ''
+        type: string
+      myplanet_min:
+        description: 'oldest myplanet version planets still accept (blank = leave as is)'
+        required: false
+        default: ''
         type: string
       require_checks:
         description: 'refuse to merge unless the prepared commit (base merged in + version bumped) is green'
@@ -66,6 +80,7 @@ permissions:
 env:
   DEFAULT_BASE: master
   PKG_FILE: package.json
+  MYPLANET_REPO: open-learning-exchange/myplanet
 
 jobs:
   automerge:
@@ -92,6 +107,65 @@ jobs:
           chmod +x "$RUNNER_TEMP/scripts/"*.sh
           echo "dir=$RUNNER_TEMP/scripts" >> "$GITHUB_OUTPUT"
 
+      - name: check the myplanet versions
+        id: myplanet
+        if: ${{ inputs.myplanet_latest != '' || inputs.myplanet_min != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
+          BASE: ${{ inputs.base || env.DEFAULT_BASE }}
+          IN_LATEST: ${{ inputs.myplanet_latest }}
+          IN_MIN: ${{ inputs.myplanet_min }}
+          VERSION_SH: ${{ steps.stage.outputs.dir }}/version.sh
+        run: |
+          set -euo pipefail
+
+          # `latest` is pasted straight into the apk download URL every planet
+          # serves, so a typo here ships a 404 to all of them. Check the
+          # release exists before any PR gets touched.
+          check_release() {
+              local v=$1 want_apk=$2 out rc=0
+              out=$(gh api "repos/$MYPLANET_REPO/releases/tags/$v" 2>&1) || rc=$?
+              if [ "$rc" -ne 0 ]; then
+                  case "$out" in
+                      *'Not Found'*|*404*)
+                          echo "::error::no $MYPLANET_REPO release tagged $v -- the apk link would 404"
+                          return 1 ;;
+                  esac
+                  # Could not ask; do not fail the drain over an API hiccup.
+                  echo "::warning::could not verify myplanet $v: $out"
+                  return 0
+              fi
+              if [ "$want_apk" = 'true' ] \
+                 && ! jq -e '[.assets[]?.name] | index("myPlanet.apk")' >/dev/null <<<"$out"; then
+                  echo "::warning::myplanet $v has no myPlanet.apk asset attached"
+              fi
+              echo "  myplanet $v: release exists"
+          }
+
+          latest=''
+          min=''
+          [ -z "$IN_LATEST" ] || latest=$("$VERSION_SH" check-myplanet "$IN_LATEST")
+          [ -z "$IN_MIN" ]    || min=$("$VERSION_SH" check-myplanet "$IN_MIN")
+
+          [ -z "$latest" ] || check_release "$latest" true
+          [ -z "$min" ]    || check_release "$min" false
+
+          # Whichever half was left blank keeps the value already on the base.
+          git fetch --quiet origin "$BASE"
+          base_pkg=$(git show "origin/$BASE:$PKG_FILE")
+          eff_latest=${latest:-$(jq -r '.myplanet.latest' <<<"$base_pkg")}
+          eff_min=${min:-$(jq -r '.myplanet.min' <<<"$base_pkg")}
+
+          if [ "$(printf '%s\n%s\n' "$eff_latest" "$eff_min" | sort -V | head -1)" != "$eff_min" ]; then
+            echo "::error::myplanet min $eff_min is newer than latest $eff_latest"
+            exit 1
+          fi
+          echo "  pinning latest=$eff_latest min=$eff_min"
+
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "min=$min"       >> "$GITHUB_OUTPUT"
+
       - name: drain the automerge queue
         shell: bash
         env:
@@ -109,4 +183,6 @@ jobs:
           VERSION_SH: ${{ steps.stage.outputs.dir }}/version.sh
           COAUTHORS_SH: ${{ steps.stage.outputs.dir }}/coauthors.sh
           OWNER_LOGIN: ${{ inputs.owner_login }}
+          MYPLANET_LATEST: ${{ steps.myplanet.outputs.latest }}
+          MYPLANET_MIN: ${{ steps.myplanet.outputs.min }}
         run: '${{ steps.stage.outputs.dir }}/automerge.sh'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,14 +1,112 @@
 name: planet automerge
 
+# Manually started queue drainer: for each PR labelled `automerge`, merge the
+# base in, bump the version, wait for the builders, squash merge. The label is
+# the safety rail. Logic in .github/scripts/automerge.sh.
+#
+# Needs AUTOMERGE_TOKEN. GITHUB_TOKEN cannot merge into a protected branch,
+# and its pushes do not trigger the workflow runs the drain waits for.
+
 on:
   workflow_dispatch:
+    inputs:
+      label:
+        description: 'label marking PRs as mergeable'
+        required: false
+        default: 'automerge'
+        type: string
+      base:
+        description: 'base branch to merge into (blank = workflow default)'
+        required: false
+        default: ''
+        type: string
+      owner_login:
+        description: 'credited as co-author on every PR they did not author'
+        required: false
+        default: 'dogi'
+        type: string
+      require_checks:
+        description: 'refuse to merge unless the prepared commit (base merged in + version bumped) is green'
+        required: false
+        default: true
+        type: boolean
+      required_workflows:
+        description: 'comma-separated workflows that must have passed on the prepared commit (blank = judge whatever ran)'
+        required: false
+        default: 'Planet Builder'
+        type: string
+      delete_branch:
+        description: 'delete each head branch after merging'
+        required: false
+        default: true
+        type: boolean
+      max_merges:
+        description: 'stop after this many merges (0 = until the queue is empty)'
+        required: false
+        default: '0'
+        type: string
+      wait_timeout_minutes:
+        description: 'how long to wait for workflows: the builders on the prepared commit, and whatever is in flight on the base'
+        required: false
+        default: '45'
+        type: string
+      dry_run:
+        description: 'report what would happen, change nothing'
+        required: false
+        default: true
+        type: boolean
+
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+  actions: read
+
+env:
+  DEFAULT_BASE: master
+  PKG_FILE: package.json
 
 jobs:
   automerge:
-    name: automerge
+    name: planet automerge
     runs-on: ubuntu-latest
+    # GitHub caps a job at 6h; stay under it and re-dispatch to continue.
+    timeout-minutes: 350
     steps:
-      - name: init
-        run: echo "automerge"
+      - name: checkout repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
+
+      - name: stage helper scripts outside the work tree
+        id: stage
+        shell: bash
+        run: |
+          # PR branches get checked out; run from a copy they cannot swap.
+          mkdir -p "$RUNNER_TEMP/scripts"
+          cp .github/scripts/automerge.sh \
+             .github/scripts/version.sh \
+             .github/scripts/coauthors.sh "$RUNNER_TEMP/scripts/"
+          chmod +x "$RUNNER_TEMP/scripts/"*.sh
+          echo "dir=$RUNNER_TEMP/scripts" >> "$GITHUB_OUTPUT"
+
+      - name: drain the automerge queue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
+          USING_PAT: ${{ secrets.AUTOMERGE_TOKEN != '' }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ inputs.base || env.DEFAULT_BASE }}
+          LABEL: ${{ inputs.label }}
+          REQUIRE_CHECKS: ${{ inputs.require_checks }}
+          REQUIRED_WORKFLOWS: ${{ inputs.required_workflows }}
+          DELETE_BRANCH: ${{ inputs.delete_branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MAX_MERGES: ${{ inputs.max_merges }}
+          WAIT_TIMEOUT_MIN: ${{ inputs.wait_timeout_minutes }}
+          VERSION_SH: ${{ steps.stage.outputs.dir }}/version.sh
+          COAUTHORS_SH: ${{ steps.stage.outputs.dir }}/coauthors.sh
+          OWNER_LOGIN: ${{ inputs.owner_login }}
+        run: '${{ steps.stage.outputs.dir }}/automerge.sh'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,8 +1,9 @@
 name: planet automerge
 
 # Manually started queue drainer: for each PR labelled `automerge`, merge the
-# base in, bump the version, wait for the builders, squash merge. The label is
-# the safety rail. Logic in .github/scripts/automerge.sh.
+# base in, bump the version, wait for the builders, squash merge, then tag the
+# merge and publish its release. The label is the safety rail. Logic in
+# .github/scripts/automerge.sh.
 #
 # The myplanet_* inputs re-pin package.json's myplanet block in the same bump
 # commit, so they land with the first merge -- an empty queue leaves them
@@ -51,6 +52,11 @@ on:
         type: string
       delete_branch:
         description: 'delete each head branch after merging'
+        required: false
+        default: true
+        type: boolean
+      create_release:
+        description: 'tag each merge and publish its release (the event that builds the versioned images)'
         required: false
         default: true
         type: boolean
@@ -177,6 +183,7 @@ jobs:
           REQUIRE_CHECKS: ${{ inputs.require_checks }}
           REQUIRED_WORKFLOWS: ${{ inputs.required_workflows }}
           DELETE_BRANCH: ${{ inputs.delete_branch }}
+          CREATE_RELEASE: ${{ inputs.create_release }}
           DRY_RUN: ${{ inputs.dry_run }}
           MAX_MERGES: ${{ inputs.max_merges }}
           WAIT_TIMEOUT_MIN: ${{ inputs.wait_timeout_minutes }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: planet automerge
+name: Planet automerge
 
 on:
   workflow_dispatch:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,17 +1,5 @@
 name: planet automerge
 
-# Manually started queue drainer: for each PR labelled `automerge`, merge the
-# base in, bump the version, wait for the builders, squash merge, then tag the
-# merge and publish its release. The label is the safety rail. Logic in
-# .github/scripts/automerge.sh.
-#
-# The myplanet_* inputs re-pin package.json's myplanet block in the same bump
-# commit, so they land with the first merge -- an empty queue leaves them
-# alone, since there is no merge to carry them.
-#
-# Needs AUTOMERGE_TOKEN. GITHUB_TOKEN cannot merge into a protected branch,
-# and its pushes do not trigger the workflow runs the drain waits for.
-
 on:
   workflow_dispatch:
     inputs:
@@ -92,7 +80,6 @@ jobs:
   automerge:
     name: planet automerge
     runs-on: ubuntu-latest
-    # GitHub caps a job at 6h; stay under it and re-dispatch to continue.
     timeout-minutes: 350
     steps:
       - name: checkout repository code

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,12 +6,7 @@ name: planet automerge
 #
 # The myplanet_* inputs re-pin package.json's myplanet block in the same bump
 # commit, so they land with the first merge -- an empty queue leaves them
-# alone, since there is no merge to carry them. Their defaults below are the
-# pins as of the last merge: a dispatch default cannot be computed (GitHub
-# does not evaluate expressions in `on:`), so each bump rewrites these two
-# lines from package.json instead. That needs a token allowed to push
-# .github/workflows; without one the drain says so, drops the sync, and
-# carries on with the version bump.
+# alone, since there is no merge to carry them.
 #
 # Needs AUTOMERGE_TOKEN. GITHUB_TOKEN cannot merge into a protected branch,
 # and its pushes do not trigger the workflow runs the drain waits for.
@@ -37,12 +32,12 @@ on:
       myplanet_latest:
         description: 'myplanet version planets offer as the latest apk (blank = leave as is)'
         required: false
-        default: 'v0.64.44'
+        default: ''
         type: string
       myplanet_min:
         description: 'oldest myplanet version planets still accept (blank = leave as is)'
         required: false
-        default: 'v0.61.54'
+        default: ''
         type: string
       require_checks:
         description: 'refuse to merge unless the prepared commit (base merged in + version bumped) is green'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,7 +6,12 @@ name: planet automerge
 #
 # The myplanet_* inputs re-pin package.json's myplanet block in the same bump
 # commit, so they land with the first merge -- an empty queue leaves them
-# alone, since there is no merge to carry them.
+# alone, since there is no merge to carry them. Their defaults below are the
+# pins as of the last merge: a dispatch default cannot be computed (GitHub
+# does not evaluate expressions in `on:`), so each bump rewrites these two
+# lines from package.json instead. That needs a token allowed to push
+# .github/workflows; without one the drain says so, drops the sync, and
+# carries on with the version bump.
 #
 # Needs AUTOMERGE_TOKEN. GITHUB_TOKEN cannot merge into a protected branch,
 # and its pushes do not trigger the workflow runs the drain waits for.
@@ -32,12 +37,12 @@ on:
       myplanet_latest:
         description: 'myplanet version planets offer as the latest apk (blank = leave as is)'
         required: false
-        default: ''
+        default: 'v0.64.44'
         type: string
       myplanet_min:
         description: 'oldest myplanet version planets still accept (blank = leave as is)'
         required: false
-        default: ''
+        default: 'v0.61.54'
         type: string
       require_checks:
         description: 'refuse to merge unless the prepared commit (base merged in + version bumped) is green'

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.23.84",
+  "version": "0.23.85",
   "myplanet": {
-    "latest": "v0.64.46",
-    "min": "v0.61.54"
+    "latest": "v0.65.55",
+    "min": "v0.64.64"
   },
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Implements an automated PR merge queue system for the `automerge` label, with version bumping and CI validation.

## Summary

Adds a complete automerge pipeline that processes labeled PRs in order, merges the base branch, bumps the semantic version, waits for CI to pass, and performs a squash merge. The workflow is manually triggered via `workflow_dispatch` with configurable parameters for safety and flexibility.

## Key Changes

- **`.github/workflows/automerge.yml`**: Workflow dispatcher with comprehensive inputs (label, base branch, required workflows, timeouts, dry-run mode, max merges). Stages helper scripts outside the work tree and invokes the main drain script with appropriate environment variables and token handling.

- **`.github/scripts/automerge.sh`**: Main queue drainer (449 lines) that:
  - Picks PRs by label in ascending number order, skipping drafts and non-open PRs
  - Validates PR state (no conflicts, review requirements met, mergeable)
  - Merges the base branch into the PR branch
  - Bumps the patch version (with rollover: `0.22.99` → `0.23.0`)
  - Pushes the prepared commit and waits for required workflows to pass
  - Waits for the base branch to settle and be green before merging
  - Handles base branch movement by re-preparing if needed (up to 2 retries)
  - Squash merges with co-author credits and optional branch deletion
  - Provides detailed logging and GitHub step summary output
  - Stops on first failure; both waits overlap for efficiency

- **`.github/scripts/version.sh`**: Semantic version helper supporting:
  - `read <file>`: Extract current version from `package.json`
  - `next <file>`: Calculate next patch version with rollover logic
  - `apply <file> <name>`: Update version in place with validation

- **`.github/scripts/coauthors.sh`**: Builds squash commit body by:
  - Extracting all User-type collaborators from PR commits
  - Parsing `Co-authored-by` trailers from commit messages and PR description
  - Filtering out bot accounts and non-GitHub email addresses
  - Crediting the configured owner if they did not author the PR
  - Deduplicating and validating against repository collaborators

## Notable Implementation Details

- **Token handling**: Supports both `GITHUB_TOKEN` (read-only) and `AUTOMERGE_TOKEN` (PAT/GitHub App) via `secrets.AUTOMERGE_TOKEN`. Detects token type and warns if workflows won't trigger on GITHUB_TOKEN pushes.
- **Conflict detection**: Checks mergeability before work begins; conflicts stop the drain (human intervention needed).
- **Base branch stability**: Waits for base to be green before merging; if base moves during PR build, re-prepares the PR (with max retries to prevent infinite loops).
- **Dry-run mode**: Enabled by default; reports what would happen without changing anything.
- **Workflow validation**: Waits for specified required workflows (e.g., "Planet Builder") to pass on the prepared commit; fails if workflows never appear or if required checks are not met.
- **Version-only validation**: Ensures version bump touches only `package.json` and only the version field, guarding against broken `version.sh` scripts.
- **Retry logic**: Push retries with exponential backoff (0, 2, 4, 8, 16 seconds).
- **Timeout handling**: Separate timeouts for workflow appearance (5m), PR settle (2m), and overall wait (configurable, default 45m).

https://claude.ai/code/session_01GqgBxRoc1q5SB9xMewfo2P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered pull request automerge queue with configurable merge limits, branch deletion, timeouts, required checks, and dry-run support.
  * Added automatic version validation and incrementing during the merge process.
  * Added support for maintaining release pins and workflow defaults.
  * Added co-author attribution for squash-merged pull requests.
  * Added retry handling, workflow monitoring, fork protection, and detailed failure reporting.
  * Added optional release creation after successful merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->