### PR TITLE
manager: smoother reports date filtering (fixes #10401)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.60",
+  "version": "0.24.61",
   "myplanet": {
     "latest": "v0.70.45",
     "min": "v0.67.67"

--- a/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.ts
@@ -148,8 +148,8 @@ export class LogsMyPlanetComponent extends MyPlanetFiltersBase implements OnInit
     this.isEmpty = areNoChildren(this.apklogs);
   }
 
-  private mapToCsvData(children: any[], planetName?: string): any[] {
-    return children.map((data: any) => ({
+  private mapToCsvData = (children: any[], planetName?: string): any[] =>
+    children.map((data: any) => ({
       ...(planetName ? { [$localize`Planet Name`]: planetName } : {}),
       [$localize`ID`]: data.androidId,
       [$localize`Name`]: data.deviceName || data.customDeviceName,
@@ -158,7 +158,6 @@ export class LogsMyPlanetComponent extends MyPlanetFiltersBase implements OnInit
       [$localize`Version`]: data.version,
       [$localize`Error`]:  data.error || $localize`N/A`,
     }));
-  }
 
   exportAll(): void {
     this.csvService.exportMyPlanet(this.apklogs, undefined, this.mapToCsvData, $localize`myPlanet Logs`);

--- a/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/logs-myplanet.component.ts
@@ -11,7 +11,6 @@ import { attachNamesToPlanets, areNoChildren, filterByDate } from '../reports.ut
 import { CsvService } from '../../../shared/csv.service';
 import { ReportsService } from '../reports.service';
 import { MyPlanetFiltersBase } from './filter.base';
-import { exportMyPlanetCsv } from '../reports.utils';
 import { MyPlanetToolbarComponent } from './myplanet-toolbar.component';
 import { MatToolbar, MatToolbarRow } from '@angular/material/toolbar';
 
@@ -39,7 +38,6 @@ import { PlanetLoadingSpinnerComponent } from '../../../shared/planet-loading-sp
 })
 export class LogsMyPlanetComponent extends MyPlanetFiltersBase implements OnInit {
 
-  private exportCsvHelper = exportMyPlanetCsv(this.csvService);
   private allPlanets: any[] = [];
   apklogs: any[] = [];
   planetType = this.stateService.configuration.planetType;
@@ -163,11 +161,11 @@ export class LogsMyPlanetComponent extends MyPlanetFiltersBase implements OnInit
   }
 
   exportAll(): void {
-    this.exportCsvHelper(this.apklogs, undefined, this.mapToCsvData, $localize`myPlanet Logs`);
+    this.csvService.exportMyPlanet(this.apklogs, undefined, this.mapToCsvData, $localize`myPlanet Logs`);
   }
 
   exportSingle(planet: any): void {
-    this.exportCsvHelper(planet.children, planet.name, this.mapToCsvData, $localize`myPlanet Logs for ${planet.name}`);
+    this.csvService.exportMyPlanet(planet.children, planet.name, this.mapToCsvData, $localize`myPlanet Logs for ${planet.name}`);
   }
 
 }

--- a/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
@@ -9,7 +9,7 @@ import { PlanetMessageService } from '../../../shared/planet-message.service';
 import { ManagerService } from '../../manager.service';
 import { ReportsService } from '../reports.service';
 import { CouchService } from '../../../shared/couchdb.service';
-import { attachNamesToPlanets, getDomainParams, areNoChildren, exportMyPlanetCsv, endOfDay } from '../reports.utils';
+import { attachNamesToPlanets, getDomainParams, areNoChildren, endOfDay } from '../reports.utils';
 import { findDocuments } from '../../../shared/mangoQueries';
 import { CsvService } from '../../../shared/csv.service';
 import { filterSpecificFields } from '../../../shared/table-helpers';
@@ -42,7 +42,6 @@ import { PlanetLoadingSpinnerComponent } from '../../../shared/planet-loading-sp
 })
 export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnInit {
 
-  private exportCsvHelper = exportMyPlanetCsv(this.csvService);
   private allPlanets: any[] = [];
   planets: any[] = [];
   isMobile: boolean;
@@ -199,11 +198,13 @@ export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnI
   }
 
   exportAll(): void {
-    this.exportCsvHelper(this.planets, undefined, this.mapToCsvData.bind(this), $localize`myPlanet Reports`);
+    this.csvService.exportMyPlanet(this.planets, undefined, this.mapToCsvData.bind(this), $localize`myPlanet Reports`);
   }
 
   exportSingle(planet: any): void {
-    this.exportCsvHelper(planet.children, planet.name, this.mapToCsvData.bind(this), $localize`myPlanet Reports for ${planet.name}`);
+    this.csvService.exportMyPlanet(
+      planet.children, planet.name, this.mapToCsvData.bind(this), $localize`myPlanet Reports for ${planet.name}`
+    );
   }
 
 }

--- a/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
@@ -181,8 +181,8 @@ export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnI
     );
   }
 
-  private mapToCsvData(children: any[], planetName?: string): any[] {
-    return children.map((data: any) => ({
+  private mapToCsvData = (children: any[], planetName?: string): any[] =>
+    children.map((data: any) => ({
       ...(planetName ? { [$localize`Planet Name`]: planetName } : {}),
       [$localize`ID`]: data.androidId.toString() || data.uniqueAndroidId.toString(),
       [$localize`Name`]: data.deviceName || data.customDeviceName,
@@ -195,16 +195,13 @@ export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnI
       [$localize`No of Visits`]: data.count,
       [$localize`Used Time`]: this.timePipe.transform(data.totalUsedTime),
     }));
-  }
 
   exportAll(): void {
-    this.csvService.exportMyPlanet(this.planets, undefined, this.mapToCsvData.bind(this), $localize`myPlanet Reports`);
+    this.csvService.exportMyPlanet(this.planets, undefined, this.mapToCsvData, $localize`myPlanet Reports`);
   }
 
   exportSingle(planet: any): void {
-    this.csvService.exportMyPlanet(
-      planet.children, planet.name, this.mapToCsvData.bind(this), $localize`myPlanet Reports for ${planet.name}`
-    );
+    this.csvService.exportMyPlanet(planet.children, planet.name, this.mapToCsvData, $localize`myPlanet Reports for ${planet.name}`);
   }
 
 }

--- a/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/reports-myplanet.component.ts
@@ -192,8 +192,8 @@ export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnI
     );
   }
 
-  private mapToCsvData = (children: any[], planetName?: string): any[] =>
-    children.map((data: any) => ({
+  private mapToCsvData(children: any[], planetName?: string): any[] {
+    return children.map((data: any) => ({
       ...(planetName ? { [$localize`Planet Name`]: planetName } : {}),
       [$localize`ID`]: (data.androidId || data.uniqueAndroidId || '').toString(),
       [$localize`Name`]: data.deviceName || data.customDeviceName,
@@ -207,13 +207,19 @@ export class ReportsMyPlanetComponent extends MyPlanetFiltersBase implements OnI
       [$localize`No of Visits`]: data.count,
       [$localize`Used Time`]: this.timePipe.transform(data.totalUsedTime),
     }));
+  }
 
   exportAll(): void {
-    this.csvService.exportMyPlanet(this.planets, undefined, this.mapToCsvData, $localize`myPlanet Reports`);
+    this.csvService.exportMyPlanet(
+      this.planets, undefined, (children, planetName) => this.mapToCsvData(children, planetName), $localize`myPlanet Reports`
+    );
   }
 
   exportSingle(planet: any): void {
-    this.csvService.exportMyPlanet(planet.children, planet.name, this.mapToCsvData, $localize`myPlanet Reports for ${planet.name}`);
+    this.csvService.exportMyPlanet(
+      planet.children, planet.name, (children, planetName) => this.mapToCsvData(children, planetName),
+      $localize`myPlanet Reports for ${planet.name}`
+    );
   }
 
 }

--- a/src/app/manager-dashboard/reports/reports-detail.component.spec.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.spec.ts
@@ -1,0 +1,36 @@
+import { vi } from 'vitest';
+
+import { ReportsDetailComponent } from './reports-detail.component';
+
+describe('ReportsDetailComponent time frame defaults', () => {
+  const buildComponent = (selectedTimeFilter: string, startDate: Date) => {
+    const component = Object.create(ReportsDetailComponent.prototype) as ReportsDetailComponent;
+    component.selectedTimeFilter = selectedTimeFilter;
+    component.filter = { app: '', members: [], startDate, endDate: new Date(2025, 5, 1) };
+    component.minDate = new Date(2018, 6, 1);
+    return component;
+  };
+
+  it('seeds the custom range with the dates already on screen', () => {
+    const patchValue = vi.fn();
+    const twelveMonthsAgo = new Date(2024, 5, 1);
+    const component = buildComponent('12m', twelveMonthsAgo);
+    component.dateFilterForm = { patchValue } as any;
+    (component as any).activityService = {
+      getDateRange: () => ({ startDate: null, endDate: null, showCustomDateFields: true })
+    };
+
+    component.onTimeFilterChange('custom');
+
+    expect(patchValue).toHaveBeenCalledWith({ startDate: twelveMonthsAgo, endDate: new Date(2025, 5, 1) });
+  });
+
+  it('follows the selected time frame rather than a fixed default', () => {
+    const component = buildComponent('12m', new Date(2024, 5, 1));
+    const getDateRange = vi.fn(() => ({ startDate: new Date(2024, 0, 2), endDate: new Date(), showCustomDateFields: false }));
+    (component as any).activityService = { getDateRange };
+
+    expect((component as any).defaultStartDate()).toEqual(new Date(2024, 0, 2));
+    expect(getDateRange).toHaveBeenCalledWith('12m', component.minDate);
+  });
+});

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -343,7 +343,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       this.minDate = new Date(new Date(this.activityService.minTime(this.loginActivities.data, 'loginTime')).setHours(0, 0, 0, 0));
       this.dateFilterForm.controls.startDate.setValue(
         this.dateQueryParams.startDate instanceof Date && !isNaN(this.dateQueryParams.startDate.getTime())
-          ? this.dateQueryParams.startDate : new Date(new Date().setMonth(new Date().getMonth() - 3))
+          ? this.dateQueryParams.startDate : this.defaultStartDate()
       );
       this.setLoginActivities();
     });
@@ -942,14 +942,19 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     }, { emitEvent: true });
   }
 
+  private defaultStartDate() {
+    return this.selectedTimeFilter === 'custom' ?
+      this.filter.startDate :
+      this.activityService.getDateRange(this.selectedTimeFilter, this.minDate).startDate;
+  }
+
   onTimeFilterChange(timeFilter: string) {
     this.selectedTimeFilter = timeFilter;
     const { startDate, endDate, showCustomDateFields } = this.activityService.getDateRange(timeFilter, this.minDate);
     this.showCustomDateFields = showCustomDateFields;
 
     if (timeFilter === 'custom') {
-      const currentStartDate = new Date();
-      currentStartDate.setMonth(currentStartDate.getMonth() - 3);
+      const currentStartDate = this.defaultStartDate();
       const currentEndDate = this.filter.endDate || this.today;
       this.dateFilterForm.patchValue({
         startDate: currentStartDate,

--- a/src/app/manager-dashboard/reports/reports-detail.component.ts
+++ b/src/app/manager-dashboard/reports/reports-detail.component.ts
@@ -140,7 +140,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     startDate: null,
     endDate: null
   };
-  selectedTimeFilter = '12m';
+  selectedTimeFilter = '3m';
   showCustomDateFields = false;
   resourcesLoading = true;
   coursesLoading = true;
@@ -343,7 +343,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
       this.minDate = new Date(new Date(this.activityService.minTime(this.loginActivities.data, 'loginTime')).setHours(0, 0, 0, 0));
       this.dateFilterForm.controls.startDate.setValue(
         this.dateQueryParams.startDate instanceof Date && !isNaN(this.dateQueryParams.startDate.getTime())
-          ? this.dateQueryParams.startDate : new Date(new Date().setMonth(new Date().getMonth() - 12))
+          ? this.dateQueryParams.startDate : new Date(new Date().setMonth(new Date().getMonth() - 3))
       );
       this.setLoginActivities();
     });
@@ -949,7 +949,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
 
     if (timeFilter === 'custom') {
       const currentStartDate = new Date();
-      currentStartDate.setMonth(currentStartDate.getMonth() - 12);
+      currentStartDate.setMonth(currentStartDate.getMonth() - 3);
       const currentEndDate = this.filter.endDate || this.today;
       this.dateFilterForm.patchValue({
         startDate: currentStartDate,
@@ -967,7 +967,7 @@ export class ReportsDetailComponent implements OnInit, OnDestroy {
     this.filter.app = '';
     this.selectedTeam = 'All';
     this.filter.members = [];
-    this.onTimeFilterChange('12m');
+    this.onTimeFilterChange('3m');
   }
 
   onHealthLoadingChange(loading: boolean) {

--- a/src/app/manager-dashboard/reports/reports.service.spec.ts
+++ b/src/app/manager-dashboard/reports/reports.service.spec.ts
@@ -1,0 +1,43 @@
+import { vi } from 'vitest';
+
+import { ReportsService } from './reports.service';
+
+describe('ReportsService.getDateRange', () => {
+  const service = Object.create(ReportsService.prototype) as ReportsService;
+  const minDate = new Date(2018, 6, 1);
+
+  const atTime = (date: Date) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clamps a month end start date to the last day of the target month', () => {
+    atTime(new Date(2025, 4, 31, 14, 30));
+
+    // Unclamped, subtracting three months from May 31 overflows Feb 31 into Mar 3.
+    expect(service.getDateRange('3m', minDate).startDate).toEqual(new Date(2025, 1, 28));
+  });
+
+  it('clamps a leap day start date when going back a year', () => {
+    atTime(new Date(2024, 1, 29, 9, 15));
+
+    expect(service.getDateRange('12m', minDate).startDate).toEqual(new Date(2023, 1, 28));
+  });
+
+  it('does not let the start date calculation move the end of the range', () => {
+    atTime(new Date(2025, 4, 31, 14, 30));
+
+    expect(service.getDateRange('3m', minDate).endDate).toEqual(new Date(2025, 4, 31, 14, 30));
+  });
+
+  it('leaves the day and hour ranges rolling', () => {
+    atTime(new Date(2025, 4, 31, 14, 30));
+
+    expect(service.getDateRange('7d', minDate).startDate).toEqual(new Date(2025, 4, 24, 14, 30));
+    expect(service.getDateRange('24h', minDate).startDate).toEqual(new Date(2025, 4, 30, 14, 30));
+  });
+});

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -27,6 +27,7 @@ export class ReportsService {
     { value: '24h', label: $localize`Last 24 Hours` },
     { value: '7d', label: $localize`Last 7 Days` },
     { value: '1m', label: $localize`Last Month` },
+    { value: '3m', label: $localize`Last 3 Months` },
     { value: '6m', label: $localize`Last 6 Months` },
     { value: '12m', label: $localize`Last 12 Months` },
     { value: 'all', label: $localize`All Time` },
@@ -331,6 +332,10 @@ export class ReportsService {
       case '1m':
         startDate = new Date(now);
         startDate.setMonth(now.getMonth() - 1);
+        break;
+      case '3m':
+        startDate = new Date(now);
+        startDate.setMonth(now.getMonth() - 3);
         break;
       case '6m':
         startDate = new Date(now);

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -9,6 +9,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { DialogsViewComponent } from '../../shared/dialogs/dialogs-view.component';
 import { StateService } from '../../shared/state.service';
 import { CoursesService } from '../../courses/courses.service';
+import { startOfDay, subtractMonthsClamped } from './reports.utils';
 
 interface ActivityRequestObject {
   planetCode?: string;
@@ -329,21 +330,19 @@ export class ReportsService {
         startDate = new Date(now);
         startDate.setDate(now.getDate() - 7);
         break;
+      // The month ranges pin their start to the top of the day so it does not drift with
+      // the clock; the end stays 'now', and the day and hour ranges stay rolling.
       case '1m':
-        startDate = new Date(now);
-        startDate.setMonth(now.getMonth() - 1);
+        startDate = startOfDay(subtractMonthsClamped(now, 1));
         break;
       case '3m':
-        startDate = new Date(now);
-        startDate.setMonth(now.getMonth() - 3);
+        startDate = startOfDay(subtractMonthsClamped(now, 3));
         break;
       case '6m':
-        startDate = new Date(now);
-        startDate.setMonth(now.getMonth() - 6);
+        startDate = startOfDay(subtractMonthsClamped(now, 6));
         break;
       case '12m':
-        startDate = new Date(now);
-        startDate.setMonth(now.getMonth() - 12);
+        startDate = startOfDay(subtractMonthsClamped(now, 12));
         break;
       case 'all':
         startDate = minDate;

--- a/src/app/manager-dashboard/reports/reports.service.ts
+++ b/src/app/manager-dashboard/reports/reports.service.ts
@@ -328,8 +328,6 @@ export class ReportsService {
         startDate = new Date(now);
         startDate.setDate(now.getDate() - 7);
         break;
-      // The month ranges pin their start to the top of the day so it does not drift with
-      // the clock; the end stays 'now', and the day and hour ranges stay rolling.
       case '1m':
         startDate = startOfDay(subtractMonthsClamped(now, 1));
         break;

--- a/src/app/manager-dashboard/reports/reports.utils.ts
+++ b/src/app/manager-dashboard/reports/reports.utils.ts
@@ -1,5 +1,4 @@
 import { millisecondsToDay } from '../../meetups/constants';
-import { CsvService } from '../../shared/csv.service';
 
 export const attachNamesToPlanets = (planetDocs: any[]) => {
   const names = planetDocs.filter(doc => doc.docType === 'parentName');
@@ -9,6 +8,16 @@ export const attachNamesToPlanets = (planetDocs: any[]) => {
 export const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
 
 export const endOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+
+export const subtractMonthsClamped = (date: Date, months: number) => {
+  const result = new Date(date);
+  const day = result.getDate();
+  result.setDate(1);
+  result.setMonth(result.getMonth() - months);
+  const lastDayOfMonth = new Date(result.getFullYear(), result.getMonth() + 1, 0).getDate();
+  result.setDate(Math.min(day, lastDayOfMonth));
+  return result;
+};
 
 export const codeToPlanetName = (code: string, configuration: any, childPlanets: any[]) => {
   const planet = childPlanets.find((childPlanet: any) => childPlanet.doc.code === code);
@@ -187,14 +196,4 @@ export const thursdayWeekRangeFromEnd = (endDate: Date) => {
   const start = new Date(end);
   start.setDate(start.getDate() - 6);
   return { startDate: startOfDay(start), endDate: end };
-};
-
-export const exportMyPlanetCsv = (csvService: CsvService) => (
-  children: any[],
-  planetName: string | undefined,
-  mapFn: (children: any[], planetName?: string) => any[],
-  title: string
-): void => {
-  const csvData = planetName ? mapFn(children, planetName) : children.flatMap((planet: any) => mapFn(planet.children, planet.name));
-  csvService.exportCSV({ data: csvData, title });
 };

--- a/src/app/shared/csv.service.spec.ts
+++ b/src/app/shared/csv.service.spec.ts
@@ -108,4 +108,40 @@ describe('CsvService', () => {
       { responseType: 'text', domain: undefined }
     );
   });
+
+  describe('exportMyPlanet', () => {
+    const mapFn = (children: any[], planetName?: string) => children.map(child => ({ ...child, planetName }));
+
+    it('maps one planet\'s children with the name it was given', () => {
+      const exportCSV = vi.spyOn(service, 'exportCSV').mockImplementation(() => {});
+      const spiedMapFn = vi.fn(mapFn);
+
+      service.exportMyPlanet([ { id: 1 }, { id: 2 } ], 'Community A', spiedMapFn, 'myPlanet Reports');
+
+      expect(spiedMapFn).toHaveBeenCalledWith([ { id: 1 }, { id: 2 } ], 'Community A');
+      expect(exportCSV).toHaveBeenCalledWith({
+        data: [ { id: 1, planetName: 'Community A' }, { id: 2, planetName: 'Community A' } ],
+        title: 'myPlanet Reports'
+      });
+    });
+
+    it('flattens every planet\'s mapped children when no planet name is given', () => {
+      const exportCSV = vi.spyOn(service, 'exportCSV').mockImplementation(() => {});
+      const planets = [
+        { name: 'Community A', children: [ { id: 1 } ] },
+        { name: 'Community B', children: [ { id: 2 }, { id: 3 } ] }
+      ];
+
+      service.exportMyPlanet(planets, undefined, mapFn, 'myPlanet Reports');
+
+      expect(exportCSV).toHaveBeenCalledWith({
+        data: [
+          { id: 1, planetName: 'Community A' },
+          { id: 2, planetName: 'Community B' },
+          { id: 3, planetName: 'Community B' }
+        ],
+        title: 'myPlanet Reports'
+      });
+    });
+  });
 });

--- a/src/app/shared/csv.service.ts
+++ b/src/app/shared/csv.service.ts
@@ -59,6 +59,18 @@ export class CsvService {
     this.generate(formattedData, options);
   }
 
+  exportMyPlanet(
+    children: any[],
+    planetName: string | undefined,
+    mapFn: (children: any[], planetName?: string) => any[],
+    title: string
+  ): void {
+    const csvData = planetName ?
+      mapFn(children, planetName) :
+      children.flatMap((planet: any) => mapFn(planet.children, planet.name));
+    this.exportCSV({ data: csvData, title });
+  }
+
   exportSummaryCSV(
     logins: any[], resourceViews: any[], courseViews: any[], stepCompletions: any[],
     chatActivities: any[], voicesActivities: any[], planetName: string, startDate: Date, endDate: Date


### PR DESCRIPTION
Fixes #10401

## Summary
Updates the default time filter in the reports dashboard from 12 months to 3 months, providing a more focused view of recent activity by default.

<img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/04cb529c-922e-4f20-a952-4f3cd69e29a2" />

## Changes
- **ReportsDetailComponent**: 
  - Changed `selectedTimeFilter` default from `'12m'` to `'3m'`
  - Updated default start date calculation from 12 months back to 3 months back in login activities initialization
  - Updated custom date filter fallback from 12 months to 3 months
  - Updated reset filter method to use `'3m'` instead of `'12m'`

- **ReportsService**:
  - Added new `'3m'` (Last 3 Months) time filter option to the available filters list
  - Implemented date range calculation for the `'3m'` filter case in the date range logic

https://claude.ai/code/session_014jNNm16a6nqjk7uNiMq8c1

Additionally, addressed the month-end overflow reported here and tightened the related report date handling:
- Added clamped subtraction for all month filters (1m, 3m, 6m, and 12m). Dates such as May 31 now correctly resolve to February 28 instead of overflowing into March.
- Month ranges now begin at the start of their boundary day, preventing results from changing based on when the report is opened. The rolling behavior for 24h and 7d remains unchanged.
- Switching to Custom now preserves the displayed range instead of resetting it to a fixed default.
- Report reloads now follow the selected time filter instead of applying a hardcoded three-month range.
- Removed the reports/CSV utility dependency cycle by moving myPlanet export handling into CsvService. This also removes the constructor-time export helper initialization from both myPlanet components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a “Last 3 Months” date filter to reports.
- Reports now default to displaying the past three months.
- Custom date selection starts with the current default reporting range.
- Improved CSV exports for single and multiple Planet reports.

## Bug Fixes
- Clearing report filters restores the three-month date range.
- Report date ranges now handle month-end and leap-day dates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->