### PR TITLE
teams: add label and filter support for financial reports

### DIFF
--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -17,9 +17,17 @@
         @if (field.type === 'textbox') {
           <mat-form-field class="full-width">
             <mat-label>{{field.placeholder}}</mat-label>
-            <input matInput type="{{field.inputType || 'text'}}" formControlName="{{field.name}}" [required]="field.required" [min]="field.min">
+            <input matInput type="{{field.inputType || 'text'}}" formControlName="{{field.name}}" [required]="field.required" [min]="field.min"
+              [attr.maxlength]="field.maxLength" [attr.list]="field.suggestions?.length ? field.name + '-suggestions' : null">
             <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
           </mat-form-field>
+          @if (field.suggestions?.length) {
+            <datalist [id]="field.name + '-suggestions'">
+              @for (suggestion of field.suggestions; track suggestion) {
+                <option [value]="suggestion"></option>
+              }
+            </datalist>
+          }
         }
         <!-- password field -->
         @if (field.type === 'password') {

--- a/src/app/teams/teams-reports-dialog.component.html
+++ b/src/app/teams/teams-reports-dialog.component.html
@@ -1,6 +1,11 @@
 <div mat-dialog-title>
   <h3>{{teamName}} <ng-container i18n>Financial Report</ng-container></h3>
-  <p class="mat-subtitle-2">{{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date : 'mediumDate' : '+0000' }}</p>
+  <p class="mat-subtitle-2">
+    @if (report.label) {
+      <span class="report-label">{{ report.label }}</span>
+    }
+    {{ report.startDate | date : 'mediumDate' : '+0000' }} - {{ report.endDate | date : 'mediumDate' : '+0000' }}
+  </p>
 </div>
 <mat-dialog-content>
   <planet-teams-reports-detail [report]="report" [showSummary]="true"></planet-teams-reports-detail>

--- a/src/app/teams/teams-reports-dialog.component.ts
+++ b/src/app/teams/teams-reports-dialog.component.ts
@@ -14,6 +14,13 @@ import { DatePipe } from '@angular/common';
     .mat-subtitle-2 {
       margin-top: 0;
     }
+    .report-label {
+      padding: 2px 8px;
+      margin-right: 4px;
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.08);
+      font-weight: 600;
+    }
   `],
   imports: [
     MatDialogTitle, CdkScrollable, MatDialogContent, TeamsReportsDetailComponent, MatDialogActions, MatButton, MatDialogClose, DatePipe

--- a/src/app/teams/teams-reports.component.html
+++ b/src/app/teams/teams-reports.component.html
@@ -7,10 +7,20 @@
     <div class="reports-toolbar">
       <span class="reports-count">
         <mat-icon>description</mat-icon>
-        <span><strong>{{ reportCards.length }}</strong>&nbsp;<ng-container i18n>reports</ng-container></span>
+        <span><strong>{{ filteredCards.length }}</strong>&nbsp;<ng-container i18n>reports</ng-container></span>
       </span>
-      <span class="spacer"></span>
       @if (reportCards.length > 0) {
+        <mat-form-field subscriptSizing="dynamic" class="reports-filter font-size-1">
+          <mat-label i18n>Filter by label or date...</mat-label>
+          <input matInput [(ngModel)]="filter" (ngModelChange)="applyFilter($event)">
+          <button type="button" mat-icon-button matSuffix (click)="applyFilter('')" [style.visibility]="filter ? 'visible' : 'hidden'"
+            matTooltip="Clear search" i18n-matTooltip i18n-aria-label aria-label="Clear search">
+            <mat-icon>close</mat-icon>
+          </button>
+        </mat-form-field>
+      }
+      <span class="spacer"></span>
+      @if (filteredCards.length > 0) {
         <button mat-stroked-button [matMenuTriggerFor]="reportsExportMenu">
           <mat-icon>file_download</mat-icon><span i18n>Export</span>
         </button>
@@ -28,9 +38,12 @@
     @if (reportCards.length === 0) {
       <p class="reports-empty" i18n>No reports available at the moment.</p>
     }
-    @if (reportCards.length > 0) {
+    @if (reportCards.length > 0 && filteredCards.length === 0) {
+      <p class="reports-empty" i18n>No reports match your search.</p>
+    }
+    @if (filteredCards.length > 0) {
       <div class="reports-grid">
-        @for (card of reportCards; track trackByReport($index, card)) {
+        @for (card of filteredCards; track trackByReport($index, card)) {
           <mat-card class="report-card"
             role="button" tabindex="0"
             (click)="openReportCard($event, card.report)"
@@ -39,7 +52,12 @@
             <mat-card-content>
               <div class="report-card-header">
                 <div>
-                  <div class="report-card-eyebrow" i18n>Financial Report</div>
+                  <div class="report-card-eyebrow-row">
+                    <span class="report-card-eyebrow" i18n>Financial Report</span>
+                    @if (card.report.label) {
+                      <span class="report-card-label" [matTooltip]="card.report.label">{{ card.report.label }}</span>
+                    }
+                  </div>
                   <div class="report-card-range">
                     {{ card.report.startDate | date : 'mediumDate' : '+0000' }} &ndash;
                     {{ card.report.endDate | date : 'mediumDate' : '+0000' }}

--- a/src/app/teams/teams-reports.component.spec.ts
+++ b/src/app/teams/teams-reports.component.spec.ts
@@ -1,0 +1,107 @@
+import { vi } from 'vitest';
+import { StateService } from '../shared/state.service';
+import { TeamsAttachmentsService } from './teams-attachments.service';
+import { TeamsReportsComponent } from './teams-reports.component';
+
+describe('TeamsReportsComponent', () => {
+  let component: TeamsReportsComponent;
+
+  const report = (overrides: any = {}) => ({
+    startDate: Date.UTC(2026, 0, 1),
+    endDate: Date.UTC(2026, 0, 31),
+    beginningBalance: 0,
+    sales: 100,
+    otherIncome: 0,
+    wages: 40,
+    otherExpenses: 0,
+    ...overrides
+  });
+
+  beforeEach(() => {
+    component = new TeamsReportsComponent(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      { receiptAttachments: () => [] } as any as TeamsAttachmentsService,
+      {} as any,
+      {} as any,
+      { configuration: { currency: {} } } as any as StateService,
+      {} as any,
+      'en-US'
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('filtering', () => {
+    beforeEach(() => {
+      component.reports = [
+        report({ _id: 'a', label: 'Q1 Audit' }),
+        report({ _id: 'b', label: 'annual review' }),
+        report({ _id: 'c' }),
+        report({ _id: 'd', label: 'Archived Label', status: 'archived' })
+      ];
+      component.ngOnChanges();
+    });
+
+    it('shows every unarchived report when no filter is set', () => {
+      expect(component.filteredCards.map(card => card.report._id)).toEqual([ 'a', 'b', 'c' ]);
+    });
+
+    it('matches a label regardless of case', () => {
+      component.applyFilter('q1 AUDIT');
+
+      expect(component.filteredCards.map(card => card.report._id)).toEqual([ 'a' ]);
+    });
+
+    it('matches the formatted date range so unlabelled reports stay findable', () => {
+      component.applyFilter('Jan 31, 2026');
+
+      expect(component.filteredCards.map(card => card.report._id)).toEqual([ 'a', 'b', 'c' ]);
+    });
+
+    it('matches nothing when the search is absent from labels and dates', () => {
+      component.applyFilter('payroll');
+
+      expect(component.filteredCards).toEqual([]);
+    });
+
+    it('ignores surrounding whitespace in the search', () => {
+      component.applyFilter('  annual  ');
+
+      expect(component.filteredCards.map(card => card.report._id)).toEqual([ 'b' ]);
+    });
+
+    it('reapplies the active filter when the reports reload', () => {
+      component.applyFilter('Q1');
+      component.reports = [ ...component.reports, report({ _id: 'e', label: 'Q1 Follow-up' }) ];
+      component.ngOnChanges();
+
+      expect(component.filteredCards.map(card => card.report._id)).toEqual([ 'a', 'e' ]);
+    });
+  });
+
+  describe('label suggestions', () => {
+    it('lists the labels already in use, deduplicated and sorted', () => {
+      component.reports = [
+        report({ label: 'Quarterly' }),
+        report({ label: 'Annual' }),
+        report({ label: 'Quarterly' })
+      ];
+      component.ngOnChanges();
+
+      expect(component['reportLabels']()).toEqual([ 'Annual', 'Quarterly' ]);
+    });
+
+    it('omits reports with no usable label', () => {
+      component.reports = [ report({ label: '  ' }), report({}), report({ label: ' Audit ' }) ];
+      component.ngOnChanges();
+
+      expect(component['reportLabels']()).toEqual([ 'Audit' ]);
+    });
+  });
+});

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -24,6 +24,9 @@ import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.
 import { MatCard, MatCardContent, MatCardActions } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
 import { PdfImageSection, TeamsTablePdfExportService } from './teams-table-pdf-export.service';
 
 interface NewReportForm {
@@ -32,6 +35,7 @@ interface NewReportForm {
   beginningBalance: string,
   description: string,
   endDate: Date,
+  label?: string,
   otherExpenses: number,
   otherIncome: number,
   receiptImages?: AttachmentInputState,
@@ -57,6 +61,10 @@ interface NewReportForm {
     MatMenu,
     MatMenuItem,
     MatMenuTrigger,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    FormsModule,
     DatePipe,
     CurrencyPipe
   ]
@@ -71,6 +79,8 @@ export class TeamsReportsComponent implements OnChanges {
   configuration = this.stateService.configuration;
   curCode = this.stateService.configuration.currency || {};
   reportCards: any[] = [];
+  filteredCards: any[] = [];
+  filter = '';
 
   ngOnChanges() {
     this.reportCards = (this.reports || [])
@@ -81,6 +91,7 @@ export class TeamsReportsComponent implements OnChanges {
         const net = income - expenses;
         return {
           report,
+          searchText: this.searchableText(report),
           receiptImageCount: this.teamsAttachmentsService.receiptAttachments(report).length,
           income,
           expenses,
@@ -89,6 +100,29 @@ export class TeamsReportsComponent implements OnChanges {
           isLoss: net < 0
         };
       });
+    this.applyFilter(this.filter);
+  }
+
+  applyFilter(filter: string) {
+    this.filter = filter;
+    const search = (filter || '').trim().toLowerCase();
+    this.filteredCards = search === '' ?
+      this.reportCards :
+      this.reportCards.filter(card => card.searchText.indexOf(search) > -1);
+  }
+
+  private searchableText(report) {
+    return [
+      report.label,
+      formatDate(report.startDate, 'mediumDate', this.localeId, 'UTC'),
+      formatDate(report.endDate, 'mediumDate', this.localeId, 'UTC')
+    ].filter(text => !!text).join(' ').toLowerCase();
+  }
+
+  private reportLabels() {
+    return Array.from(new Set(
+      this.reportCards.map(({ report }) => (report.label || '').trim()).filter(label => label !== '')
+    )).sort((a, b) => a.localeCompare(b));
   }
 
   trackByReport(index: number, card: any) {
@@ -130,6 +164,13 @@ export class TeamsReportsComponent implements OnChanges {
       this.dialogsFormService.openDialogsForm(
         dialogTitle,
         [
+          {
+            name: 'label',
+            placeholder: $localize`Label (optional)`,
+            type: 'textbox',
+            maxLength: 50,
+            suggestions: this.reportLabels()
+          },
           { name: 'startDate', placeholder: $localize`Start Date`, type: 'date', required: true },
           { name: 'endDate', placeholder: $localize`End Date`, type: 'date', required: true },
           { name: 'description', placeholder: $localize`Summary`, type: 'markdown', required: true },
@@ -183,12 +224,13 @@ export class TeamsReportsComponent implements OnChanges {
   }
 
   openDeleteReportDialog(report) {
+    const dateRange = `${$localize`Report from`} ${formatDate(report.startDate, 'mediumDate', this.localeId, 'UTC')}
+      ${$localize`to`} ${formatDate(report.endDate, 'mediumDate', this.localeId, 'UTC')}`;
     const deleteDialog = this.dialog.open(DialogsPromptComponent, {
       data: {
         changeType: 'delete',
         type: 'report',
-        displayName: `${$localize`Report from`} ${formatDate(report.startDate, 'mediumDate', this.localeId, 'UTC')}
-          ${$localize`to`} ${formatDate(report.endDate, 'mediumDate', this.localeId, 'UTC')}`,
+        displayName: report.label ? `${report.label} (${dateRange})` : dateRange,
         okClick: {
           request: this.updateReport(report),
           onNext: () => {
@@ -212,6 +254,7 @@ export class TeamsReportsComponent implements OnChanges {
       'startDate', 'endDate', 'description', 'beginningBalance', 'sales', 'otherIncome', 'wages', 'otherExpenses'
     ];
     const initialValues = {
+      label: '',
       description: '',
       beginningBalance: 0,
       sales: 0,
@@ -246,7 +289,9 @@ export class TeamsReportsComponent implements OnChanges {
       (value as Date).getTime() :
       numberFields.indexOf(key) > -1 ?
         +value :
-        value;
+        key === 'label' ?
+          ((value as string) || '').trim() :
+          value;
     const { receiptImages = this.teamsAttachmentsService.emptyAttachmentState(), ...reportFields } = newReport as NewReportForm;
     const { _id, _rev, _attachments, ...newDoc } = Object.entries(reportFields).reduce(
       (obj, [ key, value ]: [ string, string | Date | number ]) => ({
@@ -287,8 +332,8 @@ export class TeamsReportsComponent implements OnChanges {
 
   exportReportsPdf() {
     const { data, title, titleName } = this.reportsExportData();
-    const totalIncome = this.reportCards.reduce((sum, card) => sum + card.income, 0);
-    const totalExpenses = this.reportCards.reduce((sum, card) => sum + card.expenses, 0);
+    const totalIncome = this.filteredCards.reduce((sum, card) => sum + card.income, 0);
+    const totalExpenses = this.filteredCards.reduce((sum, card) => sum + card.expenses, 0);
     this.dialogsLoadingService.start();
     this.receiptImageSections()
       .pipe(finalize(() => this.dialogsLoadingService.stop()))
@@ -307,7 +352,7 @@ export class TeamsReportsComponent implements OnChanges {
           $localize`Ending Balance`
         ],
         summary: [
-          { label: $localize`Reports`, value: this.reportCards.length },
+          { label: $localize`Reports`, value: this.filteredCards.length },
           { label: $localize`Total Credit`, value: totalIncome, format: 'currency' },
           { label: $localize`Total Debit`, value: totalExpenses, format: 'currency' },
           { label: $localize`Net Profit/Loss`, value: totalIncome - totalExpenses, format: 'currency' }
@@ -318,7 +363,9 @@ export class TeamsReportsComponent implements OnChanges {
   }
 
   private reportsExportData() {
-    const data = this.reportCards.map(({ report, income, expenses, net, endingBalance }) => ({
+    const hasLabels = this.filteredCards.some(({ report }) => !!report.label);
+    const data = this.filteredCards.map(({ report, income, expenses, net, endingBalance }) => ({
+      ...(hasLabels ? { [$localize`Label`]: report.label || '' } : {}),
       [$localize`Start Date`]: fullLabel(report.startDate, this.localeId),
       [$localize`End Date`]: fullLabel(report.endDate, this.localeId),
       [$localize`Created Date`]: fullLabel(report.createdDate, this.localeId),
@@ -342,7 +389,7 @@ export class TeamsReportsComponent implements OnChanges {
   }
 
   private receiptImageSections() {
-    const reportsWithReceipts = this.reportCards
+    const reportsWithReceipts = this.filteredCards
       .map(({ report }) => report)
       .filter(report => this.teamsAttachmentsService.receiptAttachments(report).length > 0);
     if (reportsWithReceipts.length === 0) {

--- a/src/app/teams/teams-reports.scss
+++ b/src/app/teams/teams-reports.scss
@@ -35,6 +35,10 @@
       height: 18px;
     }
   }
+  .reports-filter {
+    flex: 0 1 260px;
+    min-width: 180px;
+  }
 }
 
 .reports-grid {
@@ -68,6 +72,27 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
+}
+
+.report-card-eyebrow-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.report-card-label {
+  max-width: 100%;
+  min-width: 0;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: v.$light-grey;
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 11px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .report-card-eyebrow {

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -4570,6 +4570,9 @@ Other Notes</source>
       <trans-unit id="6590475405017990661" datatype="html">
         <source>reports</source>
       </trans-unit>
+      <trans-unit id="4886946918461962420" datatype="html">
+        <source>Filter by label or date...</source>
+      </trans-unit>
       <trans-unit id="6825329815737519497" datatype="html">
         <source>Export as CSV</source>
       </trans-unit>
@@ -4578,6 +4581,9 @@ Other Notes</source>
       </trans-unit>
       <trans-unit id="1708910385866786607" datatype="html">
         <source>No reports available at the moment.</source>
+      </trans-unit>
+      <trans-unit id="9070825613982367493" datatype="html">
+        <source>No reports match your search.</source>
       </trans-unit>
       <trans-unit id="7078271376845640958" datatype="html">
         <source>Loss</source>
@@ -4605,6 +4611,9 @@ Other Notes</source>
       </trans-unit>
       <trans-unit id="add-report-dialog-title" datatype="html">
         <source>Add Report</source>
+      </trans-unit>
+      <trans-unit id="7852991617746780291" datatype="html">
+        <source>Label (optional)</source>
       </trans-unit>
       <trans-unit id="5013593594310835150" datatype="html">
         <source>Other Income</source>


### PR DESCRIPTION
## Summary
Adds the ability to label financial reports and filter the reports list by label or date range. Reports can now be given optional labels (up to 50 characters) which appear as badges on report cards and in the detail view. A new filter input allows users to search reports by label or formatted date, with suggestions populated from existing labels.

## Key Changes
- **Report labeling**: Added optional `label` field to reports with max length of 50 characters
- **Filter UI**: New search input in the reports toolbar that filters by label or date range (case-insensitive, whitespace-trimmed)
- **Label suggestions**: Autocomplete suggestions in the add/edit report dialog populated from existing report labels (deduplicated and sorted)
- **Visual improvements**: 
  - Report cards now display labels as styled badges
  - Report detail dialog shows the label prominently
  - Empty state message when filter returns no results
- **Export updates**: PDF/CSV exports now include the label column (when any report has a label) and respect the active filter
- **Form field support**: Enhanced `dialogs-form.component` to support `maxLength` and `suggestions` (datalist) on textbox fields

## Implementation Details
- Filter state is preserved when reports reload via `ngOnChanges()`
- Searchable text includes label, start date, and end date formatted as "mediumDate"
- Label is trimmed on save to prevent whitespace-only labels
- Export totals and report counts reflect the filtered view, not all reports
- Added comprehensive unit tests covering filter matching, label suggestions, and filter persistence

https://claude.ai/code/session_01YG2SVBEEzLunniF1Qg4VXA