### PR TITLE
actions: smoother workflow labeling (fixes #10412)

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -2,7 +2,13 @@ name: Planet labels
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, edited]
+    # Never `edited`: it fires on every title or description rewrite -- and
+    # coderabbit rewrites the description of each pull request several times.
+    # Every one of those queued a run that cancelled the labelling run still in
+    # flight and then skipped itself, so a push could end up unlabelled behind a
+    # pile of skipped checks. Retargeting a pull request changes its diff without
+    # a push: relabel it by hand with the dispatch below.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr:
@@ -32,7 +38,6 @@ jobs:
     name: planet labels
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     steps:
       - name: label the pull request by size
         shell: bash

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -2,12 +2,6 @@ name: Planet labels
 
 on:
   pull_request_target:
-    # Never `edited`: it fires on every title or description rewrite -- and
-    # coderabbit rewrites the description of each pull request several times.
-    # Every one of those queued a run that cancelled the labelling run still in
-    # flight and then skipped itself, so a push could end up unlabelled behind a
-    # pile of skipped checks. Retargeting a pull request changes its diff without
-    # a push: relabel it by hand with the dispatch below.
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.54",
+  "version": "0.24.55",
   "myplanet": {
     "latest": "v0.70.45",
     "min": "v0.67.67"


### PR DESCRIPTION
Fixes #10412

## Summary

Removes the `edited` event type from the `pull_request_target` trigger in the planet labels workflow and simplifies the conditional logic that was working around it.

## Changes

- **Removed `edited` from workflow trigger types**: The workflow now only runs on `opened`, `synchronize`, `reopened`, and `ready_for_review` events. The `edited` event was causing excessive workflow runs whenever CodeRabbit or other tools rewrote PR titles/descriptions, leading to cascading cancellations and skipped labelling checks.
- **Removed conditional guard**: Deleted the `if: ${{ github.event.action != 'edited' || github.event.changes.base }}` condition that was attempting to skip runs on edits (except retargeting). This is no longer needed since the trigger itself excludes the `edited` event.

## Rationale

The `edited` event fires on every title or description rewrite. CodeRabbit rewrites PR descriptions multiple times, which queued multiple workflow runs that cancelled each other and resulted in PRs remaining unlabelled. Manual relabelling via `workflow_dispatch` is available for retargeted PRs (which change the diff without a push).

https://claude.ai/code/session_01CsgFLJCRY6VhZrkN27EBib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated pull request labeling behavior.
  - Labeling checks no longer run for pull request edits, and size-based processing now runs without the previous event-specific exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->