### PR TITLE
teams: smoother surveys search toolbar aligning (fixes #10407)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.57",
+  "version": "0.24.58",
   "myplanet": {
     "latest": "v0.70.45",
     "min": "v0.67.67"

--- a/src/app/surveys/surveys.component.html
+++ b/src/app/surveys/surveys.component.html
@@ -5,14 +5,16 @@
     </button>
     <span i18n>Surveys</span>
     <span class="toolbar-fill"></span>
-    <mat-icon class="input-icon">search</mat-icon>
-    <mat-form-field class="font-size-1">
-      <mat-label i18n>Type title to search...</mat-label>
-      <input matInput [ngModel]="searchValue" (ngModelChange)="applyFilter($event)">
-      <button type="button" mat-icon-button matSuffix (click)="applyFilter('')" [style.visibility]="searchValue ? 'visible' : 'hidden'" matTooltip="Clear search" i18n-matTooltip i18n-aria-label aria-label="Clear search">
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
+    <div class="toolbar-search">
+      <mat-icon>search</mat-icon>
+      <mat-form-field subscriptSizing="dynamic" class="font-size-1">
+        <mat-label i18n>Type title to search...</mat-label>
+        <input matInput [ngModel]="searchValue" (ngModelChange)="applyFilter($event)">
+        <button type="button" mat-icon-button matSuffix (click)="applyFilter('')" [style.visibility]="searchValue ? 'visible' : 'hidden'" matTooltip="Clear search" i18n-matTooltip i18n-aria-label aria-label="Clear search">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+    </div>
   </mat-toolbar>
 }
 


### PR DESCRIPTION
Fixes #10407

### Problem
- In `src/app/surveys/surveys.component.html`, the search magnifying glass icon was placed outside `mat-form-field` with legacy class `.input-icon`.
- Under Angular Material MDC, this caused the search icon to sink low near the bottom line ripple rather than centering vertically with the search text.
- Additionally, `mat-form-field` lacked `subscriptSizing="dynamic"`, reserving empty subscript bottom-space and distorting the toolbar field height.

### Proposed Solution
- Wrapped the search controls in `.toolbar-search`, matching the modernized toolbar search pattern in `teams.component.html` and `certifications.component.html`.
- Added `subscriptSizing="dynamic"` to the `mat-form-field` so the input properly centers within the toolbar without empty subscript padding.
- Standardized the search container width and icon spacing via `.toolbar-search`.

### Verification
- **Lint**: `npm run lint` passed with 0 errors.
- **Unit Tests**: `npx vitest run src/app/surveys/surveys.component.spec.ts` passed (16/16 tests).

<img width="1024" height="194" alt="image" src="https://github.com/user-attachments/assets/3b85b9e1-4ddb-4fba-847c-ddf111fb8d9c"/>