### PR TITLE
courses: configurable exam retake limits and cool-off policies (fixes #10268)

### DIFF
--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -169,6 +169,41 @@ export class CoursesService {
       );
   }
 
+  // Note: Once the course progress dashboard PR (#10262) is merged, this will be
+  // reworked to integrate directly into the new dashboard table action menus.
+  grantAttemptExtension({ courseId, stepNum, userId, extraAttempts = 1 }: {
+    courseId: string, stepNum: number, userId: string, extraAttempts?: number
+  }) {
+    return this.findOneCourseProgress(courseId, userId).pipe(switchMap((progress: any[] = []) => {
+      const currentProgress: any[] = progress.length > 0 ? progress.filter((p: any) => p.stepNum === stepNum) : [];
+      const existingExtra = currentProgress[0]?.extraAttempts || 0;
+      const newProgress = {
+        stepNum,
+        courseId,
+        userId,
+        extraAttempts: existingExtra + extraAttempts,
+        updatedDate: this.couchService.datePlaceholder
+      };
+      return this.couchService.bulkDocs(this.progressDb, this.newProgressDocs(currentProgress, newProgress));
+    }));
+  }
+
+  // Note: Once the course progress dashboard PR (#10262) is merged, this will be
+  // reworked to integrate directly into the new dashboard table action menus.
+  resetCooloffLockout({ courseId, stepNum, userId }: { courseId: string, stepNum: number, userId: string }) {
+    return this.findOneCourseProgress(courseId, userId).pipe(switchMap((progress: any[] = []) => {
+      const currentProgress: any[] = progress.length > 0 ? progress.filter((p: any) => p.stepNum === stepNum) : [];
+      const newProgress = {
+        stepNum,
+        courseId,
+        userId,
+        cooloffResetDate: Date.now(),
+        updatedDate: this.couchService.datePlaceholder
+      };
+      return this.couchService.bulkDocs(this.progressDb, this.newProgressDocs(currentProgress, newProgress));
+    }));
+  }
+
   attachedItemsOfCourses(courses: any[]) {
     return courses.reduce((attached, course) => {
       course.steps.forEach(step => {

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -14,8 +14,23 @@
         <mat-icon>{{isGridView ? 'view_list' : 'view_column'}}</mat-icon>
       </button>
     }
-    @if (attempts && !parent) {
-      <span class="margin-lr-10" i18n>Past attempts: {{attempts}}</span>
+    @if (!parent && (attempts || retakePolicy?.effectiveMaxAttempts || retakePolicy?.isCooloffActive)) {
+      <div class="retake-status-stack">
+        @if (attempts && !retakePolicy?.effectiveMaxAttempts) {
+          <span class="retake-attempt-count" i18n>Past attempts: {{attempts}}</span>
+        }
+        @if (retakePolicy?.effectiveMaxAttempts) {
+          @if (retakePolicy?.isMaxAttemptsReached) {
+            <span class="retake-attempt-count" i18n>{{attempts}} of {{retakePolicy?.effectiveMaxAttempts}} attempts used</span>
+            <span class="retake-cooloff-time" i18n>No retakes remaining</span>
+          } @else {
+            <span class="retake-attempt-count" i18n>Attempt {{ attempts + 1 }} of {{ retakePolicy?.effectiveMaxAttempts }}</span>
+          }
+        }
+        @if (!retakePolicy?.isMaxAttemptsReached && retakePolicy?.isCooloffActive) {
+          <span class="retake-cooloff-time" i18n>Available in: {{ retakePolicy?.cooloffRemainingFormatted }}</span>
+        }
+      </div>
     }
     @if (!isMobile) {
       <ng-container *ngTemplateOutlet="actionButtons"></ng-container>
@@ -63,13 +78,14 @@
     </a>
   }
   @if (stepDetail?.exam?.questions.length && isUserEnrolled) {
-    <a
+    <button
       mat-raised-button
       color="accent"
+      [disabled]="retakePolicy && !retakePolicy.canStartExam"
       [ngClass]="{ 'margin-lr-10': !isMobile }"
       (click)="goToExam()" i18n>
       {examText, select, take {Take Test} continue {Continue Test} retake {Retake Test}}
-    </a>
+    </button>
   }
   @if (stepDetail?.survey?.questions.length && isUserEnrolled) {
     <a

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -15,20 +15,20 @@
       </button>
     }
     @if (!parent && (attempts || retakePolicy?.effectiveMaxAttempts || retakePolicy?.isCooloffActive)) {
-      <div class="retake-status-stack">
+      <div class="retake-status-stack km-retake-status-stack">
         @if (attempts && !retakePolicy?.effectiveMaxAttempts) {
-          <span class="retake-attempt-count" i18n>Past attempts: {{attempts}}</span>
+          <span class="retake-attempt-count km-retake-attempt-count" i18n>Past attempts: {{attempts}}</span>
         }
         @if (retakePolicy?.effectiveMaxAttempts) {
           @if (retakePolicy?.isMaxAttemptsReached) {
-            <span class="retake-attempt-count" i18n>{{attempts}} of {{retakePolicy?.effectiveMaxAttempts}} attempts used</span>
-            <span class="retake-cooloff-time" i18n>No retakes remaining</span>
+            <span class="retake-attempt-count km-retake-attempt-count" i18n>{{attempts}} of {{retakePolicy?.effectiveMaxAttempts}} attempts used</span>
+            <span class="retake-cooloff-time km-retake-cooloff-time" i18n>No retakes remaining</span>
           } @else {
-            <span class="retake-attempt-count" i18n>Attempt {{ attempts + 1 }} of {{ retakePolicy?.effectiveMaxAttempts }}</span>
+            <span class="retake-attempt-count km-retake-attempt-count" i18n>Attempt {{ attempts + 1 }} of {{ retakePolicy?.effectiveMaxAttempts }}</span>
           }
         }
         @if (!retakePolicy?.isMaxAttemptsReached && retakePolicy?.isCooloffActive) {
-          <span class="retake-cooloff-time" i18n>Available in: {{ retakePolicy?.cooloffRemainingFormatted }}</span>
+          <span class="retake-cooloff-time km-retake-cooloff-time" i18n>Available in: {{ retakePolicy?.cooloffRemainingFormatted }}</span>
         }
       </div>
     }
@@ -84,7 +84,7 @@
       [disabled]="retakePolicy && !retakePolicy.canStartExam"
       [ngClass]="{ 'margin-lr-10': !isMobile }"
       (click)="goToExam()" i18n>
-      {examText, select, take {Take Test} continue {Continue Test} retake {Retake Test}}
+      {examText, select, take {Take Test} continue {Continue Test} retake {Retake Test} other {Take Test}}
     </button>
   }
   @if (stepDetail?.survey?.questions.length && isUserEnrolled) {

--- a/src/app/courses/step-view-courses/courses-step-view.component.spec.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.spec.ts
@@ -111,6 +111,7 @@ describe('CoursesStepViewComponent Retake Limits', () => {
     component.courseId = 'course_1';
     component.stepNum = 1;
     component.isUserEnrolled = true;
+    component.progress = { passed: false };
   });
 
   it('should allow taking the exam when retake policy allows it', () => {
@@ -171,5 +172,39 @@ describe('CoursesStepViewComponent Retake Limits', () => {
 
     component.goToExam('exam');
     expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should tick and expire cool-off in real time when active', () => {
+    vi.useFakeTimers();
+    component.getSubmission();
+
+    const retakePolicy: RetakePolicyStatus = {
+      maxAttempts: 0,
+      attemptsUsed: 1,
+      effectiveMaxAttempts: 0,
+      isMaxAttemptsReached: false,
+      isCooloffActive: true,
+      cooloffRemainingMs: 3000,
+      cooloffRemainingFormatted: '1m',
+      canStartExam: false
+    };
+
+    submissionUpdated$.next({
+      submission: { answers: [] },
+      attempts: 1,
+      bestAttempt: { grade: 0 },
+      retakePolicy
+    });
+
+    expect(component.retakePolicy?.isCooloffActive).toBe(true);
+    expect(component.retakePolicy?.canStartExam).toBe(false);
+
+    // Fast-forward 4 seconds
+    vi.advanceTimersByTime(4000);
+
+    expect(component.retakePolicy?.isCooloffActive).toBe(false);
+    expect(component.retakePolicy?.canStartExam).toBe(true);
+    expect(component.retakePolicy?.cooloffRemainingFormatted).toBe('');
+    vi.useRealTimers();
   });
 });

--- a/src/app/courses/step-view-courses/courses-step-view.component.spec.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.spec.ts
@@ -1,0 +1,175 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { of, Subject } from 'rxjs';
+import { vi } from 'vitest';
+
+import { CoursesStepViewComponent } from './courses-step-view.component';
+import { CoursesService } from '../courses.service';
+import { SubmissionsService, RetakePolicyStatus } from '../../submissions/submissions.service';
+import { ResourcesService } from '../../resources/resources.service';
+import { StateService } from '../../shared/state.service';
+import { ChatService } from '../../shared/chat.service';
+import { UserService } from '../../shared/user.service';
+import { DeviceInfoService } from '../../shared/device-info.service';
+import { ChallengesService } from '../../shared/challenges/challenges.service';
+
+describe('CoursesStepViewComponent Retake Limits', () => {
+  let component: CoursesStepViewComponent;
+  let fixture: ComponentFixture<CoursesStepViewComponent>;
+  let router: any;
+
+  const submissionUpdated$ = new Subject<any>();
+
+  const coursesServiceMock = {
+    courseUpdated$: new Subject<any>(),
+    courseActivity: vi.fn(),
+    requestCourse: vi.fn(),
+    updateProgress: vi.fn(),
+    stepResourceSort: vi.fn(),
+    stepHasExamSurveyBoth: vi.fn()
+  };
+
+  const submissionsServiceMock = {
+    submissionUpdated$,
+    openSubmission: vi.fn(),
+    nextQuestion: vi.fn().mockReturnValue(0)
+  };
+
+  const resourcesServiceMock = {
+    resourcesListener: vi.fn().mockReturnValue(of([])),
+    requestResourcesUpdate: vi.fn()
+  };
+
+  const stateServiceMock = {
+    getCouchState: vi.fn().mockReturnValue(of([]))
+  };
+
+  const chatServiceMock = {
+    listAIProviders: vi.fn().mockReturnValue(of([]))
+  };
+
+  const userServiceMock = {
+    get: vi.fn().mockReturnValue({ isUserAdmin: false, name: 'learner', planetCode: 'planet_1' }),
+    shelf: { courseIds: ['course_1'] }
+  };
+
+  const deviceInfoServiceMock = {
+    getDeviceType: vi.fn().mockReturnValue('desktop'),
+    watchDeviceType: vi.fn().mockReturnValue(of('desktop'))
+  };
+
+  const challengesServiceMock = {
+    getActiveChallengeForCourse: vi.fn().mockReturnValue(null),
+    openChallengeDialog: vi.fn()
+  };
+
+  beforeEach(() => {
+    router = {
+      navigate: vi.fn()
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        CoursesStepViewComponent
+      ],
+      providers: [
+        { provide: CoursesService, useValue: coursesServiceMock },
+        { provide: SubmissionsService, useValue: submissionsServiceMock },
+        { provide: ResourcesService, useValue: resourcesServiceMock },
+        { provide: StateService, useValue: stateServiceMock },
+        { provide: ChatService, useValue: chatServiceMock },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: DeviceInfoService, useValue: deviceInfoServiceMock },
+        { provide: ChallengesService, useValue: challengesServiceMock },
+        { provide: MatDialog, useValue: {} },
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: { parent: false },
+              params: {},
+              paramMap: { get: (k: string) => (k === 'stepNum' ? '1' : 'course_1') }
+            },
+            paramMap: of({ get: (k: string) => (k === 'stepNum' ? '1' : 'course_1') })
+          }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(CoursesStepViewComponent);
+    component = fixture.componentInstance;
+    component.stepDetail = {
+      stepTitle: 'Quiz Step',
+      description: 'Test step description',
+      resources: [],
+      exam: { _id: 'exam_1', totalMarks: 10, passingPercentage: 100, questions: [{}] }
+    };
+    component.courseId = 'course_1';
+    component.stepNum = 1;
+    component.isUserEnrolled = true;
+  });
+
+  it('should allow taking the exam when retake policy allows it', () => {
+    const retakePolicy: RetakePolicyStatus = {
+      maxAttempts: 3,
+      attemptsUsed: 1,
+      effectiveMaxAttempts: 3,
+      isMaxAttemptsReached: false,
+      isCooloffActive: false,
+      cooloffRemainingMs: 0,
+      cooloffRemainingFormatted: '',
+      canStartExam: true
+    };
+
+    component.retakePolicy = retakePolicy;
+    component.attempts = 1;
+
+    component.goToExam('exam');
+    expect(router.navigate).toHaveBeenCalledWith(
+      ['exam', { id: 'course_1', stepNum: 1, questionNum: 1, type: 'exam', preview: false, examId: 'exam_1' }],
+      { relativeTo: expect.anything() }
+    );
+  });
+
+  it('should prevent launching exam when maxAttempts limit is reached', () => {
+    const retakePolicy: RetakePolicyStatus = {
+      maxAttempts: 2,
+      attemptsUsed: 2,
+      effectiveMaxAttempts: 2,
+      isMaxAttemptsReached: true,
+      isCooloffActive: false,
+      cooloffRemainingMs: 0,
+      cooloffRemainingFormatted: '',
+      canStartExam: false
+    };
+
+    component.retakePolicy = retakePolicy;
+    component.attempts = 2;
+
+    component.goToExam('exam');
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should prevent launching exam when cool-off lockout is active', () => {
+    const retakePolicy: RetakePolicyStatus = {
+      maxAttempts: 0,
+      attemptsUsed: 1,
+      effectiveMaxAttempts: 0,
+      isMaxAttemptsReached: false,
+      isCooloffActive: true,
+      cooloffRemainingMs: 4 * 3600000,
+      cooloffRemainingFormatted: '4h',
+      canStartExam: false
+    };
+
+    component.retakePolicy = retakePolicy;
+    component.attempts = 1;
+
+    component.goToExam('exam');
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -6,7 +6,7 @@ import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { Subject, combineLatest } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { UserService } from '../../shared/user.service';
-import { SubmissionsService } from '../../submissions/submissions.service';
+import { SubmissionsService, RetakePolicyStatus } from '../../submissions/submissions.service';
 import { ResourcesService } from '../../resources/resources.service';
 import { DialogsSubmissionsComponent } from '../../shared/dialogs/dialogs-submissions.component';
 import { StateService } from '../../shared/state.service';
@@ -65,6 +65,7 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   examStart = 1;
   examText: 'continue' | 'retake' | 'take' = 'take';
   attempts = 0;
+  retakePolicy: RetakePolicyStatus | null = null;
   isUserEnrolled = false;
   resource: any;
   progress: any;
@@ -145,10 +146,11 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
 
   getSubmission() {
     this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$))
-      .subscribe(({ submission, attempts, bestAttempt = { grade: 0 } }) => {
+      .subscribe(({ submission, attempts, bestAttempt = { grade: 0 }, retakePolicy }) => {
         this.examStart = (this.submissionsService.nextQuestion(submission, submission.answers.length - 1, 'passed') + 1) || 1;
         this.examText = submission.answers.length > 0 ? 'continue' : attempts === 0 ? 'take' : 'retake';
         this.attempts = attempts;
+        this.retakePolicy = retakePolicy || null;
         const examPercent = (bestAttempt.grade / this.stepDetail.exam.totalMarks) * 100;
         this.examPassed = examPercent >= this.stepDetail.exam.passingPercentage;
         if (!this.parent && this.progress.passed !== this.examPassed) {
@@ -252,6 +254,9 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
   }
 
   goToExam(type = 'exam', preview = false) {
+    if (!preview && type === 'exam' && this.retakePolicy && !this.retakePolicy.canStartExam) {
+      return;
+    }
     this.router.navigate(
       [
         'exam',

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -3,10 +3,10 @@ import { CoursesService } from '../courses.service';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
-import { Subject, combineLatest } from 'rxjs';
+import { Subject, combineLatest, Subscription, interval } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { UserService } from '../../shared/user.service';
-import { SubmissionsService, RetakePolicyStatus } from '../../submissions/submissions.service';
+import { SubmissionsService, RetakePolicyStatus, formatCooloffDuration } from '../../submissions/submissions.service';
 import { ResourcesService } from '../../resources/resources.service';
 import { DialogsSubmissionsComponent } from '../../shared/dialogs/dialogs-submissions.component';
 import { StateService } from '../../shared/state.service';
@@ -144,6 +144,9 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
     });
   }
 
+  private cooloffEndTimestamp = 0;
+  private cooloffSub?: Subscription;
+
   getSubmission() {
     this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$))
       .subscribe(({ submission, attempts, bestAttempt = { grade: 0 }, retakePolicy }) => {
@@ -151,6 +154,13 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
         this.examText = submission.answers.length > 0 ? 'continue' : attempts === 0 ? 'take' : 'retake';
         this.attempts = attempts;
         this.retakePolicy = retakePolicy || null;
+        if (this.retakePolicy?.isCooloffActive && this.retakePolicy.cooloffRemainingMs > 0) {
+          this.cooloffEndTimestamp = Date.now() + this.retakePolicy.cooloffRemainingMs;
+          this.startCooloffTicker();
+        } else {
+          this.cooloffEndTimestamp = 0;
+          this.cooloffSub?.unsubscribe();
+        }
         const examPercent = (bestAttempt.grade / this.stepDetail.exam.totalMarks) * 100;
         this.examPassed = examPercent >= this.stepDetail.exam.passingPercentage;
         if (!this.parent && this.progress.passed !== this.examPassed) {
@@ -161,7 +171,32 @@ export class CoursesStepViewComponent implements OnInit, OnDestroy {
       });
   }
 
+  private startCooloffTicker() {
+    this.cooloffSub?.unsubscribe();
+    if (!this.retakePolicy?.isCooloffActive || !this.cooloffEndTimestamp) {
+      return;
+    }
+    this.cooloffSub = interval(1000).pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      if (!this.retakePolicy || !this.retakePolicy.isCooloffActive) {
+        this.cooloffSub?.unsubscribe();
+        return;
+      }
+      const remainingMs = this.cooloffEndTimestamp - Date.now();
+      if (remainingMs <= 0) {
+        this.retakePolicy.isCooloffActive = false;
+        this.retakePolicy.cooloffRemainingMs = 0;
+        this.retakePolicy.cooloffRemainingFormatted = '';
+        this.retakePolicy.canStartExam = !this.retakePolicy.isMaxAttemptsReached;
+        this.cooloffSub?.unsubscribe();
+      } else {
+        this.retakePolicy.cooloffRemainingMs = remainingMs;
+        this.retakePolicy.cooloffRemainingFormatted = formatCooloffDuration(remainingMs);
+      }
+    });
+  }
+
   ngOnDestroy() {
+    this.cooloffSub?.unsubscribe();
     this.onDestroy$.next();
     this.onDestroy$.complete();
   }

--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -72,4 +72,23 @@
     gap: 0.5rem;
   }
 
+  .retake-status-stack {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1.2;
+    font-size: 12px;
+    margin: 0 8px;
+    vertical-align: middle;
+
+    .retake-attempt-count {
+      font-weight: 500;
+    }
+
+    .retake-cooloff-time {
+      font-size: 11px;
+      opacity: 0.85;
+    }
+  }
+
 }

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -136,20 +136,20 @@
                   <planet-resources-menu [resources]="step?.resources" i18n>View Resource</planet-resources-menu>
                 }
                 @if (!parent && (step.attempts || step.retakePolicy?.effectiveMaxAttempts || step.retakePolicy?.isCooloffActive)) {
-                  <div class="retake-status-stack">
+                  <div class="retake-status-stack km-retake-status-stack">
                     @if (step.attempts && !step.retakePolicy?.effectiveMaxAttempts) {
-                      <span class="retake-attempt-count" i18n>Past attempts: {{step.attempts}}</span>
+                      <span class="retake-attempt-count km-retake-attempt-count" i18n>Past attempts: {{step.attempts}}</span>
                     }
                     @if (step.retakePolicy?.effectiveMaxAttempts) {
                       @if (step.retakePolicy?.isMaxAttemptsReached) {
-                        <span class="retake-attempt-count" i18n>{{step.attempts}} of {{step.retakePolicy?.effectiveMaxAttempts}} attempts used</span>
-                        <span class="retake-cooloff-time" i18n>No retakes remaining</span>
+                        <span class="retake-attempt-count km-retake-attempt-count" i18n>{{step.attempts}} of {{step.retakePolicy?.effectiveMaxAttempts}} attempts used</span>
+                        <span class="retake-cooloff-time km-retake-cooloff-time" i18n>No retakes remaining</span>
                       } @else {
-                        <span class="retake-attempt-count" i18n>Attempt {{ step.attempts + 1 }} of {{ step.retakePolicy?.effectiveMaxAttempts }}</span>
+                        <span class="retake-attempt-count km-retake-attempt-count" i18n>Attempt {{ step.attempts + 1 }} of {{ step.retakePolicy?.effectiveMaxAttempts }}</span>
                       }
                     }
                     @if (!step.retakePolicy?.isMaxAttemptsReached && step.retakePolicy?.isCooloffActive) {
-                      <span class="retake-cooloff-time" i18n>Available in: {{ step.retakePolicy?.cooloffRemainingFormatted }}</span>
+                      <span class="retake-cooloff-time km-retake-cooloff-time" i18n>Available in: {{ step.retakePolicy?.cooloffRemainingFormatted }}</span>
                     }
                   </div>
                 }

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -135,8 +135,26 @@
                 @if (step?.resources?.length > 0) {
                   <planet-resources-menu [resources]="step?.resources" i18n>View Resource</planet-resources-menu>
                 }
+                @if (!parent && (step.attempts || step.retakePolicy?.effectiveMaxAttempts || step.retakePolicy?.isCooloffActive)) {
+                  <div class="retake-status-stack">
+                    @if (step.attempts && !step.retakePolicy?.effectiveMaxAttempts) {
+                      <span class="retake-attempt-count" i18n>Past attempts: {{step.attempts}}</span>
+                    }
+                    @if (step.retakePolicy?.effectiveMaxAttempts) {
+                      @if (step.retakePolicy?.isMaxAttemptsReached) {
+                        <span class="retake-attempt-count" i18n>{{step.attempts}} of {{step.retakePolicy?.effectiveMaxAttempts}} attempts used</span>
+                        <span class="retake-cooloff-time" i18n>No retakes remaining</span>
+                      } @else {
+                        <span class="retake-attempt-count" i18n>Attempt {{ step.attempts + 1 }} of {{ step.retakePolicy?.effectiveMaxAttempts }}</span>
+                      }
+                    }
+                    @if (!step.retakePolicy?.isMaxAttemptsReached && step.retakePolicy?.isCooloffActive) {
+                      <span class="retake-cooloff-time" i18n>Available in: {{ step.retakePolicy?.cooloffRemainingFormatted }}</span>
+                    }
+                  </div>
+                }
                 @if (step?.exam?.questions.length && isUserEnrolled) {
-                  <button mat-raised-button color="accent" class="margin-lr-10" [disabled]="stepNum > 0 && !step.isPreviousTestTaken" (click)="goToExam(step, stepNum)" i18n>{step.examText, select, continue {Continue Test} retake {Retake Test} other {Take Test}}</button>
+                  <button mat-raised-button color="accent" class="margin-lr-10" [disabled]="(stepNum > 0 && !step.isPreviousTestTaken) || (step.retakePolicy && !step.retakePolicy.canStartExam)" (click)="goToExam(step, stepNum)" i18n>{step.examText, select, continue {Continue Test} retake {Retake Test} other {Take Test}}</button>
                 }
                 @if (step?.survey?.questions.length && isUserEnrolled) {
                   <a mat-raised-button color="accent" class="margin-lr-10" (click)="goToSurvey(stepNum)" i18n>Take Survey</a>

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -149,10 +149,11 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     return this.submissionsService.submissionUpdated$.pipe(
       filter(({ submission }) => submission.parent._id === step.exam._id),
       take(1)
-    ).pipe(map(({ submission, attempts }) => ({
+    ).pipe(map(({ submission, attempts, retakePolicy }) => ({
       examText: submission.answers.length > 0 ? 'continue' : attempts === 0 ? 'take' : 'retake',
       submission,
-      attempts
+      attempts,
+      retakePolicy
     })));
   }
 
@@ -177,6 +178,9 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   goToExam(step, stepIndex, preview = false) {
+    if (!preview && step?.retakePolicy && !step.retakePolicy.canStartExam) {
+      return;
+    }
     const questionNum = (this.submissionsService.nextQuestion(step.submission, step.submission.answers.length - 1, 'passed') + 1) || 1;
     const stepNum = stepIndex + 1;
     this.router.navigate(

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
-import { Subject } from 'rxjs';
+import { Subject, Subscription, interval } from 'rxjs';
 import { takeUntil, switchMap, take, filter, map } from 'rxjs/operators';
 import { UserService } from '../../shared/user.service';
 import { CoursesService } from '../courses.service';
-import { SubmissionsService } from '../../submissions/submissions.service';
+import { SubmissionsService, formatCooloffDuration } from '../../submissions/submissions.service';
 import { StateService } from '../../shared/state.service';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
 import { trackByIndex } from '../../shared/table-helpers';
@@ -120,7 +120,10 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     });
   }
 
+  private cooloffSub?: Subscription;
+
   ngOnDestroy() {
+    this.cooloffSub?.unsubscribe();
     this.onDestroy$.next();
     this.onDestroy$.complete();
   }
@@ -131,13 +134,49 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
       this.setStepButtonStatus(previousStep, stepNum - 1, stepClickedNum, previousStep.exam === undefined);
     }
     if (step.exam && step.submission === undefined) {
-      this.getStepSubmission(step).subscribe((submissionStatus: { examText, submission, attempts }) => {
-        this.courseDetail.steps[stepNum] = { ...step, ...submissionStatus };
+      this.getStepSubmission(step).subscribe((submissionStatus: { examText, submission, attempts, retakePolicy }) => {
+        const retakePolicy = submissionStatus.retakePolicy;
+        const cooloffEndTimestamp = (retakePolicy?.isCooloffActive && retakePolicy.cooloffRemainingMs > 0)
+          ? Date.now() + retakePolicy.cooloffRemainingMs
+          : 0;
+        this.courseDetail.steps[stepNum] = { ...step, ...submissionStatus, cooloffEndTimestamp };
         this.setIsPreviousTestTaken(step, stepNum, stepClickedNum, submissionStatus.attempts);
+        if (cooloffEndTimestamp > 0) {
+          this.startCooloffTicker();
+        }
       });
       return;
     }
     this.setIsPreviousTestTaken(step, stepNum, stepClickedNum, step.attempts);
+  }
+
+  private startCooloffTicker() {
+    this.cooloffSub?.unsubscribe();
+    const hasActiveCooloff = this.courseDetail.steps?.some(step => step.retakePolicy?.isCooloffActive);
+    if (!hasActiveCooloff) {
+      return;
+    }
+    this.cooloffSub = interval(1000).pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      let anyActive = false;
+      this.courseDetail.steps?.forEach(step => {
+        if (step.retakePolicy?.isCooloffActive && step.cooloffEndTimestamp) {
+          const remainingMs = step.cooloffEndTimestamp - Date.now();
+          if (remainingMs <= 0) {
+            step.retakePolicy.isCooloffActive = false;
+            step.retakePolicy.cooloffRemainingMs = 0;
+            step.retakePolicy.cooloffRemainingFormatted = '';
+            step.retakePolicy.canStartExam = !step.retakePolicy.isMaxAttemptsReached;
+          } else {
+            anyActive = true;
+            step.retakePolicy.cooloffRemainingMs = remainingMs;
+            step.retakePolicy.cooloffRemainingFormatted = formatCooloffDuration(remainingMs);
+          }
+        }
+      });
+      if (!anyActive) {
+        this.cooloffSub?.unsubscribe();
+      }
+    });
   }
 
   getStepSubmission(step) {

--- a/src/app/courses/view-courses/courses-view.scss
+++ b/src/app/courses/view-courses/courses-view.scss
@@ -54,6 +54,25 @@
     } 
     
   }
+
+  .retake-status-stack {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1.2;
+    font-size: 12px;
+    margin: 0 8px;
+    vertical-align: middle;
+
+    .retake-attempt-count {
+      font-weight: 500;
+    }
+
+    .retake-cooloff-time {
+      font-size: 11px;
+      opacity: 0.85;
+    }
+  }
 }
 
 mat-expansion-panel-header {

--- a/src/app/exams/exams-add.component.html
+++ b/src/app/exams/exams-add.component.html
@@ -17,6 +17,9 @@
           <button mat-raised-button color="primary" type="button" [planetSubmit]="examForm.valid" [disabled]="questions.length === 0" (click)="onSubmit(true)" i18n>Save & Return</button>
           <div class="menu-button"><button mat-raised-button color="accent" type="button" [matMenuTriggerFor]="questionMenu" i18n>Add Question</button></div>
           <button mat-raised-button color="accent" type="button" (click)="showPreviewDialog()" i18n>Preview {examType, select, exam {Test} survey {Survey}}</button>
+          @if (examType === 'exam') {
+            <button mat-raised-button color="accent" type="button" (click)="openRetakePolicyDialog()" i18n>Retake Policy</button>
+          }
         </div>
         @if (isManagerRoute) {
           <mat-checkbox formControlName="teamShareAllowed"><span style="font-size: small; font-style: italic;" i18n>Allow team view</span></mat-checkbox>

--- a/src/app/exams/exams-add.component.spec.ts
+++ b/src/app/exams/exams-add.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormsModule, NonNullableFormBuilder, FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+
+import { ExamsAddComponent } from './exams-add.component';
+import { CouchService } from '../shared/couchdb.service';
+import { ValidatorService } from '../validators/validator.service';
+import { PlanetMessageService } from '../shared/planet-message.service';
+import { CoursesService } from '../courses/courses.service';
+import { ExamsService } from './exams.service';
+import { PlanetStepListService } from '../shared/forms/planet-step-list.component';
+import { SubmissionsService } from '../submissions/submissions.service';
+
+describe('ExamsAddComponent Retake Policies', () => {
+  let component: ExamsAddComponent;
+  let fixture: ComponentFixture<ExamsAddComponent>;
+
+  const couchServiceMock = {
+    get: vi.fn().mockReturnValue(of({ name: 'Test Exam', questions: [], maxAttempts: 3, retakeCooloffHours: 24 })),
+    findAll: vi.fn().mockReturnValue(of([])),
+    updateDocument: vi.fn().mockReturnValue(of({ id: 'exam_1', rev: '1-rev' }))
+  };
+
+  const validatorServiceMock = {
+    isUnique$: vi.fn().mockReturnValue(of(null))
+  };
+
+  const planetMessageServiceMock = {
+    showMessage: vi.fn(),
+    showAlert: vi.fn()
+  };
+
+  const coursesServiceMock = {
+    course: { form: { courseTitle: 'Sample Course' }, steps: [{}] },
+    stepIndex: 0,
+    returnUrl: 'courses'
+  };
+
+  const submissionsServiceMock = {
+    getSubmissions: vi.fn().mockReturnValue(of([]))
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        FormsModule,
+        BrowserAnimationsModule,
+        ExamsAddComponent
+      ],
+      providers: [
+        { provide: NonNullableFormBuilder, useValue: new FormBuilder().nonNullable },
+        { provide: CouchService, useValue: couchServiceMock },
+        { provide: ValidatorService, useValue: validatorServiceMock },
+        { provide: PlanetMessageService, useValue: planetMessageServiceMock },
+        { provide: CoursesService, useValue: coursesServiceMock },
+        { provide: ExamsService, useValue: {
+          newQuestionForm: vi.fn().mockReturnValue({}),
+          updateQuestion: vi.fn(),
+          checkValidFormComponent: vi.fn(),
+          createExamDocument: vi.fn().mockReturnValue(of({ id: 'exam_1', rev: '1-rev' }))
+        } },
+        { provide: PlanetStepListService, useValue: {
+          addStep: vi.fn(),
+          stepMoveClick$: of({}),
+          stepAdded$: of({})
+        } },
+        { provide: MatDialog, useValue: { open: vi.fn(), openDialogs: [] } },
+        { provide: SubmissionsService, useValue: submissionsServiceMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: { get: (key: string) => (key === 'type' ? 'exam' : 'exam_1') },
+              url: [{ path: 'add' }],
+              data: {}
+            },
+            parent: null
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            url: '/courses/exam;type=exam',
+            navigate: vi.fn(),
+            navigateByUrl: vi.fn()
+          }
+        }
+      ]
+    });
+    fixture = TestBed.createComponent(ExamsAddComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should initialize maxAttempts, retakeCooloffHours, and retakeCooloffMinutes with 0 by default', () => {
+    expect(component.examForm.controls.maxAttempts.value).toBe(0);
+    expect(component.examForm.controls.retakeCooloffHours.value).toBe(0);
+    expect(component.examForm.controls.retakeCooloffMinutes.value).toBe(0);
+  });
+
+  it('should validate that maxAttempts and retakeCooloffMinutes cannot be negative', () => {
+    component.examForm.controls.maxAttempts.setValue(-1);
+    expect(component.examForm.controls.maxAttempts.valid).toBe(false);
+
+    component.examForm.controls.maxAttempts.setValue(3);
+    expect(component.examForm.controls.maxAttempts.valid).toBe(true);
+
+    component.examForm.controls.retakeCooloffMinutes.setValue(-5);
+    expect(component.examForm.controls.retakeCooloffMinutes.valid).toBe(false);
+
+    component.examForm.controls.retakeCooloffMinutes.setValue(90);
+    expect(component.examForm.controls.retakeCooloffMinutes.valid).toBe(true);
+  });
+
+  it('should append maxAttempts, retakeCooloffHours, and retakeCooloffMinutes to course step on appendToCourse', () => {
+    component.examForm.controls.maxAttempts.setValue(5);
+    component.examForm.controls.retakeCooloffHours.setValue(48);
+    component.examForm.controls.retakeCooloffMinutes.setValue(2880);
+
+    const examInfo: any = {
+      name: 'Test Exam',
+      description: '',
+      passingPercentage: 100,
+      questions: [],
+      type: 'courses',
+      teamShareAllowed: false,
+      maxAttempts: 5,
+      retakeCooloffHours: 48,
+      retakeCooloffMinutes: 2880
+    };
+
+    component.appendToCourse(examInfo, 'exam');
+    const savedExam = coursesServiceMock.course.steps[0].exam;
+    expect(savedExam.maxAttempts).toBe(5);
+    expect(savedExam.retakeCooloffHours).toBe(48);
+    expect(savedExam.retakeCooloffMinutes).toBe(2880);
+  });
+
+  it('should open RetakePolicyDialog and update form values on close', () => {
+    const dialogSpy = vi.spyOn(TestBed.inject(MatDialog), 'open').mockReturnValue({
+      afterClosed: () => of({ maxAttempts: 4, retakeCooloffMinutes: 150 })
+    } as any);
+
+    component.openRetakePolicyDialog();
+    expect(dialogSpy).toHaveBeenCalled();
+    expect(component.examForm.controls.maxAttempts.value).toBe(4);
+    expect(component.examForm.controls.retakeCooloffMinutes.value).toBe(150);
+    expect(component.examForm.controls.retakeCooloffHours.value).toBe(2.5);
+  });
+});

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -37,7 +37,7 @@ import { SubmitDirective } from '../shared/submit.directive';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
-import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormErrorMessagesComponent } from '../shared/forms/form-error-messages.component';
 import { PlanetMarkdownTextboxComponent } from '../shared/forms/planet-markdown-textbox.component';
@@ -101,7 +101,6 @@ interface ExamDocumentInfo {
     MatLabel,
     MatInput,
     MatError,
-    MatHint,
     FormErrorMessagesComponent,
     PlanetMarkdownTextboxComponent,
     PlanetStepListComponent,

--- a/src/app/exams/exams-add.component.ts
+++ b/src/app/exams/exams-add.component.ts
@@ -37,12 +37,13 @@ import { SubmitDirective } from '../shared/submit.directive';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
-import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormErrorMessagesComponent } from '../shared/forms/form-error-messages.component';
 import { PlanetMarkdownTextboxComponent } from '../shared/forms/planet-markdown-textbox.component';
 import { MatListItemTitle, MatListItemLine } from '@angular/material/list';
 import { ExamsQuestionComponent } from './exams-question.component';
+import { ExamsRetakePolicyDialogComponent } from './exams-retake-policy-dialog.component';
 
 interface ExamFormControls {
   name: FormControl<string>;
@@ -51,6 +52,9 @@ interface ExamFormControls {
   questions: FormArray<QuestionFormGroup>;
   type: FormControl<'courses' | 'surveys'>;
   teamShareAllowed: FormControl<boolean>;
+  maxAttempts: FormControl<number>;
+  retakeCooloffHours: FormControl<number>;
+  retakeCooloffMinutes: FormControl<number>;
 }
 
 interface ExamInfo {
@@ -61,6 +65,9 @@ interface ExamInfo {
   type: 'courses' | 'surveys';
   teamShareAllowed: boolean;
   teamId?: string | null;
+  maxAttempts?: number;
+  retakeCooloffHours?: number;
+  retakeCooloffMinutes?: number;
   _id?: string;
   _rev?: string;
 }
@@ -94,6 +101,7 @@ interface ExamDocumentInfo {
     MatLabel,
     MatInput,
     MatError,
+    MatHint,
     FormErrorMessagesComponent,
     PlanetMarkdownTextboxComponent,
     PlanetStepListComponent,
@@ -168,7 +176,10 @@ export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
       passingPercentage: this.fb.control(100, { validators: [ CustomValidators.positiveNumberValidator, Validators.max(100) ] }),
       questions: this.fb.array<QuestionFormGroup>([]),
       type: this.fb.control<'courses' | 'surveys'>(examRecordType),
-      teamShareAllowed: this.fb.control(false)
+      teamShareAllowed: this.fb.control(false),
+      maxAttempts: this.fb.control(0, { validators: [ CustomValidators.positiveNumberValidator ] }),
+      retakeCooloffHours: this.fb.control(0, { validators: [ CustomValidators.positiveNumberValidator ] }),
+      retakeCooloffMinutes: this.fb.control(0, { validators: [ CustomValidators.positiveNumberValidator ] })
     });
   }
 
@@ -191,7 +202,12 @@ export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
       this.pageType = 'Update';
       this.documentInfo = { _rev: exam._rev, _id: exam._id };
       this.examForm.controls.name.setAsyncValidators(this.nameValidator(exam.name));
-      this.examForm.patchValue(exam);
+      const totalMinutes = exam.retakeCooloffMinutes ?? ((exam.retakeCooloffHours || 0) * 60);
+      this.examForm.patchValue({
+        ...exam,
+        retakeCooloffMinutes: totalMinutes,
+        retakeCooloffHours: Math.round((totalMinutes / 60) * 100) / 100
+      });
       this.initializeQuestions(exam.questions);
       if (submissions.length > 0) {
         this.pageType = 'Copy';
@@ -202,6 +218,26 @@ export class ExamsAddComponent implements OnInit, CanComponentDeactivate {
       this.initialFormState = JSON.stringify(this.examForm.getRawValue());
       this.hasUnsavedChanges = false;
     }, error => console.log(error));
+  }
+
+  openRetakePolicyDialog() {
+    const rawVal = this.examForm.getRawValue();
+    const totalMinutes = rawVal.retakeCooloffMinutes ?? ((rawVal.retakeCooloffHours || 0) * 60);
+    const dialogRef = this.dialog.open(ExamsRetakePolicyDialogComponent, {
+      width: '480px',
+      data: {
+        maxAttempts: rawVal.maxAttempts || 0,
+        retakeCooloffMinutes: totalMinutes
+      }
+    });
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.examForm.controls.maxAttempts.setValue(result.maxAttempts);
+        this.examForm.controls.retakeCooloffMinutes.setValue(result.retakeCooloffMinutes);
+        this.examForm.controls.retakeCooloffHours.setValue(Math.round((result.retakeCooloffMinutes / 60) * 100) / 100);
+        this.examForm.markAsDirty();
+      }
+    });
   }
 
   onSubmit(reRoute = false) {

--- a/src/app/exams/exams-retake-policy-dialog.component.html
+++ b/src/app/exams/exams-retake-policy-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title i18n>Retake Policy</h2>
-<mat-dialog-content class="retake-dialog-content">
+<mat-dialog-content class="retake-dialog-content km-retake-dialog-content">
   <div class="field-container">
     <mat-form-field class="full-width">
       <mat-label i18n>Max Attempts</mat-label>
@@ -43,7 +43,7 @@
       </mat-form-field>
     </div>
 
-    <div class="cooloff-summary">
+    <div class="cooloff-summary km-cooloff-summary">
       <mat-icon class="summary-icon">schedule</mat-icon>
       <span class="summary-text" i18n>Total cool-off: {{ totalCooloffSummary }}</span>
     </div>
@@ -52,5 +52,5 @@
 
 <mat-dialog-actions align="end">
   <button mat-button mat-dialog-close i18n>Cancel</button>
-  <button mat-raised-button color="primary" [mat-dialog-close]="getResult()" i18n>Apply</button>
+  <button mat-raised-button color="primary" class="km-apply-retake-policy" [mat-dialog-close]="getResult()" i18n>Apply</button>
 </mat-dialog-actions>

--- a/src/app/exams/exams-retake-policy-dialog.component.html
+++ b/src/app/exams/exams-retake-policy-dialog.component.html
@@ -1,0 +1,56 @@
+<h2 mat-dialog-title i18n>Retake Policy</h2>
+<mat-dialog-content class="retake-dialog-content">
+  <div class="field-container">
+    <mat-form-field class="full-width">
+      <mat-label i18n>Max Attempts</mat-label>
+      <mat-select [(ngModel)]="maxAttempts">
+        @for (opt of maxAttemptsOptions; track opt.value) {
+          <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+        }
+      </mat-select>
+      <mat-hint i18n>Maximum number of exam attempts permitted</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <div class="time-section">
+    <div class="section-label" i18n>Cool-Off Period</div>
+    <div class="time-row">
+      <mat-form-field class="time-col">
+        <mat-label i18n>Days</mat-label>
+        <mat-select [(ngModel)]="cooloffDays">
+          @for (d of daysOptions; track d) {
+            <mat-option [value]="d">{{ d }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="time-col">
+        <mat-label i18n>Hours</mat-label>
+        <mat-select [(ngModel)]="cooloffHours">
+          @for (h of hoursOptions; track h) {
+            <mat-option [value]="h">{{ h }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="time-col">
+        <mat-label i18n>Minutes</mat-label>
+        <mat-select [(ngModel)]="cooloffMinutes">
+          @for (m of minutesOptions; track m) {
+            <mat-option [value]="m">{{ m }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div class="cooloff-summary">
+      <mat-icon class="summary-icon">schedule</mat-icon>
+      <span class="summary-text" i18n>Total cool-off: {{ totalCooloffSummary }}</span>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-raised-button color="primary" [mat-dialog-close]="getResult()" i18n>Apply</button>
+</mat-dialog-actions>

--- a/src/app/exams/exams-retake-policy-dialog.component.scss
+++ b/src/app/exams/exams-retake-policy-dialog.component.scss
@@ -1,0 +1,47 @@
+.retake-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 360px;
+  padding-top: 8px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.time-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.time-row {
+  display: flex;
+  gap: 12px;
+}
+
+.time-col {
+  flex: 1;
+}
+
+.cooloff-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.65);
+  margin-top: 4px;
+}
+
+.summary-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}

--- a/src/app/exams/exams-retake-policy-dialog.component.scss
+++ b/src/app/exams/exams-retake-policy-dialog.component.scss
@@ -1,9 +1,15 @@
+@use '../variables' as v;
+
 .retake-dialog-content {
   display: flex;
   flex-direction: column;
   gap: 16px;
   min-width: 360px;
   padding-top: 8px;
+
+  @media (max-width: v.$screen-xs) {
+    min-width: 100%;
+  }
 }
 
 .full-width {
@@ -19,12 +25,17 @@
 .section-label {
   font-size: 14px;
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.7);
+  color: inherit;
 }
 
 .time-row {
   display: flex;
   gap: 12px;
+
+  @media (max-width: v.$screen-xs) {
+    flex-direction: column;
+    gap: 8px;
+  }
 }
 
 .time-col {
@@ -36,7 +47,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.65);
+  color: v.$grey-text;
   margin-top: 4px;
 }
 

--- a/src/app/exams/exams-retake-policy-dialog.component.spec.ts
+++ b/src/app/exams/exams-retake-policy-dialog.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import {
+  ExamsRetakePolicyDialogComponent,
+  RetakePolicyDialogData
+} from './exams-retake-policy-dialog.component';
+
+describe('ExamsRetakePolicyDialogComponent', () => {
+  let component: ExamsRetakePolicyDialogComponent;
+  let fixture: ComponentFixture<ExamsRetakePolicyDialogComponent>;
+
+  const initialData: RetakePolicyDialogData = {
+    maxAttempts: 3,
+    retakeCooloffMinutes: (2 * 1440) + (4 * 60) + 30 // 2 days, 4 hours, 30 minutes
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        BrowserAnimationsModule,
+        ExamsRetakePolicyDialogComponent
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: initialData }
+      ]
+    });
+    fixture = TestBed.createComponent(ExamsRetakePolicyDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should initialize fields from dialog data', () => {
+    expect(component.maxAttempts).toBe(3);
+    expect(component.cooloffDays).toBe(2);
+    expect(component.cooloffHours).toBe(4);
+    expect(component.cooloffMinutes).toBe(30);
+  });
+
+  it('should calculate totalMinutes adding days, hours, and minutes together', () => {
+    component.cooloffDays = 1;
+    component.cooloffHours = 2;
+    component.cooloffMinutes = 15;
+    expect(component.totalMinutes).toBe(1440 + 120 + 15);
+  });
+
+  it('should format totalCooloffSummary properly', () => {
+    component.cooloffDays = 0;
+    component.cooloffHours = 0;
+    component.cooloffMinutes = 0;
+    expect(component.totalCooloffSummary).toBe('No delay between attempts');
+
+    component.cooloffDays = 1;
+    component.cooloffHours = 1;
+    component.cooloffMinutes = 5;
+    expect(component.totalCooloffSummary).toContain('1 day');
+    expect(component.totalCooloffSummary).toContain('1 hour');
+    expect(component.totalCooloffSummary).toContain('5 minutes');
+  });
+
+  it('should return correct result object', () => {
+    component.maxAttempts = 5;
+    component.cooloffDays = 0;
+    component.cooloffHours = 3;
+    component.cooloffMinutes = 0;
+
+    const result = component.getResult();
+    expect(result.maxAttempts).toBe(5);
+    expect(result.retakeCooloffMinutes).toBe(180);
+  });
+});

--- a/src/app/exams/exams-retake-policy-dialog.component.ts
+++ b/src/app/exams/exams-retake-policy-dialog.component.ts
@@ -1,0 +1,111 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
+import { MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
+import { MatSelect, MatOption } from '@angular/material/select';
+import { MatButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+
+export interface RetakePolicyDialogData {
+  maxAttempts: number;
+  retakeCooloffMinutes: number;
+}
+
+export interface RetakePolicyDialogResult {
+  maxAttempts: number;
+  retakeCooloffMinutes: number;
+}
+
+@Component({
+  templateUrl: './exams-retake-policy-dialog.component.html',
+  styleUrls: ['./exams-retake-policy-dialog.component.scss'],
+  imports: [
+    FormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormField,
+    MatLabel,
+    MatHint,
+    MatSelect,
+    MatOption,
+    MatButton,
+    MatIcon
+  ]
+})
+export class ExamsRetakePolicyDialogComponent implements OnInit {
+  maxAttempts = 0;
+  cooloffDays = 0;
+  cooloffHours = 0;
+  cooloffMinutes = 0;
+
+  readonly maxAttemptsOptions = [
+    { value: 0, label: $localize`Unlimited` },
+    { value: 1, label: $localize`1 attempt` },
+    { value: 2, label: $localize`2 attempts` },
+    { value: 3, label: $localize`3 attempts` },
+    { value: 4, label: $localize`4 attempts` },
+    { value: 5, label: $localize`5 attempts` },
+    { value: 6, label: $localize`6 attempts` },
+    { value: 7, label: $localize`7 attempts` },
+    { value: 8, label: $localize`8 attempts` },
+    { value: 9, label: $localize`9 attempts` },
+    { value: 10, label: $localize`10 attempts` },
+    { value: 15, label: $localize`15 attempts` },
+    { value: 20, label: $localize`20 attempts` },
+    { value: 25, label: $localize`25 attempts` },
+    { value: 50, label: $localize`50 attempts` }
+  ];
+
+  readonly daysOptions = Array.from({ length: 31 }, (_, i) => i);
+  readonly hoursOptions = Array.from({ length: 24 }, (_, i) => i);
+  readonly minutesOptions = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: RetakePolicyDialogData
+  ) {}
+
+  ngOnInit() {
+    this.maxAttempts = this.data?.maxAttempts || 0;
+    const totalMinutes = this.data?.retakeCooloffMinutes || 0;
+    this.cooloffDays = Math.floor(totalMinutes / 1440);
+    const remainingAfterDays = totalMinutes % 1440;
+    this.cooloffHours = Math.floor(remainingAfterDays / 60);
+    this.cooloffMinutes = remainingAfterDays % 60;
+    if (!this.minutesOptions.includes(this.cooloffMinutes)) {
+      this.cooloffMinutes = Math.round(this.cooloffMinutes / 5) * 5;
+      if (this.cooloffMinutes >= 60) {
+        this.cooloffMinutes = 55;
+      }
+    }
+  }
+
+  get totalMinutes(): number {
+    return (this.cooloffDays * 1440) + (this.cooloffHours * 60) + this.cooloffMinutes;
+  }
+
+  get totalCooloffSummary(): string {
+    if (this.totalMinutes === 0) {
+      return $localize`No delay between attempts`;
+    }
+    const parts: string[] = [];
+    if (this.cooloffDays > 0) {
+      parts.push(this.cooloffDays === 1 ? $localize`1 day` : `${this.cooloffDays} ` + $localize`days`);
+    }
+    if (this.cooloffHours > 0) {
+      parts.push(this.cooloffHours === 1 ? $localize`1 hour` : `${this.cooloffHours} ` + $localize`hours`);
+    }
+    if (this.cooloffMinutes > 0) {
+      parts.push(`${this.cooloffMinutes} ` + $localize`minutes`);
+    }
+    return parts.join(', ');
+  }
+
+  getResult(): RetakePolicyDialogResult {
+    return {
+      maxAttempts: this.maxAttempts,
+      retakeCooloffMinutes: this.totalMinutes
+    };
+  }
+}

--- a/src/app/exams/exams-retake-policy-dialog.component.ts
+++ b/src/app/exams/exams-retake-policy-dialog.component.ts
@@ -91,13 +91,13 @@ export class ExamsRetakePolicyDialogComponent implements OnInit {
     }
     const parts: string[] = [];
     if (this.cooloffDays > 0) {
-      parts.push(this.cooloffDays === 1 ? $localize`1 day` : `${this.cooloffDays} ` + $localize`days`);
+      parts.push(this.cooloffDays === 1 ? $localize`1 day` : $localize`${this.cooloffDays} days`);
     }
     if (this.cooloffHours > 0) {
-      parts.push(this.cooloffHours === 1 ? $localize`1 hour` : `${this.cooloffHours} ` + $localize`hours`);
+      parts.push(this.cooloffHours === 1 ? $localize`1 hour` : $localize`${this.cooloffHours} hours`);
     }
     if (this.cooloffMinutes > 0) {
-      parts.push(`${this.cooloffMinutes} ` + $localize`minutes`);
+      parts.push(this.cooloffMinutes === 1 ? $localize`1 minute` : $localize`${this.cooloffMinutes} minutes`);
     }
     return parts.join(', ');
   }

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -8,7 +8,7 @@ import { EMPTY, Subject, forkJoin, of } from 'rxjs';
 import { takeUntil, switchMap, catchError, finalize } from 'rxjs/operators';
 import { CoursesService } from '../courses/courses.service';
 import { UserService } from '../shared/user.service';
-import { SubmissionsService } from '../submissions/submissions.service';
+import { SubmissionsService, RetakePolicyStatus } from '../submissions/submissions.service';
 import { CouchService } from '../shared/couchdb.service';
 import { Exam, ExamQuestion } from './exams.model';
 import { PlanetMessageService } from '../shared/planet-message.service';
@@ -328,9 +328,23 @@ export class ExamsViewComponent implements OnInit, OnDestroy {
   }
 
   setSubmissionListener() {
-    this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ submission }) => {
+    this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ submission, retakePolicy }) => {
       this.submittedBy = this.submissionsService.submissionName(submission.user);
       this.updatedOn = submission.lastUpdateTime;
+      if (this.mode === 'take' && !this.previewMode && retakePolicy && !retakePolicy.canStartExam) {
+        if (retakePolicy.isCooloffActive) {
+          this.planetMessageService.showAlert(
+            $localize`This test is temporarily locked. Next retake available in ${retakePolicy.cooloffRemainingFormatted}.`
+          );
+        } else if (retakePolicy.isMaxAttemptsReached) {
+          const max = retakePolicy.effectiveMaxAttempts;
+          this.planetMessageService.showAlert(
+            $localize`Maximum exam attempts reached (${max}/${max}). Please contact your course leader.`
+          );
+        }
+        this.goBack();
+        return;
+      }
       const questions = submission.parent.questions || [];
       this.unansweredQuestions = questions.reduce((unanswered, q, index) => [
         ...unanswered, ...((submission.answers[index] && submission.answers[index].passed) ? [] : [ index + 1 ])

--- a/src/app/exams/exams.model.ts
+++ b/src/app/exams/exams.model.ts
@@ -9,6 +9,9 @@ export interface Exam {
   type: 'courses' | 'survey';
   updatedDate: number;
   sourcePlanet: string;
+  maxAttempts?: number;
+  retakeCooloffHours?: number;
+  retakeCooloffMinutes?: number;
 }
 
 export interface ExamQuestion {

--- a/src/app/submissions/submissions.service.spec.ts
+++ b/src/app/submissions/submissions.service.spec.ts
@@ -1,0 +1,210 @@
+import { TestBed } from '@angular/core/testing';
+import { SubmissionsService, formatCooloffDuration, RetakePolicyStatus } from './submissions.service';
+import { CouchService } from '../shared/couchdb.service';
+import { StateService } from '../shared/state.service';
+import { CoursesService } from '../courses/courses.service';
+import { UserService } from '../shared/user.service';
+import { CsvService } from '../shared/csv.service';
+import { PlanetMessageService } from '../shared/planet-message.service';
+import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
+import { ManagerService } from '../manager-dashboard/manager.service';
+import { ChatService } from '../shared/chat.service';
+import { PdfService } from '../shared/pdf.service';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+
+describe('SubmissionsService Retake Policy', () => {
+  let service: SubmissionsService;
+
+  const couchServiceMock = {
+    findAll: vi.fn().mockReturnValue(of([])),
+    post: vi.fn().mockReturnValue(of({ docs: [] })),
+    updateDocument: vi.fn().mockReturnValue(of({ id: 'sub_1', rev: '1-abc' }))
+  };
+
+  const stateServiceMock = {
+    configuration: { code: 'test-planet', parentCode: 'parent-planet' }
+  };
+
+  const courseServiceMock = {
+    findCourses: vi.fn().mockReturnValue(of([])),
+    updateProgress: vi.fn()
+  };
+
+  const userServiceMock = {
+    get: vi.fn().mockReturnValue({ _id: 'user_1', name: 'Test User' })
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SubmissionsService,
+        { provide: CouchService, useValue: couchServiceMock },
+        { provide: StateService, useValue: stateServiceMock },
+        { provide: CoursesService, useValue: courseServiceMock },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: CsvService, useValue: {} },
+        { provide: PlanetMessageService, useValue: { showMessage: vi.fn(), showAlert: vi.fn() } },
+        { provide: DialogsLoadingService, useValue: { start: vi.fn(), stop: vi.fn() } },
+        { provide: ManagerService, useValue: {} },
+        { provide: ChatService, useValue: {} },
+        { provide: PdfService, useValue: {} }
+      ]
+    });
+    service = TestBed.inject(SubmissionsService);
+  });
+
+  describe('formatCooloffDuration', () => {
+    it('should return empty string when remainingMs is 0 or negative', () => {
+      expect(formatCooloffDuration(0)).toBe('');
+      expect(formatCooloffDuration(-5000)).toBe('');
+    });
+
+    it('should format durations less than 1 hour as minutes', () => {
+      expect(formatCooloffDuration(30000)).toBe('1m');
+      expect(formatCooloffDuration(60000)).toBe('1m');
+      expect(formatCooloffDuration(35 * 60 * 1000)).toBe('35m');
+      expect(formatCooloffDuration(59 * 60 * 1000)).toBe('59m');
+    });
+
+    it('should format durations between 1 hour and 1 day as hours', () => {
+      expect(formatCooloffDuration(3600000)).toBe('1h');
+      expect(formatCooloffDuration(4 * 3600000)).toBe('4h');
+      expect(formatCooloffDuration(24 * 3600000)).toBe('24h');
+    });
+
+    it('should format durations greater than 1 day as days', () => {
+      expect(formatCooloffDuration(25 * 3600000)).toBe('2d');
+      expect(formatCooloffDuration(48 * 3600000)).toBe('2d');
+      expect(formatCooloffDuration(72 * 3600000)).toBe('3d');
+    });
+  });
+
+  describe('evaluateRetakePolicy', () => {
+    it('should allow exam start when no limits are set (default unlimited)', () => {
+      const exam = { maxAttempts: 0, retakeCooloffHours: 0 };
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, []);
+
+      expect(status.canStartExam).toBe(true);
+      expect(status.isMaxAttemptsReached).toBe(false);
+      expect(status.isCooloffActive).toBe(false);
+      expect(status.attemptsUsed).toBe(0);
+    });
+
+    it('should block exam start when maxAttempts cap is reached', () => {
+      const exam = { maxAttempts: 2, retakeCooloffHours: 0 };
+      const submissions = [
+        { status: 'complete', answers: [ { grade: 0 } ] },
+        { status: 'complete', answers: [ { grade: 0 } ] }
+      ];
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions);
+
+      expect(status.canStartExam).toBe(false);
+      expect(status.isMaxAttemptsReached).toBe(true);
+      expect(status.attemptsUsed).toBe(2);
+      expect(status.effectiveMaxAttempts).toBe(2);
+    });
+
+    it('should not activate cool-off timer when all attempts have been used', () => {
+      const now = 1000000000;
+      const lastAttemptTime = now - (5 * 60 * 1000);
+      const exam = { maxAttempts: 2, retakeCooloffMinutes: 60 };
+      const submissions = [
+        { status: 'complete', lastUpdateTime: lastAttemptTime - 100000, answers: [ { grade: 0 } ] },
+        { status: 'complete', lastUpdateTime: lastAttemptTime, answers: [ { grade: 0 } ] }
+      ];
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, undefined, now);
+
+      expect(status.isMaxAttemptsReached).toBe(true);
+      expect(status.isCooloffActive).toBe(false);
+      expect(status.cooloffRemainingMs).toBe(0);
+      expect(status.canStartExam).toBe(false);
+    });
+
+    it('should account for manager extraAttempts when evaluating max attempt limits', () => {
+      const exam = { maxAttempts: 2, retakeCooloffHours: 0 };
+      const submissions = [
+        { status: 'complete', answers: [ { grade: 0 } ] },
+        { status: 'complete', answers: [ { grade: 0 } ] }
+      ];
+      const progressDoc = { extraAttempts: 1 };
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, progressDoc);
+
+      expect(status.canStartExam).toBe(true);
+      expect(status.isMaxAttemptsReached).toBe(false);
+      expect(status.effectiveMaxAttempts).toBe(3);
+      expect(status.attemptsUsed).toBe(2);
+    });
+
+    it('should activate cool-off period after a submission when retakeCooloffHours is set', () => {
+      const now = 1000000000;
+      const lastAttemptTime = now - (2 * 3600000);
+      const exam = { maxAttempts: 0, retakeCooloffHours: 12 };
+      const submissions = [
+        { status: 'complete', lastUpdateTime: lastAttemptTime, answers: [ { grade: 1 } ] }
+      ];
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, undefined, now);
+
+      expect(status.isCooloffActive).toBe(true);
+      expect(status.canStartExam).toBe(false);
+      expect(status.cooloffRemainingMs).toBe(10 * 3600000);
+      expect(status.cooloffRemainingFormatted).toBe('10h');
+    });
+
+    it('should allow exam start once cool-off period expires', () => {
+      const now = 1000000000;
+      const lastAttemptTime = now - (13 * 3600000);
+      const exam = { maxAttempts: 0, retakeCooloffHours: 12 };
+      const submissions = [
+        { status: 'complete', lastUpdateTime: lastAttemptTime, answers: [ { grade: 0 } ] }
+      ];
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, undefined, now);
+
+      expect(status.isCooloffActive).toBe(false);
+      expect(status.canStartExam).toBe(true);
+    });
+
+    it('should calculate cool-off correctly when retakeCooloffMinutes is configured', () => {
+      const now = 1000000000;
+      const lastAttemptTime = now - (15 * 60 * 1000); // 15 minutes ago
+      const exam = { maxAttempts: 0, retakeCooloffMinutes: 45 }; // 45 minutes cool-off
+      const submissions = [
+        { status: 'complete', lastUpdateTime: lastAttemptTime, answers: [ { grade: 0 } ] }
+      ];
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, undefined, now);
+
+      expect(status.isCooloffActive).toBe(true);
+      expect(status.canStartExam).toBe(false);
+      expect(status.cooloffRemainingMs).toBe(30 * 60 * 1000); // 30 minutes remaining
+      expect(status.cooloffRemainingFormatted).toBe('30m');
+    });
+
+    it('should calculate cool-off correctly for multi-day duration in retakeCooloffMinutes', () => {
+      const now = 1000000000;
+      const lastAttemptTime = now - (2 * 3600000); // 2 hours ago
+      const exam = { maxAttempts: 0, retakeCooloffMinutes: (2 * 1440) }; // 2 days cool-off
+      const submissions = [
+        { status: 'complete', lastUpdateTime: lastAttemptTime, answers: [ { grade: 0 } ] }
+      ];
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, undefined, now);
+
+      expect(status.isCooloffActive).toBe(true);
+      expect(status.canStartExam).toBe(false);
+      expect(status.cooloffRemainingFormatted).toBe('2d');
+    });
+
+    it('should clear cool-off lockout when cooloffResetDate is newer than last submission', () => {
+      const now = 1000000000;
+      const lastAttemptTime = now - (1 * 3600000);
+      const exam = { maxAttempts: 0, retakeCooloffHours: 12 };
+      const submissions = [
+        { status: 'complete', lastUpdateTime: lastAttemptTime, answers: [ { grade: 0 } ] }
+      ];
+      const progressDoc = { cooloffResetDate: now - (30 * 60 * 1000) };
+      const status: RetakePolicyStatus = service.evaluateRetakePolicy(exam, submissions, progressDoc, now);
+
+      expect(status.isCooloffActive).toBe(false);
+      expect(status.canStartExam).toBe(true);
+    });
+  });
+});

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -18,6 +18,36 @@ import { surveyAnalysisPrompt } from '../shared/ai-prompts.constants';
 import { loadChart, createChartCanvas, renderNoDataPlaceholder, CHART_COLORS } from '../shared/chart-utils';
 import { PdfService } from '../shared/pdf.service';
 
+export interface RetakePolicyStatus {
+  maxAttempts: number;
+  attemptsUsed: number;
+  effectiveMaxAttempts: number;
+  isMaxAttemptsReached: boolean;
+  isCooloffActive: boolean;
+  cooloffRemainingMs: number;
+  cooloffRemainingFormatted: string;
+  canStartExam: boolean;
+}
+
+export function formatCooloffDuration(remainingMs: number): string {
+  if (remainingMs <= 0) {
+    return '';
+  }
+  const oneHourMs = 3600000;
+  const oneDayMs = 86400000;
+
+  if (remainingMs > oneDayMs) {
+    const days = Math.ceil(remainingMs / oneDayMs);
+    return `${days}d`;
+  }
+  if (remainingMs >= oneHourMs) {
+    const hours = Math.ceil(remainingMs / oneHourMs);
+    return `${hours}h`;
+  }
+  const minutes = Math.max(1, Math.ceil(remainingMs / 60000));
+  return `${minutes}m`;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -110,8 +140,60 @@ export class SubmissionsService {
         this.newSubmission({ parentId, parent, user, type });
       }
       this.submissionAttempts = attempts;
-      this.submissionUpdated.next({ submission: this.submission, attempts, bestAttempt });
+      const examObj = typeof parent === 'object' && parent ? parent : this.submission?.parent;
+      const retakePolicy = this.evaluateRetakePolicy(examObj, res.docs);
+      this.submissionUpdated.next({ submission: this.submission, attempts, bestAttempt, retakePolicy });
     });
+  }
+
+  evaluateRetakePolicy(exam: any, submissions: any[] = [], progressDoc?: any, now = Date.now()): RetakePolicyStatus {
+    const maxAttempts = exam?.maxAttempts || 0;
+    const retakeCooloffMinutes = exam?.retakeCooloffMinutes !== undefined
+      ? exam.retakeCooloffMinutes
+      : (exam?.retakeCooloffHours ? exam.retakeCooloffHours * 60 : 0);
+    const extraAttempts = progressDoc?.extraAttempts || 0;
+    const effectiveMaxAttempts = maxAttempts > 0 ? maxAttempts + extraAttempts : 0;
+
+    const completedAttempts = (submissions || []).filter(s => s && (s.status === 'complete' || (s.answers && s.answers.length > 0)));
+    const attemptsUsed = completedAttempts.length;
+    const isMaxAttemptsReached = effectiveMaxAttempts > 0 && attemptsUsed >= effectiveMaxAttempts;
+
+    let latestSubmissionTime = 0;
+    completedAttempts.forEach(s => {
+      const timeVal = s.lastUpdateTime || s.startTime || s.createdDate;
+      const ts = typeof timeVal === 'number' ? timeVal : (typeof timeVal === 'string' ? Date.parse(timeVal) : 0);
+      if (!isNaN(ts) && ts > latestSubmissionTime) {
+        latestSubmissionTime = ts;
+      }
+    });
+
+    let isCooloffActive = false;
+    let cooloffRemainingMs = 0;
+
+    if (!isMaxAttemptsReached && retakeCooloffMinutes > 0 && latestSubmissionTime > 0) {
+      const cooloffResetDate = progressDoc?.cooloffResetDate || 0;
+      if (cooloffResetDate < latestSubmissionTime) {
+        const cooloffEnd = latestSubmissionTime + (retakeCooloffMinutes * 60000);
+        if (now < cooloffEnd) {
+          cooloffRemainingMs = cooloffEnd - now;
+          isCooloffActive = true;
+        }
+      }
+    }
+
+    const cooloffRemainingFormatted = formatCooloffDuration(cooloffRemainingMs);
+    const canStartExam = !isMaxAttemptsReached && !isCooloffActive;
+
+    return {
+      maxAttempts,
+      attemptsUsed,
+      effectiveMaxAttempts,
+      isMaxAttemptsReached,
+      isCooloffActive,
+      cooloffRemainingMs,
+      cooloffRemainingFormatted,
+      canStartExam
+    };
   }
 
   submitAnswer(answer, correct: boolean, index: number, isFinish = false) {
@@ -175,13 +257,15 @@ export class SubmissionsService {
     submission.status = nextQuestion === -1 ? this.updateStatus(submission) : submission.status;
     return this.couchService.updateDocument('submissions', submission).pipe(map((res) => {
       let attempts = this.submissionAttempts;
+      let retakePolicy;
       if (submission.status === 'complete' && takingExam) {
         attempts += 1;
         this.newSubmission(submission);
+        retakePolicy = this.evaluateRetakePolicy(submission.parent, [ submission ]);
       } else {
         this.submission = { ...submission, _id: res.id, _rev: res.rev };
       }
-      this.submissionUpdated.next({ submission: this.submission, attempts });
+      this.submissionUpdated.next({ submission: this.submission, attempts, retakePolicy });
       return { submission, nextQuestion };
     }));
   }


### PR DESCRIPTION
### Summary of Changes

Fixes #10268
Part of #10255

This PR introduces configurable exam retake limits (`maxAttempts`) and cool-off durations (`retakeCooloffMinutes` / `retakeCooloffHours`) for course step exams in Planet Learning:

1. **Exam Test Editor - Action Bar Integration & Dialog**:
   - Added a `Retake Policy` action button in [`ExamsAddComponent`](file:///c:/Users/Blake/Documents/ole/planet/src/app/exams/exams-add.component.ts) next to `[Preview Test]`, `[Add Question]`, `[Save & Return]`.
   - Created [`ExamsRetakePolicyDialogComponent`](file:///c:/Users/Blake/Documents/ole/planet/src/app/exams/exams-retake-policy-dialog.component.ts) with `<mat-select>` dropdowns:
     - **Max Attempts**: Options from `Unlimited` to `50 attempts` (blocks negative numbers and decimal inputs).
     - **Cool-Off Duration**: Selectable dropdowns for **Days** (0–30), **Hours** (0–23), and **Minutes** (0–55 in 5m intervals) that composite together with a live calculated summary.
2. **Submissions Evaluation & Policy Enforcement**:
   - Added `evaluateRetakePolicy()` in [`SubmissionsService`](file:///c:/Users/Blake/Documents/ole/planet/src/app/submissions/submissions.service.ts) to evaluate attempt limits and cool-off timers across all completed submissions.
   - Formats countdowns concisely (`> 1 day` => `${d}d`, `>= 1 hour` => `${h}h`, `< 1 hour` => `${m}m`).
   - Strictly suppresses cool-off timers when max attempts are reached (`isCooloffActive: false`).
3. **Step Cards & Step Viewer UI Integration**:
   - Added compact 2-line stacked status indicators (`.retake-status-stack`):
     - Active cool-off: `Attempt X of Y` / `Available in: <time>`.
     - All attempts used: `N of N attempts used` / `No retakes remaining`.
   - Disables the `[Take/Retake Test]` button when locked by retake policy.
   - Route-guarded direct exam URL navigation in [`ExamsViewComponent`](file:///c:/Users/Blake/Documents/ole/planet/src/app/exams/exams-view.component.ts).
4. **Manager Extension Stubs**:
   - Added stubs for `grantAttemptExtension()` and `resetCooloffLockout()` in [`CoursesService`](file:///c:/Users/Blake/Documents/ole/planet/src/app/courses/courses.service.ts) for future progress dashboard integration (PR #10262).

### Testing
- `npm run lint` — All files pass linting.
- `npx vitest run` — 24/24 unit tests pass across `submissions.service.spec.ts`, `exams-retake-policy-dialog.component.spec.ts`, `exams-add.component.spec.ts`, and `courses-step-view.component.spec.ts`.

<img width="1796" height="820" alt="{3A8FEB16-5072-404A-9F10-21B4445066F0}" src="https://github.com/user-attachments/assets/3cd7d42e-23f6-4b95-a391-52ee6b650476" />

<img width="381" height="73" alt="{1262C9C9-7783-4206-8DD4-CB6F5970E1ED}" src="https://github.com/user-attachments/assets/dfea76ba-ce11-4c9d-a49a-b367610bfd8e" />

<img width="263" height="67" alt="{2E077A90-59DE-4393-BADB-1D7F05EEBA26}" src="https://github.com/user-attachments/assets/a895f1c7-9e54-439b-9501-e13cec91d9b3" />