### PR TITLE
all: smoother member delimiter linting (connects #9082)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,7 +75,6 @@
         "@angular-eslint/contextual-lifecycle": "error",
         "@angular-eslint/directive-class-suffix": "error",
         "@angular-eslint/no-conflicting-lifecycle": "error",
-        // "@angular-eslint/no-host-metadata-property": "error",
         "@angular-eslint/no-input-rename": "error",
         "@angular-eslint/no-inputs-metadata-property": "error",
         "@angular-eslint/no-output-native": "error",
@@ -88,19 +87,19 @@
         "@typescript-eslint/array-type": "off",
         "@typescript-eslint/consistent-type-assertions": "error",
         // "@typescript-eslint/member-ordering": "error",
-        // "@typescript-eslint/naming-convention": [
-        //   "error",
-        //
-        //   Not transferring over the default case, it triggers on object properties which can
-        //   often come from external sources not fitting our naming conventions.
-        //   {
-        //     "selector": "default",
-        //     "format": [ "camelCase" ],
-        //     "leadingUnderscore": "allowSingleOrDouble",
-        //     "trailingUnderscore": "allowSingleOrDouble"
-        //   },
+        "@typescript-eslint/naming-convention": [
+          "error",
+        
+          // Not transferring over the default case, it triggers on object properties which can
+          // often come from external sources not fitting our naming conventions.
+          {
+            "selector": "default",
+            "format": [ "camelCase" ],
+            "leadingUnderscore": "allowSingleOrDouble",
+            "trailingUnderscore": "allowSingleOrDouble"
+          },
 
-        // ],
+        ],
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-empty-interface": "error",
         "@typescript-eslint/no-explicit-any": "off",
@@ -231,7 +230,7 @@
         "no-unsafe-finally": "error",
         "no-unused-labels": "error",
         "no-var": "error",
-        // "object-shorthand": "error",
+        "object-shorthand": "error",
         "one-var": ["error", "never"],
         "prefer-arrow/prefer-arrow-functions": "error",
         "prefer-const": "error",
@@ -257,28 +256,28 @@
         "no-multiple-empty-lines": "off",
         "no-trailing-spaces": "error",
         "quote-props": ["error", "as-needed"],
-        // "space-before-function-paren": [
-        //   "error",
-        //   {
-        //     "anonymous": "never",
-        //     "asyncArrow": "always",
-        //     "named": "never"
-        //   }
-        // ],
+        "space-before-function-paren": [
+          "error",
+          {
+            "anonymous": "never",
+            "asyncArrow": "always",
+            "named": "never"
+          }
+        ],
 
-        // "@typescript-eslint/member-delimiter-style": [
-        //   "error",
-        //   {
-        //     "multiline": {
-        //       "delimiter": "semi",
-        //       "requireLast": true
-        //     },
-        //     "singleline": {
-        //       "delimiter": "semi",
-        //       "requireLast": false
-        //     }
-        //   }
-        // ],
+        "@typescript-eslint/member-delimiter-style": [
+          "error",
+          {
+            "multiline": {
+              "delimiter": "semi",
+              "requireLast": true
+            },
+            "singleline": {
+              "delimiter": "semi",
+              "requireLast": false
+            }
+          }
+        ],
         "quotes": "off",
         "@stylistic/quotes": [
           "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,6 +85,19 @@ export default defineConfig([globalIgnores(["projects/**/*", "gateway/**/*"]), {
         "@angular-eslint/no-outputs-metadata-property": "error",
         "@angular-eslint/use-lifecycle-interface": "error",
         "@angular-eslint/use-pipe-transform-interface": "error",
+        "@stylistic/member-delimiter-style": [
+          "error",
+          {
+            "multiline": {
+              "delimiter": "semi",
+              "requireLast": true
+            },
+            "singleline": {
+              "delimiter": "comma",
+              "requireLast": false
+            }
+          }
+        ],
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/array-type": "off",
         "@typescript-eslint/consistent-type-assertions": "error",
@@ -266,6 +279,14 @@ export default defineConfig([globalIgnores(["projects/**/*", "gateway/**/*"]), {
         "no-multiple-empty-lines": "off",
         "no-trailing-spaces": "error",
         "quote-props": ["error", "as-needed"],
+        "space-before-function-paren": [
+          "error",
+          {
+            "anonymous": "never",
+            "asyncArrow": "always",
+            "named": "never"
+          }
+        ],
         "no-var": "error",
         "object-shorthand": ["error", "always"],
         quotes: "off",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.56",
+  "version": "0.24.57",
   "myplanet": {
     "latest": "v0.70.45",
     "min": "v0.67.67"

--- a/src/app/configuration/configuration-guard.service.ts
+++ b/src/app/configuration/configuration-guard.service.ts
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
 @Injectable()
 export class ConfigurationGuard {
 
-  constructor (
+  constructor(
     private router: Router,
     private couchService: CouchService
   ) {}

--- a/src/app/exams/public-surveys/public-surveys.service.ts
+++ b/src/app/exams/public-surveys/public-surveys.service.ts
@@ -19,7 +19,7 @@ export interface PublicSurvey {
 
 export interface PublicSurveyResponse {
   survey: PublicSurvey;
-  team: { _id: string; name: string; type: string };
+  team: { _id: string, name: string, type: string };
 }
 
 @Injectable({

--- a/src/app/feedback/feedback.utils.ts
+++ b/src/app/feedback/feedback.utils.ts
@@ -15,7 +15,7 @@ export const FEEDBACK_STATUS_OPTIONS = [
   { label: $localize`Closed`, value: 'closed' }
 ] as const;
 
-interface FeedbackOption { label: string; value: string }
+interface FeedbackOption { label: string, value: string }
 
 export interface FeedbackTitleContext {
   kind: 'home' | 'section' | 'item' | 'path';
@@ -66,7 +66,7 @@ export const getFeedbackTypeIcon = (value: unknown) => {
   }
 };
 
-export const getFeedbackDisplayTitle = (feedback: { title?: string; titleContext?: FeedbackTitleContext; type?: string; url?: string }) => {
+export const getFeedbackDisplayTitle = (feedback: { title?: string, titleContext?: FeedbackTitleContext, type?: string, url?: string }) => {
   // Keep explicit (manually edited) titles untouched. Older auto-generated titles also remain as saved;
   if (feedback.title?.trim()) {
     return feedback.title;

--- a/src/app/health/health-event.component.ts
+++ b/src/app/health/health-event.component.ts
@@ -240,7 +240,7 @@ export class HealthEventComponent implements OnInit, CanComponentDeactivate {
         ? /^(([6-9])(\d)|([1-2])(\d){2}|(300))\/(([4-9])(\d)|(1)(\d){2}|(200))$/.test(value)
         : true;
     }
-    const fieldLimit = limits[field] as { min: number; max: number };
+    const fieldLimit = limits[field] as { min: number, max: number };
     return (value as number) >= fieldLimit.min && (value as number) <= fieldLimit.max;
   }
 

--- a/src/app/health/health-update.component.ts
+++ b/src/app/health/health-update.component.ts
@@ -82,7 +82,7 @@ export class HealthUpdateComponent implements OnInit, CanComponentDeactivate {
 
   profileForm: FormGroup<ProfileFormGroup>;
   healthForm: FormGroup<HealthFormGroup>;
-  existingData: { _id?: string; _rev?: string; profile?: HealthFormValue } = {};
+  existingData: { _id?: string, _rev?: string, profile?: HealthFormValue } = {};
   languages = languages;
   minBirthDate: Date = this.userService.minBirthDate;
   initialFormValues: string;

--- a/src/app/login/login-form.component.ts
+++ b/src/app/login/login-form.component.ts
@@ -31,7 +31,7 @@ interface RegisterFormControls extends LoginFormControls {
 
 interface LoginCredentials {
   name: string;
-  password: string
+  password: string;
 };
 
 type LoginFormGroup = FormGroup<LoginFormControls>;

--- a/src/app/login/login-tasks.service.ts
+++ b/src/app/login/login-tasks.service.ts
@@ -87,13 +87,13 @@ export class LoginTasksService {
     return obsArr;
   }
 
-  private createParentSession({ name, password }: { name: string; password: string }) {
+  private createParentSession({ name, password }: { name: string, password: string }) {
     return this.couchService.post('_session',
       { name, password },
       { withCredentials: true, domain: this.stateService.configuration.parentDomain });
   }
 
-  private getConfigurationSyncDown(configuration: { code: string }, credentials: { name: string; password: string }) {
+  private getConfigurationSyncDown(configuration: { code: string }, credentials: { name: string, password: string }) {
     return this.syncService.sync({
       dbSource: 'communityregistrationrequests',
       dbTarget: 'configurations',

--- a/src/app/manager-dashboard/manager-currency.component.ts
+++ b/src/app/manager-dashboard/manager-currency.component.ts
@@ -25,7 +25,7 @@ import { SubmitDirective } from '../shared/submit.directive';
   ]
 })
 export class ManagerCurrencyComponent implements OnInit {
-  form: FormGroup<{ code: FormControl<string>; symbol: FormControl<string> }>;
+  form: FormGroup<{ code: FormControl<string>, symbol: FormControl<string> }>;
   configuration: any = {};
   spinnerOn = true;
 

--- a/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.ts
+++ b/src/app/manager-dashboard/reports/myplanet/myplanet-toolbar.component.ts
@@ -51,7 +51,7 @@ export class MyPlanetToolbarComponent {
   @Input() types: string[] = [];
   @Input() selectedType = '';
   @Input() showTypeFilter = false;
-  @Input() timeFilterOptions: { label: string; value: string }[] = [];
+  @Input() timeFilterOptions: { label: string, value: string }[] = [];
   @Input() selectedTimeFilter = '';
   @Input() formGroup!: FormGroup<MyPlanetFiltersForm>;
   @Input() showCustomDateFields = false;

--- a/src/app/shared/chart-utils.ts
+++ b/src/app/shared/chart-utils.ts
@@ -38,7 +38,7 @@ export const loadChart = async (keys: RegisterableKey[] = []): Promise<ChartJsMo
   return module;
 };
 
-export const createChartCanvas = (width = 300, height = 400): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D | null } => {
+export const createChartCanvas = (width = 300, height = 400): { canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D | null } => {
   const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
   const canvas = document.createElement('canvas');
   canvas.width = width * dpr;

--- a/src/app/shared/csv.service.ts
+++ b/src/app/shared/csv.service.ts
@@ -102,7 +102,7 @@ export class CsvService {
     return monthData.reduce((total, item) => total + (item.count || 0), 0);
   }
 
-  private buildSummaryTable(sections: Array<{ title: string; data: any[]; countUnique: boolean }>): any[] {
+  private buildSummaryTable(sections: Array<{ title: string, data: any[], countUnique: boolean }>): any[] {
     const allMonths = new Set<string>();
     sections.forEach(section => {
       section.data.forEach(item => allMonths.add(item.date));

--- a/src/app/shared/dialogs/dialogs-chat-share.component.ts
+++ b/src/app/shared/dialogs/dialogs-chat-share.component.ts
@@ -114,7 +114,7 @@ export class DialogsChatShareComponent implements OnInit {
     this.getTeams();
   }
 
-  teamSelect({ teamId, teamType }: { teamId: string; teamType: string }) {
+  teamSelect({ teamId, teamType }: { teamId: string, teamType: string }) {
     this.teamForm.controls.linkId.setValue(teamId);
     this.teamForm.controls.teamType.setValue(teamType);
     this.linkStepper.selected.completed = true;

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -212,11 +212,11 @@ export class DialogsFormComponent {
     return this.modalForm.dirty;
   }
 
-  getRadioOptionLabel(option: { name: string; value?: unknown } | string) {
+  getRadioOptionLabel(option: { name: string, value?: unknown } | string) {
     return typeof option === 'string' ? option : option.name;
   }
 
-  getRadioOptionValue(option: { name: string; value?: unknown } | string) {
+  getRadioOptionValue(option: { name: string, value?: unknown } | string) {
     return typeof option === 'string' ? option : option.value;
   }
 

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -16,7 +16,7 @@ export interface DialogField<TName extends string = string> {
   required?: boolean;
   disabled?: boolean;
   multiple?: boolean;
-  options?: Array<{ name: string; value?: unknown } | string>;
+  options?: Array<{ name: string, value?: unknown } | string>;
   planetBeta?: boolean;
   tooltip?: string;
   reset?: boolean;

--- a/src/app/shared/dialogs/dialogs-list.component.ts
+++ b/src/app/shared/dialogs/dialogs-list.component.ts
@@ -80,18 +80,18 @@ export class DialogsListComponent implements AfterViewInit {
   @ViewChild('paginator') paginator: MatPaginator;
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: {
-    tableData: any[],
-    columns: string[],
-    itemDescription: string,
-    nameProperty: string,
-    okClick: any,
-    dropdownSettings: { field: string, startingValue?: { value: string, text: string } },
-    filterPredicate?: any,
-    allowMulti?: boolean,
-    initialSelection?: any[],
-    disableSelection?: boolean,
-    selectionOptional?: boolean,
-    labels?: any
+    tableData: any[];
+    columns: string[];
+    itemDescription: string;
+    nameProperty: string;
+    okClick: any;
+    dropdownSettings: { field: string, startingValue?: { value: string, text: string } };
+    filterPredicate?: any;
+    allowMulti?: boolean;
+    initialSelection?: any[];
+    disableSelection?: boolean;
+    selectionOptional?: boolean;
+    labels?: any;
   }) {
     const hasFullName = this.data.columns.some(column => column === 'Full Name');
     const tableData = hasFullName ?

--- a/src/app/shared/forms/planet-markdown-textbox.component.ts
+++ b/src/app/shared/forms/planet-markdown-textbox.component.ts
@@ -11,8 +11,8 @@ import { DialogsImagesComponent } from '../dialogs/dialogs-images.component';
 import { TdTextEditorComponent } from '@covalent/text-editor';
 import { NgClass } from '@angular/common';
 
-interface ImageInfo { resourceId: string; filename: string; markdown: string; }
-interface ValueWithImages { text: string; images: ImageInfo[]; }
+interface ImageInfo { resourceId: string, filename: string, markdown: string }
+interface ValueWithImages { text: string, images: ImageInfo[] }
 interface FullscreenState {
   owner: HTMLElement;
   actions: HTMLElement;

--- a/src/app/shared/forms/planet-tag-input.component.ts
+++ b/src/app/shared/forms/planet-tag-input.component.ts
@@ -17,10 +17,10 @@ import { MatButton } from '@angular/material/button';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
 import { MatIcon } from '@angular/material/icon';
 
-interface SelectedDialogTag { tagId: string; indeterminate: boolean; }
+interface SelectedDialogTag { tagId: string, indeterminate: boolean }
 type DialogStartingTag = string | SelectedDialogTag;
-interface TagWithId extends Record<string, unknown> { _id: string; }
-interface FilteredDataItem { _id: string; tags?: TagWithId[]; }
+interface TagWithId extends Record<string, unknown> { _id: string }
+interface FilteredDataItem { _id: string, tags?: TagWithId[] }
 interface PlanetTagDialogData {
   tagUpdate: (tag: string, isSelected: boolean, tagOne?: boolean) => void;
   initTags: (editedId?: string) => void;

--- a/src/app/shared/user-challenge-status.service.ts
+++ b/src/app/shared/user-challenge-status.service.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@angular/core';
 
 interface UserStatusValue {
-  status: boolean,
-  amount: number
+  status: boolean;
+  amount: number;
 }
 
 interface UserStatus {
-  joinedCourse: UserStatusValue,
-  surveyComplete: UserStatusValue,
-  hasPost: UserStatusValue,
-  userPosts: number
+  joinedCourse: UserStatusValue;
+  surveyComplete: UserStatusValue;
+  hasPost: UserStatusValue;
+  userPosts: number;
 }
 
 @Injectable({

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -72,7 +72,7 @@ export interface NormalizedImage {
   fileName: string;
 }
 
-export const scaledDimensions = (width: number, height: number, maxDimension: number): { width: number; height: number } => {
+export const scaledDimensions = (width: number, height: number, maxDimension: number): { width: number, height: number } => {
   const scale = Math.min(1, maxDimension / Math.max(width, height));
   return {
     width: Math.max(1, Math.round(width * scale)),

--- a/src/app/submissions/submissions.service.spec.ts
+++ b/src/app/submissions/submissions.service.spec.ts
@@ -6,7 +6,7 @@ describe('SubmissionsService survey exports', () => {
   let service: SubmissionsService;
   let csvService: { exportCSV: ReturnType<typeof vi.fn> };
   let dialogsLoadingService: { stop: ReturnType<typeof vi.fn> };
-  let planetMessageService: { showAlert: ReturnType<typeof vi.fn>; showMessage: ReturnType<typeof vi.fn> };
+  let planetMessageService: { showAlert: ReturnType<typeof vi.fn>, showMessage: ReturnType<typeof vi.fn> };
   let pdfService: { download: ReturnType<typeof vi.fn> };
 
   const exam = {

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -48,7 +48,7 @@ export class SubmissionsService {
   ) { }
 
   updateSubmissions({ query, opts = {}, onlyBest, surveyId, type }: {
-    onlyBest?: boolean, opts?: any, query?: any, surveyId?: string, type?: 'exam' | 'survey'
+    onlyBest?: boolean; opts?: any; query?: any; surveyId?: string; type?: 'exam' | 'survey';
   } = {}) {
     const submissionsObs = surveyId && type
       ? this.getSubmissionsIncludingDerived(surveyId, type, 'complete')

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -200,7 +200,7 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
       const teamSurveys = allSurveys.filter((survey: any) => survey.sourceSurveyId);
       const targetTeamId = this.teamId || this.routeTeamId;
 
-      const submissionsBySurvey: Record<string, Array<{ status: string; teamId: string | null; parent?: any }>> = {};
+      const submissionsBySurvey: Record<string, Array<{ status: string, teamId: string | null, parent?: any }>> = {};
       submissions.forEach(row => {
         const [baseSurveyId] = row.key;
         (submissionsBySurvey[baseSurveyId] ||= []).push(row.value);

--- a/src/app/teams/teams-attachments.service.ts
+++ b/src/app/teams/teams-attachments.service.ts
@@ -43,7 +43,7 @@ export class TeamsAttachmentsService {
       }));
   }
 
-  receiptAttachmentImages(doc: any): Observable<Array<{ image: string; name: string }>> {
+  receiptAttachmentImages(doc: any): Observable<Array<{ image: string, name: string }>> {
     const attachments = this.receiptAttachments(doc);
     if (attachments.length === 0) {
       return of([]);
@@ -54,7 +54,7 @@ export class TeamsAttachmentsService {
         map(image => ({ image, name: attachment.name })),
         catchError(() => of(null))
       )
-    )).pipe(map(images => images.filter((image): image is { image: string; name: string } => !!image)));
+    )).pipe(map(images => images.filter((image): image is { image: string, name: string } => !!image)));
   }
 
   retainSelectedAttachments(doc: any, state: AttachmentInputState) {

--- a/src/app/teams/teams-reports.component.ts
+++ b/src/app/teams/teams-reports.component.ts
@@ -27,17 +27,17 @@ import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { PdfImageSection, TeamsTablePdfExportService } from './teams-table-pdf-export.service';
 
 interface NewReportForm {
-  _id?: string,
-  _rev?: string,
-  beginningBalance: string,
-  description: string,
-  endDate: Date,
-  otherExpenses: number,
-  otherIncome: number,
-  receiptImages?: AttachmentInputState,
-  sales: number,
-  startDate: Date,
-  wages: string
+  _id?: string;
+  _rev?: string;
+  beginningBalance: string;
+  description: string;
+  endDate: Date;
+  otherExpenses: number;
+  otherIncome: number;
+  receiptImages?: AttachmentInputState;
+  sales: number;
+  startDate: Date;
+  wages: string;
 }
 
 @Component({

--- a/src/app/users/users-table.component.ts
+++ b/src/app/users/users-table.component.ts
@@ -263,12 +263,12 @@ export class UsersTableComponent implements OnInit, OnDestroy, AfterViewInit, On
   }
 
   private openUserPrompt({ user, changeType, extraMessage, request, onSuccess, errorMessage }: {
-    user: any,
-    changeType: string,
-    extraMessage: string,
-    request: () => Observable<any>,
-    onSuccess: () => void,
-    errorMessage: string
+    user: any;
+    changeType: string;
+    extraMessage: string;
+    request: () => Observable<any>;
+    onSuccess: () => void;
+    errorMessage: string;
   }) {
     this.promptDialog = this.dialog.open(DialogsPromptComponent, {
       data: {


### PR DESCRIPTION
Adding back in rules for member delimeters and space before function.

For member delimeter I went with comma for one line and semicolon for multi line type definitions. This matches more closely to our general style across the app currently.

In addition:
- The commented no-host-metadata-property is removed because that rule no longer exists.
- Uncommented naming-convention and object-shorthand rules from the old linting file because they were already added back into the new file.

connects #9082 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized TypeScript and function formatting across the codebase.
  * Enabled ESLint rules for naming conventions, object shorthand, function spacing, and member delimiters.
  * Updated type declarations and method signatures to follow consistent delimiter and spacing conventions.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->