### PR TITLE
teams: smoother voices replies buttons hovering (fixes #10409)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planet",
   "license": "AGPL-3.0",
-  "version": "0.24.58",
+  "version": "0.24.59",
   "myplanet": {
     "latest": "v0.70.45",
     "min": "v0.67.67"

--- a/src/app/news/news-list-item.component.html
+++ b/src/app/news/news-list-item.component.html
@@ -107,7 +107,7 @@
         <button mat-button type="button" (click)="addReply(item.doc)" i18n>Reply</button>
       }
       @if (replyObject[item.doc._id]?.length > 0 && showRepliesButton) {
-        <button mat-button type="button" (click)="showReplies(item)">
+        <button mat-button type="button" matTooltip="View replies" i18n-matTooltip aria-label="View replies" i18n-aria-label (click)="showReplies(item)">
           <mat-icon>chat_bubble_outline</mat-icon> ({{replyObject[item.doc._id]?.length}})
         </button>
       }
@@ -144,7 +144,7 @@
     <button mat-button type="button" (click)="addReply(item.doc)" i18n>Reply</button>
   }
   @if (replyObject[item.doc._id]?.length > 0 && showRepliesButton) {
-    <button mat-button type="button" (click)="showReplies(item)">
+    <button mat-button type="button" matTooltip="View replies" i18n-matTooltip aria-label="View replies" i18n-aria-label (click)="showReplies(item)">
       <mat-icon>chat_bubble_outline</mat-icon> ({{replyObject[item.doc._id]?.length}})
     </button>
   }


### PR DESCRIPTION
Fixes #10409

### Problem
- In `NewsListItemComponent` (`src/app/news/news-list-item.component.html`), the replies count button (`<mat-icon>chat_bubble_outline</mat-icon> (count)`) lacked a tooltip and `aria-label`.
- Adjacent action buttons (such as Copy Voice Link, Edit Voice, and Delete Voice) have descriptive localized hover tooltips.
- Without a tooltip, users may not realize the badge/button is an interactive control that opens the discussion replies.
- Screen readers lacked an accessible label explaining the button's action.

### Proposed Solution
- Added `matTooltip="View replies" i18n-matTooltip` and `aria-label="View replies" i18n-aria-label` to the replies button in both the desktop action row and the mobile `#actionItems` menu template.

### Verification
- **Lint**: `npm run lint` passed with 0 errors.
- **Unit Tests**: `npx vitest run src/app/news/` passed (12/12 tests).

<img width="492" height="127" alt="{9B1A789F-5041-4C1A-9331-15BA8E9B7C63}" src="https://github.com/user-attachments/assets/59f6a622-fd31-41f4-b8e0-5e288f339a3c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added translated tooltips and accessible labels to the “View replies” action on desktop and mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->