### PR TITLE
all: smoother collections truncating (fixes #10343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.27",
+  "version": "0.24.28",
   "myplanet": {
     "latest": "v0.67.67",
     "min": "v0.65.55"

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -28,7 +28,7 @@
           <mat-option i18n>None</mat-option>
           @for (tag of tags; track tag) {
             <mat-option [value]="tag._id || tag.name">
-              <span class="ellipsis-text mat-subtitle-2">{{ tag.name }}</span>
+              <span class="ellipsis-text mat-subtitle-2" [title]="tag.name">{{ tag.name }}</span>
               <span class="count">({{ tag.count || 0 }})</span>
             </mat-option>
           }
@@ -41,14 +41,16 @@
     <mat-action-list>
       @for (tag of tags; track tag) {
         <mat-list-item (click)="tag.subTags.length === 0 ? tagChange(tag._id || tag.name) : toggleSubcollection($event, tag._id)" class="cursor-pointer list-item-spacing">
-          @if (tag.subTags.length > 0) {
-            <planet-tag-input-toggle-icon [isOpen]="subcollectionIsOpen.get(tag._id)" class="icon-spacing"></planet-tag-input-toggle-icon>
-          }
-          @if (tag.subTags.length === 0) {
-            <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)" class="checkbox-spacing"></mat-checkbox>
-          }
-          <span class="ellipsis-text mat-subtitle-2">{{ tag.name }}</span>
-          <span class="count">({{ tag.count || 0 }})</span>
+          <div class="tag-name-and-meta">
+            @if (tag.subTags.length > 0) {
+              <planet-tag-input-toggle-icon [isOpen]="subcollectionIsOpen.get(tag._id)" class="icon-spacing"></planet-tag-input-toggle-icon>
+            }
+            @if (tag.subTags.length === 0) {
+              <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)" class="checkbox-spacing"></mat-checkbox>
+            }
+            <span class="ellipsis-text mat-subtitle-2" [title]="tag.name">{{ tag.name }}</span>
+            <span class="count">({{ tag.count || 0 }})</span>
+          </div>
           <ng-container matListItemMeta>
             <span class="toolbar-fill"></span>
             @if (isUserAdmin) {
@@ -65,9 +67,11 @@
           @for (subTag of tag.subTags; track subTag) {
             <mat-list-item (click)="tagChange(subTag._id || subTag.name, { parentTag: tag })" class="cursor-pointer list-item-spacing">
               <mat-icon matListItemIcon class="icon-spacing">subdirectory_arrow_right</mat-icon>
-              <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)" class="checkbox-spacing"></mat-checkbox>
-              <span class="ellipsis-text mat-subtitle-2">{{ subTag.name }}</span>
-              <span class="count">({{ subTag.count || 0 }})</span>
+              <div class="tag-name-and-meta">
+                <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)" class="checkbox-spacing"></mat-checkbox>
+                <span class="ellipsis-text mat-subtitle-2" [title]="subTag.name">{{ subTag.name }}</span>
+                <span class="count">({{ subTag.count || 0 }})</span>
+              </div>
               <ng-container matListItemMeta>
                 <span class="toolbar-fill"></span>
                 @if (isUserAdmin) {
@@ -90,7 +94,7 @@
       @for (tag of tags; track tag) {
         <mat-list-item class="tag-text" (click)="tag.subTags.length === 0 ? selectOne(tag._id || tag.name) : toggleSubcollection($event, tag._id)" [ngClass]="{ 'mat-body-2': tag.subTags.length > 0 }">
           <div class="tag-name-and-meta">
-            <span class="ellipsis-text mat-subtitle-2">{{ tag.name }}</span>
+            <span class="ellipsis-text mat-subtitle-2" [title]="tag.name">{{ tag.name }}</span>
             <div class="tag-meta-container">
               <span class="count">({{ tag.count || 0 }})</span>
               @if (tag.subTags.length > 0) {
@@ -114,7 +118,7 @@
             <mat-list-item (click)="selectOne(subTag._id || subTag.name)">
               <mat-icon matListItemIcon>subdirectory_arrow_right</mat-icon>
               <div class="tag-name-and-meta">
-                <span class="ellipsis-text mat-subtitle-2">{{ subTag.name }}</span>
+                <span class="ellipsis-text mat-subtitle-2" [title]="subTag.name">{{ subTag.name }}</span>
                 <div class="tag-meta-container">
                   <span class="count">({{ subTag.count || 0 }})</span>
                 </div>

--- a/src/app/shared/forms/planet-tag-input-dialog.component.html
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.html
@@ -43,44 +43,38 @@
         <mat-list-item (click)="tag.subTags.length === 0 ? tagChange(tag._id || tag.name) : toggleSubcollection($event, tag._id)" class="cursor-pointer list-item-spacing">
           <div class="tag-name-and-meta">
             @if (tag.subTags.length > 0) {
-              <planet-tag-input-toggle-icon [isOpen]="subcollectionIsOpen.get(tag._id)" class="icon-spacing"></planet-tag-input-toggle-icon>
+              <planet-tag-input-toggle-icon [isOpen]="subcollectionIsOpen.get(tag._id)"></planet-tag-input-toggle-icon>
             }
             @if (tag.subTags.length === 0) {
-              <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)" class="checkbox-spacing"></mat-checkbox>
+              <mat-checkbox (change)="checkboxChange($event, tag._id || tag.name)" [checked]="isInMap(tag._id || tag.name, selected)" [indeterminate]="isInMap(tag._id || tag.name, indeterminate)"></mat-checkbox>
             }
-            <span class="ellipsis-text mat-subtitle-2" [title]="tag.name">{{ tag.name }}</span>
-            <span class="count">({{ tag.count || 0 }})</span>
+            <span class="ellipsis-text mat-subtitle-2" [matTooltip]="tag.name">{{ tag.name }}</span>
+            <span class="tag-meta-container"><span class="count">({{ tag.count || 0 }})</span></span>
           </div>
-          <ng-container matListItemMeta>
-            <span class="toolbar-fill"></span>
-            @if (isUserAdmin) {
-              <button mat-stroked-button (click)="editTagClick($event, tag)" i18n class="button-spacing">Edit</button>
-            }
-            <span i18n-matTooltip matTooltip="You may only delete a collection with no subcollections" [matTooltipDisabled]="tag.subTags.length === 0">
-              @if (isUserAdmin) {
+          @if (isUserAdmin) {
+            <span matListItemMeta>
+              <button mat-stroked-button (click)="editTagClick($event, tag)" i18n>Edit</button>
+              <span i18n-matTooltip matTooltip="You may only delete a collection with no subcollections" [matTooltipDisabled]="tag.subTags.length === 0">
                 <button mat-stroked-button color="warn" [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
-              }
+              </span>
             </span>
-          </ng-container>
+          }
         </mat-list-item>
         @if (subcollectionIsOpen.get(tag._id)) {
           @for (subTag of tag.subTags; track subTag) {
             <mat-list-item (click)="tagChange(subTag._id || subTag.name, { parentTag: tag })" class="cursor-pointer list-item-spacing">
-              <mat-icon matListItemIcon class="icon-spacing">subdirectory_arrow_right</mat-icon>
+              <mat-icon matListItemIcon>subdirectory_arrow_right</mat-icon>
               <div class="tag-name-and-meta">
-                <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)" class="checkbox-spacing"></mat-checkbox>
-                <span class="ellipsis-text mat-subtitle-2" [title]="subTag.name">{{ subTag.name }}</span>
-                <span class="count">({{ subTag.count || 0 }})</span>
+                <mat-checkbox (change)="checkboxChange($event, subTag._id || subTag.name)" [checked]="isInMap(subTag._id || subTag.name, selected)" [indeterminate]="isInMap(subTag._id || subTag.name, indeterminate)"></mat-checkbox>
+                <span class="ellipsis-text mat-subtitle-2" [matTooltip]="subTag.name">{{ subTag.name }}</span>
+                <span class="tag-meta-container"><span class="count">({{ subTag.count || 0 }})</span></span>
               </div>
-              <ng-container matListItemMeta>
-                <span class="toolbar-fill"></span>
-                @if (isUserAdmin) {
-                  <button mat-stroked-button (click)="editTagClick($event, subTag)" i18n class="button-spacing">Edit</button>
-                }
-                @if (isUserAdmin) {
+              @if (isUserAdmin) {
+                <span matListItemMeta>
+                  <button mat-stroked-button (click)="editTagClick($event, subTag)" i18n>Edit</button>
                   <button mat-stroked-button color="warn" (click)="deleteTag($event, subTag)" i18n>Delete</button>
-                }
-              </ng-container>
+                </span>
+              }
             </mat-list-item>
           }
         }
@@ -94,43 +88,39 @@
       @for (tag of tags; track tag) {
         <mat-list-item class="tag-text" (click)="tag.subTags.length === 0 ? selectOne(tag._id || tag.name) : toggleSubcollection($event, tag._id)" [ngClass]="{ 'mat-body-2': tag.subTags.length > 0 }">
           <div class="tag-name-and-meta">
-            <span class="ellipsis-text mat-subtitle-2" [title]="tag.name">{{ tag.name }}</span>
-            <div class="tag-meta-container">
+            <span class="ellipsis-text mat-subtitle-2" [matTooltip]="tag.name">{{ tag.name }}</span>
+            <span class="tag-meta-container">
               <span class="count">({{ tag.count || 0 }})</span>
               @if (tag.subTags.length > 0) {
                 <planet-tag-input-toggle-icon [isOpen]="subcollectionIsOpen.get(tag._id)"></planet-tag-input-toggle-icon>
               }
-            </div>
-          </div>
-          <ng-container matListItemMeta>
-            @if (isUserAdmin) {
-              <button mat-stroked-button (click)="editTagClick($event,tag)" i18n>Edit</button>
-            }
-            <span i18n-matTooltip matTooltip="You may only delete a collection with no subcollections" [matTooltipDisabled]="tag.subTags.length === 0">
-              @if (isUserAdmin) {
-                <button mat-stroked-button color="warn" [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
-              }
             </span>
-          </ng-container>
+          </div>
+          @if (isUserAdmin) {
+            <span matListItemMeta>
+              <button mat-stroked-button (click)="editTagClick($event,tag)" i18n>Edit</button>
+              <span i18n-matTooltip matTooltip="You may only delete a collection with no subcollections" [matTooltipDisabled]="tag.subTags.length === 0">
+                <button mat-stroked-button color="warn" [disabled]="tag.subTags.length > 0" (click)="deleteTag($event, tag)" i18n>Delete</button>
+              </span>
+            </span>
+          }
         </mat-list-item>
         @if (subcollectionIsOpen.get(tag._id)) {
           @for (subTag of tag.subTags; track subTag) {
             <mat-list-item (click)="selectOne(subTag._id || subTag.name)">
               <mat-icon matListItemIcon>subdirectory_arrow_right</mat-icon>
               <div class="tag-name-and-meta">
-                <span class="ellipsis-text mat-subtitle-2" [title]="subTag.name">{{ subTag.name }}</span>
-                <div class="tag-meta-container">
+                <span class="ellipsis-text mat-subtitle-2" [matTooltip]="subTag.name">{{ subTag.name }}</span>
+                <span class="tag-meta-container">
                   <span class="count">({{ subTag.count || 0 }})</span>
-                </div>
+                </span>
               </div>
-              <ng-container matListItemMeta>
-                @if (isUserAdmin) {
+              @if (isUserAdmin) {
+                <span matListItemMeta>
                   <button mat-stroked-button (click)="editTagClick($event,subTag)" i18n>Edit</button>
-                }
-                @if (isUserAdmin) {
                   <button mat-stroked-button color="warn" (click)="deleteTag($event,subTag)" i18n>Delete</button>
-                }
-              </ng-container>
+                </span>
+              }
             </mat-list-item>
           }
         }

--- a/src/app/shared/forms/planet-tag-input-dialog.component.ts
+++ b/src/app/shared/forms/planet-tag-input-dialog.component.ts
@@ -63,7 +63,6 @@ export class PlanetTagInputToggleIconComponent {
 
 }
 
-
 @Component({
   'templateUrl': 'planet-tag-input-dialog.component.html',
   'styleUrls': ['planet-tag-input-dialog.scss'],

--- a/src/app/shared/forms/planet-tag-input-dialog.scss
+++ b/src/app/shared/forms/planet-tag-input-dialog.scss
@@ -57,7 +57,6 @@
 
 .tag-name-and-meta .ellipsis-text {
   min-width: 0;
-  max-width: 50%;
   flex: 0 1 auto;
 }
 
@@ -67,6 +66,14 @@
   gap: 0.25rem;
   min-width: 0;
   flex: 1 1 auto;
+}
+
+// Everything beside the name keeps its natural size, so a long collection name
+// is the part that gives way and truncates with an ellipsis.
+.tag-name-and-meta > mat-checkbox,
+.tag-name-and-meta > planet-tag-input-toggle-icon,
+.tag-name-and-meta > .count {
+  flex: 0 0 auto;
 }
 
 .count {

--- a/src/app/shared/forms/planet-tag-input-dialog.scss
+++ b/src/app/shared/forms/planet-tag-input-dialog.scss
@@ -16,14 +16,12 @@
     padding-right: 16px;
   }
 
-  .mat-mdc-list-item-meta {
+  .mat-mdc-list-item .mat-mdc-list-item-meta {
+    display: flex;
     align-items: center;
-    gap: 0.25rem;
-    margin-left: auto;
-  }
-
-  .mat-mdc-nav-list .mat-mdc-list-item-meta {
     flex-shrink: 0;
+    gap: 0.25rem;
+    margin: 0;
   }
 
   mat-dialog-actions {
@@ -45,16 +43,6 @@
   }
 }
 
-.icon-spacing,
-.checkbox-spacing {
-  margin-right: 4px;
-}
-
-.button-spacing {
-  margin-right: 4px;
-  margin-left: 8px;
-}
-
 .tag-name-and-meta .ellipsis-text {
   min-width: 0;
   flex: 0 1 auto;
@@ -64,20 +52,13 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  min-width: 0;
-  flex: 1 1 auto;
-}
-
-// Everything beside the name keeps its natural size, so a long collection name
-// is the part that gives way and truncates with an ellipsis.
-.tag-name-and-meta > mat-checkbox,
-.tag-name-and-meta > planet-tag-input-toggle-icon,
-.tag-name-and-meta > .count {
-  flex: 0 0 auto;
 }
 
 .count {
   white-space: nowrap;
+}
+
+mat-option .count {
   margin-left: 0.25rem;
 }
 


### PR DESCRIPTION
Fixes #10343

<img width="1919" height="1077" alt="image" src="https://github.com/user-attachments/assets/b793d31d-6218-4363-8b9c-0ab265a62960" />

Improve collection truncation

## Changes

- Wraps collection names and counts in a flexible row layout.
- Uses rendered `matListItemMeta` containers so names receive all available space while counts and actions remain visible.
- Removes obsolete spacers and duplicate spacing rules.
- Adds Material tooltips to collection-list names.
- Keeps the native title fallback for the “Subcollection of…” options.
