### PR TITLE
teams: smoother member name formatting (fixes #10299)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.11",
+  "version": "0.24.12",
   "myplanet": {
     "latest": "v0.65.91",
     "min": "v0.64.64"

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -104,8 +104,8 @@ describe('DashboardComponent', () => {
     expect(component.roles).toEqual([ 'learner', 'admin' ]);
   });
 
-  it('uses the username when firstName is undefined', () => {
-    createComponent({ firstName: undefined }).detectChanges();
+  it('uses the username when no name parts are available', () => {
+    createComponent({ firstName: undefined, lastName: undefined }).detectChanges();
 
     expect(component.displayName).toBe('johndoe');
   });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -8,7 +8,7 @@ import { findDocuments } from '../shared/mangoQueries';
 import { environment } from '../../environments/environment';
 import { SubmissionsService } from '../submissions/submissions.service';
 import { StateService } from '../shared/state.service';
-import { dedupeShelfReduce, dedupeObjectArray } from '../shared/utils';
+import { dedupeShelfReduce, dedupeObjectArray, fullName } from '../shared/utils';
 import { CoursesService } from '../courses/courses.service';
 import { CoursesViewDetailDialogComponent } from '../courses/view-courses/courses-view-detail.component';
 import { foundations, foundationIcons } from '../courses/constants';
@@ -100,7 +100,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.displayName = this.user.firstName !== undefined ? `${this.user.firstName} ${this.user.lastName}` : this.user.name;
+    this.displayName = fullName(this.user) || this.user.name;
     this.planetName = this.stateService.configuration.name;
     this.getSurveys();
     this.getExams();

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -9,7 +9,7 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
   display: grid;
   grid-template-areas: "hcard";
   grid-template-columns: 1fr;
-  grid-template-rows: $top-row-height repeat(4, minmax(90px, 1fr));
+  grid-template-rows: minmax($top-row-height, auto) repeat(4, minmax(90px, 1fr));
   grid-auto-flow: row;
   grid-row-gap: 0.5rem;
   @media (max-width: v.$screen-md) {
@@ -48,9 +48,11 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
       display: flex;
       flex-direction: column;
       margin-left: 16px;
+      min-width: 0;
       h1 {
         display: flex;
         align-items: center;
+        overflow-wrap: anywhere;
       }
       .mat-subtitle-1 {
         margin: 0;

--- a/src/app/health/health.component.html
+++ b/src/app/health/health.component.html
@@ -15,7 +15,7 @@
       <a mat-raised-button color="accent" i18n [routerLink]="['update']">Update Details</a>
     }
     <a mat-raised-button color="accent" i18n [routerLink]="['event', { id: userDetail._id }]">Add Examination</a>
-    @if (userDetail.firstName === undefined) {
+    @if (!(userDetail | fullName)) {
       <span><ng-container i18n>Member login:</ng-container> {{userDetail.name}}</span>
     }
   </mat-toolbar>
@@ -35,7 +35,7 @@
           <div>
             <div>
               <h4 class="primary-text-color" i18n>Full Name</h4>
-              <p><b>{{userDetail.firstName ? ((userDetail.firstName + ' ' + userDetail.middleName + ' ' + userDetail.lastName) | truncateText:40) : 'N/A'}}</b></p>
+              <p><b>{{(userDetail | fullName | truncateText:40) || 'N/A'}}</b></p>
             </div>
             <mat-divider></mat-divider>
           </div>

--- a/src/app/health/health.component.ts
+++ b/src/app/health/health.component.ts
@@ -24,6 +24,7 @@ import { TdMarkdownComponent } from '@covalent/markdown';
 import { MatTooltip } from '@angular/material/tooltip';
 import { LabelComponent } from '../shared/label.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
+import { FullNamePipe } from '../shared/full-name.pipe';
 
 @Component({
   templateUrl: './health.component.html',
@@ -51,7 +52,8 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     MatRowDef,
     MatRow,
     DatePipe,
-    TruncateTextPipe
+    TruncateTextPipe,
+    FullNamePipe
   ]
 })
 export class HealthComponent implements OnInit, AfterViewChecked, OnDestroy {

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -91,9 +91,7 @@
     <img [src]="item.avatar" class="cursor-pointer profile-outline" (click)="openMemberDialog(item.doc.user)">
     <button mat-button type="button" class="cursor-pointer user-name-truncate margin-lr-8" (click)="openMemberDialog(item.doc.user)">
       <span class="user-name-truncate-text ellipsis">
-        {{item.doc.user.firstName ?
-        item.doc.user.firstName + ((" " + item.doc.user.middleName) || '') + ' ' + item.doc.user.lastName :
-        item.doc.user.name}}
+        {{(item.doc.user | fullName) || item.doc.user.name}}
       </span>
     </button>
     <span class="toolbar-fill"></span>

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -24,6 +24,7 @@ import { ChatOutputDirective } from '../shared/chat-output.directive';
 import { MatIconButton, MatButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { TimeAgoPipe } from '../shared/time-ago.pipe';
+import { FullNamePipe } from '../shared/full-name.pipe';
 
 @Component({
   selector: 'planet-news-list-item',
@@ -51,7 +52,8 @@ import { TimeAgoPipe } from '../shared/time-ago.pipe';
     NgTemplateOutlet,
     MatMenuItem,
     SlicePipe,
-    TimeAgoPipe
+    TimeAgoPipe,
+    FullNamePipe
   ]
 })
 export class NewsListItemComponent implements OnInit, OnChanges, OnDestroy {

--- a/src/app/shared/dialogs/dialogs-list.component.ts
+++ b/src/app/shared/dialogs/dialogs-list.component.ts
@@ -21,6 +21,7 @@ import { MatOption } from '@angular/material/autocomplete';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { MatTooltip } from '@angular/material/tooltip';
+import { fullName } from '../utils';
 
 @Component({
   templateUrl: './dialogs-list.component.html',
@@ -122,7 +123,7 @@ export class DialogsListComponent implements AfterViewInit {
 
   appendFullName(data: any[]) {
     return data.map(row => ({
-      ...row, 'Full Name': (row.firstName || '') && `${row.firstName} ${row.middleName || ''} ${row.lastName}`
+      ...row, 'Full Name': fullName(row)
     }));
   }
 

--- a/src/app/shared/full-name.pipe.ts
+++ b/src/app/shared/full-name.pipe.ts
@@ -1,0 +1,9 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { fullName } from './utils';
+
+@Pipe({ name: 'fullName' })
+export class FullNamePipe implements PipeTransform {
+  transform(user: any): string {
+    return fullName(user);
+  }
+}

--- a/src/app/shared/shared-components.module.ts
+++ b/src/app/shared/shared-components.module.ts
@@ -24,6 +24,7 @@ import { LanguageLabelComponent } from './language-label.component';
 import { RestrictDiacriticsDirective } from './restrict-diacritics.directives';
 import { ChatOutputDirective } from './chat-output.directive';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
+import { FullNamePipe } from '../shared/full-name.pipe';
 import { TimeAgoPipe } from '../shared/time-ago.pipe';
 import { PlanetLoadingSpinnerComponent } from './planet-loading-spinner.component';
 import { PreviewOverflowDirective } from './preview-overflow.directive';
@@ -53,6 +54,7 @@ import { PreviewOverflowDirective } from './preview-overflow.directive';
     RestrictDiacriticsDirective,
     ChatOutputDirective,
     TruncateTextPipe,
+    FullNamePipe,
     TimeAgoPipe,
     PreviewOverflowDirective
   ],
@@ -80,6 +82,7 @@ import { PreviewOverflowDirective } from './preview-overflow.directive';
     ChatOutputDirective,
     OverlayModule,
     TruncateTextPipe,
+    FullNamePipe,
     TimeAgoPipe,
     PreviewOverflowDirective
   ],

--- a/src/app/shared/utils.spec.ts
+++ b/src/app/shared/utils.spec.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { couchAttachmentPath, couchAttachmentUrl, normalizeImage, scaledDimensions } from './utils';
+import { couchAttachmentPath, couchAttachmentUrl, fullName, normalizeImage, scaledDimensions } from './utils';
 
 describe('utils', () => {
 
@@ -12,6 +12,22 @@ describe('utils', () => {
       expect(couchAttachmentUrl('http://localhost:2200/', '/resources/', 'doc/id', 'site/index.html')).toBe(
         'http://localhost:2200/resources/doc%2Fid/site/index.html'
       );
+    });
+
+  });
+
+  describe('fullName', () => {
+
+    it('joins only the name parts that are present', () => {
+      expect(fullName({ firstName: 'John', middleName: 'Michael', lastName: 'Doe' })).toBe('John Michael Doe');
+      expect(fullName({ firstName: 'John', lastName: 'Doe' })).toBe('John Doe');
+      expect(fullName({ firstName: 'John', middleName: '', lastName: undefined })).toBe('John');
+      expect(fullName({ lastName: 'Doe' })).toBe('Doe');
+    });
+
+    it('returns an empty string when no name parts exist so callers can fall back', () => {
+      expect(fullName({ name: 'jdoe' })).toBe('');
+      expect(fullName(undefined)).toBe('');
     });
 
   });

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -274,6 +274,9 @@ export const markdownToPlainText = (markdown: any) => {
   return (html.textContent || html.innerText || '').replace(/^\n|\n$/g, '');
 };
 
+export const fullName = (user: any) =>
+  [ user?.firstName, user?.middleName, user?.lastName ].filter(namePart => namePart).join(' ');
+
 export const truncateText = (text, length) => {
   if (!text) {
     return '';

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -10,7 +10,7 @@ import { StateService } from '../shared/state.service';
 import { ValidatorService } from '../validators/validator.service';
 import { UsersService } from '../users/users.service';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
-import { truncateText } from '../shared/utils';
+import { fullName, truncateText } from '../shared/utils';
 
 const nameField = {
   'type': 'textbox',
@@ -387,8 +387,8 @@ export class TeamsService {
 
   teamNotificationMessage(type, { team, newMembersLength = '' }) {
     const user = this.userService.get();
-    const fullName = user.firstName ? `${user.firstName} ${user.middleName} ${user.lastName}` : user.name;
-    const truncatedFullName = truncateText(fullName, 22);
+    const memberName = fullName(user) || user.name;
+    const truncatedFullName = truncateText(memberName, 22);
     const teamType = team.type || 'team';
     const teamMessage = team.type === 'services' ?
       'the <b>Community Services Directory</b>' :

--- a/src/app/users/users-achievements/users-achievements-update.component.html
+++ b/src/app/users/users-achievements/users-achievements-update.component.html
@@ -10,11 +10,7 @@
 
 <div class="planet-users-achievements-update space-container">
   <mat-toolbar class="primary-color font-size-1">
-    @if (user?.firstName) {
-      <span>{{ (user.firstName + ' ' + user.middleName + ' ' + user.lastName) | truncateText:40 }}</span>
-    } @else {
-      {{ user.name | truncateText:40 }}
-    }
+    <span>{{ ((user | fullName) || user?.name) | truncateText:40 }}</span>
   </mat-toolbar>
   <div class="view-container view-full-height">
     <div class="achievements-forms-container">

--- a/src/app/users/users-achievements/users-achievements-update.component.ts
+++ b/src/app/users/users-achievements/users-achievements-update.component.ts
@@ -29,6 +29,8 @@ import { PlanetMarkdownTextboxComponent } from '../../shared/forms/planet-markdo
 import { MatListItemTitle, MatListItemMeta } from '@angular/material/list';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { SubmitDirective } from '../../shared/submit.directive';
+import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
+import { FullNamePipe } from '../../shared/full-name.pipe';
 
 type DateValue = string | Date;
 type DateSortOrder = 'none' | 'asc' | 'desc';
@@ -104,7 +106,9 @@ type LinkFormGroup = FormGroup<LinkFormControls>;
     MatButton,
     MatCheckbox,
     SubmitDirective,
-    FileUploadComponent
+    FileUploadComponent,
+    TruncateTextPipe,
+    FullNamePipe
   ]
 })
 export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanComponentDeactivate {

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -9,11 +9,7 @@
 <div class="space-container">
   <mat-toolbar class="primary-color font-size-1 responsive-toolbar">
     <div>
-      @if (user?.firstName) {
-        <span>{{ (user.firstName + ' ' + user.middleName + ' ' + user.lastName) | truncateText:40 }}</span>
-      } @else {
-        {{ user.name | truncateText:40 }}
-      }
+      <span>{{ ((user | fullName) || user?.name) | truncateText:40 }}</span>
     </div>
     <span class="toolbar-fill"></span>
     <div class="auto-adjust-buttons">
@@ -52,7 +48,7 @@
           <div class="achievements-container">
             <div class="user-info">
               <planet-avatar [username]="userName" [planetCode]="userPlanetCode" imgClass="profile-image"></planet-avatar>
-              <h2>{{ (user.firstName + ' ' + user.middleName + ' ' + user.lastName) | truncateText:40 }}</h2>
+              <h2>{{ ((user | fullName) || user?.name) | truncateText:40 }}</h2>
               @if (!publicView) {
                 <div class="birth-info">
                   @if (user.birthDate) {

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -23,6 +23,8 @@ import { TdMarkdownComponent } from '@covalent/markdown';
 import { PlanetBetaDirective } from '../../shared/beta.directive';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 import { AvatarComponent } from '../../shared/avatar.component';
+import { fullName } from '../../shared/utils';
+import { FullNamePipe } from '../../shared/full-name.pipe';
 
 @Component({
   templateUrl: './users-achievements.component.html',
@@ -47,7 +49,8 @@ import { AvatarComponent } from '../../shared/avatar.component';
     MatListItemLine,
     DatePipe,
     TruncateTextPipe,
-    AvatarComponent
+    AvatarComponent,
+    FullNamePipe
   ]
 })
 export class UsersAchievementsComponent implements OnInit {
@@ -196,7 +199,7 @@ export class UsersAchievementsComponent implements OnInit {
       },
       {
         text: `
-          ${this.user.firstName} ${this.user.middleName ? this.user.middleName : ''} ${this.user.lastName}
+          ${fullName(this.user) || this.user.name}
           ${formattedBirthDate ? $localize`Birthdate: ${formattedBirthDate}` : ''}
           ${this.user.birthplace ? $localize`Birthplace: ${this.user.birthplace}` : ''}
           ${formattedMemberSince ? $localize`Member since: ${formattedMemberSince}` : ''}

--- a/src/app/users/users-profile/users-profile.component.html
+++ b/src/app/users/users-profile/users-profile.component.html
@@ -59,8 +59,8 @@
       <mat-list class="profile-list-lt">
         <mat-list-item>
           <h4 class="primary-text-color" matListItemTitle i18n>Full Name</h4>
-          <p matListItemLine>@if (userDetail.firstName) {
-            <b>{{(userDetail.firstName + ' ' + userDetail.middleName + ' ' + userDetail.lastName) | truncateText:40}}</b>
+          <p matListItemLine>@if (userDetail | fullName) {
+            <b>{{userDetail | fullName | truncateText:40}}</b>
           } @else {
             <b>N/A</b>
           }</p>

--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -22,6 +22,7 @@ import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/m
 import { MatDialogClose } from '@angular/material/dialog';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 import { AvatarComponent } from '../../shared/avatar.component';
+import { FullNamePipe } from '../../shared/full-name.pipe';
 
 @Component({
   selector: 'planet-users-profile',
@@ -51,7 +52,8 @@ import { AvatarComponent } from '../../shared/avatar.component';
     MatDialogClose,
     DatePipe,
     TruncateTextPipe,
-    AvatarComponent
+    AvatarComponent,
+    FullNamePipe
   ]
 })
 export class UsersProfileComponent implements OnInit, OnDestroy {

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -3,6 +3,7 @@ import { forkJoin, Subject, combineLatest, of, throwError } from 'rxjs';
 import { switchMap, map, catchError, filter } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { CouchService } from '../shared/couchdb.service';
+import { fullName } from '../shared/utils';
 import { UserService } from '../shared/user.service';
 import { StateService } from '../shared/state.service';
 import { TasksService } from '../tasks/tasks.service';
@@ -94,7 +95,7 @@ export class UsersService {
       _id: user._id,
       doc: user,
       imageSrc: '',
-      fullName: (user.firstName || user.lastName) ? `${user.firstName} ${user.middleName} ${user.lastName}` : user.name,
+      fullName: fullName(user) || user.name,
       ...this.userLoginActivities(user, this.data.loginActivities)
     };
     if (user._attachments) {


### PR DESCRIPTION
Fixes #10299

Fixes inconsistent member-name rendering across the app.

• Adds a shared full-name helper and pipe that joins only populated name fields.
• Prevents missing fields from displaying as `undefined` or adding extra spaces.
• Preserves username fallback when no name fields exist.
• Applies consistent formatting across health, dashboard, profiles, achievements, news, teams, dialogs, and user lists.
• Allows long dashboard names to wrap without overlapping tiles.
• Adds unit coverage for complete, partial, last-name-only, and absent names



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent full-name formatting across dashboards, health views, news, teams, profiles, achievements, dialogs, and user records.
  * Names now fall back to usernames when no full name is available.
  * Long dashboard names wrap and resize more gracefully.

* **Bug Fixes**
  * Improved name display for users with missing or partial name information.
  * Updated member-login visibility checks to handle available name data consistently.

* **Tests**
  * Added coverage for full-name formatting and empty-name fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->