### PR TITLE
notifications: allow deleting individual and read notifications (fixes #10303)

### DIFF
--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -3,6 +3,11 @@
     <div>
       <span i18n>Your Notifications</span>
       <button mat-stroked-button [disabled]="!anyUnread" (click)="readAllNotification()" i18n class="margin-lr">Mark all as Read</button>
+      <button mat-raised-button color="warn" class="margin-lr" [disabled]="!anyRead"
+        (click)="openClearReadDialog()">
+        <mat-icon>delete_forever</mat-icon>
+        <span i18n>Delete Read</span>
+      </button>
     </div>
     <span class="toolbar-fill"></span>
     <mat-form-field class="font-size-1 margin-lr-3 mdc-toolbar-input">
@@ -38,15 +43,20 @@
         </mat-cell>
       </ng-container>
       <ng-container matColumnDef="read">
-        <mat-cell *matCellDef="let element" >
+        <mat-cell *matCellDef="let element">
           @if (element.status==='unread') {
             <button mat-stroked-button (click)="readNotification(element)" i18n>Mark as Read</button>
           }
+          <button mat-icon-button (click)="openDeleteNotificationDialog(element)"
+            i18n-aria-label aria-label="Delete"
+            matTooltip="Delete" i18n-matTooltip>
+            <mat-icon>delete_outline</mat-icon>
+          </button>
         </mat-cell>
       </ng-container>
       <mat-row *matRowDef="let row; columns: displayedColumns;" ></mat-row>
       <tr class="mat-row" *matNoDataRow>
-        <td><div class="view-container" i18n>No Notification Found</div></td>
+        <td><div class="view-container" i18n>No Notifications Found</div></td>
       </tr>
     </mat-table>
     <mat-paginator #paginator

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -8,16 +8,19 @@ import { Subject } from 'rxjs';
 
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource, MatTable, MatColumnDef, MatCellDef, MatCell, MatRowDef, MatRow, MatNoDataRow } from '@angular/material/table';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NotificationsService } from './notifications.service';
 import { MatToolbar } from '@angular/material/toolbar';
-import { MatButton } from '@angular/material/button';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatSelect } from '@angular/material/select';
 import { NgClass, DatePipe } from '@angular/common';
 import { MatOption } from '@angular/material/autocomplete';
 import { RouterLink } from '@angular/router';
 import { ChallengesService } from '../shared/challenges/challenges.service';
+import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 
 @Component({
   templateUrl: './notifications.component.html',
@@ -25,6 +28,9 @@ import { ChallengesService } from '../shared/challenges/challenges.service';
   imports: [
     MatToolbar,
     MatButton,
+    MatIconButton,
+    MatIcon,
+    MatTooltip,
     MatFormField,
     MatLabel,
     MatSelect,
@@ -54,6 +60,8 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
   ];
   filter = { 'status': '' };
   anyUnread = true;
+  anyRead = false;
+  deleteDialog: MatDialogRef<DialogsPromptComponent> | null = null;
 
   constructor(
     private dialog: MatDialog,
@@ -76,6 +84,11 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
     this.notifications.paginator = this.paginator;
   }
 
+  updateNotificationStates() {
+    this.anyUnread = this.notifications.data.some(notification => notification.status === 'unread');
+    this.anyRead = this.notifications.data.some(notification => notification.status === 'read');
+  }
+
   getNotifications() {
     const userFilter = [ {
       'user': 'org.couchdb.user:' + this.userService.get().name
@@ -92,7 +105,7 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
       [ { 'time': 'desc' } ]))
       .subscribe(notifications => {
         this.notifications.data = notifications;
-        this.anyUnread = this.notifications.data.some(notification => notification.status === 'unread');
+        this.updateNotificationStates();
       }, (err) => console.log(err.error.reason));
   }
 
@@ -107,17 +120,59 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
       this.couchService.put('notifications/' + notification._id, updateNotificaton).subscribe((data) => {
         this.notifications.data = this.notifications.data.map((n: any) => {
           if (n._id === data.id) {
-            return Object.assign(updateNotificaton, { _rev: data.rev });
+            return { ...updateNotificaton, _rev: data.rev };
           }
           return n;
         });
         this.userService.setNotificationStateChange();
+        this.updateNotificationStates();
       }, (err) => console.log(err));
     }
   }
 
   readAllNotification() {
     this.notificationsService.setNotificationsAsRead(this.notifications.data);
+  }
+
+  openDeleteNotificationDialog(notification: any) {
+    const plainMessage = notification.message ? notification.message.replace(/<[^>]*>/g, '').trim() : '';
+    this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: this.notificationsService.deleteNotification(notification),
+          onNext: () => {
+            this.notifications.data = this.notifications.data.filter((n: any) => n._id !== notification._id);
+            this.deleteDialog?.close();
+            this.updateNotificationStates();
+          },
+          onError: () => {}
+        },
+        changeType: 'delete',
+        type: 'notification',
+        displayName: plainMessage
+      }
+    });
+  }
+
+  openClearReadDialog() {
+    const readCount = this.notifications.data.filter((n: any) => n.status === 'read').length;
+    this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
+      data: {
+        okClick: {
+          request: this.notificationsService.clearReadNotifications(this.notifications.data),
+          onNext: () => {
+            this.notifications.data = this.notifications.data.filter((n: any) => n.status !== 'read');
+            this.deleteDialog?.close();
+            this.updateNotificationStates();
+          },
+          onError: () => {}
+        },
+        changeType: 'delete',
+        type: 'notification',
+        amount: 'many',
+        count: readCount
+      }
+    });
   }
 
   openAnnouncementDialog(notification?: any) {

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -135,7 +135,8 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
   }
 
   openDeleteNotificationDialog(notification: any) {
-    const plainMessage = notification.message ? notification.message.replace(/<[^>]*>/g, '').trim() : '';
+    const doc = new DOMParser().parseFromString(notification.message || '', 'text/html');
+    const plainMessage = (doc.body.textContent || '').trim();
     this.deleteDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
         okClick: {

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -3,8 +3,8 @@ import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { findDocuments } from '../shared/mangoQueries';
-import { switchMap } from 'rxjs/operators';
-import { of, Observable } from 'rxjs';
+import { switchMap, tap, catchError } from 'rxjs/operators';
+import { of, Observable, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -18,17 +18,49 @@ export class NotificationsService {
   ) {}
 
   setNotificationsAsRead(notifications: any) {
-    const unreadArray = notifications.filter(notification => notification.status === 'unread')
+    const unreadArray = (notifications || []).filter(notification => notification.status === 'unread')
       .map(notification => ({ ...notification, status: 'read' }));
-    this.couchService.bulkDocs('notifications', unreadArray).subscribe(() => {
+    return this.couchService.bulkDocs('notifications', unreadArray).subscribe(() => {
       this.userService.setNotificationStateChange();
-    }, (err) => this.planetMessageService.showAlert($localize`There was a problem marking all as read`));
+    }, () => this.planetMessageService.showAlert($localize`There was a problem marking all as read`));
+  }
+
+  deleteNotification(notification: any): Observable<any> {
+    return this.couchService.delete('notifications/' + notification._id + '?rev=' + notification._rev).pipe(
+      tap(() => {
+        this.userService.setNotificationStateChange();
+        this.planetMessageService.showMessage($localize`Notification deleted successfully`);
+      }),
+      catchError((err) => {
+        this.planetMessageService.showAlert($localize`There was a problem deleting the notification`);
+        return throwError(err);
+      })
+    );
+  }
+
+  clearReadNotifications(notifications: any[]): Observable<any> {
+    const readArray = (notifications || [])
+      .filter(notification => notification.status === 'read')
+      .map(notification => ({ ...notification, _deleted: true }));
+    if (readArray.length === 0) {
+      return of([]);
+    }
+    return this.couchService.bulkDocs('notifications', readArray).pipe(
+      tap(() => {
+        this.userService.setNotificationStateChange();
+        this.planetMessageService.showMessage($localize`Read notifications deleted successfully`);
+      }),
+      catchError((err) => {
+        this.planetMessageService.showAlert($localize`There was a problem deleting read notifications`);
+        return throwError(err);
+      })
+    );
   }
 
   sendNotificationToUser(notifications: any): Observable<any> {
     return this.couchService.findAll(
       'notifications',
-      findDocuments({ link: notifications.link, type: notifications.type , status: notifications.status, user: notifications.user })
+      findDocuments({ link: notifications.link, type: notifications.type, status: notifications.status, user: notifications.user })
     ).pipe(
       switchMap((res: any[]) => res.length === 0 ? this.couchService.updateDocument('notifications', notifications) : of({}))
     );

--- a/src/app/shared/dialogs/dialogs-prompt.component.html
+++ b/src/app/shared/dialogs/dialogs-prompt.component.html
@@ -27,7 +27,8 @@
         report {report}
         changes {form}
         pin {pin}
-        survey {survey}}?
+        survey {survey}
+        notification {notification}}?
       }
       many
       {selected {{data.count}} {data.type, select,
@@ -37,7 +38,8 @@
         resource {resources}
         meetup {meetups}
         event {events}
-        survey {surveys}}?
+        survey {surveys}
+        notification {notifications}}?
       }
     }
   </p>


### PR DESCRIPTION
Fixes #10303

### Summary
Adds the ability to delete individual notifications and bulk-delete read notifications with confirmation dialogs, clean CouchDB purging, and live state synchronization across the navigation bar.

### Changes & Justifications

1. **Delete Read Toolbar Button (`src/app/notifications/notifications.component.html`)**:
   - Added a red raised `Delete Read` button (`mat-raised-button`, `color="warn"`) with embedded `delete_forever` icon in the top toolbar.
   - Disabled when no read notifications exist (`[disabled]="!anyRead"`).
   - Prompts a confirmation dialog showing the count of notifications to delete.

2. **Row-level Delete Action (`src/app/notifications/notifications.component.html`)**:
   - Added a standard delete icon button (`<mat-icon>delete_outline</mat-icon>`) to each notification row.
   - Includes accessible `matTooltip="Delete"` (`i18n-matTooltip`) and `aria-label="Delete"` (`i18n-aria-label`).
   - Prompts a confirmation modal with HTML formatting tags stripped for clean readability.

3. **CouchDB Purge & Service Layer (`src/app/notifications/notifications.service.ts`)**:
   - Added `deleteNotification(notification)` to remove individual notification documents via `CouchService.delete()`.
   - Added `clearReadNotifications(notifications)` to bulk-delete read notifications via `CouchService.bulkDocs()` with `{ _deleted: true }`.
   - Emits `UserService.setNotificationStateChange()` so the top navigation notification badge automatically stays synchronized.

4. **Shared Confirmation Dialog (`src/app/shared/dialogs/dialogs-prompt.component.html`)**:
   - Added `notification {notification}` (single) and `notification {notifications}` (many) to ICU select expressions.

### Verification
- `npm run lint` — All files pass linting (0 errors).
- `npm run i18n:check` — Passed cleanly (2,700 messages extracted).
- `npx vitest run` — All 28 active test files / 130 tests pass.

<img width="543" height="88" alt="{DEAEE2EC-04B3-4B4E-ABE9-2175EBBCB0E7}" src="https://github.com/user-attachments/assets/1f94430c-0268-4975-b281-77597a3e855f" />

<img width="564" height="186" alt="{AB6A2B02-779C-439B-A50A-8C6A16F08F52}" src="https://github.com/user-attachments/assets/71c6df3c-fa0c-46a2-ba13-4f0e56d94b64" />

<img width="2422" height="855" alt="image" src="https://github.com/user-attachments/assets/c0499279-032c-4d0c-a8ff-7dd2edcca00c" />

<img width="1187" height="368" alt="{D54A2333-36A6-4AF0-AA27-8B10364E39CB}" src="https://github.com/user-attachments/assets/a91efd96-417c-492a-ae55-56aff67bd337" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to delete individual notifications.
  * Added an option to clear all read notifications.
  * Added confirmation prompts with correct singular and plural wording.

* **Bug Fixes**
  * Improved notification state updates after loading, reading, or deleting notifications.
  * Updated the empty-state message for multiple notifications.
  * Added handling for empty notification lists and deletion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->