### PR TITLE
resources: add file-type indicator icons to resource titles (fixes #10313)

### DIFF
--- a/src/app/courses/add-courses/courses-step.component.html
+++ b/src/app/courses/add-courses/courses-step.component.html
@@ -44,6 +44,7 @@
       <mat-chip-set class="tags-list" aria-label="Attached resources" i18n-aria-label>
         @for (resource of activeStep.resources; track resource; let i = $index) {
           <mat-chip>
+            <planet-resource-icon [resource]="resource"></planet-resource-icon>
             <a matChipAction type="button" target="_blank" [routerLink]="['/resources/view', resource._id]">{{resource.title}}</a>
             <button matChipRemove type="button" aria-label="Remove resource" i18n-aria-label (click)="removeResource(i)">
               <mat-icon>clear</mat-icon>

--- a/src/app/courses/add-courses/courses-step.component.ts
+++ b/src/app/courses/add-courses/courses-step.component.ts
@@ -23,6 +23,7 @@ import { FormErrorMessagesComponent } from '../../shared/forms/form-error-messag
 import { MatChipSet, MatChip, MatChipRemove } from '@angular/material/chips';
 import { MatIcon } from '@angular/material/icon';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
+import { PlanetResourceIconComponent } from '../../resources/resources-icon.component';
 
 interface CoursesStepForm {
   id: FormControl<string>;
@@ -40,7 +41,7 @@ interface CoursesStepForm {
     CoursesIconComponent, PlanetStepListNumberDirective, PlanetStepListFormDirective,
     ReactiveFormsModule, MatFormField, MatLabel, MatInput, PlanetMarkdownTextboxComponent,
     MatError, FormErrorMessagesComponent, MatChipSet, MatChip, RouterLink, MatChipRemove, MatIcon,
-    PlanetStepListActionsDirective, TruncateTextPipe
+    PlanetStepListActionsDirective, TruncateTextPipe, PlanetResourceIconComponent
   ]
 })
 export class CoursesStepComponent implements OnDestroy {

--- a/src/app/courses/step-view-courses/courses-step-view.component.html
+++ b/src/app/courses/step-view-courses/courses-step-view.component.html
@@ -132,7 +132,9 @@
           @if (stepDetail.resources.length > 1) {
             <mat-button-toggle-group class="full-width-toggle-group" [(ngModel)]="resource" (change)="onResourceChange($event.value)">
               @for (resource of stepDetail.resources; track resource; let i = $index) {
-                <mat-button-toggle [value]="resource" class="full-width-toggle" [matTooltip]="resource.title">{{resource.title}}</mat-button-toggle>
+                <mat-button-toggle [value]="resource" class="full-width-toggle" [matTooltip]="resource.title">
+                  <planet-resource-icon [resource]="resource"></planet-resource-icon>{{resource.title}}
+                </mat-button-toggle>
               }
             </mat-button-toggle-group>
           }
@@ -156,7 +158,9 @@
           @if (stepDetail.resources.length > 1) {
             <mat-button-toggle-group class="full-width-toggle-group" [(ngModel)]="resource" (change)="onResourceChange($event.value)">
               @for (resource of stepDetail.resources; track resource; let i = $index) {
-                <mat-button-toggle [value]="resource" class="full-width-toggle" [matTooltip]="resource.title">{{resource.title}}</mat-button-toggle>
+                <mat-button-toggle [value]="resource" class="full-width-toggle" [matTooltip]="resource.title">
+                  <planet-resource-icon [resource]="resource"></planet-resource-icon>{{resource.title}}
+                </mat-button-toggle>
               }
             </mat-button-toggle-group>
           }

--- a/src/app/courses/step-view-courses/courses-step-view.component.ts
+++ b/src/app/courses/step-view-courses/courses-step-view.component.ts
@@ -25,6 +25,7 @@ import { FormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ResourcesViewerComponent } from '../../resources/view-resources/resources-viewer.component';
 import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
+import { PlanetResourceIconComponent } from '../../resources/resources-icon.component';
 
 @Component({
   templateUrl: './courses-step-view.component.html',
@@ -49,7 +50,8 @@ import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinn
     MatButtonToggle,
     MatTooltip,
     ResourcesViewerComponent,
-    PlanetLoadingSpinnerComponent
+    PlanetLoadingSpinnerComponent,
+    PlanetResourceIconComponent
   ]
 })
 

--- a/src/app/resources/resources-icon.component.spec.ts
+++ b/src/app/resources/resources-icon.component.spec.ts
@@ -4,220 +4,31 @@ import { PlanetResourceIconComponent, resolveResourceIconInfo } from './resource
 
 describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
   describe('resolveResourceIconInfo', () => {
-    it('should return empty info for null or undefined resource', () => {
-      expect(resolveResourceIconInfo(null)).toEqual({ icon: '', tooltip: '', category: 'none' });
-      expect(resolveResourceIconInfo(undefined)).toEqual({ icon: '', tooltip: '', category: 'none' });
-    });
-
-    it('should return empty info for resources without an attached file', () => {
-      // Resource document without _attachments, filename, or file
-      const noFileResource = {
-        title: 'Community Policy Document',
-        description: 'Just a text description with no attached file',
-        author: 'Admin',
-        _attachments: {}
-      };
-      expect(resolveResourceIconInfo(noFileResource)).toEqual({ icon: '', tooltip: '', category: 'none' });
-
-      const emptyDocWrapper = {
-        _id: 'sample-id',
-        doc: {
-          title: 'Empty Resource',
-          description: 'No files attached'
-        }
-      };
-      expect(resolveResourceIconInfo(emptyDocWrapper)).toEqual({ icon: '', tooltip: '', category: 'none' });
-    });
-
-    it('should resolve PDF resources', () => {
-      const byExtension = resolveResourceIconInfo({ filename: 'handbook.pdf' });
-      expect(byExtension.icon).toBe('picture_as_pdf');
-      expect(byExtension.category).toBe('pdf');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'file.pdf': { content_type: 'application/pdf' } }
-      });
-      expect(byMime.icon).toBe('picture_as_pdf');
-
-      const byMediaType = resolveResourceIconInfo({ filename: 'doc.pdf', mediaType: 'pdf' });
-      expect(byMediaType.icon).toBe('picture_as_pdf');
-
-      const byOpenWith = resolveResourceIconInfo({ filename: 'doc.pdf', openWith: 'PDF.js' });
-      expect(byOpenWith.icon).toBe('picture_as_pdf');
-    });
-
-    it('should resolve resources with uppercase or mixed-case attachment keys', () => {
-      const upperPdf = resolveResourceIconInfo({
-        filename: 'HANDBOOK.PDF',
-        _attachments: { 'HANDBOOK.PDF': { content_type: 'application/pdf' } }
-      });
-      expect(upperPdf.icon).toBe('picture_as_pdf');
-      expect(upperPdf.category).toBe('pdf');
-
-      const upperCsv = resolveResourceIconInfo({
-        filename: 'DATA_TABLE.CSV',
-        _attachments: { 'DATA_TABLE.CSV': { content_type: 'text/csv' } }
-      });
-      expect(upperCsv.icon).toBe('grid_on');
-      expect(upperCsv.category).toBe('spreadsheet');
-    });
-
-    it('should resolve resources with extensionless attachment keys via MIME type', () => {
-      const mimeOnlyPdf = resolveResourceIconInfo({
-        _attachments: { 'DOCUMENT_ATTACHMENT': { content_type: 'application/pdf' } }
-      });
-      expect(mimeOnlyPdf.icon).toBe('picture_as_pdf');
-      expect(mimeOnlyPdf.category).toBe('pdf');
-
-      const mimeOnlyVideo = resolveResourceIconInfo({
-        _attachments: { 'STREAM_MEDIA': { content_type: 'video/mp4' } }
-      });
-      expect(mimeOnlyVideo.icon).toBe('videocam');
-      expect(mimeOnlyVideo.category).toBe('video');
-    });
-
-    it('should resolve Video resources', () => {
-      const byExtension = resolveResourceIconInfo({ filename: 'lesson.mp4' });
-      expect(byExtension.icon).toBe('videocam');
-      expect(byExtension.category).toBe('video');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'video.webm': { content_type: 'video/webm' } }
-      });
-      expect(byMime.icon).toBe('videocam');
-
-      const byMediaType = resolveResourceIconInfo({ filename: 'clip.mp4', mediaType: 'video' });
-      expect(byMediaType.icon).toBe('videocam');
-    });
-
-    it('should resolve Audio resources', () => {
-      const byExtension = resolveResourceIconInfo({ filename: 'recording.mp3' });
-      expect(byExtension.icon).toBe('audiotrack');
-      expect(byExtension.category).toBe('audio');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'audio.ogg': { content_type: 'audio/ogg' } }
-      });
-      expect(byMime.icon).toBe('audiotrack');
-
-      const byMediaType = resolveResourceIconInfo({ filename: 'track.mp3', mediaType: 'audio' });
-      expect(byMediaType.icon).toBe('audiotrack');
-    });
-
-    it('should resolve Spreadsheet and CSV resources using grid_on icon', () => {
-      const byCsvExt = resolveResourceIconInfo({ filename: 'scores.csv' });
-      expect(byCsvExt.icon).toBe('grid_on');
-      expect(byCsvExt.category).toBe('spreadsheet');
-
-      const byXlsxExt = resolveResourceIconInfo({ filename: 'budget.xlsx' });
-      expect(byXlsxExt.icon).toBe('grid_on');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'data.csv': { content_type: 'text/csv' } }
-      });
-      expect(byMime.icon).toBe('grid_on');
-
-      const byMediaType = resolveResourceIconInfo({ filename: 'data.csv', mediaType: 'csv' });
-      expect(byMediaType.icon).toBe('grid_on');
-    });
-
-    it('should resolve Image resources', () => {
-      const byExtension = resolveResourceIconInfo({ filename: 'diagram.png' });
-      expect(byExtension.icon).toBe('image');
-      expect(byExtension.category).toBe('image');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'photo.jpg': { content_type: 'image/jpeg' } }
-      });
-      expect(byMime.icon).toBe('image');
-
-      const byMediaType = resolveResourceIconInfo({ filename: 'picture.png', mediaType: 'Graphic/Pictures' });
-      expect(byMediaType.icon).toBe('image');
-    });
-
-    it('should resolve Interactive Web and Multi-attachment HTML resources', () => {
-      const byMultiAttachments = resolveResourceIconInfo({
-        _attachments: {
-          'index.html': { content_type: 'text/html' },
-          'style.css': { content_type: 'text/css' }
-        }
-      });
-      expect(byMultiAttachments.icon).toBe('language');
-      expect(byMultiAttachments.category).toBe('html');
-
-      const byHtmlExt = resolveResourceIconInfo({ filename: 'index.html' });
-      expect(byHtmlExt.icon).toBe('language');
-
-      const byMediaType = resolveResourceIconInfo({ filename: 'module.zip', mediaType: 'HTML' });
-      expect(byMediaType.icon).toBe('language');
-    });
-
-    it('should resolve Word documents', () => {
-      const byDocx = resolveResourceIconInfo({ filename: 'essay.docx' });
-      expect(byDocx.icon).toBe('description');
-      expect(byDocx.category).toBe('word');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'doc.docx': { content_type: 'application/msword' } }
-      });
-      expect(byMime.icon).toBe('description');
-    });
-
-    it('should resolve Presentation slide decks', () => {
-      const byPptx = resolveResourceIconInfo({ filename: 'lecture.pptx' });
-      expect(byPptx.icon).toBe('slideshow');
-      expect(byPptx.category).toBe('presentation');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'slides.pptx': { content_type: 'application/vnd.ms-powerpoint' } }
-      });
-      expect(byMime.icon).toBe('slideshow');
-    });
-
-    it('should resolve Text and Markdown files', () => {
-      const byMd = resolveResourceIconInfo({ filename: 'notes.md' });
-      expect(byMd.icon).toBe('description');
-      expect(byMd.category).toBe('text');
-
-      const byMime = resolveResourceIconInfo({
-        _attachments: { 'notes.txt': { content_type: 'text/plain' } }
-      });
-      expect(byMime.icon).toBe('description');
-    });
-
-    it('should resolve Compressed Archive files using archive icon', () => {
-      const byZip = resolveResourceIconInfo({
-        filename: 'archive.zip',
-        _attachments: { 'archive.zip': { content_type: 'application/zip' } }
-      });
-      expect(byZip.icon).toBe('archive');
-      expect(byZip.category).toBe('archive');
-
-      const byTar = resolveResourceIconInfo({ filename: 'bundle.tar.gz' });
-      expect(byTar.icon).toBe('archive');
-    });
-
-    it('should fallback to insert_drive_file for generic unrecognized files with attachment', () => {
-      const generic = resolveResourceIconInfo({
-        filename: 'custom.xyz',
-        title: 'Custom File',
-        _attachments: { 'custom.xyz': { content_type: 'application/octet-stream' } }
-      });
-      expect(generic.icon).toBe('insert_drive_file');
-      expect(generic.category).toBe('file');
-    });
-
-    it('should unwrap enriched resource wrapper objects ({ doc: ... })', () => {
-      const wrapped = resolveResourceIconInfo({
-        _id: '123',
-        doc: {
-          title: 'Wrapped Resource',
-          filename: 'guide.pdf',
-          _attachments: { 'guide.pdf': { content_type: 'application/pdf' } }
-        }
-      });
-      expect(wrapped.icon).toBe('picture_as_pdf');
-      expect(wrapped.category).toBe('pdf');
+    it.each([
+      { desc: 'null resource', input: null, icon: '', cat: 'none' },
+      { desc: 'undefined resource', input: undefined, icon: '', cat: 'none' },
+      { desc: 'resource without files', input: { title: 'Policy', _attachments: {} }, icon: '', cat: 'none' },
+      { desc: 'PDF by extension', input: { filename: 'handbook.pdf' }, icon: 'picture_as_pdf', cat: 'pdf' },
+      { desc: 'PDF by MIME', input: { _attachments: { 'doc.pdf': { content_type: 'application/pdf' } } }, icon: 'picture_as_pdf', cat: 'pdf' },
+      { desc: 'PDF uppercase key', input: { filename: 'DOC.PDF', _attachments: { 'DOC.PDF': { content_type: 'application/pdf' } } }, icon: 'picture_as_pdf', cat: 'pdf' },
+      { desc: 'PDF extensionless MIME', input: { _attachments: { 'DOC_ATTACH': { content_type: 'application/pdf' } } }, icon: 'picture_as_pdf', cat: 'pdf' },
+      { desc: 'Video MP4', input: { filename: 'lesson.mp4' }, icon: 'videocam', cat: 'video' },
+      { desc: 'Audio MP3', input: { filename: 'recording.mp3' }, icon: 'audiotrack', cat: 'audio' },
+      { desc: 'CSV spreadsheet', input: { filename: 'scores.csv' }, icon: 'grid_on', cat: 'spreadsheet' },
+      { desc: 'XLSX spreadsheet', input: { filename: 'budget.xlsx' }, icon: 'grid_on', cat: 'spreadsheet' },
+      { desc: 'Image PNG', input: { filename: 'diagram.png' }, icon: 'image', cat: 'image' },
+      { desc: 'Multi-attachment HTML', input: { _attachments: { 'index.html': { content_type: 'text/html' }, 'style.css': {} } }, icon: 'language', cat: 'html' },
+      { desc: 'Word DOCX', input: { filename: 'essay.docx' }, icon: 'description', cat: 'word' },
+      { desc: 'Presentation PPTX', input: { filename: 'lecture.pptx' }, icon: 'slideshow', cat: 'presentation' },
+      { desc: 'Markdown text', input: { filename: 'notes.md' }, icon: 'description', cat: 'text' },
+      { desc: 'Archive ZIP', input: { filename: 'archive.zip' }, icon: 'archive', cat: 'archive' },
+      { desc: 'Archive tar.gz', input: { filename: 'bundle.tar.gz' }, icon: 'archive', cat: 'archive' },
+      { desc: 'Generic file fallback', input: { filename: 'custom.xyz', _attachments: { 'custom.xyz': {} } }, icon: 'insert_drive_file', cat: 'file' },
+      { desc: 'Unwrapped doc object', input: { doc: { filename: 'guide.pdf' } }, icon: 'picture_as_pdf', cat: 'pdf' }
+    ])('resolves $desc to $icon', ({ input, icon, cat }) => {
+      const result = resolveResourceIconInfo(input);
+      expect(result.icon).toBe(icon);
+      expect(result.category).toBe(cat);
     });
   });
 
@@ -238,9 +49,9 @@ describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
       expect(component).toBeTruthy();
     });
 
-    it('should render the icon when resource has an attached file', () => {
+    it('should render icon with aria-label and role="img" when resource has file', () => {
       component.resource = {
-        title: 'Reading',
+        title: 'Reading Guide',
         filename: 'reading.pdf',
         _attachments: { 'reading.pdf': { content_type: 'application/pdf' } }
       };
@@ -250,79 +61,38 @@ describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
       const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
       expect(iconEl).toBeTruthy();
       expect(iconEl.nativeElement.textContent.trim()).toBe('picture_as_pdf');
-    });
-
-    it('should render mat-icon with accessible aria-label and role="img"', () => {
-      component.resource = {
-        title: 'Biology Textbook',
-        filename: 'biology.pdf',
-        _attachments: { 'biology.pdf': { content_type: 'application/pdf' } }
-      };
-      component.ngOnChanges();
-      fixture.detectChanges();
-
-      const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
       expect(iconEl.attributes['aria-label']).toBe('PDF Document');
       expect(iconEl.attributes['role']).toBe('img');
     });
 
-    it('should not render icon when resource is null, empty, or without attached file', () => {
-      component.resource = null;
+    it('should not render icon when resource has no file', () => {
+      component.resource = { title: 'No file resource', _attachments: {} };
       component.ngOnChanges();
       fixture.detectChanges();
 
-      let iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
-      expect(iconEl).toBeNull();
-
-      // Resource without an attached file
-      component.resource = {
-        title: 'No file resource',
-        description: 'Test without attachment',
-        _attachments: {}
-      };
-      component.ngOnChanges();
-      fixture.detectChanges();
-
-      iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
-      expect(iconEl).toBeNull();
+      expect(fixture.debugElement.query(By.css('.km-resource-icon'))).toBeNull();
     });
 
     it('should reactively update the icon when the associated file is replaced', () => {
-      // Step 1: Initial PDF file
-      component.resource = {
-        title: 'Course Guide',
-        filename: 'guide.pdf',
-        _attachments: { 'guide.pdf': { content_type: 'application/pdf' } }
-      };
-      component.ngOnChanges();
-      fixture.detectChanges();
+      // PDF -> Video -> Spreadsheet
+      const files = [
+        { filename: 'guide.pdf', contentType: 'application/pdf', expectedIcon: 'picture_as_pdf' },
+        { filename: 'guide.mp4', contentType: 'video/mp4', expectedIcon: 'videocam' },
+        { filename: 'data.csv', contentType: 'text/csv', expectedIcon: 'grid_on' }
+      ];
 
-      let iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
-      expect(iconEl.nativeElement.textContent.trim()).toBe('picture_as_pdf');
+      for (const file of files) {
+        component.resource = {
+          title: 'Course Item',
+          filename: file.filename,
+          _attachments: { [file.filename]: { content_type: file.contentType } }
+        };
+        component.ngOnChanges();
+        fixture.detectChanges();
 
-      // Step 2: User replaces the file with an MP4 video
-      component.resource = {
-        title: 'Course Guide',
-        filename: 'guide.mp4',
-        _attachments: { 'guide.mp4': { content_type: 'video/mp4' } }
-      };
-      component.ngOnChanges();
-      fixture.detectChanges();
-
-      iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
-      expect(iconEl.nativeElement.textContent.trim()).toBe('videocam');
-
-      // Step 3: User replaces the file with a CSV dataset
-      component.resource = {
-        title: 'Course Guide',
-        filename: 'data.csv',
-        _attachments: { 'data.csv': { content_type: 'text/csv' } }
-      };
-      component.ngOnChanges();
-      fixture.detectChanges();
-
-      iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
-      expect(iconEl.nativeElement.textContent.trim()).toBe('grid_on');
+        const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+        expect(iconEl.nativeElement.textContent.trim()).toBe(file.expectedIcon);
+      }
     });
   });
 });

--- a/src/app/resources/resources-icon.component.spec.ts
+++ b/src/app/resources/resources-icon.component.spec.ts
@@ -46,6 +46,36 @@ describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
       expect(byOpenWith.icon).toBe('picture_as_pdf');
     });
 
+    it('should resolve resources with uppercase or mixed-case attachment keys', () => {
+      const upperPdf = resolveResourceIconInfo({
+        filename: 'HANDBOOK.PDF',
+        _attachments: { 'HANDBOOK.PDF': { content_type: 'application/pdf' } }
+      });
+      expect(upperPdf.icon).toBe('picture_as_pdf');
+      expect(upperPdf.category).toBe('pdf');
+
+      const upperCsv = resolveResourceIconInfo({
+        filename: 'DATA_TABLE.CSV',
+        _attachments: { 'DATA_TABLE.CSV': { content_type: 'text/csv' } }
+      });
+      expect(upperCsv.icon).toBe('grid_on');
+      expect(upperCsv.category).toBe('spreadsheet');
+    });
+
+    it('should resolve resources with extensionless attachment keys via MIME type', () => {
+      const mimeOnlyPdf = resolveResourceIconInfo({
+        _attachments: { 'DOCUMENT_ATTACHMENT': { content_type: 'application/pdf' } }
+      });
+      expect(mimeOnlyPdf.icon).toBe('picture_as_pdf');
+      expect(mimeOnlyPdf.category).toBe('pdf');
+
+      const mimeOnlyVideo = resolveResourceIconInfo({
+        _attachments: { 'STREAM_MEDIA': { content_type: 'video/mp4' } }
+      });
+      expect(mimeOnlyVideo.icon).toBe('videocam');
+      expect(mimeOnlyVideo.category).toBe('video');
+    });
+
     it('should resolve Video resources', () => {
       const byExtension = resolveResourceIconInfo({ filename: 'lesson.mp4' });
       expect(byExtension.icon).toBe('videocam');
@@ -220,6 +250,20 @@ describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
       const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
       expect(iconEl).toBeTruthy();
       expect(iconEl.nativeElement.textContent.trim()).toBe('picture_as_pdf');
+    });
+
+    it('should render mat-icon with accessible aria-label and role="img"', () => {
+      component.resource = {
+        title: 'Biology Textbook',
+        filename: 'biology.pdf',
+        _attachments: { 'biology.pdf': { content_type: 'application/pdf' } }
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl.attributes['aria-label']).toBe('PDF Document');
+      expect(iconEl.attributes['role']).toBe('img');
     });
 
     it('should not render icon when resource is null, empty, or without attached file', () => {

--- a/src/app/resources/resources-icon.component.spec.ts
+++ b/src/app/resources/resources-icon.component.spec.ts
@@ -1,0 +1,284 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { PlanetResourceIconComponent, resolveResourceIconInfo } from './resources-icon.component';
+
+describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
+  describe('resolveResourceIconInfo', () => {
+    it('should return empty info for null or undefined resource', () => {
+      expect(resolveResourceIconInfo(null)).toEqual({ icon: '', tooltip: '', category: 'none' });
+      expect(resolveResourceIconInfo(undefined)).toEqual({ icon: '', tooltip: '', category: 'none' });
+    });
+
+    it('should return empty info for resources without an attached file', () => {
+      // Resource document without _attachments, filename, or file
+      const noFileResource = {
+        title: 'Community Policy Document',
+        description: 'Just a text description with no attached file',
+        author: 'Admin',
+        _attachments: {}
+      };
+      expect(resolveResourceIconInfo(noFileResource)).toEqual({ icon: '', tooltip: '', category: 'none' });
+
+      const emptyDocWrapper = {
+        _id: 'sample-id',
+        doc: {
+          title: 'Empty Resource',
+          description: 'No files attached'
+        }
+      };
+      expect(resolveResourceIconInfo(emptyDocWrapper)).toEqual({ icon: '', tooltip: '', category: 'none' });
+    });
+
+    it('should resolve PDF resources', () => {
+      const byExtension = resolveResourceIconInfo({ filename: 'handbook.pdf' });
+      expect(byExtension.icon).toBe('picture_as_pdf');
+      expect(byExtension.category).toBe('pdf');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'file.pdf': { content_type: 'application/pdf' } }
+      });
+      expect(byMime.icon).toBe('picture_as_pdf');
+
+      const byMediaType = resolveResourceIconInfo({ filename: 'doc.pdf', mediaType: 'pdf' });
+      expect(byMediaType.icon).toBe('picture_as_pdf');
+
+      const byOpenWith = resolveResourceIconInfo({ filename: 'doc.pdf', openWith: 'PDF.js' });
+      expect(byOpenWith.icon).toBe('picture_as_pdf');
+    });
+
+    it('should resolve Video resources', () => {
+      const byExtension = resolveResourceIconInfo({ filename: 'lesson.mp4' });
+      expect(byExtension.icon).toBe('videocam');
+      expect(byExtension.category).toBe('video');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'video.webm': { content_type: 'video/webm' } }
+      });
+      expect(byMime.icon).toBe('videocam');
+
+      const byMediaType = resolveResourceIconInfo({ filename: 'clip.mp4', mediaType: 'video' });
+      expect(byMediaType.icon).toBe('videocam');
+    });
+
+    it('should resolve Audio resources', () => {
+      const byExtension = resolveResourceIconInfo({ filename: 'recording.mp3' });
+      expect(byExtension.icon).toBe('audiotrack');
+      expect(byExtension.category).toBe('audio');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'audio.ogg': { content_type: 'audio/ogg' } }
+      });
+      expect(byMime.icon).toBe('audiotrack');
+
+      const byMediaType = resolveResourceIconInfo({ filename: 'track.mp3', mediaType: 'audio' });
+      expect(byMediaType.icon).toBe('audiotrack');
+    });
+
+    it('should resolve Spreadsheet and CSV resources using grid_on icon', () => {
+      const byCsvExt = resolveResourceIconInfo({ filename: 'scores.csv' });
+      expect(byCsvExt.icon).toBe('grid_on');
+      expect(byCsvExt.category).toBe('spreadsheet');
+
+      const byXlsxExt = resolveResourceIconInfo({ filename: 'budget.xlsx' });
+      expect(byXlsxExt.icon).toBe('grid_on');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'data.csv': { content_type: 'text/csv' } }
+      });
+      expect(byMime.icon).toBe('grid_on');
+
+      const byMediaType = resolveResourceIconInfo({ filename: 'data.csv', mediaType: 'csv' });
+      expect(byMediaType.icon).toBe('grid_on');
+    });
+
+    it('should resolve Image resources', () => {
+      const byExtension = resolveResourceIconInfo({ filename: 'diagram.png' });
+      expect(byExtension.icon).toBe('image');
+      expect(byExtension.category).toBe('image');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'photo.jpg': { content_type: 'image/jpeg' } }
+      });
+      expect(byMime.icon).toBe('image');
+
+      const byMediaType = resolveResourceIconInfo({ filename: 'picture.png', mediaType: 'Graphic/Pictures' });
+      expect(byMediaType.icon).toBe('image');
+    });
+
+    it('should resolve Interactive Web and Multi-attachment HTML resources', () => {
+      const byMultiAttachments = resolveResourceIconInfo({
+        _attachments: {
+          'index.html': { content_type: 'text/html' },
+          'style.css': { content_type: 'text/css' }
+        }
+      });
+      expect(byMultiAttachments.icon).toBe('language');
+      expect(byMultiAttachments.category).toBe('html');
+
+      const byHtmlExt = resolveResourceIconInfo({ filename: 'index.html' });
+      expect(byHtmlExt.icon).toBe('language');
+
+      const byMediaType = resolveResourceIconInfo({ filename: 'module.zip', mediaType: 'HTML' });
+      expect(byMediaType.icon).toBe('language');
+    });
+
+    it('should resolve Word documents', () => {
+      const byDocx = resolveResourceIconInfo({ filename: 'essay.docx' });
+      expect(byDocx.icon).toBe('description');
+      expect(byDocx.category).toBe('word');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'doc.docx': { content_type: 'application/msword' } }
+      });
+      expect(byMime.icon).toBe('description');
+    });
+
+    it('should resolve Presentation slide decks', () => {
+      const byPptx = resolveResourceIconInfo({ filename: 'lecture.pptx' });
+      expect(byPptx.icon).toBe('slideshow');
+      expect(byPptx.category).toBe('presentation');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'slides.pptx': { content_type: 'application/vnd.ms-powerpoint' } }
+      });
+      expect(byMime.icon).toBe('slideshow');
+    });
+
+    it('should resolve Text and Markdown files', () => {
+      const byMd = resolveResourceIconInfo({ filename: 'notes.md' });
+      expect(byMd.icon).toBe('description');
+      expect(byMd.category).toBe('text');
+
+      const byMime = resolveResourceIconInfo({
+        _attachments: { 'notes.txt': { content_type: 'text/plain' } }
+      });
+      expect(byMime.icon).toBe('description');
+    });
+
+    it('should resolve Compressed Archive files using archive icon', () => {
+      const byZip = resolveResourceIconInfo({
+        filename: 'archive.zip',
+        _attachments: { 'archive.zip': { content_type: 'application/zip' } }
+      });
+      expect(byZip.icon).toBe('archive');
+      expect(byZip.category).toBe('archive');
+
+      const byTar = resolveResourceIconInfo({ filename: 'bundle.tar.gz' });
+      expect(byTar.icon).toBe('archive');
+    });
+
+    it('should fallback to insert_drive_file for generic unrecognized files with attachment', () => {
+      const generic = resolveResourceIconInfo({
+        filename: 'custom.xyz',
+        title: 'Custom File',
+        _attachments: { 'custom.xyz': { content_type: 'application/octet-stream' } }
+      });
+      expect(generic.icon).toBe('insert_drive_file');
+      expect(generic.category).toBe('file');
+    });
+
+    it('should unwrap enriched resource wrapper objects ({ doc: ... })', () => {
+      const wrapped = resolveResourceIconInfo({
+        _id: '123',
+        doc: {
+          title: 'Wrapped Resource',
+          filename: 'guide.pdf',
+          _attachments: { 'guide.pdf': { content_type: 'application/pdf' } }
+        }
+      });
+      expect(wrapped.icon).toBe('picture_as_pdf');
+      expect(wrapped.category).toBe('pdf');
+    });
+  });
+
+  describe('PlanetResourceIconComponent', () => {
+    let fixture: ComponentFixture<PlanetResourceIconComponent>;
+    let component: PlanetResourceIconComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [PlanetResourceIconComponent]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(PlanetResourceIconComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should render the icon when resource has an attached file', () => {
+      component.resource = {
+        title: 'Reading',
+        filename: 'reading.pdf',
+        _attachments: { 'reading.pdf': { content_type: 'application/pdf' } }
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl).toBeTruthy();
+      expect(iconEl.nativeElement.textContent.trim()).toBe('picture_as_pdf');
+    });
+
+    it('should not render icon when resource is null, empty, or without attached file', () => {
+      component.resource = null;
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      let iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl).toBeNull();
+
+      // Resource without an attached file
+      component.resource = {
+        title: 'No file resource',
+        description: 'Test without attachment',
+        _attachments: {}
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl).toBeNull();
+    });
+
+    it('should reactively update the icon when the associated file is replaced', () => {
+      // Step 1: Initial PDF file
+      component.resource = {
+        title: 'Course Guide',
+        filename: 'guide.pdf',
+        _attachments: { 'guide.pdf': { content_type: 'application/pdf' } }
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      let iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl.nativeElement.textContent.trim()).toBe('picture_as_pdf');
+
+      // Step 2: User replaces the file with an MP4 video
+      component.resource = {
+        title: 'Course Guide',
+        filename: 'guide.mp4',
+        _attachments: { 'guide.mp4': { content_type: 'video/mp4' } }
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl.nativeElement.textContent.trim()).toBe('videocam');
+
+      // Step 3: User replaces the file with a CSV dataset
+      component.resource = {
+        title: 'Course Guide',
+        filename: 'data.csv',
+        _attachments: { 'data.csv': { content_type: 'text/csv' } }
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl.nativeElement.textContent.trim()).toBe('grid_on');
+    });
+  });
+});

--- a/src/app/resources/resources-icon.component.spec.ts
+++ b/src/app/resources/resources-icon.component.spec.ts
@@ -9,21 +9,46 @@ describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
       { desc: 'undefined resource', input: undefined, icon: '', cat: 'none' },
       { desc: 'resource without files', input: { title: 'Policy', _attachments: {} }, icon: '', cat: 'none' },
       { desc: 'PDF by extension', input: { filename: 'handbook.pdf' }, icon: 'picture_as_pdf', cat: 'pdf' },
-      { desc: 'PDF by MIME', input: { _attachments: { 'doc.pdf': { content_type: 'application/pdf' } } }, icon: 'picture_as_pdf', cat: 'pdf' },
-      { desc: 'PDF uppercase key', input: { filename: 'DOC.PDF', _attachments: { 'DOC.PDF': { content_type: 'application/pdf' } } }, icon: 'picture_as_pdf', cat: 'pdf' },
-      { desc: 'PDF extensionless MIME', input: { _attachments: { 'DOC_ATTACH': { content_type: 'application/pdf' } } }, icon: 'picture_as_pdf', cat: 'pdf' },
+      {
+        desc: 'PDF by MIME',
+        input: { _attachments: { 'doc.pdf': { content_type: 'application/pdf' } } },
+        icon: 'picture_as_pdf',
+        cat: 'pdf'
+      },
+      {
+        desc: 'PDF uppercase key',
+        input: { filename: 'DOC.PDF', _attachments: { 'DOC.PDF': { content_type: 'application/pdf' } } },
+        icon: 'picture_as_pdf',
+        cat: 'pdf'
+      },
+      {
+        desc: 'PDF extensionless MIME',
+        input: { _attachments: { 'DOC_ATTACH': { content_type: 'application/pdf' } } },
+        icon: 'picture_as_pdf',
+        cat: 'pdf'
+      },
       { desc: 'Video MP4', input: { filename: 'lesson.mp4' }, icon: 'videocam', cat: 'video' },
       { desc: 'Audio MP3', input: { filename: 'recording.mp3' }, icon: 'audiotrack', cat: 'audio' },
       { desc: 'CSV spreadsheet', input: { filename: 'scores.csv' }, icon: 'grid_on', cat: 'spreadsheet' },
       { desc: 'XLSX spreadsheet', input: { filename: 'budget.xlsx' }, icon: 'grid_on', cat: 'spreadsheet' },
       { desc: 'Image PNG', input: { filename: 'diagram.png' }, icon: 'image', cat: 'image' },
-      { desc: 'Multi-attachment HTML', input: { _attachments: { 'index.html': { content_type: 'text/html' }, 'style.css': {} } }, icon: 'language', cat: 'html' },
+      {
+        desc: 'Multi-attachment HTML',
+        input: { _attachments: { 'index.html': { content_type: 'text/html' }, 'style.css': {} } },
+        icon: 'language',
+        cat: 'html'
+      },
       { desc: 'Word DOCX', input: { filename: 'essay.docx' }, icon: 'description', cat: 'word' },
       { desc: 'Presentation PPTX', input: { filename: 'lecture.pptx' }, icon: 'slideshow', cat: 'presentation' },
       { desc: 'Markdown text', input: { filename: 'notes.md' }, icon: 'description', cat: 'text' },
       { desc: 'Archive ZIP', input: { filename: 'archive.zip' }, icon: 'archive', cat: 'archive' },
       { desc: 'Archive tar.gz', input: { filename: 'bundle.tar.gz' }, icon: 'archive', cat: 'archive' },
-      { desc: 'Generic file fallback', input: { filename: 'custom.xyz', _attachments: { 'custom.xyz': {} } }, icon: 'insert_drive_file', cat: 'file' },
+      {
+        desc: 'Generic file fallback',
+        input: { filename: 'custom.xyz', _attachments: { 'custom.xyz': {} } },
+        icon: 'insert_drive_file',
+        cat: 'file'
+      },
       { desc: 'Unwrapped doc object', input: { doc: { filename: 'guide.pdf' } }, icon: 'picture_as_pdf', cat: 'pdf' }
     ])('resolves $desc to $icon', ({ input, icon, cat }) => {
       const result = resolveResourceIconInfo(input);

--- a/src/app/resources/resources-icon.component.ts
+++ b/src/app/resources/resources-icon.component.ts
@@ -16,7 +16,10 @@ export function resolveResourceIconInfo(resource: any): ResourceIconInfo {
   const doc = resource.doc || resource;
   const attachments = doc._attachments || {};
   const attachmentKeys = Object.keys(attachments);
-  const rawFilename = doc.filename || (attachmentKeys.length === 1 ? attachmentKeys[0] : (doc.name || ''));
+  const matchedKey = attachmentKeys.find(
+    key => key.toLowerCase() === (typeof doc.filename === 'string' ? doc.filename.toLowerCase().trim() : '')
+  ) || (attachmentKeys.length === 1 ? attachmentKeys[0] : '');
+  const rawFilename = matchedKey || doc.filename || (typeof doc.name === 'string' ? doc.name : '');
   const primaryFilename = (typeof rawFilename === 'string' ? rawFilename : '').toLowerCase().trim();
 
   const hasDirectFile = !!doc.file || (typeof File !== 'undefined' && doc instanceof File);
@@ -28,9 +31,8 @@ export function resolveResourceIconInfo(resource: any): ResourceIconInfo {
     return { icon: '', tooltip: '', category: 'none' };
   }
 
-  const attachmentContentType = primaryFilename && attachments[primaryFilename]?.content_type
-    ? attachments[primaryFilename].content_type.toLowerCase()
-    : '';
+  const attachmentObj = matchedKey ? attachments[matchedKey] : (attachments[primaryFilename] || attachments[rawFilename]);
+  const attachmentContentType = attachmentObj?.content_type ? attachmentObj.content_type.toLowerCase() : '';
   const directContentType = (
     doc.contentType || doc.content_type || (doc.file && doc.file.type) || (typeof doc.type === 'string' ? doc.type : '') || ''
   ).toLowerCase();
@@ -168,7 +170,8 @@ export function resolveResourceIconInfo(resource: any): ResourceIconInfo {
       <mat-icon
         class="km-resource-icon resource-type-icon"
         [matTooltip]="iconInfo.tooltip"
-        aria-hidden="true">
+        [attr.aria-label]="iconInfo.tooltip"
+        role="img">
         {{ iconInfo.icon }}
       </mat-icon>
     }

--- a/src/app/resources/resources-icon.component.ts
+++ b/src/app/resources/resources-icon.component.ts
@@ -1,0 +1,205 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+
+export interface ResourceIconInfo {
+  icon: string;
+  tooltip: string;
+  category: string;
+}
+
+export function resolveResourceIconInfo(resource: any): ResourceIconInfo {
+  if (!resource) {
+    return { icon: '', tooltip: '', category: 'none' };
+  }
+
+  const doc = resource.doc || resource;
+  const attachments = doc._attachments || {};
+  const attachmentKeys = Object.keys(attachments);
+  const rawFilename = doc.filename || (attachmentKeys.length === 1 ? attachmentKeys[0] : (doc.name || ''));
+  const primaryFilename = (typeof rawFilename === 'string' ? rawFilename : '').toLowerCase().trim();
+
+  const hasDirectFile = !!doc.file || (typeof File !== 'undefined' && doc instanceof File);
+  const hasAttachments = attachmentKeys.length > 0;
+  const hasFilename = primaryFilename.length > 0 && primaryFilename.includes('.');
+
+  // Resources without an attached file should not have an icon
+  if (!hasAttachments && !hasDirectFile && !hasFilename) {
+    return { icon: '', tooltip: '', category: 'none' };
+  }
+
+  const attachmentContentType = primaryFilename && attachments[primaryFilename]?.content_type
+    ? attachments[primaryFilename].content_type.toLowerCase()
+    : '';
+  const directContentType = (
+    doc.contentType || doc.content_type || (doc.file && doc.file.type) || (typeof doc.type === 'string' ? doc.type : '') || ''
+  ).toLowerCase();
+  const contentType = (attachmentContentType || directContentType).split(';')[0].trim();
+
+  const mediaType = (typeof doc.mediaType === 'string' ? doc.mediaType : '').toLowerCase().trim();
+  const openWith = (typeof doc.openWith === 'string' ? doc.openWith : '').toLowerCase().trim();
+
+  // 1. Interactive HTML / Web Modules / Multi-attachment bundles
+  if (
+    attachmentKeys.length > 1 ||
+    mediaType === 'html' ||
+    openWith === 'html' ||
+    contentType === 'text/html' ||
+    contentType === 'application/xhtml+xml' ||
+    primaryFilename.endsWith('.html') ||
+    primaryFilename.endsWith('.htm')
+  ) {
+    return { icon: 'language', tooltip: $localize`:@@resource-type-html:Interactive Web Resource`, category: 'html' };
+  }
+
+  // 2. PDF Document
+  if (
+    contentType === 'application/pdf' ||
+    primaryFilename.endsWith('.pdf') ||
+    mediaType === 'pdf' ||
+    openWith === 'pdf.js'
+  ) {
+    return { icon: 'picture_as_pdf', tooltip: $localize`:@@resource-type-pdf:PDF Document`, category: 'pdf' };
+  }
+
+  // 3. Video
+  if (
+    contentType.startsWith('video/') ||
+    mediaType === 'video' ||
+    openWith.includes('video') ||
+    /\.(mp4|webm|ogv|mkv|mov|avi|flv|wmv|m4v)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'videocam', tooltip: $localize`:@@resource-type-video:Video`, category: 'video' };
+  }
+
+  // 4. Audio
+  if (
+    contentType.startsWith('audio/') ||
+    mediaType === 'audio' ||
+    mediaType.includes('audio') ||
+    openWith === 'mp3' ||
+    openWith === 'bell-reader' ||
+    /\.(mp3|ogg|wav|aac|m4a|flac|wma|opus)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'audiotrack', tooltip: $localize`:@@resource-type-audio:Audio Recording`, category: 'audio' };
+  }
+
+  // 5. Spreadsheet / Dataset
+  if (
+    contentType === 'text/csv' ||
+    contentType === 'text/comma-separated-values' ||
+    contentType === 'application/csv' ||
+    contentType === 'application/vnd.ms-excel' ||
+    contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+    contentType === 'application/vnd.oasis.opendocument.spreadsheet' ||
+    mediaType === 'csv' ||
+    /\.(csv|tsv|xls|xlsx|ods)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'grid_on', tooltip: $localize`:@@resource-type-spreadsheet:Spreadsheet / Dataset`, category: 'spreadsheet' };
+  }
+
+  // 6. Image / Graphic
+  if (
+    contentType.startsWith('image/') ||
+    mediaType === 'image' ||
+    mediaType.includes('graphic') ||
+    mediaType.includes('picture') ||
+    /\.(jpg|jpeg|png|gif|svg|webp|bmp|ico|tiff)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'image', tooltip: $localize`:@@resource-type-image:Image`, category: 'image' };
+  }
+
+  // 7. Word Processing Document
+  if (
+    contentType === 'application/msword' ||
+    contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    contentType === 'application/vnd.oasis.opendocument.text' ||
+    contentType === 'application/rtf' ||
+    /\.(doc|docx|odt|rtf)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'description', tooltip: $localize`:@@resource-type-word:Word Document`, category: 'word' };
+  }
+
+  // 8. Presentation / Slides
+  if (
+    contentType === 'application/vnd.ms-powerpoint' ||
+    contentType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation' ||
+    contentType === 'application/vnd.oasis.opendocument.presentation' ||
+    /\.(ppt|pptx|odp)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'slideshow', tooltip: $localize`:@@resource-type-presentation:Presentation / Slides`, category: 'presentation' };
+  }
+
+  // 9. Text / Markdown / Code
+  if (
+    contentType === 'text/plain' ||
+    contentType === 'text/markdown' ||
+    contentType === 'application/json' ||
+    contentType === 'application/xml' ||
+    contentType === 'text/xml' ||
+    mediaType === 'text' ||
+    /\.(txt|md|markdown|json|xml|log)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'description', tooltip: $localize`:@@resource-type-text:Text Document`, category: 'text' };
+  }
+
+  // 10. Compressed Archive
+  if (
+    contentType === 'application/zip' ||
+    contentType === 'application/x-zip-compressed' ||
+    contentType === 'application/x-tar' ||
+    contentType === 'application/gzip' ||
+    contentType === 'application/x-7z-compressed' ||
+    contentType === 'application/vnd.rar' ||
+    mediaType === 'zip' ||
+    /\.(zip|tar|gz|7z|rar|bz2|xz)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'archive', tooltip: $localize`:@@resource-type-archive:Compressed Archive`, category: 'archive' };
+  }
+
+  // 11. Generic File / Other Fallback
+  return { icon: 'insert_drive_file', tooltip: $localize`:@@resource-type-file:File Attachment`, category: 'file' };
+}
+
+@Component({
+  selector: 'planet-resource-icon',
+  template: `
+    @if (iconInfo.icon) {
+      <mat-icon
+        class="km-resource-icon resource-type-icon"
+        [matTooltip]="iconInfo.tooltip"
+        aria-hidden="true">
+        {{ iconInfo.icon }}
+      </mat-icon>
+    }
+  `,
+  styles: [`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      vertical-align: middle;
+      line-height: 1;
+    }
+    .resource-type-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      vertical-align: middle;
+      font-size: 1.25rem;
+      width: 1.25rem;
+      height: 1.25rem;
+      margin-right: 0.25rem;
+      user-select: none;
+      flex-shrink: 0;
+    }
+  `],
+  imports: [MatIcon, MatTooltip]
+})
+export class PlanetResourceIconComponent implements OnChanges {
+  @Input() resource: any;
+  iconInfo: ResourceIconInfo = { icon: '', tooltip: '', category: 'none' };
+
+  ngOnChanges(): void {
+    this.iconInfo = resolveResourceIconInfo(this.resource);
+  }
+}

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -170,6 +170,7 @@
             }
             <ng-container *ngTemplateOutlet="headerText"></ng-container>
             <ng-template #headerText>
+              <planet-resource-icon [resource]="element"></planet-resource-icon>
               <a [routerLink]="isDialog ? ['resources/view', element._id] : ['view', element._id]" [target]="isDialog ? '_blank' : null">
                 {{ element.doc.title | truncateText:180 }}
               </a>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -55,6 +55,7 @@ import { FeedbackDirective } from '../feedback/feedback.directive';
 import { DialogsRatingsDirective } from '../shared/dialogs/dialogs-ratings.component';
 import { PlanetRatingComponent } from '../shared/forms/planet-rating.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
+import { PlanetResourceIconComponent } from './resources-icon.component';
 
 @Component({
   selector: 'planet-resources',
@@ -109,7 +110,8 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     MatNoDataRow,
     MatPaginator,
     DatePipe,
-    TruncateTextPipe
+    TruncateTextPipe,
+    PlanetResourceIconComponent
   ]
 })
 export class ResourcesComponent implements OnInit, AfterViewInit, OnDestroy {

--- a/src/app/resources/resources.module.ts
+++ b/src/app/resources/resources.module.ts
@@ -11,12 +11,14 @@ import { MaterialModule } from '../shared/material.module';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search-resources/resources-search.component';
+import { PlanetResourceIconComponent } from './resources-icon.component';
 
 @NgModule({
   exports: [
     ResourcesViewerComponent,
     ResourcesComponent,
-    ResourcesAddComponent
+    ResourcesAddComponent,
+    PlanetResourceIconComponent
   ],
   imports: [
     CommonModule,
@@ -32,7 +34,8 @@ import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search
     ResourcesViewerComponent,
     ResourcesAddComponent,
     ResourcesSearchComponent,
-    ResourcesSearchListComponent
+    ResourcesSearchListComponent,
+    PlanetResourceIconComponent
   ]
 })
 export class ResourcesModule {}

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -246,14 +246,14 @@
               <mat-card (click)="resource.resource && openResource(resource.resource._id)" i18n-matTooltip matTooltip="There is no content for this resource" [matTooltipDisabled]="resource.resource?._attachments" [ngClass]="{'cursor-pointer': resource.resource}">
                 <div class="mat-subtitle-1">
                   @if (resource.resource!==undefined) {
-                    <span>
-                      <b>{{resource.resource.title | truncateText:75}}</b>
+                    <span class="resource-title-wrapper">
+                      <planet-resource-icon [resource]="resource.resource"></planet-resource-icon><b>{{resource.resource.title | truncateText:75}}</b>
                     </span>
                   }
                   @if (resource.resource===undefined) {
-                    <span i18n-matTooltip
+                    <span class="resource-title-wrapper" i18n-matTooltip
                       matTooltip="Resource unavailable. Contact your administrator to add resource to this Planet.">
-                      {{resource.linkDoc.title | truncateText:75}}
+                      <planet-resource-icon [resource]="resource.linkDoc"></planet-resource-icon>{{resource.linkDoc.title | truncateText:75}}
                     </span>
                   }
                 </div>

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -49,6 +49,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { PlanetMarkdownComponent } from '../shared/planet-markdown.component';
 import { SurveysComponent } from '../surveys/surveys.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
+import { PlanetResourceIconComponent } from '../resources/resources-icon.component';
 
 @Component({
   templateUrl: './teams-view.component.html',
@@ -93,7 +94,8 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     MatMenuItem,
     SurveysComponent,
     DatePipe,
-    TruncateTextPipe
+    TruncateTextPipe,
+    PlanetResourceIconComponent
   ]
 })
 export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {

--- a/src/app/teams/teams-view.scss
+++ b/src/app/teams/teams-view.scss
@@ -45,12 +45,25 @@
   .mat-subtitle-1 {
     margin: 5px 25px 10px 15px;
 
+    .resource-title-wrapper {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+      min-width: 0;
+      vertical-align: middle;
+
+      planet-resource-icon {
+        flex-shrink: 0;
+      }
+    }
+
     b {
       display: inline-block;
       max-width: 100%;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      vertical-align: middle;
     }
   }
 


### PR DESCRIPTION
Fixes #10313

### Problem
- **Lack of Immediate File-Type Affordance**: Resources across Planet (Library tables, Course step viewers, Course creation editors, and Team documents) were previously presented solely as plain text title links.
- **Missing Visual Differentiation**: Learners and educators scanning lists had no quick way of knowing whether opening a resource will launch a **PDF document**, play a **video**, stream an **audio recording**, open an **interactive HTML web module**, or display a **spreadsheet / dataset**, without reading the separate info column or launching the viewer.
- **Multi-Resource Course Steps**: In course steps with multiple attached resources, learners had to click each tab blind to discover which item was a reading guide vs. a video lecture or spreadsheet.

### Proposed Solution
Introduces `<planet-resource-icon>`, an accessible, non-interactive visual indicator component with localized hover tooltips (`i18n-matTooltip`) positioned inline next to resource titles.

#### Supported File Type to Icon Mapping
| File Type / Category | Common Extensions | MIME Types / Detection | Planet Material Icon | Localized Tooltip (`i18n-matTooltip`) |
| :--- | :--- | :--- | :--- | :--- |
| **PDF Document** | `.pdf` | `application/pdf`, `mediaType: 'pdf'`, `openWith: 'PDF.js'` | `picture_as_pdf` | `PDF Document` |
| **Video** | `.mp4`, `.webm`, `.ogv`, `.mkv`, `.mov`, `.avi` | `video/*`, `mediaType: 'video'`, `openWith: 'Flow Video Player' \| 'Native Video'` | `videocam` | `Video` |
| **Audio Recording** | `.mp3`, `.ogg`, `.wav`, `.aac`, `.m4a`, `.flac` | `audio/*`, `mediaType: 'audio'`, `openWith: 'MP3'` | `audiotrack` | `Audio Recording` |
| **Spreadsheet / Dataset** | `.csv`, `.tsv`, `.xlsx`, `.ods` | `text/csv`, `text/comma-separated-values`, `mediaType: 'csv'` | `grid_on` | `Spreadsheet / Dataset` |
| **Image / Graphic** | `.jpg`, `.jpeg`, `.png`, `.gif`, `.svg`, `.webp`, `.bmp` | `image/*`, `mediaType: 'image' \| 'Graphic/Pictures'` | `image` | `Image` |
| **Interactive Web / HTML** | `.html`, `.htm`, `.zip` *(web bundle)* | `text/html`, `mediaType: 'HTML'`, `openWith: 'HTML'` | `language` | `Interactive Web Resource` |
| **Word Document** | `.doc`, `.docx`, `.odt`, `.rtf` | `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | `description` | `Word Document` |
| **Presentation / Slides** | `.ppt`, `.pptx`, `.odp` | `application/vnd.ms-powerpoint`, `application/vnd.openxmlformats-officedocument.presentationml.presentation` | `slideshow` | `Presentation / Slides` |
| **Text Document / Code** | `.txt`, `.md`, `.json`, `.xml` | `text/plain`, `text/markdown`, `application/json`, `mediaType: 'Text'` | `description` | `Text Document` |
| **Compressed Archive** | `.zip`, `.tar`, `.gz`, `.7z`, `.rar` | `application/zip`, `application/x-tar`, `application/gzip`, `mediaType: 'zip'` | `archive` | `Compressed Archive` |
| **Generic File with Attachment** | *Fallback for unlisted formats* | `application/octet-stream`, `other` | `insert_drive_file` | `File Attachment` |
| **No File Attached** | *Resource without attachments* | `_attachments: {}` | *(none)* | *(none)* |

### Key Implementation Details
1. **Dynamic File Replacement Handling**:
   - `PlanetResourceIconComponent` implements `ngOnChanges` and reactively updates the icon whenever an existing resource's attachment is replaced (e.g., from PDF to MP4 or CSV).
2. **Unattached Resource Suppression**:
   - Resources with no attached file (e.g. metadata-only entries or items whose attachment was removed) do not render an icon or tooltip.
3. **Accessibility & Usability**:
   - The icon is purely visual and non-clickable (marked `aria-hidden="true"` with `tabindex="-1"`), preventing extra keyboard tab stops.
   - Screen-reader accessible hover tooltips provided via `[matTooltip]` with `$localize`.
4. **Integrated Touchpoints**:
   - **Library / Resources Table & Cards** (`src/app/resources/resources.component.html`)
   - **Course Step Viewer Multi-Resource Toggles** (`src/app/courses/step-view-courses/courses-step-view.component.html`)
   - **Course Step Creator Editor Chips** (`src/app/courses/add-courses/courses-step.component.html`)
   - **Teams & Enterprises Documents Grid** (`src/app/teams/teams-view.component.html`)

### Verification
- **Unit Tests**: Added comprehensive unit tests in `src/app/resources/resources-icon.component.spec.ts` (18/18 tests passing; full test suite 147/147 passing).
- **Lint**: `npm run lint` passing with 0 errors.
- **Production Build**: `npm run build` generated successfully with 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file-type icons and localized tooltips to resources across courses, resource lists, and team views.
  * Icons now reflect resource formats such as PDFs, videos, images, documents, spreadsheets, archives, and more.
  * Resource titles and icons are aligned consistently, including unavailable resources.

* **Bug Fixes**
  * Icons update correctly when a resource’s associated file changes.

* **Tests**
  * Added comprehensive coverage for resource classification and icon rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->