### PR TITLE
surveys: smoother public survey welcoming

### DIFF
--- a/src/app/exams/public-surveys/public-survey.component.html
+++ b/src/app/exams/public-surveys/public-survey.component.html
@@ -5,7 +5,34 @@
   </div>
 }
 
-@if (survey && !isSubmitted && !showDemographics) {
+@if (isLoading) {
+  <planet-loading-spinner text="Loading survey..." i18n-text></planet-loading-spinner>
+}
+
+@if (survey && !hasStarted && !isSubmitted) {
+  <div class="survey-intro">
+    <div class="survey-intro__card km-survey-intro">
+      <mat-icon aria-hidden="true" class="survey-intro__icon primary-text-color">assignment</mat-icon>
+      <p class="survey-intro__invite" i18n>You have been invited to take the following survey</p>
+      <h1 class="survey-intro__name km-survey-name">{{ survey.name }}</h1>
+      @if (team?.name) {
+        <p class="survey-intro__team" i18n>Shared by {{ team.name }}</p>
+      }
+      <div class="survey-intro__meta">
+        <span class="survey-intro__meta-item">
+          <mat-icon aria-hidden="true">help_outline</mat-icon>
+          <span i18n>{maxQuestions, plural, =1 {1 question} other {{{maxQuestions}} questions}}</span>
+        </span>
+      </div>
+      @if (survey.description) {
+        <planet-markdown class="survey-intro__description" [content]="survey.description"></planet-markdown>
+      }
+      <button mat-raised-button color="primary" class="survey-intro__start km-start-survey" (click)="startSurvey()" i18n>Start Survey</button>
+    </div>
+  </div>
+}
+
+@if (survey && hasStarted && !isSubmitted && !showDemographics) {
   <planet-exams-question-frame
     [title]="survey.name"
     [questionNum]="questionNum"
@@ -48,7 +75,7 @@
   </planet-exams-question-frame>
 }
 
-@if (survey && showDemographics && !isSubmitted) {
+@if (survey && hasStarted && showDemographics && !isSubmitted) {
   <div class="state-view">
     <div [formGroup]="demographicsForm" class="demographics-form">
       <mat-radio-group formControlName="gender">

--- a/src/app/exams/public-surveys/public-survey.component.scss
+++ b/src/app/exams/public-surveys/public-survey.component.scss
@@ -1,3 +1,5 @@
+@use '../../variables' as v;
+
 .state-view {
   display: flex;
   flex-direction: column;
@@ -23,4 +25,94 @@
   display: flex;
   gap: 12px;
   justify-content: center;
+}
+
+.survey-intro {
+  display: flex;
+  justify-content: center;
+  padding: 5vh 1rem;
+}
+
+.survey-intro__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  width: min(100%, 620px);
+  padding: 2rem 1.5rem;
+  background-color: v.$white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px v.$shadow;
+  text-align: center;
+}
+
+.survey-intro__icon {
+  font-size: 3rem;
+  height: 3rem;
+  width: 3rem;
+}
+
+.survey-intro__invite {
+  margin: 0;
+  color: v.$grey-text;
+}
+
+.survey-intro__name {
+  margin: 0;
+  font-size: 1.75rem;
+  line-height: 1.2;
+  overflow-wrap: break-word;
+}
+
+.survey-intro__team {
+  margin: 0;
+  color: v.$grey-text;
+}
+
+.survey-intro__meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 1.5rem;
+  color: v.$grey-text;
+}
+
+.survey-intro__meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+
+  mat-icon {
+    font-size: 1.25rem;
+    height: 1.25rem;
+    width: 1.25rem;
+  }
+}
+
+.survey-intro__description {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid v.$light-grey;
+  text-align: left;
+  overflow-wrap: break-word;
+}
+
+.survey-intro__start {
+  margin-top: 0.5rem;
+}
+
+@media (max-width: v.$screen-xs) {
+  .survey-intro {
+    padding: 2vh 0.5rem;
+  }
+
+  .survey-intro__card {
+    padding: 1.5rem 1rem;
+  }
+
+  .survey-intro__name {
+    font-size: 1.4rem;
+  }
 }

--- a/src/app/exams/public-surveys/public-survey.component.spec.ts
+++ b/src/app/exams/public-surveys/public-survey.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { MatDialog } from '@angular/material/dialog';
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+
+import { PublicSurveyComponent } from './public-survey.component';
+import { PublicSurveysService } from './public-surveys.service';
+import { AndroidAppPromptService } from '../../shared/android-app-prompt.service';
+
+describe('PublicSurveyComponent', () => {
+  let fixture: ComponentFixture<PublicSurveyComponent>;
+  const paramMap = convertToParamMap({ teamId: 'team-1', surveyId: 'survey-1' });
+  const surveyResponse = {
+    survey: {
+      _id: 'survey-1',
+      name: 'Community Health Check',
+      description: 'A few questions about how the health post is serving you.',
+      questions: [
+        { body: 'How often do you visit?', type: 'select', choices: [] },
+        { body: 'What would you change?', type: 'textarea', choices: [] }
+      ],
+      type: 'survey' as const
+    },
+    team: { _id: 'team-1', name: 'Bhaktapur Learning Center', type: 'team' }
+  };
+  const publicSurveysService = { getSurvey: vi.fn(), submitSurvey: vi.fn() };
+
+  const createComponent = () => {
+    TestBed.configureTestingModule({
+      imports: [PublicSurveyComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: { paramMap: of(paramMap), snapshot: { paramMap } } },
+        { provide: PublicSurveysService, useValue: publicSurveysService },
+        { provide: MatDialog, useValue: { open: vi.fn() } },
+        { provide: AndroidAppPromptService, useValue: { openIfEligible: vi.fn() } },
+        provideHttpClient(withInterceptorsFromDi())
+      ]
+    });
+    fixture = TestBed.createComponent(PublicSurveyComponent);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    publicSurveysService.getSurvey.mockReturnValue(of(surveyResponse));
+  });
+
+  afterEach(() => {
+    publicSurveysService.getSurvey.mockReset();
+    publicSurveysService.submitSurvey.mockReset();
+  });
+
+  it('welcomes the visitor with the survey name and description instead of the first question', () => {
+    createComponent();
+
+    const intro = fixture.debugElement.query(By.css('.km-survey-intro'));
+
+    expect(intro).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('.km-survey-name')).nativeElement.textContent)
+      .toContain('Community Health Check');
+    expect(intro.nativeElement.textContent).toContain('invited');
+    expect(intro.nativeElement.textContent).toContain('Bhaktapur Learning Center');
+    expect(fixture.debugElement.query(By.css('planet-exams-question-frame'))).toBeNull();
+  });
+
+  it('tells the visitor up front how many questions there are', () => {
+    createComponent();
+
+    expect(fixture.debugElement.query(By.css('.km-survey-intro')).nativeElement.textContent).toContain('2 questions');
+  });
+
+  it('opens the first question only once the visitor chooses to start', () => {
+    createComponent();
+
+    fixture.debugElement.query(By.css('.km-start-survey')).triggerEventHandler('click');
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.km-survey-intro'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('planet-exams-question-frame'))).toBeTruthy();
+    expect(fixture.componentInstance.questionNum).toBe(1);
+  });
+
+  it('shows the error state rather than a welcome when the survey is unavailable', () => {
+    publicSurveysService.getSurvey.mockReturnValue(throwError({ error: { message: 'Survey not found or not public' } }));
+
+    createComponent();
+
+    expect(fixture.debugElement.query(By.css('.km-survey-intro'))).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Survey not found or not public');
+  });
+});

--- a/src/app/exams/public-surveys/public-survey.component.ts
+++ b/src/app/exams/public-surveys/public-survey.component.ts
@@ -13,9 +13,10 @@ import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import { ExamsQuestionFrameComponent } from '../exams-question-frame.component';
 import { ExamsTakeWidgetComponent } from '../exams-take/exams-take-widget.component';
 import { StoredExamAnswer, ExamAnswerValue, examAnswerValidator } from '../exams-take/exam-answer.helpers';
-import { PublicSurvey, PublicSurveyDemographics, PublicSurveysService } from './public-surveys.service';
+import { PublicSurvey, PublicSurveyDemographics, PublicSurveysService, PublicSurveyTeam } from './public-surveys.service';
 import { LoginDialogComponent } from '../../login/login-dialog.component';
 import { AndroidAppPromptService } from '../../shared/android-app-prompt.service';
+import { PlanetLoadingSpinnerComponent } from '../../shared/planet-loading-spinner.component';
 
 @Component({
   selector: 'planet-public-survey',
@@ -23,14 +24,17 @@ import { AndroidAppPromptService } from '../../shared/android-app-prompt.service
   styleUrls: ['./public-survey.component.scss'],
   imports: [
     MatIcon, PlanetMarkdownComponent, ExamsQuestionFrameComponent, ExamsTakeWidgetComponent, MatButton,
-    ReactiveFormsModule, MatFormField, MatLabel, MatHint, MatError, MatInput, MatRadioGroup, MatRadioButton
+    ReactiveFormsModule, MatFormField, MatLabel, MatHint, MatError, MatInput, MatRadioGroup, MatRadioButton,
+    PlanetLoadingSpinnerComponent
   ]
 })
 export class PublicSurveyComponent implements OnInit {
   @ViewChild(ExamsQuestionFrameComponent) questionFrame?: ExamsQuestionFrameComponent;
 
   survey: PublicSurvey | null = null;
+  team: PublicSurveyTeam | null = null;
   errorMessage = '';
+  hasStarted = false;
   questionNum = 1;
   answers: StoredExamAnswer[] = [];
   currentAnswer: ExamAnswerValue | null = null;
@@ -73,9 +77,11 @@ export class PublicSurveyComponent implements OnInit {
     this.route.paramMap.pipe(
       switchMap(params => this.publicSurveysService.getSurvey(params.get('teamId') || '', params.get('surveyId') || ''))
     ).subscribe({
-      next: ({ survey }) => {
+      next: ({ survey, team }) => {
         this.survey = survey;
+        this.team = team;
         this.errorMessage = '';
+        this.hasStarted = false;
         this.questionNum = 1;
         this.answers = Array.from({ length: survey.questions.length }, () => ({ value: null, valid: false }));
         this.currentAnswer = this.answers[0]?.value ?? null;
@@ -90,6 +96,10 @@ export class PublicSurveyComponent implements OnInit {
         this.isLoading = false;
       }
     });
+  }
+
+  startSurvey() {
+    this.hasStarted = true;
   }
 
   moveQuestion(direction: number) {

--- a/src/app/exams/public-surveys/public-surveys.service.ts
+++ b/src/app/exams/public-surveys/public-surveys.service.ts
@@ -9,6 +9,12 @@ export interface PublicSurveyDemographics {
   gender?: string;
 }
 
+export interface PublicSurveyTeam {
+  _id: string;
+  name: string;
+  type: string;
+}
+
 export interface PublicSurvey {
   _id: string;
   name: string;
@@ -19,7 +25,7 @@ export interface PublicSurvey {
 
 export interface PublicSurveyResponse {
   survey: PublicSurvey;
-  team: { _id: string; name: string; type: string };
+  team: PublicSurveyTeam;
 }
 
 @Injectable({


### PR DESCRIPTION
## What

Opening a public survey link dropped the visitor straight onto question 1, with no sense of what they had been asked to fill in or who was asking. This adds a welcome card before the questions:

- an invitation line ("You have been invited to take the following survey")
- the survey name
- the team that shared it
- the question count
- the survey description, rendered as markdown

The first question opens only once the visitor presses **Start Survey**. Everything after that — the question frame, the demographics step, submission — is unchanged.

Also renders a loading spinner while the survey is fetched, where the page previously sat blank.

## Notes

No gateway changes were needed. `/public/surveys/:teamId/:surveyId` already returned both `description` and the `team` doc (`gateway/src/modules/public/services/surveys.service.ts`); the client just wasn't using either. The only service change is extracting the inline team shape into a named `PublicSurveyTeam` interface.

An estimated "time to complete" was prototyped and deliberately dropped from this PR — how (and whether) to estimate duration, and whether it should extend to tests, is worth a team decision first rather than landing a guess. Worth knowing for that discussion: tests retry until the answer is correct (`src/app/exams/exams-view.component.ts:250-253`), so completion time there depends on how well the learner knows the material, not on the question count. Surveys have no wrong answers, which makes them a much more honest place for an estimate.

The i18n catalog is intentionally not regenerated here — `src/i18n/messages.xlf` is already ~500 lines behind master from other work, and extracting would bury this change in unrelated churn. The new strings are all tagged `i18n` and will be picked up by the next `npm run i18n:extract`.

## Testing

- `npm run lint` — clean
- `npx vitest run` — 364 passing, including 4 new specs for the welcome card (renders instead of question 1, shows the question count, opens question 1 only after Start Survey, falls back to the error state when the survey is unavailable)
- `npm run build` — clean
- Ran the app against a stubbed CouchDB/gateway and drove it with Playwright to confirm the card renders and Start Survey advances to question 1, on desktop and mobile widths

## Follow-ups (not in this PR)

- The in-course and team survey/test flow (`ExamsViewComponent`) has the same no-landing-page problem, but it serves take/grade/view/preview modes and runs as a dialog, so it needs more care than the public component did.
- `src/app/teams/teams-reports.component.html:81` uses `other {# attached images}` in an ICU plural. Angular does not substitute `#` here — it renders literally — so that line is likely showing "# attached images" today. Left alone as out of scope, but it looks like a live bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jkz9NwX9qfhevkcYDuY4GJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jkz9NwX9qfhevkcYDuY4GJ)_