### PR TITLE
ci: add line ending consistency check to pre-push hook

### DIFF
--- a/.github/workflows/planet.yml
+++ b/.github/workflows/planet.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the line ending check needs master to diff against
 
       - name: Setup Node.js 24
         uses: actions/setup-node@v6
@@ -50,6 +52,10 @@ jobs:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: package-lock.json
+
+      # Before npm ci: the check needs no node_modules, so it fails in seconds.
+      - name: Check line endings
+        run: npm run lint:eol
 
       - name: Install dependencies
         run: npm ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Prerequisites: Node.js v22, npm v10, Angular CLI v20. A CouchDB instance must be
 ### Angular app (root)
 
 - `npm install` — install dependencies.
-- `npm run install-hooks` — copy `git-hooks/*` into `.git/hooks`. The `pre-push` hook runs `npm run lint` in both the root and `gateway/`.
+- `npm run install-hooks` — copy `git-hooks/*` into `.git/hooks`. The `pre-push` hook runs `npm run lint:eol`, then `npm run lint` in both the root and `gateway/`.
 - `npm start` / `ng serve` — dev server on port 3000 (host `0.0.0.0`). If 3000 is taken, use `ng serve --port 3001`.
 - `npm run dev` — runs `scripts/dev-env.sh` (which templates `src/environments/environment.dev.ts` from `environment.template` using `CHAT_PORT`, `COUCH_PORT`, `PARENT_PROTOCOL` from an optional `.env`) then `ng serve --configuration dev`. Use this when chatapi or CouchDB are on non-default ports.
 - `npm run build` — production build via `ng-high-memory` (`--max_old_space_size=4096`); large builds OOM without it.
@@ -17,6 +17,7 @@ Prerequisites: Node.js v22, npm v10, Angular CLI v20. A CouchDB instance must be
 - Single spec: `ng test --include src/app/path/to/file.spec.ts` (or temporarily use `fdescribe` / `fit`).
 - `npm run lint` — ESLint over `src/**/*.{ts,html}` via `@angular-eslint/builder`. `ng lint --fix` auto-fixes.
 - `npm run lint-all` — sass-lint + `ng lint --type-check` + htmlhint. Heavier than the pre-push hook.
+- `npm run lint:eol` — `scripts/check-line-endings.mjs`, which fails on files that mix LF and CRLF. A file may be all LF or all CRLF (neither `.editorconfig` nor `.gitattributes` can express that), but never both. Only files the branch changes are inspected — measured against `origin/master` — so the mixed files already in the tree stay put until someone edits one, at which point that file has to be normalized. `node scripts/check-line-endings.mjs --all` audits the whole tree; `--base <ref>` compares against something other than master. Runs in CI (`Planet Builder` → `Tests`, before `npm ci`) and in the `pre-push` hook — the hook for fast local feedback, CI as the gate that actually binds, since hooks are opt-in, `--no-verify`-able, and absent entirely for agents that push through the API. Fork PRs are the one gap: their pushes do not trigger this repo's workflows.
 - Locales (en, so, fr, ne, ar, es): `ng serve --configuration <spa|fra|nep|ara|som>` or `LNG=es npm start`. Locale configs, base hrefs, and xlf sources are defined in `angular.json` under `projects.planet-app.i18n`.
 
 ### gateway (`gateway/`)
@@ -64,7 +65,7 @@ From `Style-Guide.md` (read it before making UI changes):
 
 ### Git workflow
 
-Develop on feature branches off `master`; the project asks for two positive reviews before merging. Install hooks (`npm run install-hooks`) so `pre-push` enforces lint in both `./` and `gateway/`.
+Develop on feature branches off `master`; the project asks for two positive reviews before merging. Install hooks (`npm run install-hooks`) so `pre-push` enforces lint in both `./` and `gateway/` plus the mixed line ending check on changed files.
 
 PR titles follow the house style `scope: smoother thing doing (fixes #N)` (see the log; the `merge-prepping` skill below automates this). `(fixes #N)` goes in the **title** — the squash commit message is the PR title, so that's what auto-closes the issue on merge.
 

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -39,6 +39,11 @@ run_lint() {
   tslint=$(npm run lint)
 }
 
+echo "Checking line endings of changed files"
+eol=$(npm run --silent lint:eol 2>&1)
+ret_code_eol=$?
+output_result $ret_code_eol "line endings" "$eol"
+
 echo "Running planet linters"
 run_lint .
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "htmlhint": "./node_modules/htmlhint-ng2/bin/htmlhint --config .htmlhintrc",
     "sass-lint": "./node_modules/sass-lint/bin/sass-lint.js -c ./sass-lint.yml -v -q",
     "lint": "ng lint planet-app",
+    "lint:eol": "node scripts/check-line-endings.mjs",
     "lint-all": "npm run sass-lint && ng lint planet-app --type-check && npm run htmlhint",
     "install-hooks": "cp -a git-hooks/. .git/hooks/",
     "webdriver-set-version": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",

--- a/scripts/check-line-endings.mjs
+++ b/scripts/check-line-endings.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+/*
+ * Rejects files that mix LF and CRLF line endings.
+ *
+ * A file may be entirely LF or entirely CRLF - that choice is left to
+ * .editorconfig and to each contributor's git configuration. What this check
+ * refuses is a single file carrying both, because that is what turns a small
+ * edit into a whole-file diff.
+ *
+ * Only files touched by the current branch are inspected, so the mixed files
+ * already in the repository stay as they are until someone edits them.
+ *
+ * Usage:
+ *   node scripts/check-line-endings.mjs                # changed files vs. master
+ *   node scripts/check-line-endings.mjs --base <ref>   # changed files vs. <ref>
+ *   node scripts/check-line-endings.mjs --all          # every tracked file
+ *   node scripts/check-line-endings.mjs <file> [...]   # only these files
+ *
+ * The base ref can also come from the EOL_BASE_REF environment variable.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+const USAGE = `Usage: node scripts/check-line-endings.mjs [--all] [--base <ref>] [file...]
+
+  --all           check every tracked file instead of the changed ones
+  --base <ref>    compare against <ref> (default: origin/master, then master)
+  -h, --help      show this message`;
+
+const DEFAULT_BASES = [ 'origin/master', 'master' ];
+const CHUNK_SIZE = 500;
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+const git = (args, allowFailure = false) => {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      maxBuffer: MAX_BUFFER,
+      stdio: [ 'ignore', 'pipe', allowFailure ? 'ignore' : 'inherit' ]
+    });
+  } catch (error) {
+    if (allowFailure) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const gitBuffer = (args) => {
+  try {
+    return execFileSync('git', args, { maxBuffer: MAX_BUFFER, stdio: [ 'ignore', 'pipe', 'ignore' ] });
+  } catch {
+    return null;
+  }
+};
+
+const splitNul = (output) => (output || '').split('\0').filter((entry) => entry !== '');
+
+const chunk = (items, size) => {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
+const parseArgs = (argv) => {
+  const options = { all: false, base: process.env.EOL_BASE_REF || '', files: [] };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--all') {
+      options.all = true;
+    } else if (arg === '--base') {
+      options.base = argv[++index] || '';
+    } else if (arg.startsWith('--base=')) {
+      options.base = arg.slice('--base='.length);
+    } else if (arg === '-h' || arg === '--help') {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg.startsWith('-')) {
+      console.error(`Unknown option: ${arg}\n\n${USAGE}`);
+      process.exit(2);
+    } else {
+      options.files.push(arg);
+    }
+  }
+  return options;
+};
+
+const commitFor = (ref) => {
+  const output = git([ 'rev-parse', '--verify', '--quiet', `${ref}^{commit}` ], true);
+  return output ? output.trim() : null;
+};
+
+// The commit this branch forked from, so only its own changes get inspected.
+// A null commit means there is no branch to compare - on the base branch itself
+// only uncommitted work is left to check.
+const resolveBase = (base) => {
+  const head = commitFor('HEAD');
+  for (const candidate of base ? [ base ] : DEFAULT_BASES) {
+    if (!commitFor(candidate)) {
+      continue;
+    }
+    const output = git([ 'merge-base', candidate, 'HEAD' ], true);
+    const mergeBase = output ? output.trim() : null;
+    if (!mergeBase) {
+      continue;
+    }
+    return mergeBase === head ? { ref: candidate, commit: null } : { ref: candidate, commit: mergeBase };
+  }
+  console.error(base
+    ? `Could not resolve base ref "${base}".`
+    : `Could not resolve a base ref (tried ${DEFAULT_BASES.join(', ')}). Pass --base <ref> or set EOL_BASE_REF.`);
+  process.exit(2);
+};
+
+const changedFiles = (baseCommit) => {
+  const files = new Set();
+  const collect = (args) => splitNul(git(args, true)).forEach((file) => files.add(file));
+  if (baseCommit) {
+    collect([ 'diff', '--name-only', '--diff-filter=ACMR', '-z', baseCommit, 'HEAD' ]);
+  }
+  // Uncommitted work counts too, so the check is useful before committing.
+  collect([ 'diff', '--name-only', '--diff-filter=ACMR', '-z', 'HEAD' ]);
+  collect([ 'ls-files', '--others', '--exclude-standard', '-z' ]);
+  return [ ...files ].sort();
+};
+
+// git reports the end-of-line style of the index and working tree copy of every
+// tracked file: lf, crlf, mixed, none, or -text for binaries.
+const trackedEolInfo = (files) => {
+  const info = new Map();
+  for (const batch of chunk(files, CHUNK_SIZE)) {
+    for (const entry of splitNul(git([ 'ls-files', '--eol', '-z', '--', ...batch ], true))) {
+      const separator = entry.indexOf('\t');
+      if (separator === -1) {
+        continue;
+      }
+      const fields = entry.slice(0, separator).trim().split(/\s+/);
+      info.set(entry.slice(separator + 1), {
+        index: (fields[0] || '').slice('i/'.length),
+        worktree: (fields[1] || '').slice('w/'.length)
+      });
+    }
+  }
+  return info;
+};
+
+const countEndings = (buffer) => {
+  let crlf = 0;
+  let lf = 0;
+  for (let index = 0; index < buffer.length; index++) {
+    if (buffer[index] !== 0x0a) {
+      continue;
+    }
+    if (index > 0 && buffer[index - 1] === 0x0d) {
+      crlf++;
+    } else {
+      lf++;
+    }
+  }
+  return { crlf, lf };
+};
+
+const contentOf = (file) => {
+  const staged = gitBuffer([ 'cat-file', 'blob', `:${file}` ]);
+  if (staged) {
+    return staged;
+  }
+  try {
+    return statSync(file).isFile() ? readFileSync(file) : null;
+  } catch {
+    return null;
+  }
+};
+
+// Untracked files are not covered by `git ls-files --eol`, so read them directly.
+const untrackedEol = (file) => {
+  const content = contentOf(file);
+  if (!content || content.includes(0)) {
+    return null;
+  }
+  const { crlf, lf } = countEndings(content);
+  return crlf > 0 && lf > 0 ? 'mixed' : 'consistent';
+};
+
+const options = parseArgs(process.argv.slice(2));
+
+// git reports paths from the repository root, so work from there as well.
+const repoRoot = (git([ 'rev-parse', '--show-toplevel' ], true) || '').trim();
+if (!repoRoot) {
+  console.error('Not inside a git repository.');
+  process.exit(2);
+}
+const givenFiles = options.files.map((file) => relative(repoRoot, resolve(file)));
+process.chdir(repoRoot);
+
+let files;
+let scope;
+if (givenFiles.length > 0) {
+  files = givenFiles;
+  scope = `${files.length} file(s) given on the command line`;
+} else if (options.all) {
+  files = splitNul(git([ 'ls-files', '-z' ]));
+  scope = `${files.length} tracked file(s)`;
+} else {
+  const base = resolveBase(options.base);
+  files = changedFiles(base.commit);
+  scope = base.commit
+    ? `${files.length} file(s) changed since ${base.ref}`
+    : `${files.length} uncommitted file(s)`;
+}
+
+if (files.length === 0) {
+  console.log('Line endings: nothing to check.');
+  process.exit(0);
+}
+
+const tracked = trackedEolInfo(files);
+const offenders = files.filter((file) => {
+  const info = tracked.get(file);
+  if (!info) {
+    return untrackedEol(file) === 'mixed';
+  }
+  // Submodules and symlinks report no end-of-line style at all.
+  if (info.index === '' && info.worktree === '') {
+    return false;
+  }
+  return info.index === 'mixed' || info.worktree === 'mixed';
+});
+
+if (offenders.length === 0) {
+  console.log(`Line endings: ${scope} checked, none mixed.`);
+  process.exit(0);
+}
+
+console.error(`Mixed line endings in ${offenders.length} file(s):\n`);
+for (const file of offenders) {
+  const content = contentOf(file);
+  const counts = content ? countEndings(content) : null;
+  console.error(`  ${file}${counts ? ` (${counts.lf} LF, ${counts.crlf} CRLF)` : ''}`);
+}
+console.error(`
+A file may use LF throughout or CRLF throughout, but never both. Normalize each
+file listed above to a single style, for example to LF:
+
+  perl -pi -e 's/\\r\\n/\\n/g' ${offenders.join(' ')}
+
+Files this branch does not touch are not affected by this check.`);
+process.exit(1);


### PR DESCRIPTION
## Summary

Adds a new line ending validation script that prevents files from mixing LF and CRLF line endings within a single file. This check runs before linting in the pre-push hook and in CI, catching mixed line endings early without blocking contributors' choice of line ending style per file.

## Changes

- **New script `scripts/check-line-endings.mjs`**: Validates that files use consistent line endings (all LF or all CRLF, never both). The script:
  - Inspects only files changed in the current branch by default (configurable via `--base <ref>` or `--all`)
  - Handles both tracked files (via `git ls-files --eol`) and untracked files (by reading content directly)
  - Reports mixed files with counts of LF and CRLF occurrences
  - Provides remediation guidance (e.g., `perl` one-liner to normalize)
  - Supports environment variable `EOL_BASE_REF` for CI integration

- **Updated `git-hooks/pre-push`**: Runs `npm run lint:eol` before the main linters, failing fast if line endings are mixed

- **Updated `package.json`**: Added `lint:eol` npm script pointing to the new check

- **Updated `.github/workflows/planet.yml`**: 
  - Sets `fetch-depth: 0` on checkout to enable diff against `master`
  - Runs line ending check before `npm ci` (no node_modules needed, fails in seconds)

- **Updated `AGENTS.md`**: Documents that the pre-push hook now runs the line ending check first

## Implementation notes

- The check respects `.editorconfig` and contributor git configuration—it only rejects *mixing* styles within a single file
- Mixed files already in the repository are left untouched until edited
- Untracked files are checked by reading content directly since `git ls-files --eol` doesn't cover them
- Submodules and symlinks are skipped (they report no end-of-line style)

https://claude.ai/code/session_01TAjxP5oqDSX8cQ2UFLeHmM