### PR TITLE
all: smoother cross-planet membership handling (fixes #10402)

### DIFF
--- a/src/app/dashboard/dashboard-tile.component.spec.ts
+++ b/src/app/dashboard/dashboard-tile.component.spec.ts
@@ -44,7 +44,8 @@ describe('DashboardTileComponent', () => {
         {} as any,
         {} as any,
         { detectChanges } as any,
-        { watchDeviceType: vi.fn(() => of(DeviceType.DESKTOP)) } as any
+        { watchDeviceType: vi.fn(() => of(DeviceType.DESKTOP)) } as any,
+        { configuration: { code: 'nation' } } as any
       ));
     });
 
@@ -132,5 +133,46 @@ describe('DashboardTileComponent', () => {
     expect(coursesService.courseResignAdmission).toHaveBeenCalledWith('course-1', 'resign', 'Course 1');
     expect(dialogRef.close).toHaveBeenCalled();
     expect(messageService.showMessage).toHaveBeenCalled();
+  });
+
+  it('leaves through the exact code-less membership the dashboard loaded', () => {
+    const dialogRef = { close: vi.fn() };
+    const dialog = { open: vi.fn().mockReturnValue(dialogRef) };
+    const teamsService = { toggleTeamMembership: vi.fn().mockReturnValue(of({})) };
+    const membershipDoc = {
+      _id: 'membership-1',
+      _rev: '1-membership',
+      userId: 'org.couchdb.user:ann',
+      teamId: 'team-1'
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ DashboardTileComponent ],
+      providers: [
+        { provide: CoursesService, useValue: {} },
+        { provide: DeviceInfoService, useValue: { watchDeviceType: vi.fn().mockReturnValue(of(undefined)) } },
+        { provide: MatDialog, useValue: dialog },
+        { provide: PlanetMessageService, useValue: { showMessage: vi.fn(), showAlert: vi.fn() } },
+        { provide: TeamsService, useValue: teamsService },
+        {
+          provide: UserService,
+          useValue: {
+            get: vi.fn().mockReturnValue({ _id: 'org.couchdb.user:ann', planetCode: 'community' }),
+            shelf: { myTeamIds: [ 'team-1' ] }
+          }
+        }
+      ]
+    });
+    const component = TestBed.createComponent(DashboardTileComponent).componentInstance;
+    component.shelfName = 'myTeamIds';
+    component.cardTitle = 'myTeams';
+
+    component.removeFromShelf({ stopPropagation: vi.fn() }, { _id: 'team-1', title: 'Team 1', membershipDoc });
+    dialog.open.mock.calls[0][1].data.okClick.request.subscribe();
+
+    // Fabricating an identity here would lose the exact persisted _id/_rev and origin semantics.
+    expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'team-1' }), true, membershipDoc
+    );
   });
 });

--- a/src/app/dashboard/dashboard-tile.component.spec.ts
+++ b/src/app/dashboard/dashboard-tile.component.spec.ts
@@ -44,8 +44,7 @@ describe('DashboardTileComponent', () => {
         {} as any,
         {} as any,
         { detectChanges } as any,
-        { watchDeviceType: vi.fn(() => of(DeviceType.DESKTOP)) } as any,
-        { configuration: { code: 'nation' } } as any
+        { watchDeviceType: vi.fn(() => of(DeviceType.DESKTOP)) } as any
       ));
     });
 

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -186,9 +186,8 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
 
   removeFromShelf(event, item: any) {
     event.stopPropagation();
-    const { _id: userId, planetCode: userPlanetCode } = this.userService.get();
     if (this.shelfName === 'myTeamIds') {
-      this.removeTeam(item, userId, userPlanetCode);
+      this.removeTeam(item);
     } else if (this.shelfName === 'resourceIds') {
       this.removeResource(item);
     } else if (this.shelfName === 'courseIds') {
@@ -238,12 +237,13 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
     });
   }
 
-  removeTeam(item, userId, userPlanetCode) {
-    const teamDoc = { userId, userPlanetCode, teamId: item._id, fromShelf: item.fromShelf };
+  removeTeam(item) {
     this.dialogPrompt = this.dialog.open(DialogsPromptComponent, {
       data: {
         okClick: {
-          request: this.teamsService.toggleTeamMembership(item, true, teamDoc).pipe(tap(() => this.teamRemoved.emit(item))),
+          request: defer(() => this.teamsService.toggleTeamMembership(item, true, item.membershipDoc).pipe(
+            tap(() => this.teamRemoved.emit(item))
+          )),
           onNext: () => {
             this.dialogPrompt.close();
             this.removeMessage(item);

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -33,7 +33,7 @@ describe('DashboardComponent', () => {
     firstName: 'John',
     lastName: 'Doe',
     roles: [ 'admin', 'learner' ],
-    planetCode: 'planet_1'
+    planetCode: 'earth_code'
   };
 
   const defaultShelf = {
@@ -140,7 +140,7 @@ describe('DashboardComponent', () => {
     expect(warnSpy).toHaveBeenCalledWith('Error fetching login activities');
   });
 
-  it('loads and maps dashboard items from the shelf', () => {
+  it('loads non-team dashboard items from the shelf without treating shelf order as membership', () => {
     couchServiceMock.bulkGet.mockImplementation((db: string) => ({
       resources: of([ { _id: 'res_1', title: 'Resource 1' } ]),
       courses: of([ { _id: 'course_1', courseTitle: 'Course 1' } ]),
@@ -153,7 +153,7 @@ describe('DashboardComponent', () => {
     expect(component.data.resources[0]).toMatchObject({ title: 'Resource 1', link: '/resources/view/res_1' });
     expect(component.data.courses[0]).toMatchObject({ title: 'Course 1', link: '/courses/view/course_1' });
     expect(component.data.meetups[0]).toMatchObject({ title: 'Meetup 1', link: '/meetups/view/meetup_1' });
-    expect(component.data.myTeams[0]).toMatchObject({ title: 'Team 1', link: '/teams/view/team_1' });
+    expect(component.data.myTeams).toEqual([]);
     expect(component.isLoading).toBe(false);
   });
 
@@ -247,8 +247,8 @@ describe('DashboardComponent', () => {
 
   it('sets canRemove only for team leaders', () => {
     couchServiceMock.findAll.mockReturnValue(of([
-      { teamId: 'leader-team', isLeader: true },
-      { teamId: 'member-team', isLeader: false }
+      { teamId: 'leader-team', userId: mockUser._id, isLeader: true },
+      { teamId: 'member-team', userId: mockUser._id, isLeader: false }
     ]));
     couchServiceMock.bulkGet.mockReturnValue(of([
       { _id: 'leader-team', name: 'Leader Team' },
@@ -265,7 +265,87 @@ describe('DashboardComponent', () => {
     ]));
   });
 
+  it('queries associated memberships under their canonical id and explicit origin', () => {
+    createComponent({
+      _id: 'org.couchdb.user:alex@community',
+      name: 'alex@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    });
+
+    component.getTeamMembership().subscribe();
+
+    expect(couchServiceMock.findAll).toHaveBeenCalledWith('teams', expect.objectContaining({
+      selector: {
+        userId: 'org.couchdb.user:alex',
+        docType: 'membership',
+        $or: [
+          { userPlanetCode: 'community' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      }
+    }));
+  });
+
+  it('accepts code-less memberships only when the team origin matches the account origin', () => {
+    const user = {
+      _id: 'org.couchdb.user:alex@community',
+      name: 'alex@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    };
+    couchServiceMock.findAll.mockReturnValue(of([
+      { _id: 'membership-community', teamId: 'community-team', userId: 'org.couchdb.user:alex' },
+      { _id: 'membership-nation', teamId: 'nation-team', userId: 'org.couchdb.user:alex' }
+    ]));
+    couchServiceMock.bulkGet.mockReturnValue(of([
+      { _id: 'community-team', name: 'Community Team', teamPlanetCode: 'community' },
+      { _id: 'nation-team', name: 'Nation Team', teamPlanetCode: 'earth_code' }
+    ]));
+    createComponent(user);
+    let teams: any[];
+
+    component.getTeamMembership().subscribe(result => teams = result);
+
+    expect(teams.map(team => team._id)).toEqual([ 'community-team' ]);
+    expect(teams[0].membershipDoc._id).toBe('membership-community');
+  });
+
+  it('preserves the explicit membership document when a code-less duplicate also survives', () => {
+    const user = {
+      _id: 'org.couchdb.user:alex@community',
+      name: 'alex@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    };
+    const explicit = {
+      _id: 'membership-explicit', teamId: 'team-1', userId: 'org.couchdb.user:alex',
+      userPlanetCode: 'community', isLeader: false
+    };
+    couchServiceMock.findAll.mockReturnValue(of([
+      { _id: 'membership-codeless', teamId: 'team-1', userId: 'org.couchdb.user:alex', isLeader: true },
+      explicit
+    ]));
+    couchServiceMock.bulkGet.mockReturnValue(of([
+      { _id: 'team-1', name: 'Community Team', teamPlanetCode: 'community' }
+    ]));
+    createComponent(user);
+    let teams: any[];
+
+    component.getTeamMembership().subscribe(result => teams = result);
+
+    expect(teams[0].membershipDoc).toBe(explicit);
+    expect(teams[0].canRemove).toBe(true);
+  });
+
   it('filters archived teams from the dashboard', () => {
+    couchServiceMock.findAll.mockImplementation((db: string) =>
+      db === 'teams' ? of([
+        { teamId: 'team_active', userId: mockUser._id, isLeader: false },
+        { teamId: 'team_archived', userId: mockUser._id, isLeader: false }
+      ]) : of([])
+    );
     couchServiceMock.bulkGet.mockImplementation((db: string, ids: string[]) =>
       db === 'teams' && ids.length > 0 ? of([
         { _id: 'team_active', name: 'Active Team', status: 'active' },
@@ -276,6 +356,15 @@ describe('DashboardComponent', () => {
     createComponent().detectChanges();
 
     expect(component.data.myTeams.map(team => team._id)).toEqual([ 'team_active' ]);
+  });
+
+  it('orders my teams by the saved tile order and appends teams missing from it', () => {
+    createComponent();
+
+    expect(component.sortByShelfOrder(
+      [ { _id: 'c' }, { _id: 'a' }, { _id: 'new' }, { _id: 'b' } ],
+      [ 'a', 'b', 'c' ]
+    ).map(team => team._id)).toEqual([ 'a', 'b', 'c', 'new' ]);
   });
 
   it('opens the course dialog with its expected configuration', () => {

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -277,10 +277,11 @@ describe('DashboardComponent', () => {
 
     expect(couchServiceMock.findAll).toHaveBeenCalledWith('teams', expect.objectContaining({
       selector: {
-        userId: 'org.couchdb.user:alex',
+        userId: { $in: [ 'org.couchdb.user:alex', 'org.couchdb.user:alex@community' ] },
         docType: 'membership',
         $or: [
           { userPlanetCode: 'community' },
+          { userPlanetCode: 'earth_code' },
           { userPlanetCode: '' },
           { userPlanetCode: { $exists: false } }
         ]
@@ -310,6 +311,32 @@ describe('DashboardComponent', () => {
 
     expect(teams.map(team => team._id)).toEqual([ 'community-team' ]);
     expect(teams[0].membershipDoc._id).toBe('membership-community');
+  });
+
+  it('loads a historical materialized membership written under the server origin', () => {
+    const user = {
+      _id: 'org.couchdb.user:alex@community',
+      name: 'alex@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    };
+    const historical = {
+      _id: 'membership-historical',
+      teamId: 'team-1',
+      userId: 'org.couchdb.user:alex@community',
+      userPlanetCode: 'earth_code',
+      docType: 'membership'
+    };
+    couchServiceMock.findAll.mockReturnValue(of([ historical ]));
+    couchServiceMock.bulkGet.mockReturnValue(of([
+      { _id: 'team-1', name: 'Nation Team', teamPlanetCode: 'earth_code' }
+    ]));
+    createComponent(user);
+    let teams: any[];
+
+    component.getTeamMembership().subscribe(result => teams = result);
+
+    expect(teams[0].membershipDoc).toBe(historical);
   });
 
   it('preserves the explicit membership document when a code-less duplicate also survives', () => {
@@ -365,6 +392,15 @@ describe('DashboardComponent', () => {
       [ { _id: 'c' }, { _id: 'a' }, { _id: 'new' }, { _id: 'b' } ],
       [ 'a', 'b', 'c' ]
     ).map(team => team._id)).toEqual([ 'a', 'b', 'c', 'new' ]);
+  });
+
+  it('does not treat saved team ordering as dashboard content', () => {
+    createComponent();
+    component.data = { resources: [], courses: [], meetups: [], myTeams: [] };
+
+    expect(component.isEmptyShelf({
+      resourceIds: [], courseIds: [], meetupIds: [], myTeamIds: [ 'old-team-order' ]
+    })).toBe(true);
   });
 
   it('opens the course dialog with its expected configuration', () => {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -5,7 +5,7 @@ import { of, forkJoin, Subject, combineLatest } from 'rxjs';
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
 import { findDocuments, userPlanetCodeSelector } from '../shared/mangoQueries';
-import { userIdentity } from '../shared/identity.utils';
+import { userIdentityCandidates } from '../shared/identity.utils';
 import { teamIdentityDocs } from '../teams/teams.utils';
 import { environment } from '../../environments/environment';
 import { SubmissionsService } from '../submissions/submissions.service';
@@ -186,11 +186,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   getTeamMembership() {
     const configuration = this.stateService.configuration;
-    const identity = userIdentity(this.user, configuration.code);
+    const identities = userIdentityCandidates(this.user, configuration.code);
+    const identity = identities[0];
+    const userIds = [ ...new Set(identities.map(candidate => candidate.userId)) ];
     return this.couchService.findAll('teams', findDocuments({
-      userId: identity.userId,
+      userId: userIds.length === 1 ? identity.userId : { $in: userIds },
       docType: 'membership',
-      ...userPlanetCodeSelector(identity.userPlanetCode)
+      ...userPlanetCodeSelector(...identities.map(candidate => candidate.userPlanetCode))
     })).pipe(
       switchMap((memberships) => forkJoin([
         of(memberships),
@@ -199,7 +201,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       map(([ memberships, teams ]: any[]) => teams
         .filter(team => team.type === undefined || team.type === 'team' || team.type === 'enterprise')
         .map(team => {
-          const matchingMemberships = teamIdentityDocs(memberships, team, identity, configuration.code);
+          const matchingMemberships = teamIdentityDocs(memberships, team, identities, configuration.code);
           return {
             ...team,
             membershipDoc: matchingMemberships.find(membership =>
@@ -224,7 +226,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   isEmptyShelf(shelf) {
     return shelf.courseIds.length === 0
       && shelf.meetupIds.length === 0
-      && shelf.myTeamIds.length === 0
       && shelf.resourceIds.length === 0;
   }
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -4,7 +4,9 @@ import { finalize, map, catchError, switchMap, auditTime, takeUntil } from 'rxjs
 import { of, forkJoin, Subject, combineLatest } from 'rxjs';
 import { UserService } from '../shared/user.service';
 import { CouchService } from '../shared/couchdb.service';
-import { findDocuments } from '../shared/mangoQueries';
+import { findDocuments, userPlanetCodeSelector } from '../shared/mangoQueries';
+import { userIdentity } from '../shared/identity.utils';
+import { teamIdentityDocs } from '../teams/teams.utils';
 import { environment } from '../../environments/environment';
 import { SubmissionsService } from '../submissions/submissions.service';
 import { StateService } from '../shared/state.service';
@@ -154,16 +156,24 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.getData('resources', userShelf.resourceIds, { linkPrefix: '/resources/view/', addId: true }),
       this.getData('courses', userShelf.courseIds, { titleField: 'courseTitle', linkPrefix: '/courses/view/', addId: true }),
       this.getData('meetups', userShelf.meetupIds, { linkPrefix: '/meetups/view/', addId: true }),
-      this.getData('teams', userShelf.myTeamIds, { titleField: 'name', linkPrefix: '/teams/view/', addId: true }),
       this.getTeamMembership()
     ]).pipe(finalize(() => this.isLoading = false)).subscribe(dashboardItems => {
       this.data.resources = dashboardItems[0];
       this.data.courses = dashboardItems[1];
       this.data.meetups = dashboardItems[2];
-      const allTeams = [ ...dashboardItems[3].map(team => ({ ...team, fromShelf: true })), ...dashboardItems[4] ];
-      this.data.myTeams = dedupeObjectArray(allTeams, [ '_id' ])
-        .filter(team => team.status !== 'archived');
+      this.data.myTeams = this.sortByShelfOrder(
+        dedupeObjectArray(dashboardItems[3], [ '_id' ]).filter(team => team.status !== 'archived'),
+        userShelf.myTeamIds
+      );
     });
+  }
+
+  // myTeamIds no longer records membership, only the order the user dragged the tile into.
+  // Teams absent from it are new since the last reorder and sort to the end, keeping their own order.
+  sortByShelfOrder(teams: any[], order: string[] = []) {
+    const rank = new Map(order.map((id, index) => [ id, index ] as [ string, number ]));
+    const at = (team) => rank.get(team._id) ?? Number.MAX_SAFE_INTEGER;
+    return [ ...teams ].sort((team1, team2) => at(team1) - at(team2));
   }
 
   getData(db: string, shelf: string[] = [], { linkPrefix, addId = false, titleField = 'title' }) {
@@ -176,17 +186,29 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   getTeamMembership() {
     const configuration = this.stateService.configuration;
-    return this.couchService.findAll(
-      'teams', findDocuments({ userPlanetCode: configuration.code, userId: this.user._id, docType: 'membership' })
-    ).pipe(
+    const identity = userIdentity(this.user, configuration.code);
+    return this.couchService.findAll('teams', findDocuments({
+      userId: identity.userId,
+      docType: 'membership',
+      ...userPlanetCodeSelector(identity.userPlanetCode)
+    })).pipe(
       switchMap((memberships) => forkJoin([
         of(memberships),
         this.getData('teams', memberships.map((doc: any) => doc.teamId), { titleField: 'name', linkPrefix: '/teams/view/', addId: true })
       ])),
-      map(([ memberships, teams ]: any[]) =>
-        teams.filter(team => team.type === undefined || team.type === 'team' || team.type === 'enterprise').map(team => ({
-          ...team, canRemove: memberships.some(membership => membership.teamId === team._id && membership.isLeader)
-        }))
+      map(([ memberships, teams ]: any[]) => teams
+        .filter(team => team.type === undefined || team.type === 'team' || team.type === 'enterprise')
+        .map(team => {
+          const matchingMemberships = teamIdentityDocs(memberships, team, identity, configuration.code);
+          return {
+            ...team,
+            membershipDoc: matchingMemberships.find(membership =>
+              membership.userPlanetCode === identity.userPlanetCode
+            ) || matchingMemberships[0],
+            canRemove: matchingMemberships.some(membership => membership.isLeader)
+          };
+        })
+        .filter(team => team.membershipDoc)
       )
     );
   }

--- a/src/app/notifications/notifications.service.spec.ts
+++ b/src/app/notifications/notifications.service.spec.ts
@@ -47,6 +47,17 @@ describe('NotificationsService', () => {
     });
   });
 
+  it('uses the legacy planet when normalizing an associated account without its own planet field', () => {
+    expect(notificationRecipient({
+      _id: 'org.couchdb.user:alex@community-c',
+      name: 'alex@community-c',
+      requestId: 'community-registration-request-1'
+    }, 'community-c')).toEqual({
+      user: 'org.couchdb.user:alex',
+      userPlanetCode: 'community-c'
+    });
+  });
+
   it('keeps origin-less legacy recipients planet-less', () => {
     expect(notificationRecipient({ _id: 'org.couchdb.user:alex' })).toEqual({
       user: 'org.couchdb.user:alex'

--- a/src/app/notifications/notifications.service.spec.ts
+++ b/src/app/notifications/notifications.service.spec.ts
@@ -83,6 +83,20 @@ describe('NotificationsService', () => {
     ]);
   });
 
+  it('queries canonical and historical notifications for an associated account', () => {
+    expect(notificationUserFilter({
+      _id: 'org.couchdb.user:alex@community-c',
+      name: 'alex@community-c',
+      planetCode: 'community-c',
+      requestId: 'request-1'
+    })).toEqual([
+      { user: 'org.couchdb.user:alex', userPlanetCode: 'community-c' },
+      { user: 'org.couchdb.user:alex', userPlanetCode: { $exists: false } },
+      { user: 'org.couchdb.user:alex@community-c', userPlanetCode: 'community-c' },
+      { user: 'org.couchdb.user:alex@community-c', userPlanetCode: { $exists: false } }
+    ]);
+  });
+
   it('keeps the legacy user filter when the current user has no planet code', () => {
     expect(notificationUserFilter({ name: 'alex' })).toEqual([
       { user: 'org.couchdb.user:alex' }

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -21,13 +21,17 @@ export const notificationRecipient = (user: any, legacyPlanetCode?: string) => {
 };
 
 export const notificationUserFilter = (user: any) => {
-  const userId = `org.couchdb.user:${user.name}`;
-  const userFilters = user.planetCode ?
+  const source = { ...user, _id: user._id || `org.couchdb.user:${user.name}` };
+  const recipient = notificationRecipient(source);
+  // Notifications stored before ID normalization address the materialized @planet ID, and writers
+  // outside notificationRecipient still use it, so the reader accepts both forms of the own account ID.
+  const recipientIds = [ ...new Set([ recipient.user, source._id ]) ];
+  const userFilters = recipientIds.flatMap(recipientId => recipient.userPlanetCode ?
     [
-      { user: userId, userPlanetCode: user.planetCode },
-      { user: userId, userPlanetCode: { $exists: false } }
+      { user: recipientId, userPlanetCode: recipient.userPlanetCode },
+      { user: recipientId, userPlanetCode: { $exists: false } }
     ] :
-    [ { user: userId } ];
+    [ { user: recipientId } ]);
   return user.isUserAdmin ? [ ...userFilters, { user: 'SYSTEM' } ] : userFilters;
 };
 

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -6,6 +6,7 @@ import { StateService } from '../shared/state.service';
 import { findDocuments } from '../shared/mangoQueries';
 import { switchMap } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
+import { canonicalUserId } from '../shared/identity.utils';
 
 /**
  * Supports raw or replicated user docs and team-member rows. Callers holding a
@@ -13,12 +14,8 @@ import { of, Observable } from 'rxjs';
  */
 export const notificationRecipient = (user: any, legacyPlanetCode?: string) => {
   const userPlanetCode = user.userPlanetCode || user.planetCode || legacyPlanetCode;
-  const storedUserId = user.couchId || user.userId || user._id;
-  const associatedSuffix = userPlanetCode ? `@${userPlanetCode}` : '';
-  const isAssociatedAccount = !!((user.requestId || user.sync) && associatedSuffix &&
-    user.name?.endsWith(associatedSuffix) && storedUserId?.endsWith(associatedSuffix));
   return {
-    user: isAssociatedAccount ? storedUserId.slice(0, -associatedSuffix.length) : storedUserId,
+    user: canonicalUserId(user, userPlanetCode),
     ...(userPlanetCode ? { userPlanetCode } : {})
   };
 };

--- a/src/app/shared/identity.utils.spec.ts
+++ b/src/app/shared/identity.utils.spec.ts
@@ -1,0 +1,50 @@
+import { canonicalUserId, userIdentity } from './identity.utils';
+
+describe('user identity utilities', () => {
+  it('keeps native and associated same-named accounts distinct by origin', () => {
+    const native = userIdentity({
+      _id: 'org.couchdb.user:alex',
+      name: 'alex',
+      planetCode: 'nation'
+    }, 'nation');
+    const associated = userIdentity({
+      _id: 'org.couchdb.user:alex@community',
+      name: 'alex@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    }, 'nation');
+
+    expect(native).toEqual({
+      userId: 'org.couchdb.user:alex',
+      userPlanetCode: 'nation'
+    });
+    expect(associated).toEqual({
+      userId: 'org.couchdb.user:alex',
+      userPlanetCode: 'community'
+    });
+  });
+
+  it('uses the wrapper id when a full user document omits its own id', () => {
+    const user = {
+      _id: 'org.couchdb.user:alex',
+      doc: { planetCode: 'community' }
+    };
+
+    expect(canonicalUserId(user)).toBe(user._id);
+    expect(userIdentity(user, 'nation')).toEqual({
+      userId: user._id,
+      userPlanetCode: 'community'
+    });
+  });
+
+  it('uses couchId as the replicated user stable id', () => {
+    expect(userIdentity({
+      _id: 'alex@community',
+      couchId: 'org.couchdb.user:alex',
+      planetCode: 'community'
+    }, 'nation')).toEqual({
+      userId: 'org.couchdb.user:alex',
+      userPlanetCode: 'community'
+    });
+  });
+});

--- a/src/app/shared/identity.utils.spec.ts
+++ b/src/app/shared/identity.utils.spec.ts
@@ -1,4 +1,4 @@
-import { canonicalUserId, userIdentity } from './identity.utils';
+import { canonicalUserId, userIdentity, userIdentityCandidates } from './identity.utils';
 
 describe('user identity utilities', () => {
   it('keeps native and associated same-named accounts distinct by origin', () => {
@@ -46,5 +46,18 @@ describe('user identity utilities', () => {
       userId: 'org.couchdb.user:alex',
       userPlanetCode: 'community'
     });
+  });
+
+  it('retains a historical materialized id as a read compatibility candidate', () => {
+    expect(userIdentityCandidates({
+      _id: 'org.couchdb.user:alex@community',
+      name: 'alex@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    }, 'nation')).toEqual([
+      { userId: 'org.couchdb.user:alex', userPlanetCode: 'community' },
+      { userId: 'org.couchdb.user:alex@community', userPlanetCode: 'community' },
+      { userId: 'org.couchdb.user:alex@community', userPlanetCode: 'nation' }
+    ]);
   });
 });

--- a/src/app/shared/identity.utils.ts
+++ b/src/app/shared/identity.utils.ts
@@ -24,3 +24,25 @@ export const userIdentity = (user: object, fallbackPlanetCode?: string) => {
     userPlanetCode: source?.userPlanetCode || source?.planetCode || fallbackPlanetCode
   };
 };
+
+// Pre-normalization membership rows can carry the locally materialized @planet ID. Keep both IDs
+// paired with the account's single origin when reading or deleting existing identity documents.
+export const userIdentityCandidates = (user: object, fallbackPlanetCode?: string) => {
+  const source = identitySource(user);
+  const identity = userIdentity(source, fallbackPlanetCode);
+  const candidates = [ identity ];
+  if (source?._id && source._id !== identity.userId) {
+    candidates.push({ ...identity, userId: source._id });
+    if (fallbackPlanetCode && fallbackPlanetCode !== identity.userPlanetCode) {
+      candidates.push({ userId: source._id, userPlanetCode: fallbackPlanetCode });
+    }
+  }
+  return candidates;
+};
+
+export const identityPlanetCode = (identity: any, fallbackPlanetCode?: string) =>
+  identity?.userPlanetCode || identity?.resolvedUserPlanetCode || identity?.planetCode || fallbackPlanetCode;
+
+export const identityMatches = (identity1: any, identity2: any, fallbackPlanetCode?: string) =>
+  identity1?.userId === identity2?.userId &&
+  identityPlanetCode(identity1, fallbackPlanetCode) === identityPlanetCode(identity2, fallbackPlanetCode);

--- a/src/app/shared/identity.utils.ts
+++ b/src/app/shared/identity.utils.ts
@@ -1,0 +1,26 @@
+const identitySource = (user: any) => user?.doc ?
+  { ...user.doc, _id: user.doc._id || user._id } :
+  user;
+
+// Replicated users carry their original CouchDB ID in couchId. Associated accounts are
+// materialized locally with an @planet suffix, which is routing data rather than part of
+// the user's stable identity.
+export const canonicalUserId = (user: object, fallbackPlanetCode?: string): string => {
+  const source = identitySource(user);
+  const userId = source?.couchId || source?.userId || source?._id;
+  const planetCode = source?.userPlanetCode || source?.planetCode || fallbackPlanetCode;
+  const associatedSuffix = planetCode ? `@${planetCode}` : '';
+  const isAssociatedAccount = !!((source?.requestId || source?.sync) && associatedSuffix &&
+    source?.name?.endsWith(associatedSuffix) && userId?.endsWith(associatedSuffix));
+  return isAssociatedAccount ? userId.slice(0, -associatedSuffix.length) : userId;
+};
+
+// Authorization needs both the stable CouchDB identity and its explicit origin. The server code is
+// only a fallback for native/legacy user objects that do not carry an origin of their own.
+export const userIdentity = (user: object, fallbackPlanetCode?: string) => {
+  const source = identitySource(user);
+  return {
+    userId: canonicalUserId(source, fallbackPlanetCode),
+    userPlanetCode: source?.userPlanetCode || source?.planetCode || fallbackPlanetCode
+  };
+};

--- a/src/app/shared/mangoQueries.ts
+++ b/src/app/shared/mangoQueries.ts
@@ -15,3 +15,14 @@ export const findDocuments = (selectors, fields: any = 0, sort: any = 0, limit =
 
 // Returns a selector to get all docs with a field matching one of the array or all docs if array is empty
 export const inSelector = (array = []) => array.length > 0 ? { $in: array } : { $gt: null };
+
+// Undefined codes must be dropped: JSON.stringify removes an undefined value, leaving a
+// bare {} inside $or. Blank stored codes are legacy planet-less values and must be matched
+// explicitly because $exists: false does not include them.
+export const userPlanetCodeSelector = (...codes: (string | undefined)[]) => ({
+  $or: [
+    ...[ ...new Set(codes.filter((code): code is string => !!code)) ].map(userPlanetCode => ({ userPlanetCode })),
+    { userPlanetCode: '' },
+    { userPlanetCode: { $exists: false } }
+  ]
+});

--- a/src/app/tasks/tasks.service.spec.ts
+++ b/src/app/tasks/tasks.service.spec.ts
@@ -48,6 +48,12 @@ describe('TasksService assignee cleanup', () => {
     expect(query.selector.$or).toContainEqual({
       assignees: { $elemMatch: { userId: 'alex', userPlanetCode: 'planet-a' } }
     });
+    expect(query.selector.$or).toContainEqual({
+      'assignee.userId': 'alex', 'assignee.userPlanetCode': ''
+    });
+    expect(query.selector.$or).toContainEqual({
+      assignees: { $elemMatch: { userId: 'alex', userPlanetCode: '' } }
+    });
   });
 
   it('removes only the matching planet and skips unchanged documents', () => {

--- a/src/app/tasks/tasks.service.ts
+++ b/src/app/tasks/tasks.service.ts
@@ -135,7 +135,9 @@ export class TasksService {
       assignees: { $elemMatch: code ? { userId, userPlanetCode: code } : { userId } }
     }));
     if (planetCodes.includes(localPlanetCode)) {
+      legacySelectors.push({ 'assignee.userId': userId, 'assignee.userPlanetCode': '' });
       legacySelectors.push({ 'assignee.userId': userId, 'assignee.userPlanetCode': { $exists: false } });
+      arraySelectors.push({ assignees: { $elemMatch: { userId, userPlanetCode: '' } } });
       arraySelectors.push({ assignees: { $elemMatch: { userId, userPlanetCode: { $exists: false } } } });
     }
     const selector: any = {

--- a/src/app/tasks/tasks.utils.spec.ts
+++ b/src/app/tasks/tasks.utils.spec.ts
@@ -45,11 +45,40 @@ describe('task assignee utilities', () => {
     }, 'planet-a')).toEqual([ { userId: 'alex', userPlanetCode: 'planet-b' } ]);
   });
 
+  it('removes an associated-account routing suffix from its stable identity', () => {
+    expect(assigneeIdentityCandidates({
+      _id: 'org.couchdb.user:alex@planet-b',
+      name: 'alex@planet-b',
+      planetCode: 'planet-b',
+      requestId: 'request-1'
+    }, 'planet-a')).toEqual([
+      { userId: 'org.couchdb.user:alex', userPlanetCode: 'planet-b' },
+      { userId: 'org.couchdb.user:alex', userPlanetCode: 'planet-a' }
+    ]);
+  });
+
   it('stores only portable display metadata', () => {
     expect(storedAssignee({
       ...local,
       attachmentDoc: { _attachments: { img: {} } },
       userDoc: { fullName: 'Alex Example', doc: { salt: 'private' } }
     })).toEqual({ ...local, userDoc: { fullName: 'Alex Example' } });
+  });
+
+  it('uses a derived member origin for task matching and persistence without changing the member row', () => {
+    const codelessMember = {
+      userId: 'alex',
+      resolvedUserPlanetCode: 'planet-b',
+      name: 'Alex'
+    };
+
+    expect(assigneeMatches(codelessMember, remote, 'planet-a')).toBe(true);
+    expect(storedAssignee(codelessMember, 'planet-a')).toEqual({
+      userId: 'alex',
+      userPlanetCode: 'planet-b',
+      name: 'Alex',
+      userDoc: undefined
+    });
+    expect(codelessMember).not.toHaveProperty('userPlanetCode');
   });
 });

--- a/src/app/tasks/tasks.utils.ts
+++ b/src/app/tasks/tasks.utils.ts
@@ -1,12 +1,9 @@
-import { canonicalUserId } from '../shared/identity.utils';
+import { canonicalUserId, identityMatches, identityPlanetCode } from '../shared/identity.utils';
 
 export interface AssigneeIdentity {
   userId: string;
   userPlanetCode?: string;
 }
-
-const assigneePlanetCode = (assignee: any, localPlanetCode?: string) =>
-  assignee?.userPlanetCode || assignee?.resolvedUserPlanetCode || assignee?.planetCode || localPlanetCode;
 
 export const assigneeIdentityCandidates = (user: any, localPlanetCode?: string): AssigneeIdentity[] => {
   const source = user?.doc ? { ...user.doc, _id: user.doc._id || user._id } : user;
@@ -14,7 +11,7 @@ export const assigneeIdentityCandidates = (user: any, localPlanetCode?: string):
   if (!userId) {
     return [];
   }
-  const planetCodes = new Set<string | undefined>([ assigneePlanetCode(source) ]);
+  const planetCodes = new Set<string | undefined>([ identityPlanetCode(source) ]);
   if ((source.requestId || source.sync) && localPlanetCode) {
     planetCodes.add(localPlanetCode);
   }
@@ -24,12 +21,11 @@ export const assigneeIdentityCandidates = (user: any, localPlanetCode?: string):
 export const assigneeKey = (
   assignee: Partial<AssigneeIdentity> = {}, localPlanetCode?: string
 ): string => assignee.userId ?
-  `${assignee.userId}\u0000${assigneePlanetCode(assignee, localPlanetCode) || ''}` : '';
+  `${assignee.userId}\u0000${identityPlanetCode(assignee, localPlanetCode) || ''}` : '';
 
 export const assigneeMatches = (
   assignee: Partial<AssigneeIdentity>, identity: Partial<AssigneeIdentity>, localPlanetCode?: string
-): boolean => assignee?.userId === identity?.userId &&
-    assigneePlanetCode(assignee, localPlanetCode) === assigneePlanetCode(identity, localPlanetCode);
+): boolean => identityMatches(assignee, identity, localPlanetCode);
 
 export const effectiveAssignees = (task: any): any[] =>
   Array.isArray(task?.assignees) && task.assignees.length > 0 ?
@@ -43,7 +39,7 @@ export const assigneeName = (assignee: any): string => assignee?.userDoc?.fullNa
 
 export const storedAssignee = (assignee: any, localPlanetCode?: string): any => ({
   userId: assignee?.userId,
-  userPlanetCode: assigneePlanetCode(assignee, localPlanetCode),
+  userPlanetCode: identityPlanetCode(assignee, localPlanetCode),
   name: assignee?.name,
   userDoc: assignee?.userDoc?.fullName ? { fullName: assignee.userDoc.fullName } : undefined
 });

--- a/src/app/tasks/tasks.utils.ts
+++ b/src/app/tasks/tasks.utils.ts
@@ -1,15 +1,21 @@
+import { canonicalUserId } from '../shared/identity.utils';
+
 export interface AssigneeIdentity {
   userId: string;
   userPlanetCode?: string;
 }
 
+const assigneePlanetCode = (assignee: any, localPlanetCode?: string) =>
+  assignee?.userPlanetCode || assignee?.resolvedUserPlanetCode || assignee?.planetCode || localPlanetCode;
+
 export const assigneeIdentityCandidates = (user: any, localPlanetCode?: string): AssigneeIdentity[] => {
-  const userId = user?.couchId || user?.userId || user?._id;
+  const source = user?.doc ? { ...user.doc, _id: user.doc._id || user._id } : user;
+  const userId = canonicalUserId(source);
   if (!userId) {
     return [];
   }
-  const planetCodes = new Set<string | undefined>([ user.userPlanetCode || user.planetCode ]);
-  if ((user.requestId || user.sync) && localPlanetCode) {
+  const planetCodes = new Set<string | undefined>([ assigneePlanetCode(source) ]);
+  if ((source.requestId || source.sync) && localPlanetCode) {
     planetCodes.add(localPlanetCode);
   }
   return [ ...planetCodes ].map(userPlanetCode => ({ userId, userPlanetCode }));
@@ -18,12 +24,12 @@ export const assigneeIdentityCandidates = (user: any, localPlanetCode?: string):
 export const assigneeKey = (
   assignee: Partial<AssigneeIdentity> = {}, localPlanetCode?: string
 ): string => assignee.userId ?
-  `${assignee.userId}\u0000${assignee.userPlanetCode || localPlanetCode || ''}` : '';
+  `${assignee.userId}\u0000${assigneePlanetCode(assignee, localPlanetCode) || ''}` : '';
 
 export const assigneeMatches = (
   assignee: Partial<AssigneeIdentity>, identity: Partial<AssigneeIdentity>, localPlanetCode?: string
 ): boolean => assignee?.userId === identity?.userId &&
-    (assignee?.userPlanetCode || localPlanetCode) === (identity?.userPlanetCode || localPlanetCode);
+    assigneePlanetCode(assignee, localPlanetCode) === assigneePlanetCode(identity, localPlanetCode);
 
 export const effectiveAssignees = (task: any): any[] =>
   Array.isArray(task?.assignees) && task.assignees.length > 0 ?
@@ -37,7 +43,7 @@ export const assigneeName = (assignee: any): string => assignee?.userDoc?.fullNa
 
 export const storedAssignee = (assignee: any, localPlanetCode?: string): any => ({
   userId: assignee?.userId,
-  userPlanetCode: assignee?.userPlanetCode || localPlanetCode,
+  userPlanetCode: assigneePlanetCode(assignee, localPlanetCode),
   name: assignee?.name,
   userDoc: assignee?.userDoc?.fullName ? { fullName: assignee.userDoc.fullName } : undefined
 });

--- a/src/app/teams/teams-member.component.html
+++ b/src/app/teams/teams-member.component.html
@@ -26,8 +26,8 @@
 @if (memberType === 'community' && !member?.doc?.leadershipTitle && !member?.doc?.isUserAdmin && actionMenu.indexOf('title') > -1) {
   <button type="button" class="tile-add-title cursor-pointer" (click)="openDialog({ member: member, change: 'title' })" i18n>+ Add title</button>
 }
-@if (member?.userPlanetCode !== planetCode) {
-  <span class="tile-muted"><ng-container i18n>Member of Planet</ng-container> {{member?.userPlanetCode}}</span>
+@if (memberPlanetCode !== planetCode) {
+  <span class="tile-muted"><ng-container i18n>Member of Planet</ng-container> {{memberPlanetCode}}</span>
 }
 @if (isSelf) {
   <span class="tile-muted" i18n>You</span>

--- a/src/app/teams/teams-member.component.spec.ts
+++ b/src/app/teams/teams-member.component.spec.ts
@@ -177,6 +177,27 @@ describe('TeamsMemberComponent', () => {
 
       expect(component.isSelf).toBe(false);
     });
+
+    it('uses the associated account explicit origin when deciding self', () => {
+      const associated = {
+        _id: 'org.couchdb.user:ann@community',
+        name: 'ann@community',
+        planetCode: 'community',
+        requestId: 'request-1'
+      };
+      component = new TeamsMemberComponent(
+        { get: () => associated } as any as UserService,
+        { configuration: { code: planetCode } } as any as StateService,
+        {} as any as TasksService,
+        usersProfileDialogService as any as UsersProfileDialogService
+      );
+
+      component.member = { userId: currentUser._id, userPlanetCode: 'community' };
+      expect(component.isSelf).toBe(true);
+
+      component.member = { userId: currentUser._id, userPlanetCode: planetCode };
+      expect(component.isSelf).toBe(false);
+    });
   });
 
   describe('member type', () => {

--- a/src/app/teams/teams-member.component.ts
+++ b/src/app/teams/teams-member.component.ts
@@ -10,6 +10,8 @@ import { MatIcon } from '@angular/material/icon';
 import { MatSelectionList, MatSelectionListChange, MatListOption, MatListItemTitle } from '@angular/material/list';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 import { TimeAgoPipe } from '../shared/time-ago.pipe';
+import { userIdentity } from '../shared/identity.utils';
+import { memberCompare, memberPlanetCode } from './teams.utils';
 
 const defaultAvatar = 'assets/image.png';
 // Must match the length of $initials-palette in _variables.scss, which owns the colors.
@@ -66,12 +68,21 @@ export class TeamsMemberComponent implements OnInit, OnChanges {
   ) {}
 
   get isTeamLeader() {
-    return !!this.teamLeader && this.member?.userId === this.teamLeader.userId &&
-      this.member?.userPlanetCode === this.teamLeader.userPlanetCode;
+    return !!this.teamLeader && memberCompare(
+      this.member, this.teamLeader, this.member?.teamPlanetCode || this.planetCode
+    );
   }
 
   get isSelf() {
-    return this.member?.userId === this.user._id && this.member?.userPlanetCode === this.planetCode;
+    return memberCompare(
+      this.member,
+      userIdentity(this.user, this.planetCode),
+      this.member?.teamPlanetCode || this.planetCode
+    );
+  }
+
+  get memberPlanetCode() {
+    return memberPlanetCode(this.member);
   }
 
   ngOnInit() {
@@ -108,7 +119,9 @@ export class TeamsMemberComponent implements OnInit, OnChanges {
   }
 
   openMemberDialog(member) {
-    this.usersProfileDialogService.open({ member });
+    this.usersProfileDialogService.open({
+      member: { ...member, userPlanetCode: memberPlanetCode(member) }
+    });
   }
 
   toggleTask(event: MatSelectionListChange) {

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -179,9 +179,9 @@
                 [member]="member"
                 [leadershipTitle]="member.userDoc?.doc?.leadershipTitle"
                 [actionMenu]="[]
-                  .concat(member.userId !== currentUserId && isUserLeader ? [ 'remove' ] : [])
-                  .concat((member.userId !== leader.userId || member.userPlanetCode !== leader.userPlanetCode) && ((user.isUserAdmin && team.teamPlanetCode === user.planetCode) || isUserLeader) ? [ 'leader' ] : [])
-                  .concat(member.userId === currentUserId || isUserLeader ? [ 'title' ] : [])"
+                  .concat(!sameMember(member, currentUserIdentity) && isUserLeader ? [ 'remove' ] : [])
+                  .concat(!sameMember(member, leader) && ((user.isUserAdmin && team.teamPlanetCode === user.planetCode) || isUserLeader) ? [ 'leader' ] : [])
+                  .concat(sameMember(member, currentUserIdentity) || isUserLeader ? [ 'title' ] : [])"
                 [visits]="visits[member?.name]"
                 [userStatus]="userStatus"
                 [teamLeader]="leader"

--- a/src/app/teams/teams-view.component.spec.ts
+++ b/src/app/teams/teams-view.component.spec.ts
@@ -1,34 +1,439 @@
+import { vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, Subject } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { CouchService } from '../shared/couchdb.service';
+import { UserService } from '../shared/user.service';
+import { StateService } from '../shared/state.service';
+import { PlanetMessageService } from '../shared/planet-message.service';
+import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service';
+import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
+import { NewsService } from '../news/news.service';
+import { ReportsService } from '../manager-dashboard/reports/reports.service';
+import { TasksService } from '../tasks/tasks.service';
+import { DeviceInfoService } from '../shared/device-info.service';
+import { TeamsService } from './teams.service';
 import { TeamsViewComponent } from './teams-view.component';
 
-describe('TeamsViewComponent task projections', () => {
-  it('projects secondary assignments and separates same-id members by planet', () => {
-    const component: any = Object.create(TeamsViewComponent.prototype);
-    const local = { userId: 'alex', userPlanetCode: 'planet-a' };
-    const remote = { userId: 'alex', userPlanetCode: 'planet-b' };
-    const other = { userId: 'other', userPlanetCode: 'planet-a' };
-    const localTask = { _id: 'local', assignees: [ other, local ], completed: false };
-    const remoteTask = { _id: 'remote', assignees: [ remote ], completed: false };
-    component.members = [ local, remote, other ];
-    component.tasksService = { sortedTasks: tasks => tasks };
-    component.planetCode = 'planet-a';
-    component.userStatus = 'member';
-    component.isUserLeader = false;
-    component.user = { _id: 'alex', planetCode: 'planet-a' };
+// The component is built through TestBed's injector rather than createComponent: the real constructor
+// and field initializers run, without pulling in the template's child component tree.
+describe('TeamsViewComponent identity', () => {
+  const serverPlanet = 'nation';
 
-    component.setTasks([ localTask, remoteTask ]);
+  let teamsService: any;
+  let tasksService: any;
+  let userService: any;
+  let dialog: any;
 
-    expect(component.members[0].tasks).toEqual([ localTask ]);
-    expect(component.members[1].tasks).toEqual([ remoteTask ]);
-    expect(component.taskCount).toBe(1);
+  const build = ({ user = { _id: 'org.couchdb.user:ann', planetCode: serverPlanet }, mode = 'team' } = {}) => {
+    teamsService = {
+      getTeamMembers: vi.fn().mockReturnValue(of([])),
+      getTeamResources: vi.fn().mockReturnValue(of([])),
+      changeTeamLeadership: vi.fn().mockReturnValue(of({})),
+      toggleTeamMembership: vi.fn().mockReturnValue(of({})),
+      removeFromRequests: vi.fn().mockReturnValue(of({})),
+      cancelJoinRequest: vi.fn().mockReturnValue(of({})),
+      sendNotifications: vi.fn().mockReturnValue(of({}))
+    };
+    tasksService = {
+      sortedTasks: (tasks) => tasks,
+      getTasks: vi.fn(),
+      tasksListener: () => of([]),
+      removeAssigneeFromTasks: vi.fn().mockReturnValue(of({}))
+    };
+    userService = { get: () => user, doesUserHaveRole: () => false };
+    dialog = { open: vi.fn().mockReturnValue({}) };
+    TestBed.configureTestingModule({
+      providers: [
+        TeamsViewComponent,
+        { provide: CouchService, useValue: { findAll: vi.fn().mockReturnValue(of([])) } },
+        { provide: UserService, useValue: userService },
+        { provide: Router, useValue: { navigate: vi.fn() } },
+        { provide: ActivatedRoute, useValue: { snapshot: { data: { mode }, params: {} }, paramMap: of(new Map()) } },
+        { provide: PlanetMessageService, useValue: { showMessage: vi.fn(), showAlert: vi.fn() } },
+        { provide: TeamsService, useValue: teamsService },
+        { provide: MatDialog, useValue: dialog },
+        { provide: DialogsLoadingService, useValue: { start: vi.fn(), stop: vi.fn() } },
+        { provide: DialogsFormService, useValue: {} },
+        { provide: NewsService, useValue: {} },
+        { provide: ReportsService, useValue: {} },
+        { provide: StateService, useValue: { configuration: { code: serverPlanet } } },
+        { provide: TasksService, useValue: tasksService },
+        { provide: DeviceInfoService, useValue: { watchDeviceType: () => new Subject() } }
+      ]
+    });
+    const component: any = TestBed.inject(TeamsViewComponent);
+    // ngOnInit's first statement; the rest of it loads a team and is out of scope here.
+    component.planetCode = serverPlanet;
+    return component;
+  };
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.restoreAllMocks();
   });
 
-  it('matches membership on the local planet code rather than the user doc planet', () => {
-    const component: any = Object.create(TeamsViewComponent.prototype);
-    component.planetCode = 'planet-a';
-    const user = { _id: 'alex', planetCode: 'planet-b' };
+  describe('membership and leadership', () => {
+    it('keeps an associated account origin distinct from a same-named server account', () => {
+      const component = build({ user: {
+        _id: 'org.couchdb.user:ann@community',
+        name: 'ann@community',
+        planetCode: 'community',
+        requestId: 'request-1'
+      } });
+      component.team = { _id: 'team-1', teamPlanetCode: 'community', teamType: 'sync' };
+      const nationMembership = { userId: 'org.couchdb.user:ann', userPlanetCode: serverPlanet };
+      const communityMembership = { userId: 'org.couchdb.user:ann', userPlanetCode: 'community' };
 
-    expect(component.isUserInMemberDocs([ { userId: 'alex', userPlanetCode: 'planet-a' } ], user)).toBe(true);
-    expect(component.isUserInMemberDocs([ { userId: 'alex' } ], user)).toBe(true);
-    expect(component.isUserInMemberDocs([ { userId: 'alex', userPlanetCode: 'planet-b' } ], user)).toBe(false);
+      expect(component.isUserInMemberDocs([ nationMembership ], component.user)).toBe(false);
+      expect(component.isUserInMemberDocs([ communityMembership ], component.user)).toBe(true);
+
+      component.planetCode = 'community';
+
+      expect(component.isUserInMemberDocs([ communityMembership ], component.user)).toBe(true);
+      expect(component.isUserInMemberDocs([ nationMembership ], component.user)).toBe(false);
+    });
+
+    it('resolves a membership row with no planet code as belonging to the viewed server', () => {
+      const component = build();
+
+      expect(component.isUserInMemberDocs([ { userId: 'org.couchdb.user:ann' } ], component.user)).toBe(true);
+    });
+
+    it('does not grant leadership from an unrelated planet leader row', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:ann', planetCode: 'community' } });
+      component.requests = [];
+      component.members = [];
+      component.route.snapshot.params = {};
+
+      component.setStatus({}, { userId: 'org.couchdb.user:ann', userPlanetCode: 'elsewhere' }, component.user);
+
+      expect(component.isUserLeader).toBe(false);
+    });
+
+    it('resolves a code-less leader through the synchronized team origin', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:ann', planetCode: 'community' } });
+      component.team = { _id: 'team-1', teamPlanetCode: 'community' };
+      component.requests = [];
+      component.members = [];
+      component.route.snapshot.params = {};
+
+      component.setStatus(component.team, { userId: 'org.couchdb.user:ann' }, component.user);
+
+      expect(component.isUserLeader).toBe(true);
+    });
+
+    it('grants leadership when the leader row belongs to the viewed server', () => {
+      const component = build();
+      component.requests = [];
+      component.members = [];
+      component.route.snapshot.params = {};
+
+      component.setStatus({}, { userId: 'org.couchdb.user:ann', userPlanetCode: serverPlanet }, component.user);
+
+      expect(component.isUserLeader).toBe(true);
+    });
+
+    it('does not treat another planet\'s member document as this user', () => {
+      const component = build();
+      component.requests = [];
+      component.members = [ { userId: 'org.couchdb.user:ann', userPlanetCode: 'community', isLeader: true } ];
+      component.route.snapshot.params = {};
+
+      component.setStatus({}, { userId: 'org.couchdb.user:other', userPlanetCode: serverPlanet }, component.user);
+
+      expect(component.userStatus).toBe('unrelated');
+      expect(component.isUserLeader).toBe(false);
+    });
+
+    it('leaves the team through the member row belonging to this user, not another planet\'s', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:ann', planetCode: 'community' } });
+      const ownRow = { _id: 'membership-home', userId: 'org.couchdb.user:ann', userPlanetCode: 'community' };
+      component.members = [
+        { _id: 'membership-elsewhere', userId: 'org.couchdb.user:ann', userPlanetCode: 'elsewhere' },
+        ownRow
+      ];
+      const team = { _id: 'team-1' };
+      component.team = team;
+
+      component.toggleMembership(team, true)().subscribe();
+
+      expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(team, true, ownRow);
+    });
+
+    it('uses the associated account origin when no member row exists yet', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:ann', planetCode: 'community' } });
+      const team = { _id: 'team-1' };
+      component.members = [];
+      component.team = team;
+
+      component.toggleMembership(team, false)().subscribe();
+
+      expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(
+        team, false, { userId: 'org.couchdb.user:ann', userPlanetCode: 'community' }
+      );
+    });
+
+    it('preserves an explicit foreign request origin when accepting it', () => {
+      const component = build();
+      const team = { _id: 'team-1', teamPlanetCode: 'community' };
+      const request = {
+        _id: 'request-1',
+        _rev: '1-request',
+        userId: 'org.couchdb.user:bob',
+        userPlanetCode: 'community',
+        docType: 'request'
+      };
+      component.team = team;
+
+      (component as any).changeObject('added', request).obs.subscribe();
+
+      expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(team, false, {
+        ...request,
+        userPlanetCode: 'community',
+        docType: 'membership'
+      });
+    });
+
+    it('resolves a code-less accepted request from the team origin', () => {
+      const component = build();
+      const team = { _id: 'team-1', teamPlanetCode: 'community' };
+      const request = {
+        _id: 'request-1',
+        _rev: '1-request',
+        userId: 'org.couchdb.user:bob',
+        docType: 'request'
+      };
+      component.team = team;
+
+      (component as any).changeObject('added', request).obs.subscribe();
+
+      expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(team, false, {
+        ...request,
+        userPlanetCode: 'community',
+        docType: 'membership'
+      });
+    });
+
+    it('uses a code-less member\'s resolved team origin during task cleanup', () => {
+      const component = build();
+      const member = {
+        _id: 'membership-1',
+        userId: 'org.couchdb.user:bob',
+        resolvedUserPlanetCode: 'community'
+      };
+      component.team = { _id: 'team-1', teamPlanetCode: 'community' };
+      component.teamId = 'team-1';
+      component.getMembers = vi.fn().mockReturnValue(of([]));
+
+      component.changeMembershipRequest('removed', member)().subscribe();
+
+      expect(tasksService.removeAssigneeFromTasks).toHaveBeenCalledWith(
+        member.userId, 'community', { teams: 'team-1' }
+      );
+    });
+
+    it('promotes against the leader row identified by composite identity', () => {
+      const component = build();
+      const currentLeader = { _id: 'membership-leader', userId: 'org.couchdb.user:ann', userPlanetCode: serverPlanet };
+      const promoted = { _id: 'membership-bob', userId: 'org.couchdb.user:bob', userPlanetCode: serverPlanet };
+      component.members = [
+        { _id: 'membership-decoy', userId: 'org.couchdb.user:ann', userPlanetCode: 'community' },
+        currentLeader,
+        promoted
+      ];
+      component.leader = { userId: 'org.couchdb.user:ann', userPlanetCode: serverPlanet };
+      component.team = { _id: 'team-1' };
+
+      component.makeLeader(promoted)().subscribe();
+
+      expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith(currentLeader, promoted);
+    });
+
+    it('demotes a malformed persisted leader by document id', () => {
+      const component = build();
+      const malformedLeader = { _id: 'membership-leader', userId: '', isLeader: true };
+      const promoted = {
+        _id: 'membership-bob', userId: 'org.couchdb.user:bob', userPlanetCode: serverPlanet
+      };
+      component.members = [ malformedLeader, promoted ];
+      component.leader = malformedLeader;
+      component.team = { _id: 'team-1', teamPlanetCode: serverPlanet };
+
+      component.makeLeader(promoted)().subscribe();
+
+      expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith(malformedLeader, promoted);
+    });
+
+    // Known gap, recorded in the workplan: with no matching row the promotion still writes
+    // isLeader on the new leader while changeTeamLeadership skips demotion, so a team can end with
+    // two leaders. This asserts only that the path is survivable, not that the outcome is correct.
+    it('survives promotion when no persisted leader record matches', () => {
+      const component = build();
+      component.members = [];
+      component.leader = { userId: 'org.couchdb.user:missing', userPlanetCode: serverPlanet };
+      component.team = { _id: 'team-1' };
+
+      expect(() => component.makeLeader({ userId: 'org.couchdb.user:bob' })().subscribe()).not.toThrow();
+      expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith({}, { userId: 'org.couchdb.user:bob' });
+    });
+
+    it('removes a cancelled associated request from local state with the canonical matcher', () => {
+      const component = build({ user: {
+        _id: 'org.couchdb.user:ann@community',
+        name: 'ann@community',
+        planetCode: 'community',
+        requestId: 'request-1'
+      } });
+      const ownRequest = {
+        userId: 'org.couchdb.user:ann', userPlanetCode: 'community', docType: 'request'
+      };
+      const sameNamedServerRequest = {
+        userId: 'org.couchdb.user:ann', userPlanetCode: serverPlanet, docType: 'request'
+      };
+      component.team = { _id: 'team-1', teamPlanetCode: 'community' };
+      component.leader = {};
+      component.members = [];
+      component.requests = [ ownRequest, sameNamedServerRequest ];
+      component.cancelDialog = { close: vi.fn() };
+
+      component.cancelJoinRequest().onNext();
+
+      expect(component.requests).toEqual([ sameNamedServerRequest ]);
+      expect(component.userStatus).toBe('unrelated');
+    });
+
+    it('excludes both stored and materialized ids from the invite dialog', () => {
+      const component = build();
+      component.members = [ {
+        userId: 'org.couchdb.user:ann',
+        userDoc: {
+          _id: 'org.couchdb.user:ann@community',
+          doc: { _id: 'org.couchdb.user:ann@community' }
+        }
+      } ];
+
+      component.openInviteMemberDialog();
+
+      expect(dialog.open.mock.calls[0][1].data.excludeIds).toEqual([
+        'org.couchdb.user:ann',
+        'org.couchdb.user:ann@community'
+      ]);
+    });
+  });
+
+  describe('label management', () => {
+    it('derives custom labels from the current team document', () => {
+      const component = build();
+      component.team = { customVoiceLabels: [ 'Initial' ] };
+      expect(component.customVoiceLabels).toEqual([ 'Initial' ]);
+
+      component.team = { customVoiceLabels: [ 'Updated' ] };
+      expect(component.customVoiceLabels).toEqual([ 'Updated' ]);
+    });
+
+    it('limits planet-level label managers to locally owned teams', () => {
+      const component = build();
+      component.isUserLeader = false;
+      component.user = { isUserAdmin: false };
+      userService.doesUserHaveRole = () => true;
+      component.team = { teamPlanetCode: 'community' };
+
+      expect(component.canManageLabels).toBe(false);
+
+      component.team = { teamPlanetCode: serverPlanet };
+      expect(component.canManageLabels).toBe(true);
+    });
+
+    it('allows a team leader to manage labels regardless of the team planet', () => {
+      const component = build();
+      component.isUserLeader = true;
+      component.user = { isUserAdmin: false };
+      userService.doesUserHaveRole = () => false;
+      component.team = { teamPlanetCode: 'community' };
+
+      expect(component.canManageLabels).toBe(true);
+    });
+  });
+
+  describe('task grouping and counts', () => {
+    const local = { userId: 'org.couchdb.user:alex', userPlanetCode: serverPlanet };
+    const remote = { userId: 'org.couchdb.user:alex', userPlanetCode: 'community' };
+    const other = { userId: 'org.couchdb.user:other', userPlanetCode: serverPlanet };
+
+    it('separates same-id members on different planets and projects secondary assignments', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:alex', planetCode: serverPlanet } });
+      const localTask = { _id: 'local', assignees: [ other, local ], completed: false };
+      const remoteTask = { _id: 'remote', assignees: [ remote ], completed: false };
+      component.members = [ local, remote, other ];
+      component.userStatus = 'member';
+      component.isUserLeader = false;
+
+      component.setTasks([ localTask, remoteTask ]);
+
+      expect(component.members[0].tasks).toEqual([ localTask ]);
+      expect(component.members[1].tasks).toEqual([ remoteTask ]);
+      expect(component.members[2].tasks).toEqual([ localTask ]);
+    });
+
+    it('counts the signed-in member card and My Tasks identically', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:alex', planetCode: serverPlanet } });
+      const mine = { _id: 'mine', assignees: [ local ], completed: false };
+      const done = { _id: 'done', assignees: [ local ], completed: true };
+      const theirs = { _id: 'theirs', assignees: [ remote ], completed: false };
+      component.members = [ local, remote ];
+      component.userStatus = 'member';
+      component.isUserLeader = false;
+
+      component.setTasks([ mine, done, theirs ]);
+
+      const currentMemberCard = component.members[0];
+      expect(currentMemberCard.tasks).toEqual([ mine, done ]);
+      expect(component.taskCount).toBe(currentMemberCard.tasks.filter(task => !task.completed).length);
+      expect(component.taskCount).toBe(1);
+    });
+
+    it('counts tasks under every identity the user is assigned by', () => {
+      // An associated account can hold assignments stamped with either its home or the server code;
+      // My Tasks filters across both, so the badge must too.
+      const component = build({ user: { _id: 'org.couchdb.user:alex', planetCode: 'community', sync: true } });
+      component.members = [ local, remote ];
+      component.userStatus = 'member';
+      component.isUserLeader = false;
+
+      component.setTasks([
+        { _id: 'server-stamped', assignees: [ local ], completed: false },
+        { _id: 'home-stamped', assignees: [ remote ], completed: false },
+        { _id: 'someone-else', assignees: [ other ], completed: false }
+      ]);
+
+      expect(component.taskCount).toBe(2);
+    });
+
+    it('counts every incomplete team task for a leader', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:alex', planetCode: serverPlanet } });
+      component.members = [ local, remote ];
+      component.userStatus = 'member';
+      component.isUserLeader = true;
+
+      component.setTasks([
+        { _id: 'a', assignees: [ local ], completed: false },
+        { _id: 'b', assignees: [ remote ], completed: false },
+        { _id: 'c', assignees: [ other ], completed: true }
+      ]);
+
+      expect(component.taskCount).toBe(2);
+    });
+
+    it('does not crash when the signed-in user has no member record', () => {
+      const component = build({ user: { _id: 'org.couchdb.user:ghost', planetCode: serverPlanet } });
+      component.members = [ local ];
+      component.userStatus = 'member';
+      component.isUserLeader = false;
+
+      expect(() => component.setTasks([ { _id: 'a', assignees: [ local ], completed: false } ])).not.toThrow();
+      expect(component.taskCount).toBe(0);
+    });
   });
 });

--- a/src/app/teams/teams-view.component.spec.ts
+++ b/src/app/teams/teams-view.component.spec.ts
@@ -190,7 +190,7 @@ describe('TeamsViewComponent identity', () => {
       (component as any).changeObject('added', request).obs.subscribe();
 
       expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(team, false, {
-        ...request,
+        userId: request.userId,
         userPlanetCode: 'community',
         docType: 'membership'
       });
@@ -210,7 +210,7 @@ describe('TeamsViewComponent identity', () => {
       (component as any).changeObject('added', request).obs.subscribe();
 
       expect(teamsService.toggleTeamMembership).toHaveBeenCalledWith(team, false, {
-        ...request,
+        userId: request.userId,
         userPlanetCode: 'community',
         docType: 'membership'
       });
@@ -266,17 +266,46 @@ describe('TeamsViewComponent identity', () => {
       expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith(malformedLeader, promoted);
     });
 
-    // Known gap, recorded in the workplan: with no matching row the promotion still writes
-    // isLeader on the new leader while changeTeamLeadership skips demotion, so a team can end with
-    // two leaders. This asserts only that the path is survivable, not that the outcome is correct.
-    it('survives promotion when no persisted leader record matches', () => {
+    it('promotes when the team has no persisted leader record', () => {
       const component = build();
       component.members = [];
       component.leader = { userId: 'org.couchdb.user:missing', userPlanetCode: serverPlanet };
       component.team = { _id: 'team-1' };
 
       expect(() => component.makeLeader({ userId: 'org.couchdb.user:bob' })().subscribe()).not.toThrow();
-      expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith({}, { userId: 'org.couchdb.user:bob' });
+      expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith(undefined, { userId: 'org.couchdb.user:bob' });
+    });
+
+    it('uses the sole persisted leader when the synthesized identity does not match', () => {
+      const component = build();
+      const persistedLeader = { _id: 'leader-1', userId: '', isLeader: true };
+      const promoted = { _id: 'member-1', userId: 'org.couchdb.user:bob' };
+      component.members = [ persistedLeader, promoted ];
+      component.leader = { userId: 'org.couchdb.user:missing', userPlanetCode: serverPlanet };
+      component.team = { _id: 'team-1' };
+
+      component.makeLeader(promoted)().subscribe();
+
+      expect(teamsService.changeTeamLeadership).toHaveBeenCalledWith(persistedLeader, promoted);
+    });
+
+    it('fails closed when multiple persisted leaders already exist', () => {
+      const component = build();
+      const error = vi.fn();
+      component.members = [
+        { _id: 'leader-1', userId: 'one', isLeader: true },
+        { _id: 'leader-2', userId: 'two', isLeader: true }
+      ];
+      component.leader = component.members[0];
+      component.team = { _id: 'team-1' };
+      component.getMembers = vi.fn().mockReturnValue(of([]));
+
+      component.makeLeader({ _id: 'member-1', userId: 'three' })().subscribe({ error });
+
+      expect(error).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Multiple persisted team leaders must be resolved before promotion.'
+      }));
+      expect(teamsService.changeTeamLeadership).not.toHaveBeenCalled();
     });
 
     it('removes a cancelled associated request from local state with the canonical matcher', () => {
@@ -304,7 +333,7 @@ describe('TeamsViewComponent identity', () => {
       expect(component.userStatus).toBe('unrelated');
     });
 
-    it('excludes both stored and materialized ids from the invite dialog', () => {
+    it('excludes the materialized associated member without hiding the same-named native user', () => {
       const component = build();
       component.members = [ {
         userId: 'org.couchdb.user:ann',
@@ -317,9 +346,25 @@ describe('TeamsViewComponent identity', () => {
       component.openInviteMemberDialog();
 
       expect(dialog.open.mock.calls[0][1].data.excludeIds).toEqual([
-        'org.couchdb.user:ann',
         'org.couchdb.user:ann@community'
       ]);
+    });
+
+    it('recognizes a historical materialized membership for an associated account', () => {
+      const component = build({ user: {
+        _id: 'org.couchdb.user:ann@community',
+        name: 'ann@community',
+        planetCode: 'community',
+        requestId: 'request-1'
+      } });
+      component.team = { _id: 'team-1', teamPlanetCode: 'community' };
+
+      expect(component.isUserInMemberDocs([ {
+        userId: 'org.couchdb.user:ann@community', userPlanetCode: 'community'
+      } ], component.user)).toBe(true);
+      expect(component.isUserInMemberDocs([ {
+        userId: 'org.couchdb.user:ann@community', userPlanetCode: serverPlanet
+      } ], component.user)).toBe(true);
     });
   });
 

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -47,7 +47,7 @@ import { SurveysComponent } from '../surveys/surveys.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 import { DialogsVoiceLabelsComponent } from '../shared/dialogs/dialogs-voice-labels.component';
 import { assigneeIdentityCandidates, isTaskAssignedTo } from '../tasks/tasks.utils';
-import { userIdentity } from '../shared/identity.utils';
+import { userIdentity, userIdentityCandidates } from '../shared/identity.utils';
 
 @Component({
   templateUrl: './teams-view.component.html',
@@ -393,7 +393,9 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   // Explicit account origin distinguishes a native user from an associated same-named account.
   // The current server is only the fallback for native/legacy user objects without their own origin.
   private matchesCurrentUser(doc, user = this.user) {
-    return memberCompare(doc, userIdentity(user, this.planetCode), this.team?.teamPlanetCode || this.planetCode);
+    return userIdentityCandidates(user, this.planetCode).some(identity => memberCompare(
+      doc, identity, this.team?.teamPlanetCode || this.planetCode
+    ));
   }
 
   sameMember(member1, member2) {
@@ -606,15 +608,20 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
           obs: this.teamsService.toggleTeamMembership(this.team, true, memberDoc),
           message: $localize`Removed: ${memberName}`
         });
-      case 'added':
+      case 'added': {
+        const requestMember = { ...memberDoc };
+        delete requestMember._id;
+        delete requestMember._rev;
+        delete requestMember.docType;
         return ({
           obs: this.teamsService.toggleTeamMembership(this.team, false, {
-            ...memberDoc,
+            ...requestMember,
             userPlanetCode: memberPlanetCode(memberDoc) || this.team.teamPlanetCode || this.planetCode,
             docType: 'membership'
           }),
           message: $localize`Accepted: ${memberName}`
         });
+      }
       case 'rejected':
         return ({
           obs: this.teamsService.removeFromRequests(this.team, memberDoc),
@@ -638,11 +645,9 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
       maxHeight: '90vh',
       data: {
         okClick: (selected: any[]) => this.addMembers(selected),
-        excludeIds: [ ...new Set(this.members.flatMap(member => [
-          member.userId,
-          member.userDoc?._id,
-          member.userDoc?.doc?._id
-        ]).filter(Boolean)) ],
+        excludeIds: [ ...new Set(this.members.map(member =>
+          member.userDoc?._id || member.userDoc?.doc?._id || member.userId
+        ).filter(Boolean)) ],
         hideChildren: true,
         mode: 'users'
       }
@@ -779,11 +784,15 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   makeLeader(member) {
+    const persistedLeaders = this.members.filter(mem => mem.isLeader);
     const currentLeader = this.members.find(mem => this.leader?._id && mem._id === this.leader._id) ||
       this.members.find(mem => memberCompare(
         mem, this.leader, this.team?.teamPlanetCode || this.planetCode
-      )) || {};
-    return () => this.teamsService.changeTeamLeadership(currentLeader, member).pipe(
+      )) || persistedLeaders[0];
+    return () => (persistedLeaders.length > 1 ?
+      throwError(new Error('Multiple persisted team leaders must be resolved before promotion.')) :
+      this.teamsService.changeTeamLeadership(currentLeader, member)
+    ).pipe(
       catchError(error => this.refreshMembersOnError(error)),
       switchMap(() => this.getMembers())
     );

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -23,7 +23,7 @@ import { DialogsResourcesViewerComponent } from '../shared/dialogs/dialogs-resou
 import { CustomValidators } from '../validators/custom-validators';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
 import { CoursesViewDetailDialogComponent } from '../courses/view-courses/courses-view-detail.component';
-import { enterpriseJoinAgreement, memberCompare, memberSort, requestDateCompare } from './teams.utils';
+import { enterpriseJoinAgreement, memberCompare, memberPlanetCode, memberSort, requestDateCompare } from './teams.utils';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatIconButton, MatButton, MatAnchor } from '@angular/material/button';
@@ -46,7 +46,8 @@ import { PlanetMarkdownComponent } from '../shared/planet-markdown.component';
 import { SurveysComponent } from '../surveys/surveys.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 import { DialogsVoiceLabelsComponent } from '../shared/dialogs/dialogs-voice-labels.component';
-import { assigneeMatches, isTaskAssignedTo } from '../tasks/tasks.utils';
+import { assigneeIdentityCandidates, isTaskAssignedTo } from '../tasks/tasks.utils';
+import { userIdentity } from '../shared/identity.utils';
 
 @Component({
   templateUrl: './teams-view.component.html',
@@ -101,7 +102,6 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   userStatus = 'unrelated';
   isUserLeader = false;
   onDestroy$ = new Subject<void>();
-  currentUserId = this.userService.get()._id;
   dialogRef: MatDialogRef<DialogsAddTableComponent>;
   user = this.userService.get();
   news: any[] = [];
@@ -302,7 +302,8 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     this.teamDataLoading = true;
     return this.teamsService.getTeamMembers(this.team, true).pipe(switchMap((docs: any[]) => {
       const src = (member) => {
-        const { attachmentDoc, userId, userPlanetCode, userDoc } = member;
+        const { attachmentDoc, userId, userDoc } = member;
+        const userPlanetCode = memberPlanetCode(member);
         if (member.attachmentDoc) {
           return `${environment.couchAddress}/attachments/${userId}@${userPlanetCode}/${Object.keys(attachmentDoc._attachments)[0]}`;
         }
@@ -312,8 +313,12 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
         return 'assets/image.png';
       };
       const docsWithName = docs.map(mem => ({ ...mem, name: mem.userId && mem.userId.split(':')[1], avatar: src(mem) }));
-      this.leader = docsWithName.find(mem => mem.isLeader) || { userId: this.team.createdBy, userPlanetCode: this.team.teamPlanetCode };
-      this.members = docsWithName.filter(mem => mem.docType === 'membership').sort((a, b) => memberSort(a, b, this.leader));
+      this.leader = docsWithName.find(mem => mem.isLeader) || {
+        userId: this.team.createdBy,
+        userPlanetCode: this.team.createdByPlanetCode || this.team.teamPlanetCode
+      };
+      this.members = docsWithName.filter(mem => mem.docType === 'membership')
+        .sort((a, b) => memberSort(a, b, this.leader, this.team.teamPlanetCode));
       this.requests = docsWithName.filter(mem => mem.docType === 'request').sort(requestDateCompare);
       this.disableAddingMembers = this.members.length >= this.team.limit;
       this.finances = docs.filter(doc => doc.docType === 'transaction');
@@ -329,14 +334,19 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   setTasks(tasks = []) {
     this.members = this.members.map(member => ({
       ...member,
-      tasks: this.tasksService.sortedTasks(tasks.filter(task => isTaskAssignedTo(task, member, this.planetCode)), member.tasks)
+      tasks: this.tasksService.sortedTasks(tasks.filter(task => {
+        const identities = this.matchesCurrentUser(member) ?
+          this.currentUserTaskIdentities() :
+          [ { userId: member.userId, userPlanetCode: memberPlanetCode(member) } ];
+        return identities.some(identity => isTaskAssignedTo(task, identity, this.planetCode));
+      }), member.tasks)
     }));
     if (this.userStatus === 'member') {
-      const currentMember = this.members.find(member => assigneeMatches(member, {
-        userId: this.user._id,
-        userPlanetCode: this.planetCode
-      }, this.planetCode));
-      const tasksForCount = this.isUserLeader ? tasks : currentMember?.tasks || [];
+      const tasksForCount = this.isUserLeader ?
+        tasks :
+        tasks.filter(task => this.currentUserTaskIdentities().some(
+          identity => isTaskAssignedTo(task, identity, this.planetCode)
+        ));
       this.taskCount = tasksForCount.filter(task => task.completed === false).length;
     }
   }
@@ -356,7 +366,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     }
     this.userStatus = this.isUserInMemberDocs(this.requests, user) ? 'requesting' : this.userStatus;
     this.userStatus = this.isUserInMemberDocs(this.members, user) ? 'member' : this.userStatus;
-    this.isUserLeader = !!leader && memberCompare(leader, { userId: user._id, userPlanetCode: user.planetCode });
+    this.isUserLeader = !!leader && this.matchesCurrentUser(leader, user);
     if (this.initTab === undefined && this.userStatus === 'member' && this.route.snapshot.params.activeTab) {
       this.initTab = this.route.snapshot.params.activeTab;
     }
@@ -372,17 +382,32 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     return this.team?.customVoiceLabels || this.emptyVoiceLabels;
   }
 
+  get currentUserIdentity() {
+    return userIdentity(this.user, this.planetCode);
+  }
+
+  currentUserTaskIdentities() {
+    return assigneeIdentityCandidates(this.user, this.planetCode);
+  }
+
+  // Explicit account origin distinguishes a native user from an associated same-named account.
+  // The current server is only the fallback for native/legacy user objects without their own origin.
+  private matchesCurrentUser(doc, user = this.user) {
+    return memberCompare(doc, userIdentity(user, this.planetCode), this.team?.teamPlanetCode || this.planetCode);
+  }
+
+  sameMember(member1, member2) {
+    return memberCompare(member1, member2, this.team?.teamPlanetCode || this.planetCode);
+  }
+
   isUserInMemberDocs(memberDocs, user) {
-    return memberDocs.some((memberDoc: any) => assigneeMatches(memberDoc, {
-      userId: user._id,
-      userPlanetCode: this.planetCode
-    }, this.planetCode));
+    return memberDocs.some((memberDoc: any) => this.matchesCurrentUser(memberDoc, user));
   }
 
   toggleMembership(team, leaveTeam) {
     return () => this.teamsService.toggleTeamMembership(
       team, leaveTeam,
-      this.members.find(doc => doc.userId === this.user._id) || { userId: this.user._id, userPlanetCode: this.user.planetCode }
+      this.members.find(doc => this.matchesCurrentUser(doc)) || this.currentUserIdentity
     ).pipe(
       catchError(error => this.refreshMembersOnError(error)),
       switchMap((newTeam) => {
@@ -480,7 +505,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
         }),
         switchMap(() => type === 'added' ? this.teamsService.removeFromRequests(this.team, memberDoc) : of({})),
         switchMap(() => type === 'removed' ?
-          this.tasksService.removeAssigneeFromTasks(memberDoc.userId, memberDoc.userPlanetCode, { teams: this.teamId }) : of({})),
+          this.tasksService.removeAssigneeFromTasks(memberDoc.userId, memberPlanetCode(memberDoc), { teams: this.teamId }) : of({})),
         switchMap(() => this.getMembers()),
         switchMap(() => this.sendNotifications(type, { members: type === 'request' ? this.members : [ memberDoc ] })),
         map(() => changeObject.message),
@@ -537,9 +562,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
       request: this.teamsService.cancelJoinRequest(this.team),
       onNext: () => {
         this.cancelDialog.close();
-        this.requests = this.requests.filter(request =>
-          request.userId !== this.user._id || request.userPlanetCode !== this.planetCode
-        );
+        this.requests = this.requests.filter(request => !this.matchesCurrentUser(request));
         this.setStatus(this.team, this.leader, this.userService.get());
         const msg = this.mode === 'enterprise'
           ? $localize`:@@enterprise-join-request-cancelled:Cancelled request to join enterprise` + ' ' + this.team.name
@@ -585,7 +608,11 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
         });
       case 'added':
         return ({
-          obs: this.teamsService.toggleTeamMembership(this.team, false, { ...memberDoc, docType: 'membership' }),
+          obs: this.teamsService.toggleTeamMembership(this.team, false, {
+            ...memberDoc,
+            userPlanetCode: memberPlanetCode(memberDoc) || this.team.teamPlanetCode || this.planetCode,
+            docType: 'membership'
+          }),
           message: $localize`Accepted: ${memberName}`
         });
       case 'rejected':
@@ -597,7 +624,7 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   updateTeam() {
-    this.teamsService.addTeamDialog(this.user._id, this.mode, this.team).subscribe((updatedTeam) => {
+    this.teamsService.addTeamDialog(this.user, this.mode, this.team).subscribe((updatedTeam) => {
       this.team = updatedTeam;
       this.planetMessageService.showMessage(
         (this.team.name || $localize`${this.configuration.name} Services Directory`) + $localize` updated successfully`);
@@ -611,7 +638,11 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
       maxHeight: '90vh',
       data: {
         okClick: (selected: any[]) => this.addMembers(selected),
-        excludeIds: this.members.map(user => user.userId),
+        excludeIds: [ ...new Set(this.members.flatMap(member => [
+          member.userId,
+          member.userDoc?._id,
+          member.userDoc?.doc?._id
+        ]).filter(Boolean)) ],
         hideChildren: true,
         mode: 'users'
       }
@@ -748,7 +779,10 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   makeLeader(member) {
-    const currentLeader = this.members.find(mem => memberCompare(mem, this.leader)) || {};
+    const currentLeader = this.members.find(mem => this.leader?._id && mem._id === this.leader._id) ||
+      this.members.find(mem => memberCompare(
+        mem, this.leader, this.team?.teamPlanetCode || this.planetCode
+      )) || {};
     return () => this.teamsService.changeTeamLeadership(currentLeader, member).pipe(
       catchError(error => this.refreshMembersOnError(error)),
       switchMap(() => this.getMembers())

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -53,12 +53,6 @@
     </mat-toolbar>
   }
 
-  @if (userNotInShelf) {
-    <div i18n style="text-align: center;">
-    Oops ... Error: no full access in Teams and Enterprises (data missing) ... please contact the manager of this site
-  </div>
-  }
-
   <div class="primary-link-hover" [ngClass]="{'view-container view-table view-full-height':!isDialog}">
     <mat-table #table class="responsive-table" [class.min-width-table]="!isDialog" [dataSource]="teams" matSort [matSortDisableClear]="true">
       <ng-container matColumnDef="doc.name">

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -32,7 +32,9 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { FeedbackDirective } from '../feedback/feedback.directive';
 import { AuthorizedRolesDirective } from '../shared/authorized-roles.directive';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
-import { enterpriseJoinAgreement } from './teams.utils';
+import { enterpriseJoinAgreement, teamIdentityDocs } from './teams.utils';
+import { userPlanetCodeSelector } from '../shared/mangoQueries';
+import { userIdentity } from '../shared/identity.utils';
 
 @Component({
   templateUrl: './teams.component.html',
@@ -112,7 +114,6 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   filter: string;
   deviceType: DeviceType;
   isMobile: boolean;
-  userNotInShelf = false;
   showFiltersRow = false;
   selection = new SelectionModel(true, []);
   selectedIds: string[] = [];
@@ -183,16 +184,6 @@ export class TeamsComponent implements OnInit, AfterViewInit {
       this.dialogsLoadingService.stop();
       this.isLoading = false;
     }, (error) => {
-      if (this.userNotInShelf) {
-        this.displayedColumns = [ 'doc.name', 'visitLog.lastVisit', 'visitLog.visitCount', 'doc.teamType' ];
-        this.couchService.findAll(this.dbName, { selector: { status: 'active' } }).subscribe((teams) => {
-          this.teams.data = this.teamList(
-            teams.filter((team: any) => (
-              team.type === this.mode || (team.type === undefined && this.mode === 'team')
-            )
-            && this.excludeIds.indexOf(team._id) === -1));
-        });
-      }
       this.dialogsLoadingService.stop();
       console.log(error);
       this.isLoading = false;
@@ -200,21 +191,11 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   }
 
   getMembershipStatus() {
-    return forkJoin([
-      this.couchService.findAll(this.dbName, { selector: { userId: this.user._id, userPlanetCode: this.planetCode } }),
-      this.couchService.get('shelf/' + this.user._id)
-    ]).pipe(
-      map(([ membershipDocs, shelf ]) => this.userMembership = [
-        ...membershipDocs,
-        ...(shelf.myTeamIds || []).map(id => ({ teamId: id, fromShelf: true, docType: 'membership', userId: this.user._id }))
-      ]),
-      catchError(error => {
-        if (error.status === 404) {
-          this.userNotInShelf = true;
-        }
-        return throwError(error);
-      })
-    );
+    const identity = userIdentity(this.user, this.planetCode);
+    return this.couchService.findAll(this.dbName, { selector: {
+      userId: identity.userId,
+      ...userPlanetCodeSelector(identity.userPlanetCode)
+    } }).pipe(map((membershipDocs: any[]) => this.userMembership = membershipDocs));
   }
 
   ngAfterViewInit() {
@@ -226,7 +207,10 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     const noVisit = { visitCount: 0, lastVisit: undefined };
     return teamRes.map((res: any) => {
       const doc = res.doc || res;
-      const membershipDoc = this.userMembership.find(req => req.teamId === doc._id) || {};
+      const identity = userIdentity(this.user, this.planetCode);
+      const matchingRows = teamIdentityDocs(this.userMembership, doc, identity, this.planetCode);
+      const membershipDoc = matchingRows.find(req => req.docType === 'membership') ||
+        matchingRows.find(req => req.docType === 'request') || {};
       const visitLog = this.teamActivities.filter(activity => activity.teamId === doc._id).reduce(({ visitCount, lastVisit }, activity) =>
         ({ visitCount: visitCount + 1, lastVisit: lastVisit && activity.time < lastVisit ? lastVisit : activity.time }), noVisit)
         || noVisit;
@@ -274,7 +258,7 @@ export class TeamsComponent implements OnInit, AfterViewInit {
 
   addTeam(team: any = {}) {
     const teamType = this.mode === 'enterprise' ? 'sync' : team.teamType;
-    this.teamsService.addTeamDialog(this.user._id, this.mode, { ...team, teamType }).subscribe({
+    this.teamsService.addTeamDialog(this.user, this.mode, { ...team, teamType }).subscribe({
       next: () => {
         this.getTeams();
         const msg = team._id

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -34,7 +34,7 @@ import { AuthorizedRolesDirective } from '../shared/authorized-roles.directive';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 import { enterpriseJoinAgreement, teamIdentityDocs } from './teams.utils';
 import { userPlanetCodeSelector } from '../shared/mangoQueries';
-import { userIdentity } from '../shared/identity.utils';
+import { userIdentityCandidates } from '../shared/identity.utils';
 
 @Component({
   templateUrl: './teams.component.html',
@@ -191,10 +191,12 @@ export class TeamsComponent implements OnInit, AfterViewInit {
   }
 
   getMembershipStatus() {
-    const identity = userIdentity(this.user, this.planetCode);
+    const identities = userIdentityCandidates(this.user, this.planetCode);
+    const identity = identities[0];
+    const userIds = [ ...new Set(identities.map(candidate => candidate.userId)) ];
     return this.couchService.findAll(this.dbName, { selector: {
-      userId: identity.userId,
-      ...userPlanetCodeSelector(identity.userPlanetCode)
+      userId: userIds.length === 1 ? identity.userId : { $in: userIds },
+      ...userPlanetCodeSelector(...identities.map(candidate => candidate.userPlanetCode))
     } }).pipe(map((membershipDocs: any[]) => this.userMembership = membershipDocs));
   }
 
@@ -207,8 +209,8 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     const noVisit = { visitCount: 0, lastVisit: undefined };
     return teamRes.map((res: any) => {
       const doc = res.doc || res;
-      const identity = userIdentity(this.user, this.planetCode);
-      const matchingRows = teamIdentityDocs(this.userMembership, doc, identity, this.planetCode);
+      const identities = userIdentityCandidates(this.user, this.planetCode);
+      const matchingRows = teamIdentityDocs(this.userMembership, doc, identities, this.planetCode);
       const membershipDoc = matchingRows.find(req => req.docType === 'membership') ||
         matchingRows.find(req => req.docType === 'request') || {};
       const visitLog = this.teamActivities.filter(activity => activity.teamId === doc._id).reduce(({ visitCount, lastVisit }, activity) =>

--- a/src/app/teams/teams.service.spec.ts
+++ b/src/app/teams/teams.service.spec.ts
@@ -155,6 +155,31 @@ describe('TeamsService membership writes', () => {
     expect(members[0].userDoc).toBe(userDoc);
   });
 
+  it('resolves a historical materialized membership to its associated user document', () => {
+    const historical = {
+      ...membership,
+      userId: 'org.couchdb.user:alex@community',
+      userPlanetCode: 'planet-a'
+    };
+    const userDoc = {
+      _id: 'org.couchdb.user:alex@community',
+      doc: {
+        _id: 'org.couchdb.user:alex@community',
+        name: 'alex@community',
+        planetCode: 'community',
+        requestId: 'request-1'
+      }
+    };
+    const { service } = createService({
+      findAll: vi.fn().mockImplementation((db: string) => of(db === 'teams' ? [ historical ] : []))
+    }, { users: [ userDoc ] });
+    let members: any[];
+
+    service.getTeamMembers(team).subscribe(result => members = result);
+
+    expect(members[0].userDoc).toBe(userDoc);
+  });
+
   it('rejects a join request by composite identity', () => {
     const request = {
       _id: 'request-1', _rev: '1-request', docType: 'request',
@@ -287,7 +312,7 @@ describe('TeamsService membership writes', () => {
     }));
   });
 
-  it('preserves a supplied revision when no persisted membership document is found', () => {
+  it('does not reuse a supplied id or revision when no persisted membership document is found', () => {
     const supplied = {
       _id: 'membership-supplied',
       _rev: '1-supplied',
@@ -303,11 +328,13 @@ describe('TeamsService membership writes', () => {
 
     service.updateMembershipDoc(team, false, supplied).subscribe({ error });
 
-    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ expect.objectContaining({
-      _id: supplied._id,
-      _rev: supplied._rev,
-      userId: supplied.userId
-    }) ]);
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ {
+      teamId: team._id,
+      userId: supplied.userId,
+      teamPlanetCode: team.teamPlanetCode,
+      teamType: team.teamType,
+      docType: 'membership'
+    } ]);
     expect(error).toHaveBeenCalledWith(expect.objectContaining({ error: 'conflict' }));
   });
 
@@ -360,7 +387,16 @@ describe('TeamsService membership writes', () => {
       role: 'Coordinator'
     }).subscribe();
 
-    expect(couchService.findAll.mock.calls[0][1].selector).toEqual({ _id: membership._id });
+    expect(couchService.findAll.mock.calls[0][1].selector).toEqual({
+      teamId: team._id,
+      docType: 'membership',
+      userId: membership.userId,
+      $or: [
+        { userPlanetCode: team.teamPlanetCode },
+        { userPlanetCode: '' },
+        { userPlanetCode: { $exists: false } }
+      ]
+    });
     expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ {
       ...codelessMembership,
       role: 'Coordinator'
@@ -457,6 +493,54 @@ describe('TeamsService membership writes', () => {
       isLeader: true,
       docType: 'membership'
     }) ]);
+  });
+
+  it('creates a membership separately from the request document when accepting a request', () => {
+    const request = {
+      _id: 'request-1',
+      _rev: '1-request',
+      teamId: team._id,
+      userId: 'org.couchdb.user:ann',
+      userPlanetCode: 'planet-a',
+      docType: 'request'
+    };
+    const { service, couchService } = createService();
+
+    service.updateMembershipDoc(team, false, request).subscribe();
+
+    expect(couchService.findAll.mock.calls[0][1].selector).toEqual(expect.objectContaining({
+      teamId: team._id,
+      docType: 'membership',
+      userId: request.userId
+    }));
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ expect.not.objectContaining({
+      _id: request._id
+    }) ]);
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ expect.objectContaining({
+      userId: request.userId,
+      userPlanetCode: request.userPlanetCode,
+      docType: 'membership'
+    }) ]);
+  });
+
+  it('does not notify an associated actor about their own team action', () => {
+    const associated = {
+      _id: 'org.couchdb.user:ann@community',
+      name: 'ann@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    };
+    const updateDocument = vi.fn().mockReturnValue(of({}));
+    const { service } = createService({ updateDocument }, {}, {
+      get: vi.fn().mockReturnValue(associated)
+    });
+
+    service.sendNotifications('message', [ associated ], {
+      team: { ...team, teamPlanetCode: 'planet-a' },
+      url: '/teams/view/team-1'
+    }).subscribe();
+
+    expect(updateDocument).toHaveBeenCalledWith('notifications/_bulk_docs', { docs: [] });
   });
 
   it('keeps the notification recipient user and planet code together', () => {
@@ -707,6 +791,21 @@ describe('TeamsService membership writes', () => {
       ...membership,
       _deleted: true
     } ]);
+  });
+
+  it('fails a leave without writing or archiving when no membership matches', () => {
+    const { service, couchService } = createService();
+    const error = vi.fn();
+
+    service.toggleTeamMembership(team, true, {
+      userId: membership.userId,
+      userPlanetCode: membership.userPlanetCode
+    }).subscribe({ error });
+
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Membership document not found.'
+    }));
+    expect(couchService.bulkDocs).not.toHaveBeenCalled();
   });
 
   it('rejects a membership update without a user ID before querying or writing', () => {

--- a/src/app/teams/teams.service.spec.ts
+++ b/src/app/teams/teams.service.spec.ts
@@ -7,22 +7,35 @@ describe('TeamsService membership writes', () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  const createService = (couchOverrides: any = {}) => {
+  const createService = (
+    couchOverrides: any = {}, usersServiceOverrides: any = {}, userServiceOverrides: any = {}
+  ) => {
     const couchService = {
       findAll: vi.fn().mockReturnValue(of([])),
       get: vi.fn().mockReturnValue(of({})),
       bulkDocs: vi.fn().mockReturnValue(of(successfulBulkResponse)),
       ...couchOverrides
     };
+    const usersService = {
+      requestUserData: vi.fn(),
+      usersListener: vi.fn().mockReturnValue(of(usersServiceOverrides.users || []))
+    };
+    const userService = {
+      get: vi.fn().mockReturnValue({
+        _id: 'org.couchdb.user:current', name: 'current', planetCode: 'planet-a'
+      }),
+      addImageForReplication: vi.fn().mockReturnValue(of({})),
+      ...userServiceOverrides
+    };
     const service = new TeamsService(
       couchService as any,
       {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
+      userService as any,
+      usersService as any,
+      { configuration: { code: 'planet-a' } } as any,
       {} as any
     );
-    return { service, couchService };
+    return { service, couchService, userService, usersService };
   };
 
   const team = {
@@ -103,28 +116,197 @@ describe('TeamsService membership writes', () => {
     } ]);
   });
 
-  it('preserves shelf identity when no persisted membership document is found', () => {
-    const shelfMembership = {
-      _id: 'org.couchdb.user:shelf-member',
-      _rev: '1-shelf',
-      fromShelf: true,
-      myTeamIds: [ team._id ],
+  it('reads team members from membership documents only, without scanning shelf', () => {
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockImplementation((db: string) => of(db === 'teams' ? [ membership ] : []))
+    });
+    let members: any[];
+
+    service.getTeamMembers(team).subscribe(result => members = result);
+
+    expect(couchService.findAll.mock.calls.map(call => call[0])).toEqual([ 'teams', 'attachments' ]);
+    expect(members.length).toBe(1);
+  });
+
+  it('resolves a membership with no planet code from the team origin without persisting the inference', () => {
+    const codeless = { ...membership, userPlanetCode: undefined };
+    const sameNamedElsewhere = { _id: membership.userId, doc: { planetCode: team.teamPlanetCode } };
+    const { service } = createService({
+      findAll: vi.fn().mockImplementation((db: string) => of(db === 'teams' ? [ codeless ] : []))
+    }, { users: [ sameNamedElsewhere ] });
+    let members: any[];
+
+    service.getTeamMembers(team).subscribe(result => members = result);
+
+    expect(members[0].userPlanetCode).toBeUndefined();
+    expect(members[0].resolvedUserPlanetCode).toBe(team.teamPlanetCode);
+    expect(members[0].userDoc).toBe(sameNamedElsewhere);
+  });
+
+  it('resolves the user document for a membership carrying an explicit planet code', () => {
+    const userDoc = { _id: membership.userId, doc: { planetCode: membership.userPlanetCode } };
+    const { service } = createService({
+      findAll: vi.fn().mockImplementation((db: string) => of(db === 'teams' ? [ membership ] : []))
+    }, { users: [ userDoc ] });
+    let members: any[];
+
+    service.getTeamMembers(team).subscribe(result => members = result);
+
+    expect(members[0].userDoc).toBe(userDoc);
+  });
+
+  it('rejects a join request by composite identity', () => {
+    const request = {
+      _id: 'request-1', _rev: '1-request', docType: 'request',
+      userId: 'org.couchdb.user:ann', userPlanetCode: 'planet-a'
+    };
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockReturnValue(of([ request ]))
+    });
+
+    service.removeFromRequests(team, { userId: 'org.couchdb.user:ann', userPlanetCode: 'planet-a' }).subscribe();
+
+    expect(couchService.findAll).toHaveBeenCalledWith('teams', expect.objectContaining({
+      selector: expect.objectContaining({
+        teamId: team._id,
+        docType: 'request',
+        userId: 'org.couchdb.user:ann',
+        $or: [
+          { userPlanetCode: 'planet-a' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      })
+    }));
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ { ...request, _deleted: true } ]);
+  });
+
+  it('does not widen request rejection to another planet sharing the user id', () => {
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockReturnValue(of([]))
+    });
+
+    service.removeFromRequests(team, { userId: 'org.couchdb.user:ann', userPlanetCode: 'community' }).subscribe();
+
+    // 'planet-a' is this server. Including it here would tombstone a different same-named user's request.
+    expect(couchService.findAll.mock.calls[0][1].selector.$or).toEqual([
+      { userPlanetCode: 'community' },
+      { userPlanetCode: '' },
+      { userPlanetCode: { $exists: false } }
+    ]);
+  });
+
+  it('rejects a request stored without a planet code as well as one carrying the team origin', () => {
+    const codelessRequest = {
+      _id: 'request-codeless', _rev: '1-request', docType: 'request', userId: 'org.couchdb.user:ann'
+    };
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockReturnValue(of([ codelessRequest ]))
+    });
+
+    const remoteTeam = { ...team, teamPlanetCode: 'community' };
+    service.removeFromRequests(remoteTeam, { userId: 'org.couchdb.user:ann' }).subscribe();
+
+    expect(couchService.findAll).toHaveBeenCalledWith('teams', expect.objectContaining({
+      selector: expect.objectContaining({
+        $or: [
+          { userPlanetCode: 'community' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      })
+    }));
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ { ...codelessRequest, _deleted: true } ]);
+  });
+
+  it('does not delete a code-less team-origin request when removing an explicit foreign request', () => {
+    const explicit = {
+      _id: 'request-foreign', _rev: '1-foreign', docType: 'request',
+      userId: 'org.couchdb.user:ann', userPlanetCode: 'community'
+    };
+    const codeless = {
+      _id: 'request-local', _rev: '1-local', docType: 'request', userId: explicit.userId
+    };
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockReturnValue(of([ explicit, codeless ]))
+    });
+
+    service.removeFromRequests(team, {
+      userId: explicit.userId, userPlanetCode: explicit.userPlanetCode
+    }).subscribe();
+
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ { ...explicit, _deleted: true } ]);
+  });
+
+  it('rejects request cleanup without a user id before issuing a broad query', () => {
+    const { service, couchService } = createService();
+    const error = vi.fn();
+
+    service.removeFromRequests(team, { userPlanetCode: 'planet-a' }).subscribe({ error });
+
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Request user ID is required.'
+    }));
+    expect(couchService.findAll).not.toHaveBeenCalled();
+    expect(couchService.bulkDocs).not.toHaveBeenCalled();
+  });
+
+  it('writes and cancels an associated join request under its explicit origin', () => {
+    const associated = {
+      _id: 'org.couchdb.user:ann@community',
+      name: 'ann@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    };
+    const request = {
+      _id: 'request-doc', _rev: '1-request', userId: 'org.couchdb.user:ann', userPlanetCode: 'community'
+    };
+    const updateDocument = vi.fn().mockReturnValue(of({ id: request._id, rev: request._rev }));
+    const { service, couchService } = createService({
+      updateDocument,
+      findAll: vi.fn().mockReturnValue(of([ request ]))
+    }, {}, { get: vi.fn().mockReturnValue(associated) });
+
+    service.requestToJoinTeam(team, associated).subscribe();
+    service.cancelJoinRequest(team).subscribe();
+
+    expect(updateDocument).toHaveBeenCalledWith('teams', expect.objectContaining({
+      userId: 'org.couchdb.user:ann',
+      userPlanetCode: 'community',
+      docType: 'request'
+    }));
+    expect(couchService.findAll).toHaveBeenCalledWith('teams', expect.objectContaining({
+      selector: expect.objectContaining({
+        userId: 'org.couchdb.user:ann',
+        $or: [
+          { userPlanetCode: 'community' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      })
+    }));
+  });
+
+  it('preserves a supplied revision when no persisted membership document is found', () => {
+    const supplied = {
+      _id: 'membership-supplied',
+      _rev: '1-supplied',
       teamId: team._id,
-      userId: 'org.couchdb.user:shelf-member'
+      userId: 'org.couchdb.user:supplied'
     };
     const { service, couchService } = createService({
       bulkDocs: vi.fn().mockReturnValue(of({
-        res: [ { id: shelfMembership._id, error: 'conflict', reason: 'Document update conflict.' } ]
+        res: [ { id: supplied._id, error: 'conflict', reason: 'Document update conflict.' } ]
       }))
     });
     const error = vi.fn();
 
-    service.updateMembershipDoc(team, false, shelfMembership).subscribe({ error });
+    service.updateMembershipDoc(team, false, supplied).subscribe({ error });
 
     expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ expect.objectContaining({
-      _id: shelfMembership._id,
-      _rev: shelfMembership._rev,
-      userId: shelfMembership.userId
+      _id: supplied._id,
+      _rev: supplied._rev,
+      userId: supplied.userId
     }) ]);
     expect(error).toHaveBeenCalledWith(expect.objectContaining({ error: 'conflict' }));
   });
@@ -146,15 +328,14 @@ describe('TeamsService membership writes', () => {
     } ]);
   });
 
-  it('preserves stored planet identity when a stale shelf row matches a persisted membership', () => {
+  it('preserves stored planet identity when the update omits a planet code', () => {
     const { service, couchService } = createService({
       findAll: vi.fn().mockReturnValue(of([ membership ]))
     });
 
     service.updateMembershipDoc(team, false, {
       _id: membership.userId,
-      _rev: '1-shelf',
-      fromShelf: true,
+      _rev: '1-stale',
       teamId: team._id,
       userId: membership.userId,
       role: 'Coordinator'
@@ -162,6 +343,26 @@ describe('TeamsService membership writes', () => {
 
     expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ {
       ...membership,
+      role: 'Coordinator'
+    } ]);
+  });
+
+  it('does not persist a planet code derived only for display and comparison', () => {
+    const codelessMembership = { ...membership };
+    delete codelessMembership.userPlanetCode;
+    const { service, couchService } = createService({
+      findAll: vi.fn().mockReturnValue(of([ codelessMembership ]))
+    });
+
+    service.updateMembershipDoc(team, false, {
+      ...codelessMembership,
+      resolvedUserPlanetCode: team.teamPlanetCode,
+      role: 'Coordinator'
+    }).subscribe();
+
+    expect(couchService.findAll.mock.calls[0][1].selector).toEqual({ _id: membership._id });
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ {
+      ...codelessMembership,
       role: 'Coordinator'
     } ]);
   });
@@ -197,6 +398,86 @@ describe('TeamsService membership writes', () => {
       },
       { _id: request._id, _rev: request._rev, _deleted: true }
     ]);
+  });
+
+  it('writes an associated member under their canonical id and explicit origin', () => {
+    const selected = [ {
+      _id: 'org.couchdb.user:new@community',
+      name: 'new@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    } ];
+    const { service, couchService } = createService();
+
+    service.addMembers(team, selected, []).subscribe();
+
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [ {
+      teamId: team._id,
+      userId: 'org.couchdb.user:new',
+      teamPlanetCode: team.teamPlanetCode,
+      teamType: team.teamType,
+      userPlanetCode: 'community',
+      docType: 'membership'
+    } ]);
+  });
+
+  it('creates an associated account team with a matching creator membership identity', () => {
+    const associated = {
+      _id: 'org.couchdb.user:ann@community',
+      name: 'ann@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    };
+    const updateDocument = vi.fn().mockReturnValue(of({ id: team._id, rev: '1-team' }));
+    const bulkDocs = vi.fn().mockReturnValue(of(successfulBulkResponse));
+    const service = new TeamsService(
+      {
+        datePlaceholder: 'now',
+        updateDocument,
+        findAll: vi.fn().mockReturnValue(of([])),
+        bulkDocs
+      } as any,
+      { confirm: vi.fn().mockReturnValue(of({ name: 'New team' })) } as any,
+      {} as any,
+      {} as any,
+      { configuration: { code: 'planet-a', parentCode: 'earth', planetType: 'community' } } as any,
+      {} as any
+    );
+
+    service.addTeamDialog(associated, 'team').subscribe();
+
+    expect(updateDocument).toHaveBeenCalledWith('teams', expect.objectContaining({
+      createdBy: 'org.couchdb.user:ann',
+      createdByPlanetCode: 'community',
+      teamPlanetCode: 'planet-a'
+    }));
+    expect(bulkDocs).toHaveBeenCalledWith('teams', [ expect.objectContaining({
+      userId: 'org.couchdb.user:ann',
+      userPlanetCode: 'community',
+      isLeader: true,
+      docType: 'membership'
+    }) ]);
+  });
+
+  it('keeps the notification recipient user and planet code together', () => {
+    const service = new TeamsService(
+      { datePlaceholder: 'now' } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      { configuration: { code: 'planet-a' } } as any,
+      {} as any
+    );
+
+    expect(service.teamNotification('Welcome', 'added', {
+      _id: 'org.couchdb.user:new@community',
+      name: 'new@community',
+      planetCode: 'community',
+      requestId: 'request-1'
+    }, { team, url: '/teams/view/team-1;activeTab=members' })).toEqual(expect.objectContaining({
+      user: 'org.couchdb.user:new',
+      userPlanetCode: 'community'
+    }));
   });
 
   it('reports an individual add-member bulk failure', () => {
@@ -373,6 +654,10 @@ describe('TeamsService membership writes', () => {
 
     expect(error).toHaveBeenCalledWith(expect.objectContaining({ error: 'conflict' }));
     expect(bulkDocs).toHaveBeenCalledTimes(1);
+    expect(bulkDocs.mock.calls[0][1][0]).toEqual(expect.objectContaining({
+      _id: 'membership-new',
+      isLeader: true
+    }));
   });
 
   [
@@ -406,36 +691,6 @@ describe('TeamsService membership writes', () => {
     }).subscribe();
 
     expect(couchService.bulkDocs).toHaveBeenCalledTimes(1);
-  });
-
-  it('fails a shelf promotion before demoting until origin-aware migration is available', () => {
-    const shelf = {
-      _id: 'org.couchdb.user:new',
-      _rev: '1-shelf',
-      myTeamIds: [ team._id ]
-    };
-    const bulkDocs = vi.fn().mockReturnValue(of({
-      res: [ { error: 'conflict', reason: 'Document update conflict.' } ]
-    }));
-    const { service } = createService({
-      bulkDocs
-    });
-    const error = vi.fn();
-
-    service.changeTeamLeadership(membership, {
-      ...shelf,
-      fromShelf: true,
-      teamId: team._id,
-      userId: shelf._id
-    }).subscribe({ error });
-
-    expect(error).toHaveBeenCalledWith(expect.objectContaining({ error: 'conflict' }));
-    expect(bulkDocs).toHaveBeenCalledTimes(1);
-    expect(bulkDocs.mock.calls[0][1][0]).toEqual(expect.objectContaining({
-      _id: shelf._id,
-      _rev: shelf._rev,
-      isLeader: true
-    }));
   });
 
   it('sanitizes membership deletion writes', () => {

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -4,13 +4,17 @@ import { switchMap, map, take } from 'rxjs/operators';
 import { CouchService } from '../shared/couchdb.service';
 import { UserService } from '../shared/user.service';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
-import { findDocuments } from '../shared/mangoQueries';
+import { findDocuments, userPlanetCodeSelector } from '../shared/mangoQueries';
 import { CustomValidators } from '../validators/custom-validators';
 import { StateService } from '../shared/state.service';
 import { ValidatorService } from '../validators/validator.service';
 import { UsersService } from '../users/users.service';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
 import { fullName, truncateText } from '../shared/utils';
+import { memberCompare, memberIdentity } from './teams.utils';
+import { canonicalUserId, userIdentity } from '../shared/identity.utils';
+import { assigneeIdentityCandidates } from '../tasks/tasks.utils';
+import { notificationRecipient } from '../notifications/notifications.service';
 
 const nameField = {
   type: 'textbox',
@@ -64,8 +68,9 @@ export class TeamsService {
     private validatorService: ValidatorService
   ) {}
 
-  addTeamDialog(userId: string, type: 'team' | 'enterprise' | 'services', team: any = {}) {
+  addTeamDialog(user: any, type: 'team' | 'enterprise' | 'services', team: any = {}) {
     const configuration = this.stateService.configuration;
+    const creatorIdentity = userIdentity(user, configuration.code);
     const key = `${team._id ? 'update' : 'create'}-${type === 'enterprise' ? 'enterprise' : 'team'}`;
     const title = {
       'create-team': $localize`:@@create-team:Create Team`,
@@ -93,14 +98,24 @@ export class TeamsService {
     return this.dialogsFormService.confirm(title, this.addTeamFields(configuration, type), formGroup, true)
       .pipe(
         switchMap((response: any) => response !== undefined ?
-          this.updateTeam(
-            { limit: 12, status: 'active', createdDate: this.couchService.datePlaceholder, teamPlanetCode: configuration.code,
-              parentCode: configuration.parentCode, createdBy: userId, ...team, ...response, type }
-          ) :
+          this.updateTeam({
+            limit: 12,
+            status: 'active',
+            createdDate: this.couchService.datePlaceholder,
+            teamPlanetCode: configuration.code,
+            parentCode: configuration.parentCode,
+            ...(!team._id ? {
+              createdBy: creatorIdentity.userId,
+              createdByPlanetCode: creatorIdentity.userPlanetCode
+            } : {}),
+            ...team,
+            ...response,
+            type
+          }) :
           empty()
         ),
         switchMap((response) => !team._id ?
-          this.toggleTeamMembership(response, false, { userId, userPlanetCode: configuration.code, isLeader: true }) :
+          this.toggleTeamMembership(response, false, { ...creatorIdentity, isLeader: true }) :
           of(response)
         )
       );
@@ -132,31 +147,39 @@ export class TeamsService {
   }
 
   requestToJoinTeam(team, user) {
-    const userPlanetCode = this.stateService.configuration.code;
+    const identity = userIdentity(user, this.stateService.configuration.code);
     return this.couchService.updateDocument(this.dbName, {
       createdDate: this.couchService.datePlaceholder,
-      ...this.membershipProps(team, { userId: user._id, userPlanetCode }, 'request')
+      ...this.membershipProps(team, identity, 'request')
     }).pipe(
       switchMap(() => team.teamType === 'sync' ? this.userService.addImageForReplication(true, [ user ]) : of({}))
     );
   }
 
   removeFromRequests(team, memberInfo) {
-    return this.couchService.findAll(this.dbName, findDocuments(this.membershipProps(team, memberInfo, 'request'))).pipe(
-      switchMap((docs: any[]) => this.couchService.bulkDocs(this.dbName, docs.map(doc => ({ ...doc, _deleted: true }))))
+    const { userId, userPlanetCode } = memberIdentity(memberInfo, team);
+    if (!userId) {
+      return throwError(new Error('Request user ID is required.'));
+    }
+    return this.couchService.findAll(this.dbName, findDocuments({
+      teamId: team._id,
+      docType: 'request',
+      userId,
+      ...userPlanetCodeSelector(userPlanetCode)
+    })).pipe(
+      switchMap((docs: any[]) => this.couchService.bulkDocs(this.dbName, docs
+        .filter(doc => memberCompare(doc, { userId, userPlanetCode }, team.teamPlanetCode))
+        .map(doc => ({ ...doc, _deleted: true }))))
     );
   }
 
   cancelJoinRequest(team) {
     const user = this.userService.get();
-    return this.removeFromRequests(team, { userId: user._id, userPlanetCode: this.stateService.configuration.code });
+    return this.removeFromRequests(team, userIdentity(user, this.stateService.configuration.code));
   }
 
   toggleTeamMembership(team, leaveTeam, memberInfo) {
-    return (memberInfo.fromShelf === true && leaveTeam === true ?
-      this.updateShelf(memberInfo) :
-      this.updateMembershipDoc(team, leaveTeam, memberInfo)
-    ).pipe(
+    return this.updateMembershipDoc(team, leaveTeam, memberInfo).pipe(
       switchMap(() => leaveTeam ? this.isTeamEmpty(team) : of(team)),
       switchMap((isEmpty) => isEmpty === true ? this.updateTeam({ ...team, status: 'archived' }) : of(team)),
       switchMap((newTeam) => of({ ...team, ...newTeam }))
@@ -182,7 +205,8 @@ export class TeamsService {
     }
     const deleted = leaveTeam ? { _deleted: true } : {};
     const membershipProps = this.membershipProps(team, memberInfo, 'membership');
-    return this.couchService.findAll(this.dbName, findDocuments(membershipProps)).pipe(
+    const lookupSelector = memberInfo._id ? { _id: memberInfo._id } : membershipProps;
+    return this.couchService.findAll(this.dbName, findDocuments(lookupSelector)).pipe(
       map((docs) => docs.length === 0 ? [ membershipProps ] : docs),
       switchMap((membershipDocs: any[]) => this.writeMembershipDocs(
         membershipDocs.map(membershipDoc => this.membershipWriteDoc(
@@ -201,14 +225,18 @@ export class TeamsService {
   }
 
   addMembers(team, selected, requests) {
-    if (selected.some(user => !user?._id)) {
+    const selectedIdentities = selected.map(user => userIdentity(
+      user, team.teamPlanetCode || this.stateService.configuration.code
+    ));
+    if (selectedIdentities.some(identity => !identity.userId)) {
       return throwError(new Error('Membership user ID is required.'));
     }
-    const selectedUserIds = new Set(selected.map(user => user._id));
-    const newMembershipDocs = selected.map(user =>
-      this.membershipProps(team, { userId: user._id, userPlanetCode: user.planetCode }, 'membership')
+    const newMembershipDocs = selectedIdentities.map(identity =>
+      this.membershipProps(team, identity, 'membership')
     );
-    const requestsToDelete = requests.filter(request => selectedUserIds.has(request.userId))
+    const requestsToDelete = requests.filter(request => selectedIdentities.some(identity =>
+      memberCompare(request, identity, team.teamPlanetCode)
+    ))
       .map(({ _id, _rev }) => ({ _id, _rev, _deleted: true }));
     return this.writeMembershipDocs([ ...newMembershipDocs, ...requestsToDelete ], newMembershipDocs.length);
   }
@@ -229,9 +257,8 @@ export class TeamsService {
   }
 
   changeTeamLeadership(oldLeader, newLeader) {
-    const shouldDemoteOldLeader = Boolean(oldLeader?._id) && oldLeader._id !== newLeader?._id && oldLeader.fromShelf !== true;
+    const shouldDemoteOldLeader = Boolean(oldLeader?._id) && oldLeader._id !== newLeader?._id;
     return this.freshMembershipDoc(newLeader).pipe(
-      // Shelf revisions belong to another database, so preserving them makes unsupported promotions fail closed with a conflict.
       switchMap(freshNewLeader => this.writeMembershipDocs([
         this.membershipWriteDoc(freshNewLeader, { isLeader: true })
       ])),
@@ -244,14 +271,6 @@ export class TeamsService {
         ) : of(promotionResponse)
       )
     );
-  }
-
-  // Included for backwards compatibility for older teams where membership was stored in shelf.  Only for member leaving a team.
-  updateShelf(membershipDoc) {
-    const { userId, teamId } = membershipDoc;
-    return this.couchService.get('shelf/' + userId).pipe(switchMap(shelf =>
-      this.userService.updateShelf(shelf.myTeamIds.filter(myTeamId => myTeamId !== teamId), 'myTeamIds')
-    ));
   }
 
   // Membership documents contain exactly this persisted schema; other member fields are enriched view data.
@@ -298,7 +317,7 @@ export class TeamsService {
     if (!member?.userId) {
       return throwError(new Error('Membership user ID is required.'));
     }
-    return member._id && member.fromShelf !== true ?
+    return member._id ?
       this.couchService.get(`${this.dbName}/${member._id}`).pipe(map(doc => ({ ...member, ...doc }))) :
       of(member);
   }
@@ -345,17 +364,28 @@ export class TeamsService {
     this.usersService.requestUserData();
     return forkJoin([
       this.couchService.findAll(this.dbName, findDocuments(selector)),
-      this.couchService.findAll('shelf', findDocuments({ myTeamIds: { $in: [ team._id ] } }, 0)),
       this.usersService.usersListener(true).pipe(take(1)),
       this.couchService.findAll('attachments')
-    ]).pipe(map(([ membershipDocs, shelves, users, attachments ]: any[]) => [
-      ...membershipDocs.map(doc => ({
-        ...doc,
-        userDoc: users.find(user => (user.doc.couchId || user._id) === doc.userId && user.doc.planetCode === doc.userPlanetCode),
-        attachmentDoc: attachments.find(attachment => attachment._id === `${doc.userId}@${doc.userPlanetCode}`)
-      })),
-      ...shelves.map((shelf: any) => ({ ...shelf, fromShelf: true, docType: 'membership', userId: shelf._id, teamId: team._id }))
-    ]));
+    ]).pipe(map(([ membershipDocs, users, attachments ]: any[]) => {
+      const usersWithIdentities = users.map(user => ({
+        user,
+        identities: assigneeIdentityCandidates(user, this.stateService.configuration.code)
+      }));
+      return membershipDocs.map(doc => {
+        if (doc.docType !== 'membership' && doc.docType !== 'request') {
+          return doc;
+        }
+        const identity = memberIdentity(doc, team);
+        return {
+          ...doc,
+          resolvedUserPlanetCode: identity.userPlanetCode,
+          userDoc: usersWithIdentities.find(({ identities }) => identities.some(
+            candidate => memberCompare(candidate, identity, team.teamPlanetCode)
+          ))?.user,
+          attachmentDoc: attachments.find(attachment => attachment._id === `${identity.userId}@${identity.userPlanetCode}`)
+        };
+      });
+    }));
   }
 
   getTeamResources(linkDocs: any[]) {
@@ -374,9 +404,14 @@ export class TeamsService {
   }
 
   sendNotifications(type, members, notificationParams) {
+    const currentUser = {
+      user: canonicalUserId(this.userService.get()),
+      userPlanetCode: this.stateService.configuration.code
+    };
     const notifications = members.filter((user: any) => {
-      const userId = user.userId || user._id;
-      return this.userService.get()._id !== userId && user.name !== 'satellite';
+      const recipient = notificationRecipient(user, notificationParams.team.teamPlanetCode);
+      return (currentUser.user !== recipient.user || currentUser.userPlanetCode !== recipient.userPlanetCode) &&
+        user.name !== 'satellite';
     }).map((user: any) => this.teamNotification(this.teamNotificationMessage(type, notificationParams), type, user, notificationParams));
     return this.couchService.updateDocument('notifications/_bulk_docs', { docs: notifications });
   }
@@ -414,10 +449,9 @@ export class TeamsService {
 
   teamNotification(message, type, user, { team, url }) {
     const link = url.split(';')[0];
-    const userId = user.userId || user._id;
     const linkParams = type === 'request' ? { activeTab: 'applicantTab' } : {};
     return {
-      user: userId,
+      ...notificationRecipient(user, team.teamPlanetCode),
       message,
       link,
       linkParams,
@@ -425,8 +459,7 @@ export class TeamsService {
       type: 'team',
       priority: 1,
       status: 'unread',
-      time: this.couchService.datePlaceholder,
-      userPlanetCode: user.userPlanetCode
+      time: this.couchService.datePlaceholder
     };
   }
 

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -12,8 +12,7 @@ import { UsersService } from '../users/users.service';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
 import { fullName, truncateText } from '../shared/utils';
 import { memberCompare, memberIdentity } from './teams.utils';
-import { canonicalUserId, userIdentity } from '../shared/identity.utils';
-import { assigneeIdentityCandidates } from '../tasks/tasks.utils';
+import { userIdentity, userIdentityCandidates } from '../shared/identity.utils';
 import { notificationRecipient } from '../notifications/notifications.service';
 
 const nameField = {
@@ -204,15 +203,31 @@ export class TeamsService {
       return throwError(new Error('Membership user ID is required.'));
     }
     const deleted = leaveTeam ? { _deleted: true } : {};
-    const membershipProps = this.membershipProps(team, memberInfo, 'membership');
-    const lookupSelector = memberInfo._id ? { _id: memberInfo._id } : membershipProps;
+    const persistedMemberInfo = { ...memberInfo };
+    delete persistedMemberInfo._id;
+    delete persistedMemberInfo._rev;
+    delete persistedMemberInfo.docType;
+    const membershipProps = this.membershipProps(team, persistedMemberInfo, 'membership');
+    const identity = memberIdentity(memberInfo, team);
+    const lookupSelector = {
+      teamId: team._id,
+      docType: 'membership',
+      userId: persistedMemberInfo.userId,
+      ...userPlanetCodeSelector(identity.userPlanetCode)
+    };
     return this.couchService.findAll(this.dbName, findDocuments(lookupSelector)).pipe(
-      map((docs) => docs.length === 0 ? [ membershipProps ] : docs),
+      map((docs) => docs.filter(doc => memberCompare(
+        doc, identity, team.teamPlanetCode
+      ))),
+      switchMap((docs) => leaveTeam && docs.length === 0 ?
+        throwError(new Error('Membership document not found.')) :
+        of(docs.length === 0 ? [ membershipProps ] : docs)
+      ),
       switchMap((membershipDocs: any[]) => this.writeMembershipDocs(
         membershipDocs.map(membershipDoc => this.membershipWriteDoc(
           {
             ...membershipDoc,
-            ...memberInfo,
+            ...persistedMemberInfo,
             ...membershipProps,
             ...(membershipProps.userPlanetCode === undefined && membershipDoc.userPlanetCode !== undefined ?
               { userPlanetCode: membershipDoc.userPlanetCode } : {}),
@@ -369,7 +384,7 @@ export class TeamsService {
     ]).pipe(map(([ membershipDocs, users, attachments ]: any[]) => {
       const usersWithIdentities = users.map(user => ({
         user,
-        identities: assigneeIdentityCandidates(user, this.stateService.configuration.code)
+        identities: userIdentityCandidates(user, this.stateService.configuration.code)
       }));
       return membershipDocs.map(doc => {
         if (doc.docType !== 'membership' && doc.docType !== 'request') {
@@ -404,10 +419,9 @@ export class TeamsService {
   }
 
   sendNotifications(type, members, notificationParams) {
-    const currentUser = {
-      user: canonicalUserId(this.userService.get()),
-      userPlanetCode: this.stateService.configuration.code
-    };
+    const currentUser = notificationRecipient(
+      this.userService.get(), notificationParams.team.teamPlanetCode
+    );
     const notifications = members.filter((user: any) => {
       const recipient = notificationRecipient(user, notificationParams.team.teamPlanetCode);
       return (currentUser.user !== recipient.user || currentUser.userPlanetCode !== recipient.userPlanetCode) &&

--- a/src/app/teams/teams.utils.spec.ts
+++ b/src/app/teams/teams.utils.spec.ts
@@ -1,65 +1,67 @@
-import { memberCompare } from './teams.utils';
-import { TeamsViewComponent } from './teams-view.component';
+import { memberCompare, memberIdentity, memberPlanetCode, teamIdentityDocs } from './teams.utils';
 
 describe('team member helpers', () => {
-  it('does not treat matching user IDs from different planets as the same member', () => {
-    expect(memberCompare(
-      { userId: 'org.couchdb.user:leader', userPlanetCode: 'planet-a' },
-      { userId: 'org.couchdb.user:leader', userPlanetCode: 'planet-b' }
-    )).toBe(false);
+  describe('memberIdentity', () => {
+    it('keeps an explicitly stored planet code', () => {
+      expect(memberIdentity(
+        { userId: 'org.couchdb.user:ann', userPlanetCode: 'community' },
+        { teamPlanetCode: 'nation' }
+      )).toEqual({ userId: 'org.couchdb.user:ann', userPlanetCode: 'community' });
+    });
+
+    it('resolves a member with no planet code from the team origin, not the viewing server', () => {
+      expect(memberIdentity(
+        { userId: 'org.couchdb.user:ann' },
+        { teamPlanetCode: 'community' }
+      )).toEqual({ userId: 'org.couchdb.user:ann', userPlanetCode: 'community' });
+    });
+
+    it('leaves the planet code undefined when neither side supplies one', () => {
+      expect(memberIdentity({ userId: 'org.couchdb.user:ann' }, {}))
+        .toEqual({ userId: 'org.couchdb.user:ann', userPlanetCode: undefined });
+    });
+
+    it('prefers stored identity over derived view identity', () => {
+      expect(memberPlanetCode({
+        userPlanetCode: 'stored', resolvedUserPlanetCode: 'derived'
+      })).toBe('stored');
+      expect(memberPlanetCode({ resolvedUserPlanetCode: 'derived' })).toBe('derived');
+    });
   });
 
-  it('does not grant leader access from a non-authoritative membership document', () => {
-    const component = Object.create(TeamsViewComponent.prototype) as any;
-    component.requests = [];
-    component.members = [ {
-      userId: 'org.couchdb.user:member',
-      userPlanetCode: 'local',
-      isLeader: true
-    } ];
-    component.planetCode = 'local';
-    component.route = { snapshot: { params: {} } };
+  describe('memberCompare', () => {
+    it('does not treat matching user IDs from different planets as the same member', () => {
+      expect(memberCompare(
+        { userId: 'org.couchdb.user:leader', userPlanetCode: 'planet-a' },
+        { userId: 'org.couchdb.user:leader', userPlanetCode: 'planet-b' }
+      )).toBe(false);
+    });
 
-    component.setStatus(
-      {},
-      { userId: 'org.couchdb.user:actual-leader', userPlanetCode: 'local' },
-      { _id: 'org.couchdb.user:member', planetCode: 'local' }
-    );
+    it('does not treat two identity-less members as the same person', () => {
+      expect(memberCompare({}, {}, 'nation')).toBe(false);
+      expect(memberCompare({ userPlanetCode: 'nation' }, { userPlanetCode: 'nation' })).toBe(false);
+    });
 
-    expect(component.isUserLeader).toBe(false);
+    it('tolerates missing member objects', () => {
+      expect(memberCompare(undefined, { userId: 'org.couchdb.user:one' })).toBe(false);
+      expect(memberCompare({ userId: 'org.couchdb.user:one' }, undefined)).toBe(false);
+    });
   });
 
-  it('derives custom labels from the current team document', () => {
-    const component = Object.create(TeamsViewComponent.prototype) as any;
-    component.team = { customVoiceLabels: [ 'Initial' ] };
-    expect(component.customVoiceLabels).toEqual([ 'Initial' ]);
+  describe('teamIdentityDocs', () => {
+    it('resolves code-less rows through each team origin before accepting them', () => {
+      const rows = [
+        { _id: 'community-row', teamId: 'community-team', userId: 'org.couchdb.user:ann' },
+        { _id: 'nation-row', teamId: 'nation-team', userId: 'org.couchdb.user:ann' }
+      ];
+      const identity = { userId: 'org.couchdb.user:ann', userPlanetCode: 'community' };
 
-    component.team = { customVoiceLabels: [ 'Updated' ] };
-    expect(component.customVoiceLabels).toEqual([ 'Updated' ]);
-  });
-
-  it('limits planet-level label managers to locally owned teams', () => {
-    const component = Object.create(TeamsViewComponent.prototype) as any;
-    component.isUserLeader = false;
-    component.planetCode = 'local';
-    component.team = { teamPlanetCode: 'remote' };
-    component.user = { isUserAdmin: false };
-    component.userService = { doesUserHaveRole: () => true };
-
-    expect(component.canManageLabels).toBe(false);
-
-    component.team.teamPlanetCode = 'local';
-    expect(component.canManageLabels).toBe(true);
-  });
-
-  it('allows a team leader to manage labels regardless of the team planet', () => {
-    const component = Object.create(TeamsViewComponent.prototype) as any;
-    component.isUserLeader = true;
-    component.planetCode = 'local';
-    component.team = { teamPlanetCode: 'remote' };
-    component.user = { isUserAdmin: false };
-    component.userService = { doesUserHaveRole: () => false };
-
-    expect(component.canManageLabels).toBe(true);
+      expect(teamIdentityDocs(
+        rows, { _id: 'community-team', teamPlanetCode: 'community' }, identity, 'nation'
+      )).toEqual([ rows[0] ]);
+      expect(teamIdentityDocs(
+        rows, { _id: 'nation-team', teamPlanetCode: 'nation' }, identity, 'nation'
+      )).toEqual([]);
+    });
   });
 });

--- a/src/app/teams/teams.utils.ts
+++ b/src/app/teams/teams.utils.ts
@@ -1,10 +1,32 @@
+import { assigneeMatches } from '../tasks/tasks.utils';
+
+// Keep the resolved view identity behind one accessor so consumers cannot accidentally forget the
+// fallback or reverse its precedence. Explicitly stored identity always wins.
+export const memberPlanetCode = (member: any): string | undefined =>
+  member?.userPlanetCode || member?.resolvedUserPlanetCode;
+
+// Membership rows written before an explicit planet code was stored carry none. Their origin is the
+// team's own planet, never the planet of whoever happens to be viewing the row.
+export const memberIdentity = (member: any, team?: any) => ({
+  userId: member?.userId,
+  userPlanetCode: memberPlanetCode(member) || team?.teamPlanetCode
+});
+
 const memberNameCompare = (member1, member2) => {
   const memberName = (member) =>
     (member.userDoc && member.userDoc.doc.lastName) || (member.userId || '').split(':')[1] || member.userId || '';
   return memberName(member1).localeCompare(memberName(member2));
 };
 
-export const memberCompare = (member1, member2) => member1.userId === member2.userId && member1.userPlanetCode === member2.userPlanetCode;
+// Single composite-identity comparison for members. Delegates to the task comparator so a member card,
+// a task assignment and a leadership check can never disagree about who a user is.
+export const memberCompare = (member1, member2, localPlanetCode?: string) =>
+  Boolean(member1?.userId) && assigneeMatches(member1, member2 || {}, localPlanetCode);
+
+export const teamIdentityDocs = (docs: any[], team: any, identity: any, fallbackPlanetCode?: string) =>
+  docs.filter(doc => doc.teamId === team._id && memberCompare(
+    doc, identity, team.teamPlanetCode || fallbackPlanetCode
+  ));
 
 export const requestDateCompare = (request1, request2) =>
   (request1.createdDate || 0) - (request2.createdDate || 0) ||  (request1.userId || '').localeCompare(request2.userId || '');
@@ -13,9 +35,9 @@ export const enterpriseJoinAgreement = () =>
   $localize`By requesting to join, you agree to follow this \
 enterprise's rules and guidelines.`;
 
-export const memberSort = (member1, member2, leader) => memberCompare(member1, leader) ?
+export const memberSort = (member1, member2, leader, localPlanetCode?: string) => memberCompare(member1, leader, localPlanetCode) ?
   -1 :
-  memberCompare(member2, leader) ?
+  memberCompare(member2, leader, localPlanetCode) ?
     1 :
     memberNameCompare(member1, member2);
 

--- a/src/app/teams/teams.utils.ts
+++ b/src/app/teams/teams.utils.ts
@@ -1,4 +1,4 @@
-import { assigneeMatches } from '../tasks/tasks.utils';
+import { identityMatches } from '../shared/identity.utils';
 
 // Keep the resolved view identity behind one accessor so consumers cannot accidentally forget the
 // fallback or reverse its precedence. Explicitly stored identity always wins.
@@ -21,12 +21,14 @@ const memberNameCompare = (member1, member2) => {
 // Single composite-identity comparison for members. Delegates to the task comparator so a member card,
 // a task assignment and a leadership check can never disagree about who a user is.
 export const memberCompare = (member1, member2, localPlanetCode?: string) =>
-  Boolean(member1?.userId) && assigneeMatches(member1, member2 || {}, localPlanetCode);
+  Boolean(member1?.userId) && identityMatches(member1, member2 || {}, localPlanetCode);
 
-export const teamIdentityDocs = (docs: any[], team: any, identity: any, fallbackPlanetCode?: string) =>
-  docs.filter(doc => doc.teamId === team._id && memberCompare(
-    doc, identity, team.teamPlanetCode || fallbackPlanetCode
-  ));
+export const teamIdentityDocs = (docs: any[], team: any, identity: any | any[], fallbackPlanetCode?: string) => {
+  const identities = Array.isArray(identity) ? identity : [ identity ];
+  return docs.filter(doc => doc.teamId === team._id && identities.some(candidate => memberCompare(
+    doc, candidate, team.teamPlanetCode || fallbackPlanetCode
+  )));
+};
 
 export const requestDateCompare = (request1, request2) =>
   (request1.createdDate || 0) - (request2.createdDate || 0) ||  (request1.userId || '').localeCompare(request2.userId || '');

--- a/src/app/users/users.service.spec.ts
+++ b/src/app/users/users.service.spec.ts
@@ -3,17 +3,33 @@ import { vi } from 'vitest';
 import { UsersService } from './users.service';
 
 describe('UsersService notifications', () => {
-  it('routes role notifications through the recipient planet and stable CouchDB ID', () => {
-    const notificationsService = {
-      sendNotificationToUser: vi.fn().mockReturnValue(of({}))
+  const createService = ({ couch = {}, tasks = {}, notifications = {} }: any = {}) => {
+    const couchService = {
+      datePlaceholder: 'now',
+      get: vi.fn().mockReturnValue(of({ _rev: '1-shelf' })),
+      delete: vi.fn().mockReturnValue(of({})),
+      findAll: vi.fn().mockReturnValue(of([])),
+      bulkDocs: vi.fn().mockReturnValue(of([])),
+      ...couch
     };
-    const service = new UsersService(
-      { datePlaceholder: 'now' } as any,
-      {} as any,
-      { couchStateListener: () => NEVER } as any,
-      {} as any,
-      notificationsService as any
-    );
+    const tasksService = { removeAssigneeFromTasks: vi.fn().mockReturnValue(of([])), ...tasks };
+    const notificationsService = { sendNotificationToUser: vi.fn().mockReturnValue(of({})), ...notifications };
+    return {
+      couchService,
+      tasksService,
+      notificationsService,
+      service: new UsersService(
+        couchService as any,
+        {} as any,
+        { configuration: { code: 'planet-a' }, couchStateListener: () => NEVER } as any,
+        tasksService as any,
+        notificationsService as any
+      )
+    };
+  };
+
+  it('routes role notifications through the recipient planet and stable CouchDB ID', () => {
+    const { service, notificationsService } = createService();
 
     service.sendNotifications({
       _id: 'alex@community-c',
@@ -34,21 +50,7 @@ describe('UsersService notifications', () => {
   });
 
   it('cleans associated and code-less task identities when deleting users', () => {
-    const couchService = {
-      datePlaceholder: 'now',
-      get: vi.fn().mockReturnValue(of({ _rev: '1-shelf' })),
-      delete: vi.fn().mockReturnValue(of({})),
-      findAll: vi.fn().mockReturnValue(of([])),
-      bulkDocs: vi.fn().mockReturnValue(of([]))
-    };
-    const tasksService = { removeAssigneeFromTasks: vi.fn().mockReturnValue(of([])) };
-    const service = new UsersService(
-      couchService as any,
-      {} as any,
-      { configuration: { code: 'planet-a' }, couchStateListener: () => NEVER } as any,
-      tasksService as any,
-      {} as any
-    );
+    const { service, tasksService } = createService();
 
     service.deleteUser({
       _id: 'org.couchdb.user:alex@planet-b',
@@ -75,5 +77,91 @@ describe('UsersService notifications', () => {
       'org.couchdb.user:legacy',
       undefined
     );
+  });
+
+  it('scopes team membership deletion to the user planet', () => {
+    const { service, couchService } = createService();
+
+    service.deleteUserFromTeams({ _id: 'org.couchdb.user:alex', planetCode: 'planet-b' }).subscribe();
+
+    expect(couchService.findAll).toHaveBeenCalledWith('teams', {
+      selector: {
+        userId: 'org.couchdb.user:alex',
+        $or: [
+          { userPlanetCode: 'planet-b' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      }
+    });
+  });
+
+  it('falls back to the local planet when the user carries no planet code', () => {
+    const { service, couchService } = createService();
+
+    service.deleteUserFromTeams({ _id: 'org.couchdb.user:alex' }).subscribe();
+
+    expect(couchService.findAll).toHaveBeenCalledWith('teams', {
+      selector: {
+        userId: 'org.couchdb.user:alex',
+        $or: [
+          { userPlanetCode: 'planet-a' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      }
+    });
+  });
+
+  it('deletes a replicated user by the canonical id membership documents use', () => {
+    const { service, couchService } = createService();
+
+    service.deleteUserFromTeams({
+      _id: 'org.couchdb.user:alex@planet-b',
+      couchId: 'org.couchdb.user:alex',
+      planetCode: 'planet-b'
+    }).subscribe();
+
+    expect(couchService.findAll).toHaveBeenCalledWith('teams', {
+      selector: {
+        userId: 'org.couchdb.user:alex',
+        $or: [
+          { userPlanetCode: 'planet-b' },
+          { userPlanetCode: '' },
+          { userPlanetCode: { $exists: false } }
+        ]
+      }
+    });
+  });
+
+  it('filters code-less team rows by team origin and preserves same-named local accounts', () => {
+    const matchingExplicit = {
+      _id: 'foreign-explicit', userId: 'org.couchdb.user:alex', userPlanetCode: 'planet-b'
+    };
+    const matchingCodeless = {
+      _id: 'foreign-codeless', userId: 'org.couchdb.user:alex', userPlanetCode: '', teamPlanetCode: 'planet-b'
+    };
+    const sameNamedLocal = {
+      _id: 'local-explicit', userId: 'org.couchdb.user:alex', userPlanetCode: 'planet-a'
+    };
+    const localCodeless = {
+      _id: 'local-codeless', userId: 'org.couchdb.user:alex', teamPlanetCode: 'planet-a'
+    };
+    const unknownOrigin = { _id: 'unknown', userId: 'org.couchdb.user:alex' };
+    const findAll = vi.fn().mockReturnValue(of([
+      matchingExplicit, matchingCodeless, sameNamedLocal, localCodeless, unknownOrigin
+    ]));
+    const { service, couchService } = createService({ couch: { findAll } });
+
+    service.deleteUserFromTeams({
+      _id: 'org.couchdb.user:alex@planet-b',
+      couchId: 'org.couchdb.user:alex',
+      planetCode: 'planet-b'
+    }).subscribe();
+
+    expect(couchService.bulkDocs).toHaveBeenCalledWith('teams', [
+      { ...matchingExplicit, _deleted: true },
+      { ...matchingCodeless, _deleted: true }
+    ]);
   });
 });

--- a/src/app/users/users.service.spec.ts
+++ b/src/app/users/users.service.spec.ts
@@ -49,7 +49,7 @@ describe('UsersService notifications', () => {
     });
   });
 
-  it('cleans associated and code-less task identities when deleting users', () => {
+  it('limits destructive task cleanup to the deleted account origin', () => {
     const { service, tasksService } = createService();
 
     service.deleteUser({
@@ -63,7 +63,7 @@ describe('UsersService notifications', () => {
 
     expect(tasksService.removeAssigneeFromTasks).toHaveBeenCalledWith(
       'org.couchdb.user:alex',
-      [ 'planet-b', 'planet-a' ]
+      'planet-b'
     );
 
     tasksService.removeAssigneeFromTasks.mockClear();
@@ -75,7 +75,7 @@ describe('UsersService notifications', () => {
 
     expect(tasksService.removeAssigneeFromTasks).toHaveBeenCalledWith(
       'org.couchdb.user:legacy',
-      undefined
+      'planet-a'
     );
   });
 
@@ -124,9 +124,10 @@ describe('UsersService notifications', () => {
 
     expect(couchService.findAll).toHaveBeenCalledWith('teams', {
       selector: {
-        userId: 'org.couchdb.user:alex',
+        userId: { $in: [ 'org.couchdb.user:alex', 'org.couchdb.user:alex@planet-b' ] },
         $or: [
           { userPlanetCode: 'planet-b' },
+          { userPlanetCode: 'planet-a' },
           { userPlanetCode: '' },
           { userPlanetCode: { $exists: false } }
         ]

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -8,9 +8,8 @@ import { UserService } from '../shared/user.service';
 import { StateService } from '../shared/state.service';
 import { TasksService } from '../tasks/tasks.service';
 import { NotificationsService, notificationRecipient } from '../notifications/notifications.service';
-import { assigneeIdentityCandidates } from '../tasks/tasks.utils';
 import { userPlanetCodeSelector } from '../shared/mangoQueries';
-import { userIdentity } from '../shared/identity.utils';
+import { identityMatches, userIdentity, userIdentityCandidates } from '../shared/identity.utils';
 
 @Injectable({
   providedIn: 'root'
@@ -191,17 +190,15 @@ export class UsersService {
 
   deleteUser(user) {
     const userId = 'org.couchdb.user:' + user.name;
-    const taskIdentities = assigneeIdentityCandidates(user, this.stateService.configuration.code);
-    const taskPlanetCodes = taskIdentities.map(({ userPlanetCode }) => userPlanetCode)
-      .filter((code): code is string => !!code);
+    const taskIdentity = userIdentity(user, this.stateService.configuration.code);
     return this.couchService.get('shelf/' + userId).pipe(
       switchMap(shelfUser => forkJoin([
         this.couchService.delete('_users/' + userId + '?rev=' + user._rev),
         this.couchService.delete('shelf/' + userId + '?rev=' + shelfUser._rev),
         this.deleteUserFromTeams(user),
         this.tasksService.removeAssigneeFromTasks(
-          taskIdentities[0]?.userId || user._id,
-          taskPlanetCodes.length > 0 ? taskPlanetCodes : undefined
+          taskIdentity.userId || user._id,
+          taskIdentity.userPlanetCode
         )
       ])),
       map(() => this.requestUsers(true))
@@ -209,14 +206,19 @@ export class UsersService {
   }
 
   deleteUserFromTeams(user) {
-    const identity = userIdentity(user, this.stateService.configuration.code);
+    const identities = userIdentityCandidates(user, this.stateService.configuration.code);
+    const identity = identities[0];
+    const userIds = [ ...new Set(identities.map(candidate => candidate.userId)) ];
     return this.couchService.findAll('teams', { selector: {
-      userId: identity.userId,
-      ...userPlanetCodeSelector(identity.userPlanetCode)
+      userId: userIds.length === 1 ? identity.userId : { $in: userIds },
+      ...userPlanetCodeSelector(...identities.map(candidate => candidate.userPlanetCode))
     } }).pipe(
       switchMap(teams => {
+        // Missing stored and team origins cannot be attributed safely, so destructive cleanup skips them.
         const docsWithUser = teams
-          .filter((doc: any) => (doc.userPlanetCode || doc.teamPlanetCode) === identity.userPlanetCode)
+          .filter((doc: any) => identities.some(candidate => identityMatches(
+            doc, candidate, doc.teamPlanetCode
+          )))
           .map((doc: any) => ({ ...doc, _deleted: true }));
         return this.couchService.bulkDocs('teams', docsWithUser);
       })

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -9,6 +9,8 @@ import { StateService } from '../shared/state.service';
 import { TasksService } from '../tasks/tasks.service';
 import { NotificationsService, notificationRecipient } from '../notifications/notifications.service';
 import { assigneeIdentityCandidates } from '../tasks/tasks.utils';
+import { userPlanetCodeSelector } from '../shared/mangoQueries';
+import { userIdentity } from '../shared/identity.utils';
 
 @Injectable({
   providedIn: 'root'
@@ -207,9 +209,15 @@ export class UsersService {
   }
 
   deleteUserFromTeams(user) {
-    return this.couchService.findAll('teams', { selector: { userId: user._id } }).pipe(
+    const identity = userIdentity(user, this.stateService.configuration.code);
+    return this.couchService.findAll('teams', { selector: {
+      userId: identity.userId,
+      ...userPlanetCodeSelector(identity.userPlanetCode)
+    } }).pipe(
       switchMap(teams => {
-        const docsWithUser = teams.map((doc: any) => ({ ...doc, _deleted: true }));
+        const docsWithUser = teams
+          .filter((doc: any) => (doc.userPlanetCode || doc.teamPlanetCode) === identity.userPlanetCode)
+          .map((doc: any) => ({ ...doc, _deleted: true }));
         return this.couchService.bulkDocs('teams', docsWithUser);
       })
     );


### PR DESCRIPTION
Fixes #10402

# Summary
- Centralize user and member identity resolution around canonical user ID plus planet origin.
- Preserve explicit planet origins and resolve blank membership origins from the team without persisting the inferred value.
- Keep native and associated accounts with the same user ID distinct.
- Apply consistent identity handling to membership, leadership, tasks, requests, invitations, profile routing, notifications, and dashboard teams.
- Preserve existing membership `_id`, `_rev`, leadership state, and notification routing contracts.
- Scope destructive task and team cleanup by planet origin.
- Remove shelf-backed membership reads and writes, including the unbounded shelf scan.
- Retain `shelf.myTeamIds` only as dashboard ordering metadata.
- Handle missing and malformed membership or leader records safely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved team membership handling so users with the same name on different planets remain distinct.
  - Team lists now consistently reflect active memberships and shelf ordering.
  - Leaving a team preserves the correct membership record.
  - Improved matching for task assignees, notifications, invitations, and team leadership.
  - Associated accounts now retain the correct identity and planet information.
  - Team and user removal actions are more precisely scoped, reducing accidental changes to unrelated accounts.
  - Improved compatibility with historical membership and notification records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->