### PR TITLE
teams: smoother resources removing (fixes #10280)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.17",
+  "version": "0.24.18",
   "myplanet": {
     "latest": "v0.65.91",
     "min": "v0.64.64"

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -276,7 +276,7 @@
                   </button>
                 }
                 <mat-menu #resourceMenu="matMenu">
-                  <button mat-menu-item (click)="openDialogPrompt(resource, 'resource', { changeType: 'remove', type: 'document' })">
+                  <button mat-menu-item (click)="openDialogPrompt(resource, 'resource', { changeType: 'remove', type: mode === 'team' ? 'resource' : 'document' })">
                     <mat-icon>clear</mat-icon>
                     <span i18n>Remove</span>
                   </button>


### PR DESCRIPTION
Fixes #10280 

- Adds conditional checking of organizational type to pass the correct item type for the confirmation dialog

<img width="1789" height="730" alt="image" src="https://github.com/user-attachments/assets/1a5d2be7-0903-4216-8f58-df684d5eb914" />

<img width="1611" height="733" alt="image" src="https://github.com/user-attachments/assets/d719b46c-056a-4a9e-8e5a-98c3ffeaee11" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resource removal prompts to use clearer, context-appropriate terminology for team, enterprise, and services modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->