### PR TITLE
dashboard: smoother shelf cards styles (fixes #10405)

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -59,7 +59,7 @@ $shelf-library-text: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 900);
 $shelf-courses-accent: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 500);
 $shelf-courses-lighter: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 100);
 $shelf-courses-dark: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 800);
-$shelf-courses-text: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 900);
+$shelf-courses-text: mat.m2-get-contrast-color-from-palette(mat.$m2-orange-palette, 100);
 $shelf-teams-accent: mat.m2-get-color-from-palette(mat.$m2-green-palette, 500);
 $shelf-teams-lighter: mat.m2-get-color-from-palette(mat.$m2-green-palette, 100);
 $shelf-teams-dark: mat.m2-get-color-from-palette(mat.$m2-green-palette, 700);

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -51,6 +51,24 @@ $planet-green-dark: mat.m2-get-color-from-palette($planet-app-green, $dark-hue);
 $primary-lighter-text: mat.m2-get-color-from-palette($planet-app-primary, 900);
 $accent-lighter-text: color.adjust($accent, $lightness: -30%);
 
+// Dashboard shelf theme tokens (library / courses / teams / life)
+$shelf-library-accent: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 500);
+$shelf-library-lighter: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 100);
+$shelf-library-dark: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 700);
+$shelf-library-text: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 900);
+$shelf-courses-accent: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 500);
+$shelf-courses-lighter: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 100);
+$shelf-courses-dark: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 800);
+$shelf-courses-text: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 900);
+$shelf-teams-accent: mat.m2-get-color-from-palette(mat.$m2-green-palette, 500);
+$shelf-teams-lighter: mat.m2-get-color-from-palette(mat.$m2-green-palette, 100);
+$shelf-teams-dark: mat.m2-get-color-from-palette(mat.$m2-green-palette, 700);
+$shelf-teams-text: mat.m2-get-color-from-palette(mat.$m2-green-palette, 900);
+$shelf-life-accent: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 500);
+$shelf-life-lighter: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 100);
+$shelf-life-dark: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 700);
+$shelf-life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
+
 // Backgrounds for generated member initials, picked by hashing the name. A fixed set
 // rather than a computed hue, so every option is theme-derived and verified: each
 // clears WCAG AA against white text, the blue at 4.6:1 being the tightest.

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -112,7 +112,7 @@ $search-filters-height: 25vh;
 // Height of dashboard
 $dashboard-height: calc(100vh - 128px);
 $dashboard-tile-height: calc((#{$dashboard-height} - 3rem) / 4);
-$dashboard-tile-width: 125px;
+$dashboard-tile-width: 148px;
 // Widths for forms fitting 1, 2, or 3 mat-input-fields horizontally
 $form-width-3: 550px;
 $form-width-2: 365px;

--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -30,12 +30,11 @@
       [cdkDropListOrientation]="isAccordionMode ? 'vertical' : 'horizontal'"
       (cdkDropListDropped)="drop($event)">
       @if (!isLoading) {
-        @for (item of itemData; track item; let even = $even) {
+        @for (item of itemData; track item) {
           <ng-container *planetAuthorizedRoles="item.authorization || '_any'">
             <div
               class="dashboard-item"
               [ngClass]="{
-                'bg-grey': even,
                 'accordion-item': isAccordionMode,
                 'has-course-cover': cardType === 'myCourses' && item.coverFileName
               }"
@@ -48,18 +47,23 @@
                 [routerLink]="recentlyDragged ? null : item.link"
                 [state]="item.returnState ? { returnState: item.returnState } : undefined"
                 [matTooltip]="item.tooltip">
-                @if (cardType === 'myCourses' && item.coverFileName) {
-                  <div class="dashboard-course-cover">
+                <div class="tile-band band-{{cardType}}"></div>
+                <div class="tile-avatar avatar-{{cardType}}" [class.dashboard-course-cover]="cardType === 'myCourses' && item.coverFileName">
+                  @if (cardType === 'myCourses' && item.coverFileName) {
                     <img [src]="coverImageUrl(item)" alt="Course cover" i18n-alt>
+                  } @else {
+                    <mat-icon class="tile-icon">{{ getItemIcon(item) }}</mat-icon>
+                  }
+                </div>
+                @if (item.badge) {
+                  <div class="tile-chips">
+                    <span class="tile-chip chip-{{cardType}}" [matTooltip]="badgeDescription(item)" [attr.aria-label]="badgeDescription(item)">
+                      {{item.badge}}
+                    </span>
                   </div>
                 }
-                @if (item.firstLine || item.badge) {
-                  <p [matBadge]="item.badge" [matBadgeHidden]="item.badge===0" matBadgeOverlap="false" matBadgePosition="before" [matBadgeDescription]="badgeDescription(item)">
-                    {{item.firstLine}}
-                  </p>
-                }
                 <p class="dashboard-text" [ngStyle]="{ '-webkit-line-clamp': dashboardTextLines(item),'word-wrap': 'break-word' }">
-                  {{(cardType === 'myLife' && isAccordionMode) ? '' : (item.title | truncateText:50)}}
+                  {{item.title | truncateText:50}}
                 </p>
               </a>
               @if (cardType!=='myLife' && !item?.canRemove) {

--- a/src/app/dashboard/dashboard-tile.component.spec.ts
+++ b/src/app/dashboard/dashboard-tile.component.spec.ts
@@ -133,4 +133,28 @@ describe('DashboardTileComponent', () => {
     expect(dialogRef.close).toHaveBeenCalled();
     expect(messageService.showMessage).toHaveBeenCalled();
   });
+
+  it('resolves library item icons according to resource file type standards', () => {
+    TestBed.configureTestingModule({
+      imports: [ DashboardTileComponent ],
+      providers: [
+        { provide: CoursesService, useValue: {} },
+        { provide: DeviceInfoService, useValue: { watchDeviceType: vi.fn().mockReturnValue(of(undefined)) } },
+        { provide: MatDialog, useValue: {} },
+        { provide: PlanetMessageService, useValue: {} },
+        { provide: TeamsService, useValue: {} },
+        { provide: UserService, useValue: { get: vi.fn().mockReturnValue({}) } }
+      ]
+    });
+    const component = TestBed.createComponent(DashboardTileComponent).componentInstance;
+    component.cardType = 'myLibrary';
+
+    expect(component.getItemIcon({ filename: 'book.pdf' })).toBe('picture_as_pdf');
+    expect(component.getItemIcon({ filename: 'video.mp4' })).toBe('videocam');
+    expect(component.getItemIcon({ filename: 'audio.mp3' })).toBe('audiotrack');
+    expect(component.getItemIcon({ filename: 'data.csv' })).toBe('grid_on');
+    expect(component.getItemIcon({ filename: 'photo.png' })).toBe('image');
+    expect(component.getItemIcon({ filename: 'doc.docx' })).toBe('description');
+    expect(component.getItemIcon({})).toBe('insert_drive_file');
+  });
 });

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -24,6 +24,7 @@ import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
 import { environment } from '../../environments/environment';
 import { couchAttachmentUrl } from '../shared/utils';
+import { resolveResourceIconInfo } from '../resources/resources-icon.component';
 
 @Component({
   selector: 'planet-dashboard-tile-title',
@@ -311,18 +312,8 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
       return 'school';
     }
     if (this.cardType === 'myLibrary') {
-      switch (item?.mediaType) {
-        case 'video':
-          return 'movie';
-        case 'audio':
-          return 'audiotrack';
-        case 'image':
-          return 'image';
-        case 'pdf':
-          return 'picture_as_pdf';
-        default:
-          return 'menu_book';
-      }
+      const resourceIcon = resolveResourceIconInfo(item).icon;
+      return resourceIcon || 'insert_drive_file';
     }
     if (this.cardType === 'myTeams') {
       return 'group';

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -19,7 +19,6 @@ import { RouterLink } from '@angular/router';
 import { MatIcon } from '@angular/material/icon';
 import { AuthorizedRolesDirective } from '../shared/authorized-roles.directive';
 import { MatTooltip } from '@angular/material/tooltip';
-import { MatBadge } from '@angular/material/badge';
 import { MatIconButton } from '@angular/material/button';
 import { PlanetLoadingSpinnerComponent } from '../shared/planet-loading-spinner.component';
 import { TruncateTextPipe } from '../shared/truncate-text.pipe';
@@ -57,7 +56,6 @@ export class DashboardTileTitleComponent {
     AuthorizedRolesDirective,
     CdkDrag,
     MatTooltip,
-    MatBadge,
     NgStyle,
     MatIconButton,
     PlanetLoadingSpinnerComponent,
@@ -152,7 +150,7 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
     const itemStyle = window.getComputedStyle(item);
     const padding = this.cssPixels(itemStyle.paddingTop) + this.cssPixels(itemStyle.paddingBottom);
     const reservedHeight = Array.from(item.children)
-      .filter(element => element.matches('.dashboard-course-cover, p:not(.dashboard-text)'))
+      .filter(element => element.matches('.dashboard-course-cover, .tile-band, .tile-avatar, .tile-chips, p:not(.dashboard-text)'))
       .reduce((height, element) => height + this.elementOuterHeight(element as HTMLElement), 0);
     const fontSize = this.cssPixels(itemStyle.fontSize) || 16;
     // line-height: normal varies by browser, but should be between 1-1.2
@@ -306,5 +304,54 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
 
   coverImageUrl(item: any): string {
     return couchAttachmentUrl(environment.couchAddress, 'courses', item._id, item.coverFileName);
+  }
+
+  getItemIcon(item: any): string {
+    if (this.cardType === 'myCourses') {
+      return 'school';
+    }
+    if (this.cardType === 'myLibrary') {
+      switch (item?.mediaType) {
+        case 'video':
+          return 'movie';
+        case 'audio':
+          return 'audiotrack';
+        case 'image':
+          return 'image';
+        case 'pdf':
+          return 'picture_as_pdf';
+        default:
+          return 'menu_book';
+      }
+    }
+    if (this.cardType === 'myTeams') {
+      return 'group';
+    }
+    if (this.cardType === 'myLife') {
+      const link = item?.link || '';
+      if (link.includes('submissions')) {
+        return 'assignment';
+      }
+      if (link.includes('chat')) {
+        return 'chat';
+      }
+      if (link.includes('Progress')) {
+        return 'equalizer';
+      }
+      if (link.includes('Personals')) {
+        return 'folder';
+      }
+      if (link.includes('Achievements')) {
+        return 'star';
+      }
+      if (link.includes('Surveys')) {
+        return 'poll';
+      }
+      if (link.includes('Health')) {
+        return 'favorite';
+      }
+      return 'star';
+    }
+    return 'category';
   }
 }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -1,26 +1,5 @@
-@use '@angular/material' as mat;
 @use '../mixins' as m;
 @use '../variables' as v;
-
-$library-accent: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 500);
-$library-lighter: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 100);
-$library-dark: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 700);
-$library-text: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 900);
-
-$courses-accent: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 500);
-$courses-lighter: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 100);
-$courses-dark: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 800);
-$courses-text: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 900);
-
-$teams-accent: mat.m2-get-color-from-palette(mat.$m2-green-palette, 500);
-$teams-lighter: mat.m2-get-color-from-palette(mat.$m2-green-palette, 100);
-$teams-dark: mat.m2-get-color-from-palette(mat.$m2-green-palette, 700);
-$teams-text: mat.m2-get-color-from-palette(mat.$m2-green-palette, 900);
-
-$life-accent: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 500);
-$life-lighter: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 100);
-$life-dark: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 700);
-$life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
 
 :host {
 
@@ -29,27 +8,27 @@ $life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
   min-width: 0;
 
   &.planet-library-theme {
-    .tile-band { background: $library-lighter; }
-    .tile-avatar .tile-icon { color: $library-dark; }
-    .tile-chip { background: $library-lighter; color: $library-text; }
+    .tile-band { background: v.$shelf-library-lighter; }
+    .tile-avatar .tile-icon { color: v.$shelf-library-dark; }
+    .tile-chip { background: v.$shelf-library-lighter; color: v.$shelf-library-text; }
   }
 
   &.planet-courses-theme {
-    .tile-band { background: $courses-lighter; }
-    .tile-avatar .tile-icon { color: $courses-dark; }
-    .tile-chip { background: $courses-lighter; color: $courses-text; }
+    .tile-band { background: v.$shelf-courses-lighter; }
+    .tile-avatar .tile-icon { color: v.$shelf-courses-dark; }
+    .tile-chip { background: v.$shelf-courses-lighter; color: v.$shelf-courses-text; }
   }
 
   &.planet-teams-theme {
-    .tile-band { background: $teams-lighter; }
-    .tile-avatar .tile-icon { color: $teams-dark; }
-    .tile-chip { background: $teams-lighter; color: $teams-text; }
+    .tile-band { background: v.$shelf-teams-lighter; }
+    .tile-avatar .tile-icon { color: v.$shelf-teams-dark; }
+    .tile-chip { background: v.$shelf-teams-lighter; color: v.$shelf-teams-text; }
   }
 
   &.planet-meetups-theme {
-    .tile-band { background: $life-lighter; }
-    .tile-avatar .tile-icon { color: $life-dark; }
-    .tile-chip { background: $life-lighter; color: $life-text; }
+    .tile-band { background: v.$shelf-life-lighter; }
+    .tile-avatar .tile-icon { color: v.$shelf-life-dark; }
+    .tile-chip { background: v.$shelf-life-lighter; color: v.$shelf-life-text; }
   }
 
   .dashboard-card {
@@ -146,19 +125,19 @@ $life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
             background: v.$primary-lighter;
 
             &.band-myLibrary {
-              background: $library-lighter;
+              background: v.$shelf-library-lighter;
             }
 
             &.band-myCourses {
-              background: $courses-lighter;
+              background: v.$shelf-courses-lighter;
             }
 
             &.band-myTeams {
-              background: $teams-lighter;
+              background: v.$shelf-teams-lighter;
             }
 
             &.band-myLife {
-              background: $life-lighter;
+              background: v.$shelf-life-lighter;
             }
           }
 
@@ -196,19 +175,19 @@ $life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
             }
 
             &.avatar-myLibrary .tile-icon {
-              color: $library-dark;
+              color: v.$shelf-library-dark;
             }
 
             &.avatar-myCourses .tile-icon {
-              color: $courses-dark;
+              color: v.$shelf-courses-dark;
             }
 
             &.avatar-myTeams .tile-icon {
-              color: $teams-dark;
+              color: v.$shelf-teams-dark;
             }
 
             &.avatar-myLife .tile-icon {
-              color: $life-dark;
+              color: v.$shelf-life-dark;
             }
           }
 
@@ -236,23 +215,23 @@ $life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
             color: v.$primary-lighter-text;
 
             &.chip-myLibrary {
-              background: $library-lighter;
-              color: $library-text;
+              background: v.$shelf-library-lighter;
+              color: v.$shelf-library-text;
             }
 
             &.chip-myCourses {
-              background: $courses-lighter;
-              color: $courses-text;
+              background: v.$shelf-courses-lighter;
+              color: v.$shelf-courses-text;
             }
 
             &.chip-myTeams {
-              background: $teams-lighter;
-              color: $teams-text;
+              background: v.$shelf-teams-lighter;
+              color: v.$shelf-teams-text;
             }
 
             &.chip-myLife {
-              background: $life-lighter;
-              color: $life-text;
+              background: v.$shelf-life-lighter;
+              color: v.$shelf-life-text;
             }
           }
 
@@ -275,7 +254,7 @@ $life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
               width: 16px;
               height: 16px;
               line-height: 16px;
-              color: rgba(0, 0, 0, 0.45);
+              color: v.$grey-text;
             }
 
             &:hover > .mat-icon {
@@ -443,15 +422,27 @@ $life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
       max-height: 300px;
     }
   }
+}
 
-  @media (prefers-reduced-motion: reduce) {
-    .dashboard-card .right-tile .dashboard-items .dashboard-item {
-      transition: none;
+@media (prefers-reduced-motion: reduce) {
+  :host {
+    .dashboard-card {
+      .right-tile {
+        transition: none;
+      }
 
-      &:hover {
-        transform: none;
+      .dashboard-items .dashboard-item {
+        transition: none;
+
+        &:hover {
+          transform: none;
+        }
       }
     }
+  }
+
+  .cdk-drag-animating {
+    transition: none;
   }
 }
 

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -1,11 +1,56 @@
+@use '@angular/material' as mat;
 @use '../mixins' as m;
 @use '../variables' as v;
+
+$library-accent: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 500);
+$library-lighter: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 100);
+$library-dark: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 700);
+$library-text: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 900);
+
+$courses-accent: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 500);
+$courses-lighter: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 100);
+$courses-dark: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 800);
+$courses-text: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 900);
+
+$teams-accent: mat.m2-get-color-from-palette(mat.$m2-green-palette, 500);
+$teams-lighter: mat.m2-get-color-from-palette(mat.$m2-green-palette, 100);
+$teams-dark: mat.m2-get-color-from-palette(mat.$m2-green-palette, 700);
+$teams-text: mat.m2-get-color-from-palette(mat.$m2-green-palette, 900);
+
+$life-accent: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 500);
+$life-lighter: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 100);
+$life-dark: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 700);
+$life-text: mat.m2-get-color-from-palette(mat.$m2-purple-palette, 900);
 
 :host {
 
   @include m.left-right-grid-areas;
   // For Firefox.  Otherwise grid tile will expand to fit text.
   min-width: 0;
+
+  &.planet-library-theme {
+    .tile-band { background: $library-lighter; }
+    .tile-avatar .tile-icon { color: $library-dark; }
+    .tile-chip { background: $library-lighter; color: $library-text; }
+  }
+
+  &.planet-courses-theme {
+    .tile-band { background: $courses-lighter; }
+    .tile-avatar .tile-icon { color: $courses-dark; }
+    .tile-chip { background: $courses-lighter; color: $courses-text; }
+  }
+
+  &.planet-teams-theme {
+    .tile-band { background: $teams-lighter; }
+    .tile-avatar .tile-icon { color: $teams-dark; }
+    .tile-chip { background: $teams-lighter; color: $teams-text; }
+  }
+
+  &.planet-meetups-theme {
+    .tile-band { background: $life-lighter; }
+    .tile-avatar .tile-icon { color: $life-dark; }
+    .tile-chip { background: $life-lighter; color: $life-text; }
+  }
 
   .dashboard-card {
     display: grid;
@@ -52,6 +97,8 @@
       .dashboard-items {
         display: grid;
         grid-auto-columns: v.$dashboard-tile-width;
+        gap: 8px;
+        padding: 4px 6px;
         transition: transform 0.5s;
 
         .dashboard-item {
@@ -59,22 +106,32 @@
           grid-row-end: 1;
           display: flex;
           flex-direction: column;
-          justify-content: center;
           align-items: center;
           text-align: center;
           padding: 0;
           position: relative;
           word-break: break-word;
+          background: v.$white;
+          border-radius: 12px;
+          box-shadow: 0 1px 3px v.$shadow;
+          overflow: hidden;
+          transition: transform 0.15s, box-shadow 0.15s;
+
+          &:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 18px v.$shadow;
+          }
 
           > .dashboard-item-link {
             display: flex;
             flex: 1 1 auto;
             align-self: stretch;
             flex-direction: column;
-            justify-content: center;
             align-items: center;
             min-width: 0;
-            padding: 1rem 0.5rem;
+            padding: 0 0 0.5rem;
+            color: inherit;
+            text-decoration: none;
 
             &:focus-visible {
               outline: 2px solid v.$primary;
@@ -82,52 +139,178 @@
             }
           }
 
-          &:nth-child(even):last-child {
-            border-right: 1px solid rgba(0, 0, 0, 0.1);
-          }
-          .delete-item {
-            position: absolute;
-            top: -0.25rem;
-            right: -0.25rem;
-            --mat-icon-button-ripple-color: transparent;
-            --mat-icon-button-state-layer-color: transparent;
-            > .mat-icon {
-              width: auto;
+          .tile-band {
+            height: 36px;
+            width: 100%;
+            flex-shrink: 0;
+            background: v.$primary-lighter;
+
+            &.band-myLibrary {
+              background: $library-lighter;
+            }
+
+            &.band-myCourses {
+              background: $courses-lighter;
+            }
+
+            &.band-myTeams {
+              background: $teams-lighter;
+            }
+
+            &.band-myLife {
+              background: $life-lighter;
             }
           }
+
+          .tile-avatar {
+            position: relative;
+            margin-top: -18px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            border: 2px solid v.$white;
+            background: v.$white;
+            box-shadow: 0 1px 3px v.$shadow;
+            flex-shrink: 0;
+            overflow: hidden;
+
+            img {
+              width: 100%;
+              height: 100%;
+              object-fit: cover;
+              border-radius: 50%;
+            }
+
+            .tile-icon {
+              font-size: 20px;
+              width: 20px;
+              height: 20px;
+              line-height: 20px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              color: v.$grey-text;
+            }
+
+            &.avatar-myLibrary .tile-icon {
+              color: $library-dark;
+            }
+
+            &.avatar-myCourses .tile-icon {
+              color: $courses-dark;
+            }
+
+            &.avatar-myTeams .tile-icon {
+              color: $teams-dark;
+            }
+
+            &.avatar-myLife .tile-icon {
+              color: $life-dark;
+            }
+          }
+
+          .tile-chips {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 4px;
+            margin-top: 4px;
+            max-width: 100%;
+
+            &:empty {
+              display: none;
+            }
+          }
+
+          .tile-chip {
+            font-size: 11px;
+            font-weight: 500;
+            padding: 1px 8px;
+            border-radius: 999px;
+            line-height: 16px;
+            white-space: nowrap;
+            background: v.$primary-lighter;
+            color: v.$primary-lighter-text;
+
+            &.chip-myLibrary {
+              background: $library-lighter;
+              color: $library-text;
+            }
+
+            &.chip-myCourses {
+              background: $courses-lighter;
+              color: $courses-text;
+            }
+
+            &.chip-myTeams {
+              background: $teams-lighter;
+              color: $teams-text;
+            }
+
+            &.chip-myLife {
+              background: $life-lighter;
+              color: $life-text;
+            }
+          }
+
+          .delete-item {
+            position: absolute;
+            top: 2px;
+            right: 2px;
+            z-index: 2;
+            width: 24px;
+            height: 24px;
+            padding: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            --mat-icon-button-ripple-color: transparent;
+            --mat-icon-button-state-layer-color: transparent;
+
+            > .mat-icon {
+              font-size: 16px;
+              width: 16px;
+              height: 16px;
+              line-height: 16px;
+              color: rgba(0, 0, 0, 0.45);
+            }
+
+            &:hover > .mat-icon {
+              color: v.$warn;
+            }
+          }
+
           p {
             margin: 0;
           }
 
           .dashboard-text {
+            margin-top: 4px;
+            padding: 0 6px;
+            font-size: 13px;
+            font-weight: 500;
+            line-height: 1.25;
             display: -webkit-box;
-            width: calc(#{v.$dashboard-tile-width} - 1rem);
+            width: calc(#{v.$dashboard-tile-width} - 12px);
             -webkit-box-orient: vertical;
             overflow: hidden;
           }
 
-          &.has-course-cover {
-            > .dashboard-item-link {
-              padding: 0.5rem;
-            }
-          }
-
           .dashboard-course-cover {
             display: flex;
-            margin-bottom: 0.25rem;
-
-            img {
-              width: 48px;
-              height: 48px;
-              object-fit: cover;
-              border-radius: 4px;
-              border: 1px solid v.$grey;
-            }
           }
         }
 
         .dashboard-empty-link {
           padding: 1rem 0.5rem;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          color: v.$grey-text;
+          text-decoration: none;
         }
 
         .dashboard-empty-link:focus-visible {
@@ -156,7 +339,6 @@
       grid-template-columns: 1fr;
       grid-template-rows: auto 1fr;
 
-
       .left-tile {
         border-radius: 2px 2px 0 0;
         flex-direction: row;
@@ -183,49 +365,74 @@
             display: flex;
             flex-direction: column;
             grid-auto-columns: unset;
+            gap: 6px;
+            padding: 6px 8px;
           }
 
           .dashboard-item {
             &.accordion-item {
               flex-direction: row;
               justify-content: flex-start;
+              align-items: center;
               text-align: start;
               padding: 0;
+              min-height: 48px;
+              box-shadow: 0 1px 2px v.$shadow;
+
+              .tile-band {
+                display: none;
+              }
 
               > .dashboard-item-link {
                 flex-direction: row;
                 justify-content: flex-start;
+                align-items: center;
                 text-align: start;
-                padding: 0.75rem 1rem;
+                padding: 0.5rem 0.75rem;
+                width: 100%;
               }
 
-              .dashboard-course-cover {
-                margin-bottom: 0;
-                margin-inline-end: 0.5rem;
-              }
+              .tile-avatar {
+                margin-top: 0;
+                margin-inline-end: 0.75rem;
+                flex-shrink: 0;
+                width: 36px;
+                height: 36px;
+                border-width: 2px;
 
-              p {
-                margin-inline-end: 0.5rem;
-
-                &[matBadgePosition="before"] {
-                  margin-inline-start: 8px;
+                img {
+                  width: 32px;
+                  height: 32px;
                 }
+
+                .tile-icon {
+                  font-size: 20px;
+                  width: 20px;
+                  height: 20px;
+                }
+              }
+
+              .tile-chips {
+                margin-top: 0;
+                margin-inline-start: auto;
+                margin-inline-end: 0.5rem;
+                flex-shrink: 0;
               }
 
               .dashboard-text {
                 width: auto;
                 flex: 1;
+                margin-top: 0;
+                padding: 0;
               }
-            }
 
-            .delete-item {
-              position: relative;
-              top: 0;
-              right: 0;
-            }
-
-            .dashboard-text {
-              width: auto;
+              .delete-item {
+                position: relative;
+                top: 0;
+                right: 0;
+                flex-shrink: 0;
+                margin-inline-start: 4px;
+              }
             }
           }
         }
@@ -237,4 +444,27 @@
     }
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .dashboard-card .right-tile .dashboard-items .dashboard-item {
+      transition: none;
+
+      &:hover {
+        transform: none;
+      }
+    }
+  }
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px v.$shadow;
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.3;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -196,7 +196,7 @@
             flex-wrap: wrap;
             justify-content: center;
             gap: 4px;
-            margin-top: 4px;
+            margin-top: 6px;
             max-width: 100%;
 
             &:empty {
@@ -267,16 +267,21 @@
           }
 
           .dashboard-text {
-            margin-top: 4px;
+            margin-top: 8px;
             padding: 0 8px;
-            font-size: 13px;
+            font-size: 14px;
             font-weight: 500;
-            line-height: 1.25;
+            line-height: 1.35;
+            letter-spacing: 0.01em;
             display: -webkit-box;
             width: 100%;
             box-sizing: border-box;
             -webkit-box-orient: vertical;
             overflow: hidden;
+          }
+
+          .tile-chips + .dashboard-text {
+            margin-top: 4px;
           }
 
           .dashboard-course-cover {

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -119,7 +119,7 @@
           }
 
           .tile-band {
-            height: 36px;
+            height: 42px;
             width: 100%;
             flex-shrink: 0;
             background: v.$primary-lighter;
@@ -143,16 +143,16 @@
 
           .tile-avatar {
             position: relative;
-            margin-top: -18px;
+            margin-top: -24px;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 40px;
-            height: 40px;
+            width: 48px;
+            height: 48px;
             border-radius: 50%;
-            border: 2px solid v.$white;
+            border: 2.5px solid v.$white;
             background: v.$white;
-            box-shadow: 0 1px 3px v.$shadow;
+            box-shadow: 0 2px 5px v.$shadow;
             flex-shrink: 0;
             overflow: hidden;
 
@@ -164,10 +164,10 @@
             }
 
             .tile-icon {
-              font-size: 20px;
-              width: 20px;
-              height: 20px;
-              line-height: 20px;
+              font-size: 24px;
+              width: 24px;
+              height: 24px;
+              line-height: 24px;
               display: flex;
               align-items: center;
               justify-content: center;
@@ -375,19 +375,19 @@
                 margin-top: 0;
                 margin-inline-end: 0.75rem;
                 flex-shrink: 0;
-                width: 36px;
-                height: 36px;
+                width: 40px;
+                height: 40px;
                 border-width: 2px;
 
                 img {
-                  width: 32px;
-                  height: 32px;
+                  width: 36px;
+                  height: 36px;
                 }
 
                 .tile-icon {
-                  font-size: 20px;
-                  width: 20px;
-                  height: 20px;
+                  font-size: 22px;
+                  width: 22px;
+                  height: 22px;
                 }
               }
 
@@ -444,12 +444,6 @@
   .cdk-drag-animating {
     transition: none;
   }
-}
-
-.cdk-drag-preview {
-  box-sizing: border-box;
-  border-radius: 12px;
-  box-shadow: 0 8px 24px v.$shadow;
 }
 
 .cdk-drag-placeholder {

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -268,12 +268,13 @@
 
           .dashboard-text {
             margin-top: 4px;
-            padding: 0 6px;
+            padding: 0 8px;
             font-size: 13px;
             font-weight: 500;
             line-height: 1.25;
             display: -webkit-box;
-            width: calc(#{v.$dashboard-tile-width} - 12px);
+            width: 100%;
+            box-sizing: border-box;
             -webkit-box-orient: vertical;
             overflow: hidden;
           }

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -196,7 +196,7 @@
             flex-wrap: wrap;
             justify-content: center;
             gap: 4px;
-            margin-top: 6px;
+            margin-top: auto;
             max-width: 100%;
 
             &:empty {
@@ -267,7 +267,7 @@
           }
 
           .dashboard-text {
-            margin-top: 8px;
+            margin: auto 0;
             padding: 0 8px;
             font-size: 14px;
             font-weight: 500;
@@ -282,6 +282,7 @@
 
           .tile-chips + .dashboard-text {
             margin-top: 4px;
+            margin-bottom: auto;
           }
 
           .dashboard-course-cover {
@@ -398,7 +399,7 @@
               }
 
               .tile-chips {
-                margin-top: 0;
+                margin: 0;
                 margin-inline-start: auto;
                 margin-inline-end: 0.5rem;
                 flex-shrink: 0;
@@ -407,8 +408,12 @@
               .dashboard-text {
                 width: auto;
                 flex: 1;
-                margin-top: 0;
+                margin: 0;
                 padding: 0;
+              }
+
+              .tile-chips + .dashboard-text {
+                margin: 0;
               }
 
               .delete-item {

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -1,7 +1,6 @@
 @use '../variables' as v;
 
-$card-width: calc(106px + 2rem);
-$top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
+$top-row-height: 130px;
 
 :host {
   height: calc(#{v.$dashboard-height} + 32px);
@@ -38,7 +37,7 @@ $top-row-height: calc(#{v.$dashboard-tile-width} + 0.5rem);
     margin: 0 2px;
 
     img {
-      width: calc(#{v.$dashboard-tile-width} - 0.5rem);
+      width: 120px;
       max-width: 15vh;
       max-height: 15vh;
       border-radius: 50%;

--- a/src/app/resources/resources-icon.component.spec.ts
+++ b/src/app/resources/resources-icon.component.spec.ts
@@ -1,0 +1,101 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { PlanetResourceIconComponent, resolveResourceIconInfo } from './resources-icon.component';
+
+describe('PlanetResourceIconComponent & resolveResourceIconInfo', () => {
+  describe('resolveResourceIconInfo', () => {
+    it.each([
+      { desc: 'null resource', input: null, icon: '', cat: 'none' },
+      { desc: 'undefined resource', input: undefined, icon: '', cat: 'none' },
+      { desc: 'resource without files', input: { title: 'Policy', _attachments: {} }, icon: '', cat: 'none' },
+      { desc: 'PDF by extension', input: { filename: 'handbook.pdf' }, icon: 'picture_as_pdf', cat: 'pdf' },
+      {
+        desc: 'PDF by MIME',
+        input: { _attachments: { 'doc.pdf': { content_type: 'application/pdf' } } },
+        icon: 'picture_as_pdf',
+        cat: 'pdf'
+      },
+      {
+        desc: 'PDF uppercase key',
+        input: { filename: 'DOC.PDF', _attachments: { 'DOC.PDF': { content_type: 'application/pdf' } } },
+        icon: 'picture_as_pdf',
+        cat: 'pdf'
+      },
+      {
+        desc: 'PDF extensionless MIME',
+        input: { _attachments: { DOC_ATTACH: { content_type: 'application/pdf' } } },
+        icon: 'picture_as_pdf',
+        cat: 'pdf'
+      },
+      { desc: 'Video MP4', input: { filename: 'lesson.mp4' }, icon: 'videocam', cat: 'video' },
+      { desc: 'Audio MP3', input: { filename: 'recording.mp3' }, icon: 'audiotrack', cat: 'audio' },
+      { desc: 'CSV spreadsheet', input: { filename: 'scores.csv' }, icon: 'grid_on', cat: 'spreadsheet' },
+      { desc: 'XLSX spreadsheet', input: { filename: 'budget.xlsx' }, icon: 'grid_on', cat: 'spreadsheet' },
+      { desc: 'Image PNG', input: { filename: 'diagram.png' }, icon: 'image', cat: 'image' },
+      {
+        desc: 'Multi-attachment HTML',
+        input: { _attachments: { 'index.html': { content_type: 'text/html' }, 'style.css': {} } },
+        icon: 'language',
+        cat: 'html'
+      },
+      { desc: 'Word DOCX', input: { filename: 'essay.docx' }, icon: 'description', cat: 'word' },
+      { desc: 'Presentation PPTX', input: { filename: 'lecture.pptx' }, icon: 'slideshow', cat: 'presentation' },
+      { desc: 'Markdown text', input: { filename: 'notes.md' }, icon: 'description', cat: 'text' },
+      { desc: 'Archive ZIP', input: { filename: 'archive.zip' }, icon: 'archive', cat: 'archive' },
+      { desc: 'Archive tar.gz', input: { filename: 'bundle.tar.gz' }, icon: 'archive', cat: 'archive' },
+      {
+        desc: 'Generic file fallback',
+        input: { filename: 'custom.xyz', _attachments: { 'custom.xyz': {} } },
+        icon: 'insert_drive_file',
+        cat: 'file'
+      },
+      { desc: 'Unwrapped doc object', input: { doc: { filename: 'guide.pdf' } }, icon: 'picture_as_pdf', cat: 'pdf' }
+    ])('resolves $desc to $icon', ({ input, icon, cat }) => {
+      const result = resolveResourceIconInfo(input);
+      expect(result.icon).toBe(icon);
+      expect(result.category).toBe(cat);
+    });
+  });
+
+  describe('PlanetResourceIconComponent', () => {
+    let fixture: ComponentFixture<PlanetResourceIconComponent>;
+    let component: PlanetResourceIconComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [PlanetResourceIconComponent]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(PlanetResourceIconComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should render icon with aria-label and role="img" when resource has file', () => {
+      component.resource = {
+        title: 'Reading Guide',
+        filename: 'reading.pdf',
+        _attachments: { 'reading.pdf': { content_type: 'application/pdf' } }
+      };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      const iconEl = fixture.debugElement.query(By.css('.km-resource-icon'));
+      expect(iconEl).toBeTruthy();
+      expect(iconEl.nativeElement.textContent.trim()).toBe('picture_as_pdf');
+      expect(iconEl.attributes['aria-label']).toBe('PDF Document');
+      expect(iconEl.attributes['role']).toBe('img');
+    });
+
+    it('should not render icon when resource has no file', () => {
+      component.resource = { title: 'No file resource', _attachments: {} };
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.km-resource-icon'))).toBeNull();
+    });
+  });
+});

--- a/src/app/resources/resources-icon.component.ts
+++ b/src/app/resources/resources-icon.component.ts
@@ -31,10 +31,11 @@ export const resolveResourceIconInfo = (resource: any): ResourceIconInfo => {
     return { icon: '', tooltip: '', category: 'none' };
   }
 
+  const asString = (value: unknown): string => (typeof value === 'string' ? value : '');
   const attachmentObj = matchedKey ? attachments[matchedKey] : (attachments[primaryFilename] || attachments[rawFilename]);
-  const attachmentContentType = attachmentObj?.content_type ? attachmentObj.content_type.toLowerCase() : '';
+  const attachmentContentType = asString(attachmentObj?.content_type).toLowerCase();
   const directContentType = (
-    doc.contentType || doc.content_type || (doc.file && doc.file.type) || (typeof doc.type === 'string' ? doc.type : '') || ''
+    asString(doc.contentType) || asString(doc.content_type) || asString(doc.file && doc.file.type) || asString(doc.type)
   ).toLowerCase();
   const contentType = (attachmentContentType || directContentType).split(';')[0].trim();
 

--- a/src/app/resources/resources-icon.component.ts
+++ b/src/app/resources/resources-icon.component.ts
@@ -1,0 +1,208 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+
+export interface ResourceIconInfo {
+  icon: string;
+  tooltip: string;
+  category: string;
+}
+
+export const resolveResourceIconInfo = (resource: any): ResourceIconInfo => {
+  if (!resource) {
+    return { icon: '', tooltip: '', category: 'none' };
+  }
+
+  const doc = resource.doc || resource;
+  const attachments = doc._attachments || {};
+  const attachmentKeys = Object.keys(attachments);
+  const matchedKey = attachmentKeys.find(
+    key => key.toLowerCase() === (typeof doc.filename === 'string' ? doc.filename.toLowerCase().trim() : '')
+  ) || (attachmentKeys.length === 1 ? attachmentKeys[0] : '');
+  const rawFilename = matchedKey || doc.filename || (typeof doc.name === 'string' ? doc.name : '');
+  const primaryFilename = (typeof rawFilename === 'string' ? rawFilename : '').toLowerCase().trim();
+
+  const hasDirectFile = !!doc.file || (typeof File !== 'undefined' && doc instanceof File);
+  const hasAttachments = attachmentKeys.length > 0;
+  const hasFilename = primaryFilename.length > 0 && primaryFilename.includes('.');
+
+  // Resources without an attached file should not have an icon
+  if (!hasAttachments && !hasDirectFile && !hasFilename) {
+    return { icon: '', tooltip: '', category: 'none' };
+  }
+
+  const attachmentObj = matchedKey ? attachments[matchedKey] : (attachments[primaryFilename] || attachments[rawFilename]);
+  const attachmentContentType = attachmentObj?.content_type ? attachmentObj.content_type.toLowerCase() : '';
+  const directContentType = (
+    doc.contentType || doc.content_type || (doc.file && doc.file.type) || (typeof doc.type === 'string' ? doc.type : '') || ''
+  ).toLowerCase();
+  const contentType = (attachmentContentType || directContentType).split(';')[0].trim();
+
+  const mediaType = (typeof doc.mediaType === 'string' ? doc.mediaType : '').toLowerCase().trim();
+  const openWith = (typeof doc.openWith === 'string' ? doc.openWith : '').toLowerCase().trim();
+
+  // 1. Interactive HTML / Web Modules / Multi-attachment bundles
+  if (
+    attachmentKeys.length > 1 ||
+    mediaType === 'html' ||
+    openWith === 'html' ||
+    contentType === 'text/html' ||
+    contentType === 'application/xhtml+xml' ||
+    primaryFilename.endsWith('.html') ||
+    primaryFilename.endsWith('.htm')
+  ) {
+    return { icon: 'language', tooltip: $localize`:@@resource-type-html:Interactive Web Resource`, category: 'html' };
+  }
+
+  // 2. PDF Document
+  if (
+    contentType === 'application/pdf' ||
+    primaryFilename.endsWith('.pdf') ||
+    mediaType === 'pdf' ||
+    openWith === 'pdf.js'
+  ) {
+    return { icon: 'picture_as_pdf', tooltip: $localize`:@@resource-type-pdf:PDF Document`, category: 'pdf' };
+  }
+
+  // 3. Video
+  if (
+    contentType.startsWith('video/') ||
+    mediaType === 'video' ||
+    openWith.includes('video') ||
+    /\.(mp4|webm|ogv|mkv|mov|avi|flv|wmv|m4v)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'videocam', tooltip: $localize`:@@resource-type-video:Video`, category: 'video' };
+  }
+
+  // 4. Audio
+  if (
+    contentType.startsWith('audio/') ||
+    mediaType === 'audio' ||
+    mediaType.includes('audio') ||
+    openWith === 'mp3' ||
+    openWith === 'bell-reader' ||
+    /\.(mp3|ogg|wav|aac|m4a|flac|wma|opus)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'audiotrack', tooltip: $localize`:@@resource-type-audio:Audio Recording`, category: 'audio' };
+  }
+
+  // 5. Spreadsheet / Dataset
+  if (
+    contentType === 'text/csv' ||
+    contentType === 'text/comma-separated-values' ||
+    contentType === 'application/csv' ||
+    contentType === 'application/vnd.ms-excel' ||
+    contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+    contentType === 'application/vnd.oasis.opendocument.spreadsheet' ||
+    mediaType === 'csv' ||
+    /\.(csv|tsv|xls|xlsx|ods)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'grid_on', tooltip: $localize`:@@resource-type-spreadsheet:Spreadsheet / Dataset`, category: 'spreadsheet' };
+  }
+
+  // 6. Image / Graphic
+  if (
+    contentType.startsWith('image/') ||
+    mediaType === 'image' ||
+    mediaType.includes('graphic') ||
+    mediaType.includes('picture') ||
+    /\.(jpg|jpeg|png|gif|svg|webp|bmp|ico|tiff)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'image', tooltip: $localize`:@@resource-type-image:Image`, category: 'image' };
+  }
+
+  // 7. Word Processing Document
+  if (
+    contentType === 'application/msword' ||
+    contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    contentType === 'application/vnd.oasis.opendocument.text' ||
+    contentType === 'application/rtf' ||
+    /\.(doc|docx|odt|rtf)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'description', tooltip: $localize`:@@resource-type-word:Word Document`, category: 'word' };
+  }
+
+  // 8. Presentation / Slides
+  if (
+    contentType === 'application/vnd.ms-powerpoint' ||
+    contentType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation' ||
+    contentType === 'application/vnd.oasis.opendocument.presentation' ||
+    /\.(ppt|pptx|odp)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'slideshow', tooltip: $localize`:@@resource-type-presentation:Presentation / Slides`, category: 'presentation' };
+  }
+
+  // 9. Text / Markdown / Code
+  if (
+    contentType === 'text/plain' ||
+    contentType === 'text/markdown' ||
+    contentType === 'application/json' ||
+    contentType === 'application/xml' ||
+    contentType === 'text/xml' ||
+    mediaType === 'text' ||
+    /\.(txt|md|markdown|json|xml|log)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'description', tooltip: $localize`:@@resource-type-text:Text Document`, category: 'text' };
+  }
+
+  // 10. Compressed Archive
+  if (
+    contentType === 'application/zip' ||
+    contentType === 'application/x-zip-compressed' ||
+    contentType === 'application/x-tar' ||
+    contentType === 'application/gzip' ||
+    contentType === 'application/x-7z-compressed' ||
+    contentType === 'application/vnd.rar' ||
+    mediaType === 'zip' ||
+    /\.(zip|tar|gz|7z|rar|bz2|xz)$/i.test(primaryFilename)
+  ) {
+    return { icon: 'archive', tooltip: $localize`:@@resource-type-archive:Compressed Archive`, category: 'archive' };
+  }
+
+  // 11. Generic File / Other Fallback
+  return { icon: 'insert_drive_file', tooltip: $localize`:@@resource-type-file:File Attachment`, category: 'file' };
+};
+
+@Component({
+  selector: 'planet-resource-icon',
+  template: `
+    @if (iconInfo.icon) {
+      <mat-icon
+        class="km-resource-icon resource-type-icon"
+        [matTooltip]="iconInfo.tooltip"
+        [attr.aria-label]="iconInfo.tooltip"
+        role="img">
+        {{ iconInfo.icon }}
+      </mat-icon>
+    }
+  `,
+  styles: [`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      vertical-align: middle;
+      line-height: 1;
+    }
+    .resource-type-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      vertical-align: middle;
+      font-size: 1.25rem;
+      width: 1.25rem;
+      height: 1.25rem;
+      margin-right: 0.25rem;
+      user-select: none;
+      flex-shrink: 0;
+    }
+  `],
+  imports: [MatIcon, MatTooltip]
+})
+export class PlanetResourceIconComponent implements OnChanges {
+  @Input() resource: any;
+  iconInfo: ResourceIconInfo = { icon: '', tooltip: '', category: 'none' };
+
+  ngOnChanges(): void {
+    this.iconInfo = resolveResourceIconInfo(this.resource);
+  }
+}

--- a/src/app/resources/resources.module.ts
+++ b/src/app/resources/resources.module.ts
@@ -11,12 +11,14 @@ import { MaterialModule } from '../shared/material.module';
 import { PlanetDialogsModule } from '../shared/dialogs/planet-dialogs.module';
 import { SharedComponentsModule } from '../shared/shared-components.module';
 import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search-resources/resources-search.component';
+import { PlanetResourceIconComponent } from './resources-icon.component';
 
 @NgModule({
   exports: [
     ResourcesViewerComponent,
     ResourcesComponent,
-    ResourcesAddComponent
+    ResourcesAddComponent,
+    PlanetResourceIconComponent
   ],
   imports: [
     CommonModule,
@@ -32,7 +34,8 @@ import { ResourcesSearchComponent, ResourcesSearchListComponent } from './search
     ResourcesViewerComponent,
     ResourcesAddComponent,
     ResourcesSearchComponent,
-    ResourcesSearchListComponent
+    ResourcesSearchListComponent,
+    PlanetResourceIconComponent
   ]
 })
 export class ResourcesModule {}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1105,3 +1105,24 @@ body {
   }
 
 }
+
+/* CDK Drag & Drop global preview styles */
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px v.$shadow;
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.3;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cdk-drag-animating {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Fixes #10405

### Description

Following the recent visual upgrades to user cards (e.g. `TeamsMemberComponent`), this PR overhauls the shelf items across `myDashboard` (`myLibrary`, `myCourses`, `myTeams`, `myLife`) to adopt a modern card UI.

Previously, shelf cards used flat alternating grey cells with basic text and badges. This update replaces them with clean rounded cards featuring top theme accent bands, circular avatar badges (with course covers or shelf/tool icons), structured status chips, and smooth hover elevation, while matching each shelf's primary card accent color.

### What's Changed

• Modern Card Layout: Upgraded shelf items to elevated white cards with 12px rounded corners, subtle shadows, and hover lift.
• Matching Shelf Accents: Added `.tile-band` across the top of cards, styled to match the dashboard primary card color for each shelf (Pink for Library, Orange for Courses, Green for Teams, Purple for My Life).
• Circular Avatar Badges: Introduced `.tile-avatar` overlapping the band displaying course cover images or shelf/tool Material icons.
• Status Chips: Converted legacy badge counts to structured `.tile-chips` with shelf-accented `.tile-chip` indicators.
• Mobile & Responsiveness: Streamlined mobile accordion list layout for smooth vertical rendering and preserved CDK drag-drop shelf reordering.

### Note on Git Diff & Resource Icons
Part of the larger diff in this PR includes `PlanetResourceIconComponent` and its unit tests (`src/app/resources/resources-icon.component.ts`), forwarded from sibling PR #10315. We brought over the shared file-type detection logic so dashboard library cards can immediately display the standardized icons (PDF, video, audio, spreadsheet, image, web, doc, archive, etc.) without leaving blank avatar circles on items lacking an explicit `mediaType`. The file is identical to the one in PR #10315, so both will merge cleanly into `master` without conflicts.

## Before 

<img width="1104" height="862" alt="image" src="https://github.com/user-attachments/assets/fc5e02bc-4c1a-4507-afbb-31a5b975a2bd"/>

## After

<img width="1852" height="1073" alt="image" src="https://github.com/user-attachments/assets/6a35e86a-515d-4603-90df-e3109bc048fc" />