### PR TITLE
voices: smoother notification reply thread navigating (fixes #10319)

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -105,7 +105,8 @@
       <div class="notification-items">
         <a mat-menu-item (click)="readAllNotification()" i18n>Mark all as Read</a>
         @for (notification of notifications; track notification) {
-          <a [routerLink]="notification.type !== 'challenges' ? (!notification.link ? '/notifications' : notification.link !== '/' ? [notification.link, notification.linkParams || {}] : '/') : null"
+          <a [routerLink]="notification.type !== 'challenges' ? (!notification.link ? '/notifications' : notification.link) : null"
+            [queryParams]="notification.linkParams"
             class="menu-item-notification"
             [ngClass]="{'primary-text-color':notification.status==='unread'}"
             mat-menu-item

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -109,8 +109,12 @@
         <button mat-button type="button" (click)="addReply(item.doc)" i18n>Reply</button>
       }
       @if (replyObject[item.doc._id]?.length > 0 && showRepliesButton) {
-        <button mat-button type="button" (click)="showReplies(item)">
-          <mat-icon>chat_bubble_outline</mat-icon> ({{replyObject[item.doc._id]?.length}})
+        <button mat-button type="button" class="reply-count-button" (click)="showReplies(item)">
+          <mat-icon>chat_bubble_outline</mat-icon>
+          <span> ({{replyObject[item.doc._id]?.length}})</span>
+          @if (hasUnreadReplies) {
+            <span class="unread-reply-dot" i18n-aria-label aria-label="Unread replies"></span>
+          }
         </button>
       }
       <button mat-icon-button type="button" matTooltip="Copy Voice Link" i18n-matTooltip (click)="copyLink(item.doc)">
@@ -142,8 +146,12 @@
     <button mat-button type="button" (click)="addReply(item.doc)" i18n>Reply</button>
   }
   @if (replyObject[item.doc._id]?.length > 0 && showRepliesButton) {
-    <button mat-button type="button" (click)="showReplies(item)">
-      <mat-icon>chat_bubble_outline</mat-icon> ({{replyObject[item.doc._id]?.length}})
+    <button mat-button type="button" class="reply-count-button" (click)="showReplies(item)">
+      <mat-icon>chat_bubble_outline</mat-icon>
+      <span> ({{replyObject[item.doc._id]?.length}})</span>
+      @if (hasUnreadReplies) {
+        <span class="unread-reply-dot" i18n-aria-label aria-label="Unread replies"></span>
+      }
     </button>
   }
   <button mat-icon-button type="button" matTooltip="Copy Voice Link" i18n-matTooltip (click)="copyLink(item.doc)">

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -113,7 +113,7 @@
           <mat-icon>chat_bubble_outline</mat-icon>
           <span> ({{replyObject[item.doc._id]?.length}})</span>
           @if (hasUnreadReplies) {
-            <span class="unread-reply-dot" i18n-aria-label aria-label="Unread replies"></span>
+            <span class="unread-reply-dot" role="img" i18n-aria-label aria-label="Unread replies"></span>
           }
         </button>
       }
@@ -150,7 +150,7 @@
       <mat-icon>chat_bubble_outline</mat-icon>
       <span> ({{replyObject[item.doc._id]?.length}})</span>
       @if (hasUnreadReplies) {
-        <span class="unread-reply-dot" i18n-aria-label aria-label="Unread replies"></span>
+        <span class="unread-reply-dot" role="img" i18n-aria-label aria-label="Unread replies"></span>
       }
     </button>
   }

--- a/src/app/news/news-list-item.component.ts
+++ b/src/app/news/news-list-item.component.ts
@@ -63,6 +63,7 @@ export class NewsListItemComponent implements OnInit, OnChanges, OnDestroy {
   @Input() showRepliesButton = true;
   @Input() editable = true;
   @Input() shareTarget: 'community' | 'nation' | 'center';
+  @Input() hasUnreadReplies = false;
   @Output() changeReplyViewing = new EventEmitter<any>();
   @Output() updateNews = new EventEmitter<any>();
   @Output() deleteNews = new EventEmitter<any>();
@@ -163,16 +164,18 @@ export class NewsListItemComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   sendNewsNotifications(news: any = '') {
-    const replyBy = this.currentUser.name;
-    const userId = news.user._id;
-    if (replyBy === news.user.name) {
+    const replyBy = this.userService.get()?.name || this.currentUser.name;
+    const targetName = news?.user?.name || (news?.user?._id ? news.user._id.replace('org.couchdb.user:', '') : '');
+    if (!targetName || replyBy === targetName) {
       return;
     }
-    const link = this.router.url;
+    const userId = 'org.couchdb.user:' + targetName;
+    const link = this.router.url.split(';')[0].split('?')[0] || '/';
     const notification = {
       user: userId,
       'message':  $localize`<b>${replyBy}</b> replied to your ${news.viewableBy === 'community' ? 'community ' : ''}message.`,
       link,
+      linkParams: { replyTo: news._id },
       'priority': 1,
       'type': 'replyMessage',
       'replyTo': news._id,

--- a/src/app/news/news-list-item.scss
+++ b/src/app/news/news-list-item.scss
@@ -52,3 +52,14 @@ mat-card-content {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.unread-reply-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: v.$warn;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+

--- a/src/app/news/news-list.component.html
+++ b/src/app/news/news-list.component.html
@@ -32,6 +32,7 @@
         [replyObject]="replyObject"
         [editable]="editable"
         [shareTarget]="shareTarget"
+        [hasUnreadReplies]="unreadReplyIds.has(item.doc?._id || item._id)"
         (changeReplyViewing)="showReplies($event)"
         (updateNews)="openUpdateDialog($event)"
         (deleteNews)="openDeleteDialog($event)"

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -1,10 +1,13 @@
 import { Component, Input, OnInit, OnChanges, EventEmitter, Output, AfterViewInit, ViewChild, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { ActivatedRoute, Router } from '@angular/router';
-import { forkJoin, of, Subscription } from 'rxjs';
+import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { forkJoin, of, Subscription, Subject } from 'rxjs';
+import { takeUntil, filter } from 'rxjs/operators';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { NewsService } from './news.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { UserService } from '../shared/user.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { CustomValidators } from '../validators/custom-validators';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
@@ -59,6 +62,9 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   pageIndex = 0;
   pageSizeOptions = [ 5, 10, 25, 50 ];
   totalItems = 0;
+  unreadReplyIds = new Set<string>();
+  private pendingReplyTo?: string;
+  private onDestroy$ = new Subject<void>();
   private routerEventsSubscription: Subscription;
 
   constructor(
@@ -66,6 +72,8 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
     private dialogsFormService: DialogsFormService,
     private dialogsLoadingService: DialogsLoadingService,
     private newsService: NewsService,
+    private notificationsService: NotificationsService,
+    private userService: UserService,
     private planetMessageService: PlanetMessageService,
     private dialogGuard: DialogGuardService,
     private router: Router,
@@ -73,11 +81,44 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   ) {}
 
   ngOnInit() {
-    this.routerEventsSubscription = this.router.events.subscribe(() => {
-      this.initNews();
-    });
+    this.routerEventsSubscription = this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.initNews();
+      });
 
+    this.userService.notificationStateChange$
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe(() => {
+        this.loadUnreadReplyIds();
+      });
+
+    this.userService.userChange$
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe(() => {
+        this.loadUnreadReplyIds();
+      });
+
+    const deepLinkReplyTo = this.route.snapshot.paramMap.get('replyTo') || this.route.snapshot.queryParamMap.get('replyTo');
+    if (deepLinkReplyTo) {
+      this.pendingReplyTo = deepLinkReplyTo;
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { replyTo: null },
+        replaceUrl: true
+      });
+    }
+
+    this.loadUnreadReplyIds();
     this.initNews();
+  }
+
+  loadUnreadReplyIds() {
+    this.notificationsService.getUnreadReplyIds$()
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe(ids => {
+        this.unreadReplyIds = new Set(ids || []);
+      });
   }
 
   ngOnChanges() {
@@ -94,6 +135,16 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
         isLatest = false;
       }
     });
+
+    if (this.pendingReplyTo) {
+      const target = this.items.find(item => item._id === this.pendingReplyTo || item.doc?._id === this.pendingReplyTo);
+      if (target) {
+        this.showReplies(target);
+        this.pendingReplyTo = undefined;
+        return;
+      }
+    }
+
     this.displayedItems = this.replyObject[this.replyViewing._id];
     this.loadPagedItems(true);
     if (this.replyViewing._id !== 'root') {
@@ -111,6 +162,8 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
 
   ngOnDestroy() {
     this.routerEventsSubscription?.unsubscribe();
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
     if (this.observer) {
       this.observer.disconnect();
     }
@@ -135,14 +188,25 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   }
 
   initNews() {
-    const newVoiceId = this.route.firstChild?.snapshot.paramMap.get('id') || 'root';
-    this.filterNewsToShow(newVoiceId);
+    const childPath = this.route.firstChild?.routeConfig?.path;
+    const voiceId = (childPath === 'voices/:id') ? this.route.firstChild?.snapshot.paramMap.get('id') : null;
+
+    if (voiceId) {
+      this.filterNewsToShow(voiceId);
+    } else {
+      this.filterNewsToShow('root');
+    }
   }
 
   showReplies(news) {
     // remember the conversation’s true root post, even from deep threads
     if (news._id !== 'root') {
       this.lastRootPostId = this.getThreadRootId(news);
+      const newsId = news.doc?._id || news._id;
+      if (this.unreadReplyIds.has(newsId)) {
+        this.unreadReplyIds.delete(newsId);
+        this.notificationsService.markReplyNotificationsAsRead(newsId);
+      }
     }
     if (this.useReplyRoutes) {
       this.navigateToReply(news._id);

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -64,6 +64,7 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   totalItems = 0;
   unreadReplyIds = new Set<string>();
   private pendingReplyTo?: string;
+  private deepLinkHandled = false;
   private onDestroy$ = new Subject<void>();
   private routerEventsSubscription: Subscription;
 
@@ -126,9 +127,10 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
       }
     });
 
-    if (this.pendingReplyTo) {
+    if (this.pendingReplyTo && !this.deepLinkHandled) {
       const target = this.items.find(item => item._id === this.pendingReplyTo || item.doc?._id === this.pendingReplyTo);
       if (target) {
+        this.deepLinkHandled = true;
         this.showReplies(target);
         this.pendingReplyTo = undefined;
         return;
@@ -184,11 +186,12 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
 
     if (voiceId) {
       this.filterNewsToShow(voiceId);
-    } else if (deepLinkReplyTo) {
+    } else if (deepLinkReplyTo && !this.deepLinkHandled) {
       this.pendingReplyTo = deepLinkReplyTo;
       if (this.items.length > 0) {
         const target = this.items.find(item => item._id === deepLinkReplyTo || item.doc?._id === deepLinkReplyTo);
         if (target) {
+          this.deepLinkHandled = true;
           this.showReplies(target);
           this.pendingReplyTo = undefined;
         }
@@ -208,6 +211,7 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
         this.notificationsService.markReplyNotificationsAsRead(newsId);
       }
     } else {
+      this.deepLinkHandled = true;
       this.pendingReplyTo = undefined;
     }
     if (this.useReplyRoutes) {

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -64,7 +64,6 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   totalItems = 0;
   unreadReplyIds = new Set<string>();
   private pendingReplyTo?: string;
-  private deepLinkHandled = false;
   private onDestroy$ = new Subject<void>();
   private routerEventsSubscription: Subscription;
 
@@ -86,6 +85,16 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
       .pipe(filter(event => event instanceof NavigationEnd))
       .subscribe(() => {
         this.initNews();
+      });
+
+    this.route.queryParamMap
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe(params => {
+        const replyTo = params.get('replyTo');
+        if (replyTo) {
+          this.pendingReplyTo = replyTo;
+          this.checkAndNavigateToPendingReply();
+        }
       });
 
     merge(this.userService.notificationStateChange$, this.userService.userChange$)
@@ -125,25 +134,28 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
       }
     });
 
-    if (this.pendingReplyTo && !this.deepLinkHandled) {
-      const target = this.items.find(item => item._id === this.pendingReplyTo || item.doc?._id === this.pendingReplyTo);
-      if (target) {
-        this.deepLinkHandled = true;
-        this.showReplies(target);
-        this.pendingReplyTo = undefined;
+    if (this.pendingReplyTo) {
+      this.checkAndNavigateToPendingReply();
+      return;
+    }
+
+    const childPath = this.route.firstChild?.routeConfig?.path;
+    const voiceId = (childPath === 'voices/:id') ? this.route.firstChild?.snapshot.paramMap.get('id') : null;
+    if (voiceId) {
+      this.filterNewsToShow(voiceId);
+      return;
+    }
+
+    if (this.replyViewing._id !== 'root') {
+      const current = this.items.find(item => item._id === this.replyViewing._id);
+      if (current) {
+        this.filterNewsToShow(current._id);
         return;
       }
     }
 
-    this.displayedItems = this.replyObject[this.replyViewing._id];
+    this.displayedItems = this.replyObject.root || [];
     this.loadPagedItems(true);
-    if (this.replyViewing._id !== 'root') {
-      this.replyViewing = this.items.find(item => item._id === this.replyViewing._id) || { _id: 'root' };
-      if (this.replyViewing._id === 'root') {
-        this.displayedItems = this.replyObject.root || [];
-        this.loadPagedItems(true);
-      }
-    }
   }
 
   ngAfterViewInit() {
@@ -183,40 +195,46 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
     const deepLinkReplyTo = this.route.snapshot.paramMap.get('replyTo') || this.route.snapshot.queryParamMap.get('replyTo');
 
     if (voiceId) {
+      this.pendingReplyTo = undefined;
       this.filterNewsToShow(voiceId);
-    } else if (deepLinkReplyTo && !this.deepLinkHandled) {
+    } else if (deepLinkReplyTo) {
       this.pendingReplyTo = deepLinkReplyTo;
-      if (this.items.length > 0) {
-        const target = this.items.find(item => item._id === deepLinkReplyTo || item.doc?._id === deepLinkReplyTo);
-        if (target) {
-          this.deepLinkHandled = true;
-          this.showReplies(target);
-          this.pendingReplyTo = undefined;
-        }
-      }
+      this.checkAndNavigateToPendingReply();
     } else {
+      this.pendingReplyTo = undefined;
       this.filterNewsToShow('root');
     }
   }
 
+  private checkAndNavigateToPendingReply() {
+    if (!this.pendingReplyTo || !this.items || this.items.length === 0) {
+      return;
+    }
+    const target = this.items.find(item => item._id === this.pendingReplyTo || item.doc?._id === this.pendingReplyTo);
+    if (target) {
+      this.pendingReplyTo = undefined;
+      this.showReplies(target);
+    }
+  }
+
   showReplies(news) {
+    let targetNewsId = news._id;
     // remember the conversation’s true root post, even from deep threads
     if (news._id !== 'root') {
       this.lastRootPostId = this.getThreadRootId(news);
+      targetNewsId = this.lastRootPostId || news._id;
       const newsId = news.doc?._id || news._id;
       if (this.unreadReplyIds.has(newsId)) {
         this.unreadReplyIds.delete(newsId);
         this.notificationsService.markReplyNotificationsAsRead(newsId);
       }
     } else {
-      this.deepLinkHandled = true;
       this.pendingReplyTo = undefined;
     }
+    this.filterNewsToShow(targetNewsId);
     if (this.useReplyRoutes) {
-      this.navigateToReply(news._id);
-      return;
+      this.navigateToReply(targetNewsId);
     }
-    this.filterNewsToShow(news._id);
   }
 
   // climb replies until you reach the top-level post (_id with no replyTo)
@@ -242,6 +260,10 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
 
   filterNewsToShow(newsId) {
     if (newsId === this.replyViewing._id) {
+      return;
+    }
+    if (newsId !== 'root' && (!this.items || this.items.length === 0)) {
+      this.pendingReplyTo = newsId;
       return;
     }
     const news = this.items.find(item => item._id === newsId) || { _id: 'root' };

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -99,16 +99,6 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
         this.loadUnreadReplyIds();
       });
 
-    const deepLinkReplyTo = this.route.snapshot.paramMap.get('replyTo') || this.route.snapshot.queryParamMap.get('replyTo');
-    if (deepLinkReplyTo) {
-      this.pendingReplyTo = deepLinkReplyTo;
-      this.router.navigate([], {
-        relativeTo: this.route,
-        queryParams: { replyTo: null },
-        replaceUrl: true
-      });
-    }
-
     this.loadUnreadReplyIds();
     this.initNews();
   }
@@ -190,10 +180,20 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
   initNews() {
     const childPath = this.route.firstChild?.routeConfig?.path;
     const voiceId = (childPath === 'voices/:id') ? this.route.firstChild?.snapshot.paramMap.get('id') : null;
+    const deepLinkReplyTo = this.route.snapshot.paramMap.get('replyTo') || this.route.snapshot.queryParamMap.get('replyTo');
 
     if (voiceId) {
       this.filterNewsToShow(voiceId);
-    } else {
+    } else if (deepLinkReplyTo) {
+      this.pendingReplyTo = deepLinkReplyTo;
+      if (this.items.length > 0) {
+        const target = this.items.find(item => item._id === deepLinkReplyTo || item.doc?._id === deepLinkReplyTo);
+        if (target) {
+          this.showReplies(target);
+          this.pendingReplyTo = undefined;
+        }
+      }
+    } else if (this.replyViewing._id === 'root') {
       this.filterNewsToShow('root');
     }
   }
@@ -207,6 +207,8 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
         this.unreadReplyIds.delete(newsId);
         this.notificationsService.markReplyNotificationsAsRead(newsId);
       }
+    } else {
+      this.pendingReplyTo = undefined;
     }
     if (this.useReplyRoutes) {
       this.navigateToReply(news._id);

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnInit, OnChanges, EventEmitter, Output, AfterViewInit, ViewChild, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
-import { forkJoin, of, Subscription, Subject } from 'rxjs';
-import { takeUntil, filter } from 'rxjs/operators';
+import { forkJoin, of, Subscription, Subject, merge } from 'rxjs';
+import { takeUntil, filter, switchMap, tap } from 'rxjs/operators';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
 import { NewsService } from './news.service';
@@ -88,16 +88,14 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
         this.initNews();
       });
 
-    this.userService.notificationStateChange$
-      .pipe(takeUntil(this.onDestroy$))
-      .subscribe(() => {
-        this.loadUnreadReplyIds();
-      });
-
-    this.userService.userChange$
-      .pipe(takeUntil(this.onDestroy$))
-      .subscribe(() => {
-        this.loadUnreadReplyIds();
+    merge(this.userService.notificationStateChange$, this.userService.userChange$)
+      .pipe(
+        tap(() => this.unreadReplyIds.clear()),
+        switchMap(() => this.notificationsService.getUnreadReplyIds$()),
+        takeUntil(this.onDestroy$)
+      )
+      .subscribe(ids => {
+        this.unreadReplyIds = new Set(ids || []);
       });
 
     this.loadUnreadReplyIds();

--- a/src/app/news/news-list.component.ts
+++ b/src/app/news/news-list.component.ts
@@ -196,7 +196,7 @@ export class NewsListComponent implements OnInit, OnChanges, AfterViewInit, OnDe
           this.pendingReplyTo = undefined;
         }
       }
-    } else if (this.replyViewing._id === 'root') {
+    } else {
       this.filterNewsToShow('root');
     }
   }

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -20,7 +20,7 @@
         <mat-cell *matCellDef="let element" (click)="readNotification(element)">
           <p [ngClass]="{'primary-text-color':element.status==='unread'}">
             @if (element.link) {
-              <a [routerLink]="element.linkParams ? [ element.link || '/', element.linkParams ] : (element.link || '/')">
+              <a [routerLink]="element.link || '/'" [queryParams]="element.linkParams">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -19,15 +19,15 @@
       <ng-container matColumnDef="message">
         <mat-cell *matCellDef="let element" (click)="readNotification(element)">
           <p [ngClass]="{'primary-text-color':element.status==='unread'}">
-            @if (element.link) {
-              <a [routerLink]="element.link || '/'" [queryParams]="element.linkParams">
+            @if (element.type === 'challenges') {
+              <a (click)="openAnnouncementDialog(element)">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>
                 }
               </a>
             } @else {
-              <a (click)="element.type === 'challenges' && openAnnouncementDialog(element)">
+              <a [routerLink]="element.link || '/'" [queryParams]="element.linkParams">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -20,7 +20,7 @@
         <mat-cell *matCellDef="let element" (click)="readNotification(element)">
           <p [ngClass]="{'primary-text-color':element.status==='unread'}">
             @if (element.link) {
-              <a [routerLink]="element.link === '/' ? '/' : [ element.link, element.linkParams || {} ]">
+              <a [routerLink]="[ element.link || '/', element.linkParams || {} ]">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -20,7 +20,7 @@
         <mat-cell *matCellDef="let element" (click)="readNotification(element)">
           <p [ngClass]="{'primary-text-color':element.status==='unread'}">
             @if (element.link) {
-              <a [routerLink]="element.link === '/' ? '/' : [ element.link, element.linkParams || {} ]">
+              <a [routerLink]="element.linkParams ? [ element.link || '/', element.linkParams ] : (element.link || '/')">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -20,7 +20,7 @@
         <mat-cell *matCellDef="let element" (click)="readNotification(element)">
           <p [ngClass]="{'primary-text-color':element.status==='unread'}">
             @if (element.link) {
-              <a [routerLink]="element.linkParams ? [ element.link || '/', element.linkParams ] : (element.link || '/')">
+              <a [routerLink]="element.link === '/' ? '/' : [ element.link, element.linkParams || {} ]">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -20,7 +20,7 @@
         <mat-cell *matCellDef="let element" (click)="readNotification(element)">
           <p [ngClass]="{'primary-text-color':element.status==='unread'}">
             @if (element.link) {
-              <a [routerLink]="[ element.link || '/', element.linkParams || {} ]">
+              <a [routerLink]="element.linkParams ? [ element.link || '/', element.linkParams ] : (element.link || '/')">
                 <span [innerHTML]="element.message"></span>
                 @if (element.time > 0) {
                   <span class="mat-caption margin-lr-8">{{element.time | date: 'medium'}}</span>

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -66,6 +66,9 @@ export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy 
     this.userService.notificationStateChange$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
       this.getNotifications();
     });
+    this.userService.userChange$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      this.getNotifications();
+    });
   }
 
   ngOnInit() {
@@ -107,8 +110,11 @@ export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy 
           this.notifications.paginator = this.paginator;
         }
         this.anyUnread = this.notifications.data.some(notification => notification.status === 'unread');
-        this.cdr.markForCheck();
-      }, (err) => console.log(err?.error?.reason || err));
+        this.cdr.detectChanges();
+      }, (err) => {
+        console.log(err?.error?.reason || err);
+        this.cdr.detectChanges();
+      });
   }
 
   onFilterChange(filterValue: string) {

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -83,7 +83,7 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
     if (this.userService.get().isUserAdmin) {
       userFilter.push({ 'user': 'SYSTEM' });
     }
-    this.couchService.findAll('notifications/_find', findDocuments(
+    this.couchService.findAll('notifications', findDocuments(
       { '$or': userFilter,
       // The sorted item must be included in the selector for sort to work
         'time': { '$gt': 0 }

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { findDocuments } from '../shared/mangoQueries';
@@ -42,7 +42,7 @@ import { ChallengesService } from '../shared/challenges/challenges.service';
     DatePipe
   ]
 })
-export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy {
+export class NotificationsComponent implements OnInit, AfterViewInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   notifications = new MatTableDataSource<any>();
   displayedColumns = [ 'message', 'read' ];
@@ -61,12 +61,8 @@ export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy 
     private couchService: CouchService,
     private userService: UserService,
     private challengesService: ChallengesService,
-    private cdr: ChangeDetectorRef,
   ) {
     this.userService.notificationStateChange$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
-      this.getNotifications();
-    });
-    this.userService.userChange$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
       this.getNotifications();
     });
   }
@@ -80,11 +76,6 @@ export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy 
     this.notifications.paginator = this.paginator;
   }
 
-  ngOnDestroy() {
-    this.onDestroy$.next();
-    this.onDestroy$.complete();
-  }
-
   getNotifications() {
     const user = this.userService.get();
     if (!user || !user.name) {
@@ -96,25 +87,17 @@ export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy 
     if (user.isUserAdmin) {
       userFilter.push({ 'user': 'SYSTEM' });
     }
-    this.couchService.findAll('notifications', findDocuments(
+    this.couchService.post('notifications/_find', findDocuments(
       { '$or': userFilter,
       // The sorted item must be included in the selector for sort to work
         'time': { '$gt': 0 }
       },
       0,
       [ { 'time': 'desc' } ]))
-      .pipe(takeUntil(this.onDestroy$))
-      .subscribe(notifications => {
-        this.notifications.data = notifications || [];
-        if (this.paginator) {
-          this.notifications.paginator = this.paginator;
-        }
+      .subscribe((res: any) => {
+        this.notifications.data = res.docs || [];
         this.anyUnread = this.notifications.data.some(notification => notification.status === 'unread');
-        this.cdr.detectChanges();
-      }, (err) => {
-        console.log(err?.error?.reason || err);
-        this.cdr.detectChanges();
-      });
+      }, (err) => console.log(err?.error?.reason || err));
   }
 
   onFilterChange(filterValue: string) {

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -77,27 +77,23 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
   }
 
   getNotifications() {
-    const user = this.userService.get();
-    if (!user || !user.name) {
-      return;
-    }
     const userFilter = [ {
-      'user': 'org.couchdb.user:' + user.name
+      'user': 'org.couchdb.user:' + this.userService.get().name
     } ];
-    if (user.isUserAdmin) {
+    if (this.userService.get().isUserAdmin) {
       userFilter.push({ 'user': 'SYSTEM' });
     }
-    this.couchService.post('notifications/_find', findDocuments(
+    this.couchService.findAll('notifications/_find', findDocuments(
       { '$or': userFilter,
       // The sorted item must be included in the selector for sort to work
         'time': { '$gt': 0 }
       },
       0,
       [ { 'time': 'desc' } ]))
-      .subscribe((res: any) => {
-        this.notifications.data = res.docs || [];
+      .subscribe(notifications => {
+        this.notifications.data = notifications;
         this.anyUnread = this.notifications.data.some(notification => notification.status === 'unread');
-      }, (err) => console.log(err?.error?.reason || err));
+      }, (err) => console.log(err.error.reason));
   }
 
   onFilterChange(filterValue: string) {

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { findDocuments } from '../shared/mangoQueries';
@@ -42,7 +42,7 @@ import { ChallengesService } from '../shared/challenges/challenges.service';
     DatePipe
   ]
 })
-export class NotificationsComponent implements OnInit, AfterViewInit {
+export class NotificationsComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   notifications = new MatTableDataSource<any>();
   displayedColumns = [ 'message', 'read' ];
@@ -61,6 +61,7 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
     private couchService: CouchService,
     private userService: UserService,
     private challengesService: ChallengesService,
+    private cdr: ChangeDetectorRef,
   ) {
     this.userService.notificationStateChange$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
       this.getNotifications();
@@ -76,11 +77,20 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
     this.notifications.paginator = this.paginator;
   }
 
+  ngOnDestroy() {
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
+  }
+
   getNotifications() {
+    const user = this.userService.get();
+    if (!user || !user.name) {
+      return;
+    }
     const userFilter = [ {
-      'user': 'org.couchdb.user:' + this.userService.get().name
+      'user': 'org.couchdb.user:' + user.name
     } ];
-    if (this.userService.get().isUserAdmin) {
+    if (user.isUserAdmin) {
       userFilter.push({ 'user': 'SYSTEM' });
     }
     this.couchService.findAll('notifications', findDocuments(
@@ -90,10 +100,15 @@ export class NotificationsComponent implements OnInit, AfterViewInit {
       },
       0,
       [ { 'time': 'desc' } ]))
+      .pipe(takeUntil(this.onDestroy$))
       .subscribe(notifications => {
-        this.notifications.data = notifications;
+        this.notifications.data = notifications || [];
+        if (this.paginator) {
+          this.notifications.paginator = this.paginator;
+        }
         this.anyUnread = this.notifications.data.some(notification => notification.status === 'unread');
-      }, (err) => console.log(err.error.reason));
+        this.cdr.markForCheck();
+      }, (err) => console.log(err?.error?.reason || err));
   }
 
   onFilterChange(filterValue: string) {

--- a/src/app/notifications/notifications.service.spec.ts
+++ b/src/app/notifications/notifications.service.spec.ts
@@ -1,0 +1,64 @@
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+import { NotificationsService } from './notifications.service';
+
+describe('NotificationsService reply notifications', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const createService = (couchOverrides: any = {}, userOverrides: any = {}) => {
+    const couchService = {
+      findAll: vi.fn().mockReturnValue(of([])),
+      bulkDocs: vi.fn().mockReturnValue(of([])),
+      updateDocument: vi.fn().mockReturnValue(of({})),
+      ...couchOverrides
+    };
+    const userService = {
+      get: vi.fn().mockReturnValue({ name: 'learner1', ...userOverrides }),
+      setNotificationStateChange: vi.fn()
+    };
+    const planetMessageService = {
+      showAlert: vi.fn()
+    };
+    const service = new NotificationsService(
+      userService as any,
+      couchService as any,
+      planetMessageService as any
+    );
+    return { service, couchService, userService };
+  };
+
+  it('retrieves unread replyTo IDs for the current user', () => {
+    const mockNotifications = [
+      { _id: 'n1', type: 'replyMessage', replyTo: 'voice-123', status: 'unread' },
+      { _id: 'n2', type: 'replyMessage', replyTo: 'voice-456', status: 'unread' }
+    ];
+    const { service } = createService({
+      findAll: vi.fn().mockReturnValue(of(mockNotifications))
+    });
+
+    let result: string[] = [];
+    service.getUnreadReplyIds$().subscribe(ids => {
+      result = ids;
+    });
+
+    expect(result).toEqual(['voice-123', 'voice-456']);
+  });
+
+  it('marks matching unread notifications as read when viewing a thread', () => {
+    const mockNotifications = [
+      { _id: 'n1', type: 'replyMessage', replyTo: 'voice-123', status: 'unread' }
+    ];
+    const bulkDocsSpy = vi.fn().mockReturnValue(of([]));
+    const { service, userService } = createService({
+      findAll: vi.fn().mockReturnValue(of(mockNotifications)),
+      bulkDocs: bulkDocsSpy
+    });
+
+    service.markReplyNotificationsAsRead('voice-123');
+
+    expect(bulkDocsSpy).toHaveBeenCalledWith('notifications', [
+      { _id: 'n1', type: 'replyMessage', replyTo: 'voice-123', status: 'read' }
+    ]);
+    expect(userService.setNotificationStateChange).toHaveBeenCalled();
+  });
+});

--- a/src/app/notifications/notifications.service.spec.ts
+++ b/src/app/notifications/notifications.service.spec.ts
@@ -61,4 +61,44 @@ describe('NotificationsService reply notifications', () => {
     ]);
     expect(userService.setNotificationStateChange).toHaveBeenCalled();
   });
+
+  it('stores notifications for distinct replyTo targets even with the same link', () => {
+    const updateDocumentSpy = vi.fn().mockReturnValue(of({ ok: true }));
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockReturnValue(of([])),
+      updateDocument: updateDocumentSpy
+    });
+
+    const notif1 = {
+      user: 'org.couchdb.user:learner1',
+      link: '/',
+      type: 'replyMessage',
+      replyTo: 'voice-1',
+      status: 'unread'
+    };
+    const notif2 = {
+      user: 'org.couchdb.user:learner1',
+      link: '/',
+      type: 'replyMessage',
+      replyTo: 'voice-2',
+      status: 'unread'
+    };
+
+    service.sendNotificationToUser(notif1).subscribe();
+    service.sendNotificationToUser(notif2).subscribe();
+
+    expect(couchService.findAll).toHaveBeenCalledWith(
+      'notifications',
+      expect.objectContaining({
+        selector: expect.objectContaining({ replyTo: 'voice-1' })
+      })
+    );
+    expect(couchService.findAll).toHaveBeenCalledWith(
+      'notifications',
+      expect.objectContaining({
+        selector: expect.objectContaining({ replyTo: 'voice-2' })
+      })
+    );
+    expect(updateDocumentSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -26,9 +26,18 @@ export class NotificationsService {
   }
 
   sendNotificationToUser(notifications: any): Observable<any> {
+    const selector: any = {
+      link: notifications.link,
+      type: notifications.type,
+      status: notifications.status,
+      user: notifications.user
+    };
+    if (notifications.replyTo) {
+      selector.replyTo = notifications.replyTo;
+    }
     return this.couchService.findAll(
       'notifications',
-      findDocuments({ link: notifications.link, type: notifications.type , status: notifications.status, user: notifications.user })
+      findDocuments(selector)
     ).pipe(
       switchMap((res: any[]) => res.length === 0 ? this.couchService.updateDocument('notifications', notifications) : of({}))
     );

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -3,7 +3,7 @@ import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { findDocuments } from '../shared/mangoQueries';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, map, catchError } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 
 @Injectable({
@@ -33,4 +33,50 @@ export class NotificationsService {
       switchMap((res: any[]) => res.length === 0 ? this.couchService.updateDocument('notifications', notifications) : of({}))
     );
   }
+
+  getUnreadReplyIds$(): Observable<string[]> {
+    const user = this.userService.get();
+    if (!user || !user.name) {
+      return of([]);
+    }
+    return this.couchService.findAll(
+      'notifications',
+      findDocuments({
+        user: 'org.couchdb.user:' + user.name,
+        type: 'replyMessage',
+        status: 'unread'
+      })
+    ).pipe(
+      map((notifications: any[]) =>
+        (notifications || [])
+          .map((n: any) => n.replyTo)
+          .filter(Boolean)
+      ),
+      catchError(() => of([]))
+    );
+  }
+
+  markReplyNotificationsAsRead(replyToId: string): void {
+    if (!replyToId) {
+      return;
+    }
+    const user = this.userService.get();
+    if (!user || !user.name) {
+      return;
+    }
+    this.couchService.findAll(
+      'notifications',
+      findDocuments({
+        user: 'org.couchdb.user:' + user.name,
+        type: 'replyMessage',
+        status: 'unread',
+        replyTo: replyToId
+      })
+    ).subscribe((notifications: any[]) => {
+      if (notifications && notifications.length > 0) {
+        this.setNotificationsAsRead(notifications);
+      }
+    }, () => {});
+  }
 }
+


### PR DESCRIPTION
## Description
When replying to community voices / messages, notifications sent to authors did not direct them specifically to the reply thread, and authors had no in-app visual indicator on posts indicating when unread replies were waiting.

This PR upgrades voices reply handling with:
1. **Direct Reply Thread Deep-Linking**: Clicking a reply notification opens directly to the targeted message and conversation thread.
2. **Unread Reply Indicator Dot**: Displays a subtle circular indicator dot on the far right of the Replies button (`[💬] (count) [●]`) when there are unread replies for the logged-in user.
3. **Automatic Read-State Sync**: Opening a thread automatically marks its reply notifications as read and clears the indicator.
4. **Session & Account-Switch Reactivity**: Listens to `UserService.userChange$` and `notificationStateChange$` so unread indicators stay dynamically in sync across account switches in the same session.
5. **Fixed Notifications Page Data Fetching**: Resolved `POST /notifications/_find/_find` 404 URL in `NotificationsComponent` so all notifications load immediately in a single query.

Fixes #10319

## Testing Done
- Added unit tests in `src/app/notifications/notifications.service.spec.ts` testing unread reply ID queries and notification read-state updates.
- Verified test suite passes: `npx vitest run` (29 files, 132 passed).
- Verified ESLint: `npm run lint` (0 errors, 0 warnings).
- Verified production build: `npm run build`.

<img width="429" height="78" alt="image" src="https://github.com/user-attachments/assets/1fd5381c-76be-4232-867f-896cfbc59280" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unread-reply indicators to news items on desktop and mobile.
  * Unread reply notifications now refresh automatically and can be marked as read when replies are opened.
  * Reply notification links support direct navigation to specific replies.
  * Challenge notifications now open announcement dialogs.

* **Bug Fixes**
  * Improved reply notification recipient handling and navigation.
  * Updated notification retrieval for more reliable results.

* **Tests**
  * Added coverage for retrieving and marking reply notifications as read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->