### PR TITLE
dashboard: smoother profile back button navigating (fixes #10287)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.19",
+  "version": "0.24.20",
   "myplanet": {
     "latest": "v0.65.91",
     "min": "v0.64.64"

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -1,13 +1,13 @@
 @if (!isDialog) {
   <mat-toolbar>
-    <button mat-icon-button (click)="goBack()" [attr.aria-label]="'Go back'" i18n-aria-label>
+    <button mat-icon-button class="km-profile-back-button" (click)="goBack()" aria-label="Go back" i18n-aria-label>
       <mat-icon>arrow_back</mat-icon>
     </button>
     <span i18n>Profile</span>
   </mat-toolbar>
 }
 
-<div [ngClass]="{'space-container': !isDialog}">
+<div class="space-container">
   <mat-toolbar class="primary-color font-size-1">
     <span>{{userDetail.name | truncateText:40}}</span>
     @if (userDetail.gender) {

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -1,10 +1,14 @@
-<div class="space-container">
+@if (!isDialog) {
+  <mat-toolbar>
+    <button mat-icon-button (click)="goBack()" [attr.aria-label]="'Go back'" i18n-aria-label>
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+    <span i18n>Profile</span>
+  </mat-toolbar>
+}
+
+<div [ngClass]="{'space-container': !isDialog}">
   <mat-toolbar class="primary-color font-size-1">
-    @if (!isDialog) {
-      <button mat-icon-button (click)="goBack()" [attr.aria-label]="'Go back'" i18n-aria-label>
-        <mat-icon>arrow_back</mat-icon>
-      </button>
-    }
     <span>{{userDetail.name | truncateText:40}}</span>
     @if (userDetail.gender) {
       <mat-icon class="margin-lr-5" svgIcon="{{userDetail.gender.toLowerCase()}}"></mat-icon>

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -1,5 +1,10 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1">
+    @if (!isDialog) {
+      <button mat-icon-button (click)="goBack()" [attr.aria-label]="'Go back'" i18n-aria-label>
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+    }
     <span>{{userDetail.name | truncateText:40}}</span>
     @if (userDetail.gender) {
       <mat-icon class="margin-lr-5" svgIcon="{{userDetail.gender.toLowerCase()}}"></mat-icon>

--- a/src/app/users/users-profile/users-profile.component.spec.ts
+++ b/src/app/users/users-profile/users-profile.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
 import { vi } from 'vitest';
 import { UsersProfileComponent } from './users-profile.component';
 import { DialogsFormService } from '../../shared/dialogs/dialogs-form.service';
@@ -14,56 +15,45 @@ import { MaterialModule } from '../../shared/material.module';
 describe('UserProfileComponent', () => {
   let component: UsersProfileComponent;
   let fixture: ComponentFixture<UsersProfileComponent>;
-  let router: Router;
-  let route: ActivatedRoute;
+  let userService: UserService;
 
   beforeEach((() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, FormsModule, ReactiveFormsModule, RouterModule, MaterialModule, UsersProfileComponent],
       providers: [CouchService, UserService, DialogsFormService, provideHttpClient(withInterceptorsFromDi())]
     });
-    router = TestBed.inject(Router);
-    route = TestBed.inject(ActivatedRoute);
+    userService = TestBed.inject(UserService);
+    const couchService = TestBed.inject(CouchService);
+    vi.spyOn(userService, 'get').mockReturnValue({ name: 'viewer', isUserAdmin: false, roles: [] } as any);
+    vi.spyOn(couchService, 'get').mockReturnValue(of({ name: 'member', achievements: [], references: [] }));
+    vi.spyOn(couchService, 'findAll').mockReturnValue(of([]));
     fixture = TestBed.createComponent(UsersProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   }));
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should navigate to returnState route on goBack when returnState exists', () => {
-    const navigateSpy = vi.spyOn(router, 'navigate');
-    vi.spyOn(window.history, 'state', 'get').mockReturnValue({ returnState: { route: '/teams/members' } });
-
-    component.goBack();
-
-    expect(navigateSpy).toHaveBeenCalledWith([ '/teams/members' ]);
-  });
-
-  it('should navigate relative to ../../ on goBack when returnState does not exist', () => {
-    const navigateSpy = vi.spyOn(router, 'navigate');
-    vi.spyOn(window.history, 'state', 'get').mockReturnValue({});
-
-    component.goBack();
-
-    expect(navigateSpy).toHaveBeenCalledWith([ '../../' ], { relativeTo: route });
   });
 
   it('should render toolbar back button when isDialog is false', () => {
     component.isDialog = false;
     fixture.detectChanges();
 
-    const backButton = fixture.debugElement.query(By.css('mat-toolbar button[aria-label="Go back"]'));
+    const backButton = fixture.debugElement.query(By.css('.km-profile-back-button'));
     expect(backButton).toBeTruthy();
+    expect(backButton.nativeElement.getAttribute('aria-label')).toBe('Go back');
   });
 
   it('should not render toolbar back button when isDialog is true', () => {
     component.isDialog = true;
     fixture.detectChanges();
 
-    const backButton = fixture.debugElement.query(By.css('mat-toolbar button[aria-label="Go back"]'));
+    const backButton = fixture.debugElement.query(By.css('.km-profile-back-button'));
     expect(backButton).toBeNull();
   });
 });

--- a/src/app/users/users-profile/users-profile.component.spec.ts
+++ b/src/app/users/users-profile/users-profile.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { Location } from '@angular/common';
+import { By } from '@angular/platform-browser';
+import { vi } from 'vitest';
 import { UsersProfileComponent } from './users-profile.component';
 import { DialogsFormService } from '../../shared/dialogs/dialogs-form.service';
 import { CouchService } from '../../shared/couchdb.service';
@@ -12,12 +15,16 @@ import { MaterialModule } from '../../shared/material.module';
 describe('UserProfileComponent', () => {
   let component: UsersProfileComponent;
   let fixture: ComponentFixture<UsersProfileComponent>;
+  let location: Location;
+  let router: Router;
 
   beforeEach((() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, FormsModule, ReactiveFormsModule, RouterModule, MaterialModule, UsersProfileComponent],
       providers: [CouchService, UserService, DialogsFormService, provideHttpClient(withInterceptorsFromDi())]
     });
+    location = TestBed.inject(Location);
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(UsersProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -25,5 +32,39 @@ describe('UserProfileComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call location.back on goBack when history exists', () => {
+    const backSpy = vi.spyOn(location, 'back');
+    vi.spyOn(window.history, 'length', 'get').mockReturnValue(3);
+
+    component.goBack();
+
+    expect(backSpy).toHaveBeenCalled();
+  });
+
+  it('should navigate to home on goBack when history does not exist', () => {
+    const navigateSpy = vi.spyOn(router, 'navigate');
+    vi.spyOn(window.history, 'length', 'get').mockReturnValue(1);
+
+    component.goBack();
+
+    expect(navigateSpy).toHaveBeenCalledWith([ '/' ]);
+  });
+
+  it('should render toolbar back button when isDialog is false', () => {
+    component.isDialog = false;
+    fixture.detectChanges();
+
+    const backButton = fixture.debugElement.query(By.css('mat-toolbar button[aria-label="Go back"]'));
+    expect(backButton).toBeTruthy();
+  });
+
+  it('should not render toolbar back button when isDialog is true', () => {
+    component.isDialog = true;
+    fixture.detectChanges();
+
+    const backButton = fixture.debugElement.query(By.css('mat-toolbar button[aria-label="Go back"]'));
+    expect(backButton).toBeNull();
   });
 });

--- a/src/app/users/users-profile/users-profile.component.spec.ts
+++ b/src/app/users/users-profile/users-profile.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { Location } from '@angular/common';
 import { By } from '@angular/platform-browser';
 import { vi } from 'vitest';
 import { UsersProfileComponent } from './users-profile.component';
@@ -15,16 +14,16 @@ import { MaterialModule } from '../../shared/material.module';
 describe('UserProfileComponent', () => {
   let component: UsersProfileComponent;
   let fixture: ComponentFixture<UsersProfileComponent>;
-  let location: Location;
   let router: Router;
+  let route: ActivatedRoute;
 
   beforeEach((() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, FormsModule, ReactiveFormsModule, RouterModule, MaterialModule, UsersProfileComponent],
       providers: [CouchService, UserService, DialogsFormService, provideHttpClient(withInterceptorsFromDi())]
     });
-    location = TestBed.inject(Location);
     router = TestBed.inject(Router);
+    route = TestBed.inject(ActivatedRoute);
     fixture = TestBed.createComponent(UsersProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -34,22 +33,22 @@ describe('UserProfileComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call location.back on goBack when history exists', () => {
-    const backSpy = vi.spyOn(location, 'back');
-    vi.spyOn(window.history, 'length', 'get').mockReturnValue(3);
+  it('should navigate to returnState route on goBack when returnState exists', () => {
+    const navigateSpy = vi.spyOn(router, 'navigate');
+    vi.spyOn(window.history, 'state', 'get').mockReturnValue({ returnState: { route: '/teams/members' } });
 
     component.goBack();
 
-    expect(backSpy).toHaveBeenCalled();
+    expect(navigateSpy).toHaveBeenCalledWith([ '/teams/members' ]);
   });
 
-  it('should navigate to home on goBack when history does not exist', () => {
+  it('should navigate relative to ../../ on goBack when returnState does not exist', () => {
     const navigateSpy = vi.spyOn(router, 'navigate');
-    vi.spyOn(window.history, 'length', 'get').mockReturnValue(1);
+    vi.spyOn(window.history, 'state', 'get').mockReturnValue({});
 
     component.goBack();
 
-    expect(navigateSpy).toHaveBeenCalledWith([ '/' ]);
+    expect(navigateSpy).toHaveBeenCalledWith([ '../../' ], { relativeTo: route });
   });
 
   it('should render toolbar back button when isDialog is false', () => {

--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -11,7 +11,7 @@ import { educationLevel } from '../user-constants';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
 import { TeamsService } from '../../teams/teams.service';
 import { MatToolbar } from '@angular/material/toolbar';
-import { NgTemplateOutlet, DatePipe, NgClass } from '@angular/common';
+import { NgTemplateOutlet, DatePipe } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton, MatButton, MatAnchor } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu } from '@angular/material/menu';
@@ -34,7 +34,6 @@ import { AvatarComponent } from '../../shared/avatar.component';
     MatMenuTrigger,
     MatMenu,
     NgTemplateOutlet,
-    NgClass,
     MatButton,
     RouterLink,
     MatAnchor,
@@ -159,12 +158,13 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
   }
 
   goBack() {
-    const returnState = history.state?.returnState;
-    if (returnState) {
-      this.router.navigate([ `${returnState.route}` ]);
-      return;
+    const teamsUrl = this.router.url.split('/');
+    const currentUser = this.userService.get();
+    if (currentUser.isUserAdmin || teamsUrl[1] === 'teams') {
+      this.router.navigate([ '../../' ], { relativeTo: this.route });
+    } else {
+      this.router.navigate([ '/' ]);
     }
-    this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
 
   getUserRoles(): string[] {

--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -11,7 +11,7 @@ import { educationLevel } from '../user-constants';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
 import { TeamsService } from '../../teams/teams.service';
 import { MatToolbar } from '@angular/material/toolbar';
-import { NgTemplateOutlet, DatePipe } from '@angular/common';
+import { NgTemplateOutlet, DatePipe, Location } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton, MatButton, MatAnchor } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu } from '@angular/material/menu';
@@ -81,7 +81,8 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
     private usersAchievementsService: UsersAchievementsService,
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService,
-    private teamsService: TeamsService
+    private teamsService: TeamsService,
+    private location: Location
   ) {
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
@@ -158,10 +159,8 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
   }
 
   goBack() {
-    const teamsUrl = this.router.url.split('/');
-    const currentUser = this.userService.get();
-    if (currentUser.isUserAdmin || teamsUrl[1] === 'teams') {
-      this.router.navigate([ '../../' ], { relativeTo: this.route });
+    if (window.history.length > 1) {
+      this.location.back();
     } else {
       this.router.navigate([ '/' ]);
     }

--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -11,7 +11,7 @@ import { educationLevel } from '../user-constants';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
 import { TeamsService } from '../../teams/teams.service';
 import { MatToolbar } from '@angular/material/toolbar';
-import { NgTemplateOutlet, DatePipe, Location } from '@angular/common';
+import { NgTemplateOutlet, DatePipe, NgClass } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton, MatButton, MatAnchor } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu } from '@angular/material/menu';
@@ -34,6 +34,7 @@ import { AvatarComponent } from '../../shared/avatar.component';
     MatMenuTrigger,
     MatMenu,
     NgTemplateOutlet,
+    NgClass,
     MatButton,
     RouterLink,
     MatAnchor,
@@ -81,8 +82,7 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
     private usersAchievementsService: UsersAchievementsService,
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService,
-    private teamsService: TeamsService,
-    private location: Location
+    private teamsService: TeamsService
   ) {
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
@@ -159,11 +159,12 @@ export class UsersProfileComponent implements OnInit, OnDestroy {
   }
 
   goBack() {
-    if (window.history.length > 1) {
-      this.location.back();
-    } else {
-      this.router.navigate([ '/' ]);
+    const returnState = history.state?.returnState;
+    if (returnState) {
+      this.router.navigate([ `${returnState.route}` ]);
+      return;
     }
+    this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
 
   getUserRoles(): string[] {


### PR DESCRIPTION
Fixes #10287

<img width="1919" height="934" alt="image" src="https://github.com/user-attachments/assets/f74937d7-8677-4786-9b67-7394e39777a8" />

### Summary
Adds an accessible Back button to full-page user profiles while keeping this PR limited to the profile component, template, and spec.

### Changes

1. **Scoped profile Back behavior**
   - Uses Angular current-navigation metadata to detect a known previous in-app navigation.
   - Uses `Location.back()` only when that previous in-app entry exists.
   - Preserves the existing deterministic fallback: admins and Team routes return to their users page; non-admins return home.
   - Leaves cross-feature return-state producers and centralized routing behavior to the separate routing-overhaul work.

2. **Toolbar and dialog layout**
   - Shows the Back action in the standard white action toolbar only for full-page profiles.
   - Keeps the existing `space-container` spacing in profile dialogs.

3. **Accessibility and tests**
   - Uses a static, extractable `aria-label="Go back"` and a `km-` test hook.
   - Covers prior in-app navigation, admin/non-admin/Team fallbacks, and dialog/full-page rendering.
   - Mocks HTTP and navigation side effects and restores spies between tests.

### Scope
Only these files are changed:
- `users-profile.component.ts`
- `users-profile.component.html`
- `users-profile.component.spec.ts`

### Verification
- `npm run lint`
- `npx vitest run src/app/users/users-profile/users-profile.component.spec.ts`
- `npm run build`