### PR TITLE
courses: smoother active step resuming (fixes #10290)

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -237,6 +237,18 @@
                 <span i18n>Edit Course</span>
               </a>
             }
+            @if (element.admission && element.doc.steps.length) {
+              <a mat-menu-item [routerLink]="['/courses/view', element._id, 'step', getActiveStepInfo(element).stepNum]">
+                <mat-icon>play_circle_outline</mat-icon>
+                @if (getActiveStepInfo(element).isCompleted) {
+                  <span i18n>Review Course</span>
+                } @else if (getActiveStepInfo(element).hasStarted) {
+                  <span i18n>Resume Course</span>
+                } @else {
+                  <span i18n>Start Course</span>
+                }
+              </a>
+            }
             <a mat-menu-item [routerLink]="['/courses/view', element._id]">
               <mat-icon>visibility</mat-icon>
               <span i18n>View Course</span>

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -588,4 +588,8 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.previewOverflow.set(this.getPreviewKey(element), hasOverflow);
   }
 
+  getActiveStepInfo(element: any) {
+    return this.coursesService.getActiveStep(element?.doc, element?.progress);
+  }
+
 }

--- a/src/app/courses/courses.service.ts
+++ b/src/app/courses/courses.service.ts
@@ -12,6 +12,14 @@ import { dedupeObjectArray } from '../shared/utils';
 import { MarkdownService } from '../shared/markdown.service';
 import { UsersService } from '../users/users.service';
 
+export interface ActiveStepInfo {
+  stepNum: number;
+  stepIndex: number;
+  stepTitle: string;
+  isCompleted: boolean;
+  hasStarted: boolean;
+}
+
 // Service for updating and storing active course for single course views.
 @Injectable({
   providedIn: 'root'
@@ -270,6 +278,92 @@ export class CoursesService {
       description: markdownText(course),
       steps: course.steps.map(step => ({ ...step, description: markdownText(step), images: undefined })),
       images: this.markdownService.filterMissingImages([ markdownText(course), ...course.steps.map(step => markdownText(step)) ], images)
+    };
+  }
+
+  getActiveStep(course: any, progress: any[] = [], submissions: any[] = []): ActiveStepInfo {
+    const steps = course?.steps || [];
+    if (steps.length === 0) {
+      return {
+        stepNum: 1,
+        stepIndex: 0,
+        stepTitle: '',
+        isCompleted: false,
+        hasStarted: false
+      };
+    }
+    const safeProgress = Array.isArray(progress) ? progress : [];
+    const safeSubmissions = Array.isArray(submissions) ? submissions : [];
+    const hasStarted = safeProgress.some((p: any) => p && (p.stepNum > 0 || p.passed)) || safeSubmissions.length > 0;
+
+    const hasAnyAssessments = steps.some((step: any) =>
+      (step?.exam?.questions?.length > 0) || (step?.survey?.questions?.length > 0)
+    );
+
+    const isStepResolved = (step: any, index: number) => {
+      const stepProg = safeProgress.find((p: any) => p && p.stepNum === (index + 1));
+      if (stepProg?.passed) {
+        return true;
+      }
+      const hasExam = step?.exam?.questions?.length > 0;
+      const hasSurvey = step?.survey?.questions?.length > 0;
+
+      // If the course contains assessments, steps without tests or surveys are non-blocking
+      if (hasAnyAssessments && !hasExam && !hasSurvey) {
+        return true;
+      }
+
+      if (hasExam) {
+        const examId = step.exam._id;
+        const stepSubs = safeSubmissions.filter((s: any) =>
+          s && (s.parentId === `${examId}@${course?._id}` || s.parentId === examId || s.parent?._id === examId)
+        );
+        const hasAwaitingGrading = stepSubs.some((s: any) =>
+          s.status === 'requires grading' ||
+          s.status === 'complete' ||
+          (s.status === 'pending' && s.answers?.length > 0 && s.answers.every((a: any) => a.value !== undefined && a.value !== ''))
+        );
+        if (hasAwaitingGrading) {
+          return true;
+        }
+      }
+
+      if (hasSurvey) {
+        const surveyId = step.survey._id;
+        const stepSubs = safeSubmissions.filter((s: any) =>
+          s && (s.parentId === `${surveyId}@${course?._id}` || s.parentId === surveyId || s.parent?._id === surveyId)
+        );
+        const hasCompletedSurvey = stepSubs.some((s: any) => s.status === 'complete');
+        if (hasCompletedSurvey) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    const firstIncompleteIndex = steps.findIndex((step: any, index: number) => !isStepResolved(step, index));
+
+    if (firstIncompleteIndex === -1) {
+      return {
+        stepNum: 1,
+        stepIndex: 0,
+        stepTitle: steps[0]?.stepTitle || $localize`Step 1`,
+        isCompleted: true,
+        hasStarted: true
+      };
+    }
+
+    const stepNum = firstIncompleteIndex + 1;
+    const activeStep = steps[firstIncompleteIndex];
+    const stepTitle = activeStep?.stepTitle || $localize`Step ${stepNum}`;
+
+    return {
+      stepNum,
+      stepIndex: firstIncompleteIndex,
+      stepTitle,
+      isCompleted: false,
+      hasStarted
     };
   }
 

--- a/src/app/courses/view-courses/courses-view.component.html
+++ b/src/app/courses/view-courses/courses-view.component.html
@@ -55,7 +55,21 @@
         </button>
       }
     }
-    <button class="view-step-button" mat-raised-button color="accent" (click)="viewStep()" i18n [disabled]="!courseDetail?.steps?.length">View Step</button>
+    @if (!isUserEnrolled || !courseDetail?.steps?.length) {
+      <button class="view-step-button" mat-raised-button color="accent" (click)="viewStep()" i18n [disabled]="!courseDetail?.steps?.length">View Step</button>
+    } @else if (activeStepInfo?.isCompleted) {
+      <button class="view-step-button" mat-raised-button color="accent" (click)="viewStep()" i18n>Review Course</button>
+    } @else if (activeStepInfo?.hasStarted) {
+      <button class="view-step-button" mat-raised-button color="accent" (click)="viewStep()" [matTooltip]="activeStepInfo.stepTitle">
+        <span i18n>Resume (Step {{activeStepInfo.stepNum}})</span>
+        <mat-icon class="margin-lr-3">arrow_forward</mat-icon>
+      </button>
+    } @else {
+      <button class="view-step-button" mat-raised-button color="accent" (click)="viewStep()" [matTooltip]="activeStepInfo.stepTitle">
+        <span i18n>Start Course</span>
+        <mat-icon class="margin-lr-3">arrow_forward</mat-icon>
+      </button>
+    }
   </ng-template>
 
   <div class="view-container view-full-height">

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
-import { Subject } from 'rxjs';
-import { takeUntil, switchMap, take, filter, map } from 'rxjs/operators';
+import { Subject, forkJoin, of } from 'rxjs';
+import { takeUntil, switchMap, take, filter, map, catchError } from 'rxjs/operators';
+import { findDocuments } from '../../shared/mangoQueries';
 import { UserService } from '../../shared/user.service';
-import { CoursesService } from '../courses.service';
+import { CoursesService, ActiveStepInfo } from '../courses.service';
 import { SubmissionsService } from '../../submissions/submissions.service';
 import { StateService } from '../../shared/state.service';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
@@ -28,29 +29,30 @@ import { ResourcesMenuComponent } from '../../resources/view-resources/resources
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
 
 @Component({
+  selector: 'planet-courses-view',
   templateUrl: './courses-view.component.html',
-  styleUrls: ['courses-view.scss'],
+  styleUrls: ['./courses-view.scss'],
   imports: [
     MatToolbar,
     MatIconAnchor,
+    MatIconButton,
     MatIcon,
     NgTemplateOutlet,
-    MatIconButton,
-    MatMenuTrigger,
-    MatMenu,
     MatButton,
     CoursesProgressBarComponent,
-    NgClass,
     CoursesViewDetailComponent,
     MatExpansionPanel,
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
     MatExpansionPanelDescription,
     CoursesIconComponent,
+    NgClass,
     PlanetMarkdownComponent,
     MatExpansionPanelActionRow,
     ResourcesMenuComponent,
     MatAnchor,
+    MatMenuTrigger,
+    MatMenu,
     MatMenuItem,
     PlanetLoadingSpinnerComponent
   ]
@@ -62,6 +64,8 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   parent = this.route.snapshot.data.parent;
   isUserEnrolled = false;
   progress = [ { stepNum: 1 } ];
+  submissions: any[] = [];
+  activeStepInfo: ActiveStepInfo;
   fullView = 'on';
   currentView: string;
   courseId: string;
@@ -104,16 +108,38 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
         }));
         this.progress = progress;
         this.isUserEnrolled = this.checkMyCourses(course._id);
+        this.activeStepInfo = this.coursesService.getActiveStep(this.courseDetail, this.progress, this.submissions);
         this.canManage = (this.currentUser.isUserAdmin && !this.parent) ||
           this.courseDetail.creator !== undefined &&
           (this.currentUser.name === this.courseDetail.creator.slice(0, this.courseDetail.creator.indexOf('@')));
-        return this.stateService.getCouchState('exams', 'local');
+        return forkJoin([
+          this.stateService.getCouchState('exams', 'local'),
+          this.submissionsService.getSubmissions(findDocuments({
+            'user.name': this.currentUser.name,
+            parentId: { $regex: '@' + course._id }
+          })).pipe(catchError(() => of([])))
+        ]);
       }),
       takeUntil(this.onDestroy$)
-    ).subscribe((exams) => {
+    ).subscribe(([exams, submissions]) => {
       const stepExam = (step) => step.exam && exams.find(exam => exam._id === step.exam._id) || step.exam;
       this.courseDetail.steps = this.courseDetail.steps.map(step => ({ ...step, exam: stepExam(step) }));
+      this.submissions = submissions || [];
+      this.activeStepInfo = this.coursesService.getActiveStep(this.courseDetail, this.progress, this.submissions);
     }, () => this.isLoading = false);
+    this.submissionsService.submissionUpdated$.pipe(takeUntil(this.onDestroy$)).subscribe(({ submission }) => {
+      if (submission) {
+        const existingIndex = this.submissions.findIndex(s =>
+          s._id === submission._id || (s.parentId === submission.parentId && s.parent?._id === submission.parent?._id)
+        );
+        if (existingIndex > -1) {
+          this.submissions[existingIndex] = submission;
+        } else {
+          this.submissions.push(submission);
+        }
+        this.activeStepInfo = this.coursesService.getActiveStep(this.courseDetail, this.progress, this.submissions);
+      }
+    });
     this.route.paramMap.pipe(takeUntil(this.onDestroy$)).subscribe((params: ParamMap) => {
       this.courseId = params.get('id');
       this.coursesService.requestCourse({ courseId: this.courseId, forceLatest: true, parent: this.parent });
@@ -163,10 +189,8 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   }
 
   viewStep() {
-    const latestStep = this.progress.reduce((stepNum, prog) => {
-      return prog.stepNum > stepNum ? prog.stepNum : stepNum;
-    }, 1);
-    this.router.navigate([ './step/' + latestStep ], { relativeTo: this.route });
+    const stepNum = this.activeStepInfo?.stepNum || 1;
+    this.router.navigate([ './step/' + stepNum ], { relativeTo: this.route });
   }
 
   goToSurvey(stepNum, preview = false) {
@@ -214,6 +238,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     const courseTitle = this.courseDetail.courseTitle;
     this.coursesService.courseResignAdmission(courseId, type, courseTitle).subscribe((res) => {
       this.isUserEnrolled = !this.isUserEnrolled;
+      this.activeStepInfo = this.coursesService.getActiveStep(this.courseDetail, this.progress, this.submissions);
     }, (error) => ((error)));
   }
 

--- a/src/app/courses/view-courses/courses-view.scss
+++ b/src/app/courses/view-courses/courses-view.scss
@@ -35,8 +35,12 @@
     margin-left: 8px;
   }
 
-  .view-step-button{
+  .view-step-button {
     flex-shrink: 0;
+    max-width: 450px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   @media (max-width: v.$screen-sm) {


### PR DESCRIPTION
Fixes #10290

### Summary
Adds a 1-click quick-action button in the course overview header and an action in the course row kebab menu to resume enrolled courses directly at the learner's active step.

### Changes & Justifications

1. **Active Step & Assessment Resolution (`src/app/courses/courses.service.ts`)**:
   - Added `ActiveStepInfo` interface and `getActiveStep(course, progress, submissions)` helper.
   - Accurately resolves the next actionable step by skipping steps that have already been passed or have an assessment (exam/survey) submitted and awaiting teacher grading.
   - Steps with no assessments (tests/surveys) do not block progression.
   - Triggers `Review Course` mode when all actionable steps in the course are completed or awaiting grading.

2. **Course Overview Banner Button (`src/app/courses/view-courses/courses-view.component.html` & `courses-view.component.ts`)**:
   - Replaced static action with dynamic button reflecting current status:
     - `Resume (Step X)` (with tooltip showing step title) for in-progress courses.
     - `Start Course` for newly enrolled courses.
     - `Review Course` when all steps/exams are completed or submitted.
     - `View Step` for non-enrolled viewers.
   - Subscribed to course submission updates to dynamically recalculate the active step.

3. **Course List Action Menu (`src/app/courses/courses.component.html`)**:
   - Added `Resume Course` / `Start Course` / `Review Course` action to the course row kebab menu for enrolled learners without altering table layout.

### Verification
- `npm run lint` — All files pass linting.
- `npm test` — All 130 tests pass.