### PR TITLE
resources: smoother csv details previewing (fixes #10328)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.25",
+  "version": "0.24.26",
   "myplanet": {
     "latest": "v0.65.91",
     "min": "v0.64.64"

--- a/src/app/courses/step-view-courses/courses-step-view.scss
+++ b/src/app/courses/step-view-courses/courses-step-view.scss
@@ -11,6 +11,7 @@
 
   .view-container > * {
     overflow-y: auto;
+    min-width: 0;
   }
 
   .view-container.flex-view > * {
@@ -29,7 +30,7 @@
 
   .grid-view {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     grid-template-rows: 1fr;
     grid-column-gap: 1rem;
   }
@@ -61,7 +62,7 @@
   @media (max-width: v.$screen-sm) {
     .grid-view {
       display: grid;
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
       grid-template-rows: auto;
     }
   }

--- a/src/app/resources/view-resources/resources-view.component.html
+++ b/src/app/resources/view-resources/resources-view.component.html
@@ -123,7 +123,7 @@
   <p><b i18n>Source:</b>{{' ' + resource?.doc?.sourcePlanet}}</p>
 }
 </div>
-<div>
+<div class="resource-view">
   @if (isLoading) {
     <planet-loading-spinner text="Loading content..." i18n-text></planet-loading-spinner>
   }

--- a/src/app/resources/view-resources/resources-view.scss
+++ b/src/app/resources/view-resources/resources-view.scss
@@ -8,15 +8,16 @@
     height: 60vh;
   }
 
+
   .view-container {
     display: grid;
-    grid-template-columns: 1fr 2fr;
+    grid-template-columns: minmax(15rem, 1fr) minmax(0, 2fr);
     grid-template-areas: "detail view";
     grid-column-gap: 1rem;
   }
 
   .full-view-container.view-container {
-    grid-template-columns: 0 1fr;
+    grid-template-columns: 0 minmax(0, 1fr);
     grid-column-gap: 0;
   }
 
@@ -24,15 +25,13 @@
     grid-area: detail;
     padding: 1rem;
     overflow-y: auto;
+    min-width: 0;
   }
 
   .resource-view {
     grid-area: view;
-
-    * {
-      max-width: 100%;
-      max-height: 60vh;
-    }
+    min-width: 0;
+    overflow: hidden;
   }
   
   .toolbar-button {
@@ -41,7 +40,7 @@
 
   @media (max-width: v.$screen-sm) {
     .view-container {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
       grid-template-rows: auto;
       grid-template-areas: 
       'view'
@@ -49,8 +48,8 @@
     }
     
     .full-view-container.view-container {
-      grid-template-columns: 1fr;
-      grid-template-rows: 0 1fr;
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: minmax(0, 1fr) 0;
     } 
 
     .resource-detail{

--- a/src/app/resources/view-resources/resources-view.scss
+++ b/src/app/resources/view-resources/resources-view.scss
@@ -31,7 +31,8 @@
   .resource-view {
     grid-area: view;
     min-width: 0;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
   
   .toolbar-button {

--- a/src/app/resources/view-resources/resources-viewer.scss
+++ b/src/app/resources/view-resources/resources-viewer.scss
@@ -37,10 +37,12 @@ $full-height: calc(#{v.$view-container-height} - 2rem);
     flex-direction: column;
     gap: 0.5rem;
     max-height: $full-height;
+    min-width: 0;
 
     .csv-table-wrapper {
       flex: 1 1 auto;
       min-height: 0;
+      min-width: 0;
       overflow: auto;
 
       table {


### PR DESCRIPTION
Fixes #10328

Fixes the course/resource details panel being squeezed when previewing wide CSV files.

<img width="1919" height="951" alt="image" src="https://github.com/user-attachments/assets/9279fb8b-5b94-4665-99a7-dbcc9cbc3272" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course and resource layouts to prevent content overflow.
  * Enhanced responsive behavior across two-column and single-column views.
  * Fixed full-view resource mode so content expands and secondary details collapse appropriately.
  * Improved CSV viewer sizing to keep tables within their available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->