### PR TITLE
courses/resources: smoother rating prompt on leave (fixes #6640)

### DIFF
--- a/src/app/courses/courses-router.module.ts
+++ b/src/app/courses/courses-router.module.ts
@@ -16,7 +16,7 @@ const routes: Routes = [
   { path: 'add', component: CoursesAddComponent },
   { path: 'update/:id', component: CoursesAddComponent },
   { path: 'view/:id/update', component: CoursesAddComponent },
-  { path: 'view/:id', component: CoursesViewComponent },
+  { path: 'view/:id', component: CoursesViewComponent, canDeactivate: [UnsavedChangesGuard] },
   { path: 'exam', component: ExamsAddComponent },
   { path: 'survey', component: ExamsAddComponent },
   { path: 'view/:id/step/:stepNum', component: CoursesStepViewComponent, },

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
-import { Subject, defer } from 'rxjs';
+import { Observable, Subject, defer } from 'rxjs';
 import { takeUntil, switchMap, take, filter, map } from 'rxjs/operators';
 import { UserService } from '../../shared/user.service';
 import { CoursesService } from '../courses.service';
 import { SubmissionsService } from '../../submissions/submissions.service';
 import { StateService } from '../../shared/state.service';
 import { DeviceInfoService, DeviceType } from '../../shared/device-info.service';
+import { RatingService } from '../../shared/forms/rating.service';
 import { trackByIndex } from '../../shared/table-helpers';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconButton, MatButton } from '@angular/material/button';
@@ -74,6 +75,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
   deviceTypes: typeof DeviceType = DeviceType;
   courseIcons = courseIcons;
   trackByFn = trackByIndex;
+  promptedForRating = false;
   constructor(
     private router: Router,
     private userService: UserService,
@@ -82,7 +84,8 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     private submissionsService: SubmissionsService,
     private stateService: StateService,
     private deviceInfoService: DeviceInfoService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private ratingService: RatingService
   ) {
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
@@ -251,6 +254,14 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
       return;
     }
     this.router.navigate([ '../../' ], { relativeTo: this.route });
+  }
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (this.promptedForRating || !this.courseDetail?._id) {
+      return true;
+    }
+    this.promptedForRating = true;
+    return this.ratingService.promptRating(this.courseDetail, 'course', this.parent);
   }
 
 }

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, ParamMap, Router, RouterStateSnapshot } from '@angular/router';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { Observable, Subject, defer } from 'rxjs';
 import { takeUntil, switchMap, take, filter, map } from 'rxjs/operators';
@@ -257,8 +257,23 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
 
-  canDeactivate(): Observable<boolean> | boolean {
-    if (this.promptedForRating || !this.courseDetail?._id) {
+  canDeactivate(
+    currentRoute?: ActivatedRouteSnapshot,
+    currentState?: RouterStateSnapshot,
+    nextState?: RouterStateSnapshot
+  ): Observable<boolean> | boolean {
+    const nextUrl = nextState?.url || '';
+    if (
+      this.promptedForRating ||
+      !this.courseDetail?._id ||
+      this.canManage ||
+      nextUrl.includes('/update') ||
+      nextUrl.includes('/step/') ||
+      nextUrl.includes('/exam') ||
+      nextUrl.includes('/survey') ||
+      nextUrl.includes('/progress/') ||
+      nextUrl.includes('/enrolled/')
+    ) {
       return true;
     }
     this.promptedForRating = true;

--- a/src/app/courses/view-courses/courses-view.component.ts
+++ b/src/app/courses/view-courses/courses-view.component.ts
@@ -118,6 +118,7 @@ export class CoursesViewComponent implements OnInit, OnDestroy {
     }, () => this.isLoading = false);
     this.route.paramMap.pipe(takeUntil(this.onDestroy$)).subscribe((params: ParamMap) => {
       this.courseId = params.get('id');
+      this.promptedForRating = false;
       this.coursesService.requestCourse({ courseId: this.courseId, forceLatest: true, parent: this.parent });
     });
   }

--- a/src/app/resources/resources-router.module.ts
+++ b/src/app/resources/resources-router.module.ts
@@ -8,7 +8,7 @@ import { ResourcesAddComponent } from './resources-add.component';
 
 const routes: Routes = [
   { path: '', component: ResourcesComponent },
-  { path: 'view/:id', component: ResourcesViewComponent },
+  { path: 'view/:id', component: ResourcesViewComponent, canDeactivate: [UnsavedChangesGuard] },
   { path: 'add', component: ResourcesAddComponent, canDeactivate: [UnsavedChangesGuard] },
   { path: 'update/:id', component: ResourcesAddComponent, canDeactivate: [UnsavedChangesGuard] }
 ];

--- a/src/app/resources/view-resources/resources-view.component.spec.ts
+++ b/src/app/resources/view-resources/resources-view.component.spec.ts
@@ -133,7 +133,8 @@ describe('ResourcesViewComponent', () => {
     component.resource = { _id: 'r-1' };
     component.promptedForRating = false;
 
-    component.canDeactivate();
+    const result = component.canDeactivate();
+    (result as Observable<boolean>).subscribe(val => expect(val).toBe(true));
 
     expect(ratingServiceMock.promptRating).toHaveBeenCalledWith({ _id: 'r-1' }, 'resource', component.parent);
     expect(component.promptedForRating).toBe(true);

--- a/src/app/resources/view-resources/resources-view.component.spec.ts
+++ b/src/app/resources/view-resources/resources-view.component.spec.ts
@@ -131,6 +131,7 @@ describe('ResourcesViewComponent', () => {
 
   it('delegates to ratingService.promptRating on canDeactivate', () => {
     component.resource = { _id: 'r-1' };
+    component.canManage = false;
     component.promptedForRating = false;
 
     const result = component.canDeactivate();
@@ -140,15 +141,20 @@ describe('ResourcesViewComponent', () => {
     expect(component.promptedForRating).toBe(true);
   });
 
-  it('skips promptRating if already prompted', () => {
+  it('skips promptRating when navigating to edit/update or if already prompted', () => {
     component.resource = { _id: 'r-1' };
-    component.promptedForRating = true;
+    component.canManage = false;
+    component.promptedForRating = false;
     ratingServiceMock.promptRating.mockClear();
 
-    const result = component.canDeactivate();
-
+    const editResult = component.canDeactivate(undefined, undefined, { url: '/resources/update/r-1' } as any);
     expect(ratingServiceMock.promptRating).not.toHaveBeenCalled();
-    expect(result).toBe(true);
+    expect(editResult).toBe(true);
+
+    component.promptedForRating = true;
+    const promptedResult = component.canDeactivate();
+    expect(ratingServiceMock.promptRating).not.toHaveBeenCalled();
+    expect(promptedResult).toBe(true);
   });
 
 

--- a/src/app/resources/view-resources/resources-view.component.spec.ts
+++ b/src/app/resources/view-resources/resources-view.component.spec.ts
@@ -14,6 +14,7 @@ import { StateService } from '../../shared/state.service';
 import { ResourcesService } from '../resources.service';
 import { PlanetMessageService } from '../../shared/planet-message.service';
 import { DeviceInfoService } from '../../shared/device-info.service';
+import { RatingService } from '../../shared/forms/rating.service';
 
 describe('ResourcesViewComponent', () => {
 
@@ -22,6 +23,10 @@ describe('ResourcesViewComponent', () => {
   let statusElement;
   let testimage;
   let de;
+
+  const ratingServiceMock = {
+    promptRating: vi.fn().mockReturnValue(of(true))
+  };
 
   const dialogsFormServiceMock = {
     confirm: vi.fn().mockReturnValue(of({})),
@@ -50,6 +55,7 @@ describe('ResourcesViewComponent', () => {
   };
 
   beforeEach(() => {
+    ratingServiceMock.promptRating.mockReturnValue(of(true));
     resourcesServiceMock.resourcesListener.mockReturnValue(of([]));
     TestBed.configureTestingModule({
       imports: [ ResourcesViewComponent, MatIconTestingModule ],
@@ -59,6 +65,7 @@ describe('ResourcesViewComponent', () => {
         { provide: StateService, useValue: stateServiceMock },
         { provide: UserService, useValue: userServiceMock },
         { provide: ResourcesService, useValue: resourcesServiceMock },
+        { provide: RatingService, useValue: ratingServiceMock },
         PlanetMessageService,
         DeviceInfoService,
         { provide: CouchService, useValue: couchServiceMock },
@@ -120,6 +127,27 @@ describe('ResourcesViewComponent', () => {
 
     expect(component.downloadFileSize).toBe('2.4 MB');
     expect(component.formattedFileSize).toBe('');
+  });
+
+  it('delegates to ratingService.promptRating on canDeactivate', () => {
+    component.resource = { _id: 'r-1' };
+    component.promptedForRating = false;
+
+    component.canDeactivate();
+
+    expect(ratingServiceMock.promptRating).toHaveBeenCalledWith({ _id: 'r-1' }, 'resource', component.parent);
+    expect(component.promptedForRating).toBe(true);
+  });
+
+  it('skips promptRating if already prompted', () => {
+    component.resource = { _id: 'r-1' };
+    component.promptedForRating = true;
+    ratingServiceMock.promptRating.mockClear();
+
+    const result = component.canDeactivate();
+
+    expect(ratingServiceMock.promptRating).not.toHaveBeenCalled();
+    expect(result).toBe(true);
   });
 
 

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, ParamMap, Router, RouterStateSnapshot } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
 import { Observable, Subject, defer } from 'rxjs';
 import { environment } from '../../../environments/environment';
@@ -187,8 +187,19 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
     this.router.navigate([ '../../' ], { relativeTo: this.route });
   }
 
-  canDeactivate(): Observable<boolean> | boolean {
-    if (this.promptedForRating || !this.resource?._id) {
+  canDeactivate(
+    currentRoute?: ActivatedRouteSnapshot,
+    currentState?: RouterStateSnapshot,
+    nextState?: RouterStateSnapshot
+  ): Observable<boolean> | boolean {
+    const nextUrl = nextState?.url || '';
+    if (
+      this.promptedForRating ||
+      !this.resource?._id ||
+      this.canManage ||
+      nextUrl.includes('/update') ||
+      nextUrl.includes('/add')
+    ) {
       return true;
     }
     this.promptedForRating = true;

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
-import { Subject, defer } from 'rxjs';
+import { Observable, Subject, defer } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { UserService } from '../../shared/user.service';
 import { ResourcesService } from '../resources.service';
@@ -23,6 +23,7 @@ import { ResourcesViewerComponent } from './resources-viewer.component';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogsPromptComponent } from '../../shared/dialogs/dialogs-prompt.component';
 import { formatResourceAttachmentSize, formatResourceAttachmentsSize } from '../resources.utils';
+import { RatingService } from '../../shared/forms/rating.service';
 
 @Component({
   templateUrl: './resources-view.component.html',
@@ -79,6 +80,8 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
   deviceType: DeviceType;
   deviceTypes: typeof DeviceType = DeviceType;
 
+  promptedForRating = false;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -87,7 +90,8 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
     private resourcesService: ResourcesService,
     private planetMessageService: PlanetMessageService,
     private deviceInfoService: DeviceInfoService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private ratingService: RatingService
   ) {
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
       this.deviceType = deviceType;
@@ -180,5 +184,13 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
       return;
     }
     this.router.navigate([ '../../' ], { relativeTo: this.route });
+  }
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (this.promptedForRating || !this.resource?._id) {
+      return true;
+    }
+    this.promptedForRating = true;
+    return this.ratingService.promptRating(this.resource, 'resource', this.parent);
   }
 }

--- a/src/app/resources/view-resources/resources-view.component.ts
+++ b/src/app/resources/view-resources/resources-view.component.ts
@@ -104,6 +104,7 @@ export class ResourcesViewComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.onDestroy$))
       .subscribe((params: ParamMap) => {
         this.resourceId = params.get('id');
+        this.promptedForRating = false;
         this.resourcesService.requestResourcesUpdate(this.parent);
       }, error => console.log(error), () => console.log('complete getting resource id'));
     this.resourcesService.resourcesListener(this.parent).pipe(takeUntil(this.onDestroy$))

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -71,7 +71,9 @@ export interface DialogsFormData<T extends DialogFormValueMap = DialogFormValueM
   formGroup: DialogFormGroupInput<T>;
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class DialogsFormService {
 
   private dialogRef?: MatDialogRef<DialogsFormComponent>;

--- a/src/app/shared/forms/rating.service.spec.ts
+++ b/src/app/shared/forms/rating.service.spec.ts
@@ -1,10 +1,14 @@
-﻿import { of } from 'rxjs';
+import { of } from 'rxjs';
 import { describe, it, expect, vi } from 'vitest';
 import { RatingService } from './rating.service';
 
 describe('RatingService promptRating', () => {
   const setup = (inShelf = true, dialogResult: any = undefined) => {
-    const couch = { updateDocument: vi.fn().mockReturnValue(of({ ok: true })), datePlaceholder: 'DATE' };
+    const couch = {
+      findAll: vi.fn().mockReturnValue(of([])),
+      updateDocument: vi.fn().mockReturnValue(of({ ok: true })),
+      datePlaceholder: 'DATE'
+    };
     const user = { get: () => ({ _id: 'u-1', name: 'tester' }), countInShelf: () => ({ inShelf }) };
     const state = { configuration: { code: 'c1', parentCode: 'p1', parentDomain: 'dom' } };
     const dialogs = { confirm: vi.fn().mockReturnValue(of(dialogResult)) };
@@ -19,6 +23,7 @@ describe('RatingService promptRating', () => {
     expect(dialogs.confirm).toHaveBeenCalled();
     expect(couch.updateDocument).toHaveBeenCalledWith('ratings', expect.objectContaining({ rate: 5, item: 'r-1' }));
     expect(msg.showMessage).toHaveBeenCalled();
+    expect(msg.showAlert).not.toHaveBeenCalled();
   });
 
   it('skips prompt when item is already rated or not in shelf', () => {

--- a/src/app/shared/forms/rating.service.spec.ts
+++ b/src/app/shared/forms/rating.service.spec.ts
@@ -3,109 +3,31 @@ import { describe, it, expect, vi } from 'vitest';
 import { RatingService } from './rating.service';
 
 describe('RatingService promptRating', () => {
-  const setup = (options: { inShelf?: boolean; existingRate?: number; dialogResult?: any } = {}) => {
-    const couchService = {
-      findAll: vi.fn().mockReturnValue(of([])),
-      updateDocument: vi.fn().mockReturnValue(of({ ok: true })),
-      datePlaceholder: 'DATE'
-    };
-    const userService = {
-      get: vi.fn().mockReturnValue({ _id: 'u-1', name: 'tester' }),
-      countInShelf: vi.fn().mockReturnValue({ inShelf: options.inShelf ?? true })
-    };
-    const stateService = {
-      configuration: { code: 'c1', parentCode: 'p1', parentDomain: 'parent.dom' }
-    };
-    const dialogsFormService = {
-      confirm: vi.fn().mockReturnValue(of(options.dialogResult))
-    };
-    const planetMessageService = {
-      showMessage: vi.fn(),
-      showAlert: vi.fn()
-    };
-
-    const service = new RatingService(
-      couchService as any,
-      userService as any,
-      stateService as any,
-      dialogsFormService as any,
-      planetMessageService as any
-    );
-
-    return { service, couchService, dialogsFormService, planetMessageService };
+  const setup = (inShelf = true, dialogResult: any = undefined) => {
+    const couch = { updateDocument: vi.fn().mockReturnValue(of({ ok: true })), datePlaceholder: 'DATE' };
+    const user = { get: () => ({ _id: 'u-1', name: 'tester' }), countInShelf: () => ({ inShelf }) };
+    const state = { configuration: { code: 'c1', parentCode: 'p1', parentDomain: 'dom' } };
+    const dialogs = { confirm: vi.fn().mockReturnValue(of(dialogResult)) };
+    const msg = { showMessage: vi.fn(), showAlert: vi.fn() };
+    const service = new RatingService(couch as any, user as any, state as any, dialogs as any, msg as any);
+    return { service, couch, dialogs, msg };
   };
 
-  it('skips prompt when item is not in user shelf', () => {
-    const { service, dialogsFormService } = setup({ inShelf: false });
-    const item = { _id: 'r-1' };
-
-    let completed = false;
-    service.promptRating(item, 'resource').subscribe(res => {
-      expect(res).toBe(true);
-      completed = true;
-    });
-
-    expect(completed).toBe(true);
-    expect(dialogsFormService.confirm).not.toHaveBeenCalled();
-  });
-
-  it('skips prompt when item is already rated by the user', () => {
-    const { service, dialogsFormService } = setup({ inShelf: true });
-    const item = { _id: 'r-1', rating: { userRating: { rate: 4 } } };
-
-    let completed = false;
-    service.promptRating(item, 'resource').subscribe(res => {
-      expect(res).toBe(true);
-      completed = true;
-    });
-
-    expect(completed).toBe(true);
-    expect(dialogsFormService.confirm).not.toHaveBeenCalled();
-  });
-
   it('prompts dialog and saves rating when enrolled and unrated', () => {
-    const { service, dialogsFormService, couchService, planetMessageService } = setup({
-      inShelf: true,
-      dialogResult: { rate: 5, comment: 'Great resource!' }
-    });
-    const item = { _id: 'r-1', title: 'Test Resource' };
-
-    let completed = false;
-    service.promptRating(item, 'resource').subscribe(res => {
-      expect(res).toBe(true);
-      completed = true;
-    });
-
-    expect(completed).toBe(true);
-    expect(dialogsFormService.confirm).toHaveBeenCalled();
-    expect(couchService.updateDocument).toHaveBeenCalledWith(
-      'ratings',
-      expect.objectContaining({
-        type: 'resource',
-        item: 'r-1',
-        title: 'Test Resource',
-        rate: 5,
-        comment: 'Great resource!'
-      })
-    );
-    expect(planetMessageService.showMessage).toHaveBeenCalled();
+    const { service, dialogs, couch, msg } = setup(true, { rate: 5, comment: 'Nice' });
+    service.promptRating({ _id: 'r-1', title: 'Res' }, 'resource').subscribe(res => expect(res).toBe(true));
+    expect(dialogs.confirm).toHaveBeenCalled();
+    expect(couch.updateDocument).toHaveBeenCalledWith('ratings', expect.objectContaining({ rate: 5, item: 'r-1' }));
+    expect(msg.showMessage).toHaveBeenCalled();
   });
 
-  it('returns true and does not save if user dismisses dialog without rating', () => {
-    const { service, dialogsFormService, couchService } = setup({
-      inShelf: true,
-      dialogResult: undefined
-    });
-    const item = { _id: 'r-1' };
+  it('skips prompt when item is already rated or not in shelf', () => {
+    const { service, dialogs } = setup(false);
+    service.promptRating({ _id: 'r-1' }, 'resource').subscribe(res => expect(res).toBe(true));
+    expect(dialogs.confirm).not.toHaveBeenCalled();
 
-    let completed = false;
-    service.promptRating(item, 'resource').subscribe(res => {
-      expect(res).toBe(true);
-      completed = true;
-    });
-
-    expect(completed).toBe(true);
-    expect(dialogsFormService.confirm).toHaveBeenCalled();
-    expect(couchService.updateDocument).not.toHaveBeenCalled();
+    const { service: s2, dialogs: d2 } = setup(true);
+    s2.promptRating({ _id: 'r-1', rating: { userRating: { rate: 4 } } }, 'resource').subscribe();
+    expect(d2.confirm).not.toHaveBeenCalled();
   });
 });

--- a/src/app/shared/forms/rating.service.spec.ts
+++ b/src/app/shared/forms/rating.service.spec.ts
@@ -1,0 +1,111 @@
+﻿import { of } from 'rxjs';
+import { describe, it, expect, vi } from 'vitest';
+import { RatingService } from './rating.service';
+
+describe('RatingService promptRating', () => {
+  const setup = (options: { inShelf?: boolean; existingRate?: number; dialogResult?: any } = {}) => {
+    const couchService = {
+      findAll: vi.fn().mockReturnValue(of([])),
+      updateDocument: vi.fn().mockReturnValue(of({ ok: true })),
+      datePlaceholder: 'DATE'
+    };
+    const userService = {
+      get: vi.fn().mockReturnValue({ _id: 'u-1', name: 'tester' }),
+      countInShelf: vi.fn().mockReturnValue({ inShelf: options.inShelf ?? true })
+    };
+    const stateService = {
+      configuration: { code: 'c1', parentCode: 'p1', parentDomain: 'parent.dom' }
+    };
+    const dialogsFormService = {
+      confirm: vi.fn().mockReturnValue(of(options.dialogResult))
+    };
+    const planetMessageService = {
+      showMessage: vi.fn(),
+      showAlert: vi.fn()
+    };
+
+    const service = new RatingService(
+      couchService as any,
+      userService as any,
+      stateService as any,
+      dialogsFormService as any,
+      planetMessageService as any
+    );
+
+    return { service, couchService, dialogsFormService, planetMessageService };
+  };
+
+  it('skips prompt when item is not in user shelf', () => {
+    const { service, dialogsFormService } = setup({ inShelf: false });
+    const item = { _id: 'r-1' };
+
+    let completed = false;
+    service.promptRating(item, 'resource').subscribe(res => {
+      expect(res).toBe(true);
+      completed = true;
+    });
+
+    expect(completed).toBe(true);
+    expect(dialogsFormService.confirm).not.toHaveBeenCalled();
+  });
+
+  it('skips prompt when item is already rated by the user', () => {
+    const { service, dialogsFormService } = setup({ inShelf: true });
+    const item = { _id: 'r-1', rating: { userRating: { rate: 4 } } };
+
+    let completed = false;
+    service.promptRating(item, 'resource').subscribe(res => {
+      expect(res).toBe(true);
+      completed = true;
+    });
+
+    expect(completed).toBe(true);
+    expect(dialogsFormService.confirm).not.toHaveBeenCalled();
+  });
+
+  it('prompts dialog and saves rating when enrolled and unrated', () => {
+    const { service, dialogsFormService, couchService, planetMessageService } = setup({
+      inShelf: true,
+      dialogResult: { rate: 5, comment: 'Great resource!' }
+    });
+    const item = { _id: 'r-1', title: 'Test Resource' };
+
+    let completed = false;
+    service.promptRating(item, 'resource').subscribe(res => {
+      expect(res).toBe(true);
+      completed = true;
+    });
+
+    expect(completed).toBe(true);
+    expect(dialogsFormService.confirm).toHaveBeenCalled();
+    expect(couchService.updateDocument).toHaveBeenCalledWith(
+      'ratings',
+      expect.objectContaining({
+        type: 'resource',
+        item: 'r-1',
+        title: 'Test Resource',
+        rate: 5,
+        comment: 'Great resource!'
+      })
+    );
+    expect(planetMessageService.showMessage).toHaveBeenCalled();
+  });
+
+  it('returns true and does not save if user dismisses dialog without rating', () => {
+    const { service, dialogsFormService, couchService } = setup({
+      inShelf: true,
+      dialogResult: undefined
+    });
+    const item = { _id: 'r-1' };
+
+    let completed = false;
+    service.promptRating(item, 'resource').subscribe(res => {
+      expect(res).toBe(true);
+      completed = true;
+    });
+
+    expect(completed).toBe(true);
+    expect(dialogsFormService.confirm).toHaveBeenCalled();
+    expect(couchService.updateDocument).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/forms/rating.service.ts
+++ b/src/app/shared/forms/rating.service.ts
@@ -2,9 +2,12 @@ import { Injectable } from '@angular/core';
 import { CouchService } from '../couchdb.service';
 import { findDocuments } from '../mangoQueries';
 import { UserService } from '../user.service';
-import { of, Subject } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Observable, of, Subject } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { StateService } from '../state.service';
+import { DialogField, DialogsFormService } from '../dialogs/dialogs-form.service';
+import { PlanetMessageService } from '../planet-message.service';
+import { FormControl, FormGroup } from '@angular/forms';
 
 const startingRating = { rateSum: 0, totalRating: 0, maleRating: 0, femaleRating: 0, userRating: {}, allRatings: [] };
 
@@ -20,7 +23,9 @@ export class RatingService {
   constructor(
     private couchService: CouchService,
     private userService: UserService,
-    private stateService: StateService
+    private stateService: StateService,
+    private dialogsFormService: DialogsFormService,
+    private planetMessageService: PlanetMessageService
   ) {}
 
   newRatings(parent: boolean) {
@@ -81,6 +86,80 @@ export class RatingService {
       return this.addRatingToItem(id, index + 1, ratings, ratingInfo);
     }
     return ratingInfo;
+  }
+
+  promptRating(item: any, type: 'course' | 'resource', parent: boolean = false): Observable<boolean> {
+    const user = this.userService.get();
+    if (!user?._id || !item?._id) {
+      return of(true);
+    }
+    const idType = type === 'course' ? 'courseIds' : 'resourceIds';
+    const { inShelf } = this.userService.countInShelf([ item._id ], idType);
+    if (!inShelf) {
+      return of(true);
+    }
+    const userRating = item.rating?.userRating;
+    if (userRating?.rate && userRating.rate > 0) {
+      return of(true);
+    }
+
+    const formGroup = new FormGroup({
+      rate: new FormControl<number>(0),
+      comment: new FormControl<string>('')
+    });
+
+    const popupFields: DialogField[] = [
+      {
+        label: $localize`Rate`,
+        type: 'rating',
+        name: 'rate',
+        placeholder: $localize`Your Rating`,
+        required: false
+      },
+      {
+        label: $localize`Comment`,
+        type: 'textarea',
+        name: 'comment',
+        placeholder: $localize`Would you like to leave a comment?`,
+        required: false
+      }
+    ];
+
+    const title = type === 'course'
+      ? $localize`How would you rate this course?`
+      : $localize`How would you rate this resource?`;
+
+    return this.dialogsFormService.confirm(title, popupFields, formGroup).pipe(
+      switchMap((res: any) => {
+        if (res && res.rate > 0) {
+          const configuration = this.stateService.configuration;
+          const newRating = {
+            type,
+            item: item._id,
+            title: item.title || item.courseTitle,
+            createdTime: this.couchService.datePlaceholder,
+            ...res,
+            time: this.couchService.datePlaceholder,
+            user: this.userService.get(),
+            createdOn: configuration.code,
+            parentCode: configuration.parentCode
+          };
+          return this.couchService.updateDocument(this.dbName, newRating).pipe(
+            map(() => {
+              this.planetMessageService.showMessage($localize`Thank you, your rating is submitted!`);
+              this.newRatings(parent);
+              return true;
+            }),
+            catchError(() => {
+              this.planetMessageService.showAlert($localize`There was an issue updating your rating`);
+              return of(true);
+            })
+          );
+        }
+        return of(true);
+      }),
+      catchError(() => of(true))
+    );
   }
 
 }

--- a/src/app/shared/unsaved-changes.guard.ts
+++ b/src/app/shared/unsaved-changes.guard.ts
@@ -1,28 +1,38 @@
 import { Injectable } from '@angular/core';
 
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { UnsavedChangesPromptComponent } from './unsaved-changes.component';
 
 export interface CanComponentDeactivate {
-  canDeactivate: () => Observable<boolean> | Promise<boolean> | boolean;
+  canDeactivate: (
+    currentRoute?: ActivatedRouteSnapshot,
+    currentState?: RouterStateSnapshot,
+    nextState?: RouterStateSnapshot
+  ) => Observable<boolean> | Promise<boolean> | boolean;
   onLeaveConfirmed?: () => void;
 }
 
 @Injectable({
   providedIn: 'root'
 })
-export class UnsavedChangesGuard  {
+export class UnsavedChangesGuard {
 
   constructor(
     private dialog: MatDialog
   ) {}
 
-  canDeactivate(component: CanComponentDeactivate): Observable<boolean> | Promise<boolean> | boolean {
+  canDeactivate(
+    component: CanComponentDeactivate,
+    currentRoute?: ActivatedRouteSnapshot,
+    currentState?: RouterStateSnapshot,
+    nextState?: RouterStateSnapshot
+  ): Observable<boolean> | Promise<boolean> | boolean {
     // Only handle components that implement the CanComponentDeactivate interface properly
     if (component && component.canDeactivate) {
-      const result = component.canDeactivate();
+      const result = component.canDeactivate(currentRoute, currentState, nextState);
 
       // If component returns false (has unsaved changes), show dialog
       if (result === false) {


### PR DESCRIPTION
## Description
- Implements rating prompt functionality to encourage learners to rate educational courses and library resources upon navigating away from them if they have not yet submitted a rating.
- Adds `promptRating()` to `RatingService`:
  - Validates that the active user is logged in and enrolled in the resource/course (`inShelf: true`).
  - Skips prompting if the user has already submitted a rating (`userRating.rate > 0`).
  - Prompts with the rating modal form (`DialogsFormService.confirm()`) containing star rating selection and optional comments.
  - On submission (`rate > 0`), persists the rating document to CouchDB (`ratings` database), refreshes aggregate rating statistics via `newRatings(parent)`, displays a localized toast (*"Thank you, your rating is submitted!"*), and completes navigation.
  - On dismissal or cancellation, allows navigation to proceed smoothly without blocking the user.
- Integrates `canDeactivate()` on `CoursesViewComponent` and `ResourcesViewComponent` using `UnsavedChangesGuard` on `view/:id` routes in `courses-router.module.ts` and `resources-router.module.ts`.
- Skips the rating prompt when:
  - Entering edit/update mode (`/courses/view/:id/update`, `/courses/update/:id`, `/resources/update/:id`).
  - Navigating to internal course steps, exams, surveys, or leader progress views (`/step/`, `/exam`, `/survey`, `/progress/`, `/enrolled/`).
  - The current user is an admin or creator managing the content (`canManage: true`).
- Adds unit tests covering prompt condition checks, submit handling, edit route skips, and route deactivation delegation.

Fixes #6640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rating prompts for eligible courses and resources when leaving their viewing pages.
  - Users can submit ratings and comments, with confirmation or error feedback.
  - Rating prompts are skipped when an item is already rated or not eligible.

- **Bug Fixes**
  - Improved navigation handling to prevent accidental loss of unsaved changes.
  - Rating prompts no longer appear when navigating to editing or related workflow pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->