### PR TITLE
fix: correct typo Blood Pressur -> Blood Pressure in health-event

### DIFF
--- a/src/app/health/health-event.component.html
+++ b/src/app/health/health-event.component.html
@@ -19,7 +19,7 @@
           <mat-error><planet-form-error-messages [control]="healthForm.controls.pulse"></planet-form-error-messages></mat-error>
         </mat-form-field>
         <mat-form-field>
-          <mat-label i18n>Blood Pressur</mat-label>
+          <mat-label i18n>Blood Pressure</mat-label>
           <input matInput formControlName="bp">
           <mat-error><planet-form-error-messages [control]="healthForm.controls.bp"></planet-form-error-messages></mat-error>
         </mat-form-field>


### PR DESCRIPTION
Fixes #10305

Corrects "Blood Pressur" (missing e) to "Blood Pressure" in the health-event component HTML template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Blood Pressure form label spelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->