### PR TITLE
teams: smoother join requests alerting (fixes #10307)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.23",
+  "version": "0.24.24",
   "myplanet": {
     "latest": "v0.65.91",
     "min": "v0.64.64"

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -45,7 +45,7 @@
                   <img [src]="coverImageUrl(item)" alt="Course cover" i18n-alt>
                 </div>
               }
-              <p [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false" matBadgePosition="before">
+              <p [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false" matBadgePosition="before" [matBadgeDescription]="badgeDescription(item)">
                 {{item.firstLine}}
               </p>
               <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': dashboardTextLines(item),'word-wrap': 'break-word' }">

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -238,6 +238,10 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
     }, 300);
   }
 
+  badgeDescription(item: any): string {
+    return $localize`Pending: ${item.badge}:count:`;
+  }
+
   getRemoveTooltip(cardTitle: string): string {
     return $localize`Remove from ${cardTitle}`;
   }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -73,8 +73,8 @@
     @if (isLoggedIn) {
       <ng-container *planetAuthorizedRoles="'learner'">
         @if (notifications.length > 0) {
-          <button mat-icon-button [matMenuTriggerFor]="notificationMenu" i18n-title title="Notifications">
-            <mat-icon matBadge={{notifications.length}} matBadgeColor="warn" MatBadgeSize="small">notifications</mat-icon>
+          <button mat-icon-button [matMenuTriggerFor]="notificationMenu" [attr.aria-label]="notificationsLabel" i18n-title title="Notifications">
+            <mat-icon [matBadge]="notifications.length" matBadgeColor="warn" matBadgeSize="small">notifications</mat-icon>
           </button>
         } @else {
           <button mat-icon-button routerLink="/notifications" i18n-title title="No Notification"><mat-icon>notifications_none</mat-icon></button>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -87,6 +87,10 @@ export class HomeComponent implements OnInit, DoCheck, AfterViewChecked, OnDestr
   configuration = this.stateService.configuration;
   planetType = this.stateService.configuration.planetType;
 
+  get notificationsLabel(): string {
+    return $localize`Notifications: ${this.notifications.length}:count:`;
+  }
+
   constructor(
     private dialog: MatDialog,
     private couchService: CouchService,

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -137,7 +137,9 @@
     </mat-tab>
     <mat-tab>
       <ng-template mat-tab-label>
-        <ng-container i18n>{ mode, select, team {Members} enterprise {Team} services {Members} }</ng-container> ({{members.length + requests.length}})
+        <span [matBadge]="requests.length" [matBadgeHidden]="requests.length === 0 || userStatus !== 'member'" matBadgeColor="accent" matBadgeOverlap="false">
+          <ng-container i18n>{ mode, select, team {Members} enterprise {Team} services {Members} }</ng-container> ({{members.length}})
+        </span>
       </ng-template>
       @if (!teamDataLoading && requests.length > 0) {
         <div class="join-requests-section" style="margin-top: 32px;">

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -137,7 +137,7 @@
     </mat-tab>
     <mat-tab>
       <ng-template mat-tab-label>
-        <span [matBadge]="requests.length" [matBadgeHidden]="requests.length === 0 || userStatus !== 'member'" matBadgeColor="accent" matBadgeOverlap="false">
+        <span [matBadge]="requests.length" [matBadgeHidden]="requests.length === 0 || userStatus !== 'member'" matBadgeColor="accent" matBadgeOverlap="false" [matBadgeDescription]="requestBadgeDescription">
           <ng-container i18n>{ mode, select, team {Members} enterprise {Team} services {Members} }</ng-container> ({{members.length}})
         </span>
       </ng-template>
@@ -203,7 +203,7 @@
     @if (team?.public === true || userStatus === 'member') {
       <mat-tab #taskTab>
         <ng-template mat-tab-label>
-          <ng-container><span [matBadge]="taskCount" [matBadgeHidden]="taskCount === 0" matBadgeOverlap="false" i18n>Tasks</span></ng-container>
+          <ng-container><span [matBadge]="taskCount" [matBadgeHidden]="taskCount === 0" matBadgeOverlap="false" [matBadgeDescription]="taskBadgeDescription" i18n>Tasks</span></ng-container>
         </ng-template>
         @if (taskCount === 0) {
           <p i18n>There are currently no tasks assigned to this { mode, select, team {team} enterprise {enterprise} }.</p>

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -138,6 +138,14 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
 
+  get requestBadgeDescription(): string {
+    return $localize`Pending join requests: ${this.requests.length}:count:`;
+  }
+
+  get taskBadgeDescription(): string {
+    return $localize`Incomplete tasks: ${this.taskCount}:count:`;
+  }
+
   constructor(
     private couchService: CouchService,
     private userService: UserService,


### PR DESCRIPTION
Fixes #10307 

- Adds a badge displaying the number of member join requests for better team manager UX
- Existing counter now excludes applicants

<img width="1054" height="973" alt="image" src="https://github.com/user-attachments/assets/4ffe70cd-9de6-4c87-ba52-ce8816ac8d33" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added pending-request badges to the Members tab when requests await review.
  * Updated member counts to include confirmed members only.
  * Added accessible descriptions for pending requests, incomplete tasks, dashboard badges, and notifications.
  * Improved notification badge behavior and labeling in the toolbar.
  * The pending-request badge remains hidden when there are no requests or the viewer is not a member.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->