### PR TITLE
teams: add strict membership queries for safe team archival

### DIFF
--- a/src/app/shared/couchdb.service.spec.ts
+++ b/src/app/shared/couchdb.service.spec.ts
@@ -1,0 +1,67 @@
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+import { CouchService } from './couchdb.service';
+
+describe('CouchService paginated queries', () => {
+  const createService = (postResponses: any[]) => {
+    const http = {
+      post: vi.fn().mockImplementation(() => postResponses.shift() || of({ docs: [] }))
+    };
+    const planetMessageService = { showAlert: vi.fn() };
+    return { service: new CouchService(http as any, planetMessageService as any), http };
+  };
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports a failed find as an empty result on the default path', () => {
+    const { service } = createService([ throwError(new Error('find failed')) ]);
+    const next = vi.fn();
+    const error = vi.fn();
+
+    service.findAll('teams').subscribe({ next, error });
+
+    expect(next).toHaveBeenCalledWith([]);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('propagates an initial page failure on the strict path', () => {
+    const { service } = createService([ throwError(new Error('find failed')) ]);
+    const next = vi.fn();
+    const error = vi.fn();
+
+    service.findAllStrict('teams').subscribe({ next, error });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'find failed' }));
+  });
+
+  it('propagates a later page failure on the strict path', () => {
+    const { service, http } = createService([
+      of({ docs: [ { _id: 'membership-1' } ], bookmark: 'page-2' }),
+      throwError(new Error('find failed'))
+    ]);
+    const next = vi.fn();
+    const error = vi.fn();
+
+    service.findAllStrict('teams').subscribe({ next, error });
+
+    expect(http.post).toHaveBeenCalledTimes(2);
+    expect(next).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'find failed' }));
+  });
+
+  it('collects every page of a successful strict query', () => {
+    const { service, http } = createService([
+      of({ docs: [ { _id: 'membership-1' } ], bookmark: 'page-2' }),
+      of({ docs: [ { _id: 'membership-2' } ], bookmark: 'page-3' }),
+      of({ docs: [] })
+    ]);
+    const next = vi.fn();
+
+    service.findAllStrict('teams', { selector: {}, limit: 1 }).subscribe({ next });
+
+    expect(http.post).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(http.post.mock.calls[1][1])).toEqual({ selector: {}, limit: 1, bookmark: 'page-2' });
+    expect(next).toHaveBeenCalledWith([ { _id: 'membership-1' }, { _id: 'membership-2' } ]);
+  });
+});

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -100,6 +100,12 @@ export class CouchService {
     return this.findAllRequest(db, query, opts).pipe(flatMap(({ docs }) => docs), toArray());
   }
 
+  // Same as findAll, except every page of the query must succeed.  A failed '_find' request errors instead of
+  // resolving to an empty list, so callers which treat an empty result as proof of absence can rely on it.
+  findAllStrict(db: string, query: any = { selector: { _id: { $gt: null } }, limit: 1000 }, opts?: any) {
+    return this.findAllRequest(db, query, opts, true).pipe(flatMap(({ docs }) => docs), toArray());
+  }
+
   findAllStream(db: string, query: any = { selector: { _id: { $gt: null } }, limit: 1000 }, opts?: any) {
     return this.findAllRequest(db, query, opts).pipe(map(({ docs }) => docs));
   }
@@ -122,10 +128,11 @@ export class CouchService {
     );
   }
 
-  private findAllRequest(db: string, query: any, opts: any) {
-    return this.post(db + '/_find', query, opts).pipe(
-      catchError(() => of({ docs: [], rows: [] })),
-      expand((res) => res.docs.length > 0 ? this.post(db + '/_find', { ...query, bookmark: res.bookmark }, opts) : empty())
+  private findAllRequest(db: string, query: any, opts: any, strict = false) {
+    const findPage = (pageQuery: any) => this.post(db + '/_find', pageQuery, opts);
+    const firstPage = strict ? findPage(query) : findPage(query).pipe(catchError(() => of({ docs: [], rows: [] })));
+    return firstPage.pipe(
+      expand((res) => res.docs.length > 0 ? findPage({ ...query, bookmark: res.bookmark }) : empty())
     );
   }
 

--- a/src/app/teams/teams.service.spec.ts
+++ b/src/app/teams/teams.service.spec.ts
@@ -1,4 +1,4 @@
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { TeamsService } from './teams.service';
 
@@ -10,12 +10,14 @@ describe('TeamsService membership writes', () => {
   const createService = (couchOverrides: any = {}) => {
     const couchService = {
       findAll: vi.fn().mockReturnValue(of([])),
+      findAllStrict: vi.fn().mockReturnValue(of([])),
       get: vi.fn().mockReturnValue(of({})),
       bulkDocs: vi.fn().mockReturnValue(of(successfulBulkResponse)),
       ...couchOverrides
     };
     const service = new TeamsService(
       couchService as any,
+      {} as any,
       {} as any,
       {} as any,
       {} as any,
@@ -512,5 +514,200 @@ describe('TeamsService membership writes', () => {
 
     expect(next).toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
+  });
+});
+
+describe('TeamsService membership safety', () => {
+  const team = {
+    _id: 'team-1',
+    teamPlanetCode: 'planet-a',
+    teamType: 'local'
+  };
+
+  const leavingMember = {
+    userId: 'org.couchdb.user:alex',
+    userPlanetCode: 'planet-a'
+  };
+
+  const leavingMembershipDoc = {
+    _id: 'membership-1',
+    _rev: '1-membership',
+    teamId: team._id,
+    teamPlanetCode: team.teamPlanetCode,
+    teamType: team.teamType,
+    userId: leavingMember.userId,
+    userPlanetCode: leavingMember.userPlanetCode,
+    docType: 'membership'
+  };
+
+  const remainingMembershipDoc = {
+    ...leavingMembershipDoc,
+    _id: 'membership-2',
+    _rev: '1-membership-2',
+    userId: 'org.couchdb.user:blake'
+  };
+
+  const remainingShelfDoc = {
+    _id: 'org.couchdb.user:blake',
+    _rev: '1-shelf',
+    myTeamIds: [ team._id ]
+  };
+
+  afterEach(() => vi.restoreAllMocks());
+
+  const createService = ({
+    teamsQuery = of([]),
+    shelfQuery = of([]),
+    attachmentsQuery = of([]),
+    usersQuery = of([])
+  }: any = {}) => {
+    const couchService = {
+      findAll: vi.fn().mockReturnValue(of([ leavingMembershipDoc ])),
+      findAllStrict: vi.fn().mockImplementation((db: string) => {
+        switch (db) {
+          case 'teams':
+            return teamsQuery;
+          case 'shelf':
+            return shelfQuery;
+          default:
+            return attachmentsQuery;
+        }
+      }),
+      get: vi.fn().mockReturnValue(of({})),
+      bulkDocs: vi.fn().mockReturnValue(of({ res: [ { id: leavingMembershipDoc._id, rev: '2-membership' } ] })),
+      updateDocument: vi.fn().mockReturnValue(of({ id: team._id, rev: '2-team' }))
+    };
+    const usersService = {
+      requestUserData: vi.fn(),
+      usersListener: vi.fn().mockReturnValue(usersQuery)
+    };
+    const planetMessageService = { showAlert: vi.fn() };
+    const service = new TeamsService(
+      couchService as any,
+      {} as any,
+      {} as any,
+      usersService as any,
+      {} as any,
+      {} as any,
+      planetMessageService as any
+    );
+    return { service, couchService, usersService, planetMessageService };
+  };
+
+  it('archives the team once every authoritative membership read succeeds with no members left', () => {
+    const { service, couchService } = createService();
+    const error = vi.fn();
+
+    service.toggleTeamMembership(team, true, leavingMember).subscribe({ error });
+
+    expect(couchService.findAllStrict).toHaveBeenCalledWith('teams', expect.objectContaining({
+      selector: expect.objectContaining({ teamId: team._id, docType: 'membership' })
+    }));
+    expect(couchService.findAllStrict).toHaveBeenCalledWith('shelf', expect.objectContaining({
+      selector: { myTeamIds: { $in: [ team._id ] } }
+    }));
+    expect(couchService.updateDocument).toHaveBeenCalledWith('teams', expect.objectContaining({ status: 'archived' }));
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('does not archive the team while a membership document remains', () => {
+    const { service, couchService } = createService({ teamsQuery: of([ remainingMembershipDoc ]) });
+    const error = vi.fn();
+
+    service.toggleTeamMembership(team, true, leavingMember).subscribe({ error });
+
+    expect(couchService.updateDocument).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('does not archive the team while a shelf membership remains', () => {
+    const { service, couchService } = createService({ shelfQuery: of([ remainingShelfDoc ]) });
+    const error = vi.fn();
+
+    service.toggleTeamMembership(team, true, leavingMember).subscribe({ error });
+
+    expect(couchService.updateDocument).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('propagates a failed membership query instead of archiving the team', () => {
+    const { service, couchService } = createService({ teamsQuery: throwError(new Error('membership find failed')) });
+    const error = vi.fn();
+
+    service.toggleTeamMembership(team, true, leavingMember).subscribe({ error });
+
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'membership find failed' }));
+    expect(couchService.updateDocument).not.toHaveBeenCalled();
+  });
+
+  it('propagates a failed shelf query instead of archiving the team', () => {
+    const { service, couchService } = createService({ shelfQuery: throwError(new Error('shelf find failed')) });
+    const error = vi.fn();
+
+    service.toggleTeamMembership(team, true, leavingMember).subscribe({ error });
+
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'shelf find failed' }));
+    expect(couchService.updateDocument).not.toHaveBeenCalled();
+  });
+
+  it('reports a team with only a shelf membership as not empty', () => {
+    const { service } = createService({ shelfQuery: of([ remainingShelfDoc ]) });
+    const next = vi.fn();
+
+    service.isTeamEmpty(team).subscribe({ next });
+
+    expect(next).toHaveBeenCalledWith(false);
+  });
+
+  it('decides emptiness without user or attachment enrichment', () => {
+    const { service, couchService, usersService } = createService({
+      usersQuery: throwError(new Error('users unavailable')),
+      attachmentsQuery: throwError(new Error('attachments unavailable'))
+    });
+    const next = vi.fn();
+    const error = vi.fn();
+
+    service.isTeamEmpty(team).subscribe({ next, error });
+
+    expect(next).toHaveBeenCalledWith(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(usersService.usersListener).not.toHaveBeenCalled();
+    expect(couchService.findAllStrict).not.toHaveBeenCalledWith('attachments');
+  });
+
+  it('keeps membership rows and surfaces the failure when enrichment cannot be loaded', () => {
+    const { service, planetMessageService } = createService({
+      teamsQuery: of([ remainingMembershipDoc ]),
+      shelfQuery: of([ remainingShelfDoc ]),
+      usersQuery: throwError(new Error('users unavailable')),
+      attachmentsQuery: throwError(new Error('attachments unavailable'))
+    });
+    const next = vi.fn();
+    const error = vi.fn();
+
+    service.getTeamMembers(team).subscribe({ next, error });
+
+    expect(error).not.toHaveBeenCalled();
+    expect(planetMessageService.showAlert).toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith([
+      { ...remainingMembershipDoc, userDoc: undefined, attachmentDoc: undefined },
+      { ...remainingShelfDoc, fromShelf: true, docType: 'membership', userId: remainingShelfDoc._id, teamId: team._id }
+    ]);
+  });
+
+  it('enriches membership rows without changing which members exist', () => {
+    const userDoc = { _id: remainingMembershipDoc.userId, doc: { planetCode: 'planet-a' } };
+    const attachmentDoc = { _id: `${remainingMembershipDoc.userId}@${remainingMembershipDoc.userPlanetCode}` };
+    const { service, planetMessageService } = createService({
+      teamsQuery: of([ remainingMembershipDoc ]),
+      usersQuery: of([ userDoc ]),
+      attachmentsQuery: of([ attachmentDoc ])
+    });
+    const next = vi.fn();
+
+    service.getTeamMembers(team).subscribe({ next });
+
+    expect(planetMessageService.showAlert).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith([ { ...remainingMembershipDoc, userDoc, attachmentDoc } ]);
   });
 });

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
-import { of, empty, forkJoin, throwError } from 'rxjs';
-import { switchMap, map, take } from 'rxjs/operators';
+import { Observable, of, empty, forkJoin, throwError } from 'rxjs';
+import { switchMap, map, take, catchError } from 'rxjs/operators';
 import { CouchService } from '../shared/couchdb.service';
 import { UserService } from '../shared/user.service';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
 import { findDocuments } from '../shared/mangoQueries';
 import { CustomValidators } from '../validators/custom-validators';
 import { StateService } from '../shared/state.service';
+import { PlanetMessageService } from '../shared/planet-message.service';
 import { ValidatorService } from '../validators/validator.service';
 import { UsersService } from '../users/users.service';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
@@ -61,7 +62,8 @@ export class TeamsService {
     private userService: UserService,
     private usersService: UsersService,
     private stateService: StateService,
-    private validatorService: ValidatorService
+    private validatorService: ValidatorService,
+    private planetMessageService: PlanetMessageService
   ) {}
 
   addTeamDialog(userId: string, type: 'team' | 'enterprise' | 'services', team: any = {}) {
@@ -335,27 +337,54 @@ export class TeamsService {
     };
   }
 
-  getTeamMembers(team, withAllLinks = false) {
+  // Authoritative membership read.  Every source that can hold a membership is queried strictly, so a team
+  // only looks empty when all of the queries succeeded and none of them returned a member.
+  getActiveTeamMembershipRecords(team) {
+    return this.getActiveTeamRecords(team, false);
+  }
+
+  private getActiveTeamRecords(team, withAllLinks: boolean) {
     const selector = {
       teamId: team._id,
       teamPlanetCode: team.teamPlanetCode,
       status: { $or: [ { $exists: false }, { $ne: 'archived' } ] },
       ...(withAllLinks ? {} : { docType: 'membership' })
     };
-    this.usersService.requestUserData();
     return forkJoin([
-      this.couchService.findAll(this.dbName, findDocuments(selector)),
-      this.couchService.findAll('shelf', findDocuments({ myTeamIds: { $in: [ team._id ] } }, 0)),
-      this.usersService.usersListener(true).pipe(take(1)),
-      this.couchService.findAll('attachments')
-    ]).pipe(map(([ membershipDocs, shelves, users, attachments ]: any[]) => [
-      ...membershipDocs.map(doc => ({
-        ...doc,
-        userDoc: users.find(user => (user.doc.couchId || user._id) === doc.userId && user.doc.planetCode === doc.userPlanetCode),
-        attachmentDoc: attachments.find(attachment => attachment._id === `${doc.userId}@${doc.userPlanetCode}`)
-      })),
+      this.couchService.findAllStrict(this.dbName, findDocuments(selector)),
+      this.couchService.findAllStrict('shelf', findDocuments({ myTeamIds: { $in: [ team._id ] } }, 0))
+    ]).pipe(map(([ teamDocs, shelves ]: any[]) => [
+      ...teamDocs,
       ...shelves.map((shelf: any) => ({ ...shelf, fromShelf: true, docType: 'membership', userId: shelf._id, teamId: team._id }))
     ]));
+  }
+
+  getTeamMembers(team, withAllLinks = false) {
+    return this.getActiveTeamRecords(team, withAllLinks).pipe(
+      switchMap((records: any[]) => this.enrichTeamRecords(records))
+    );
+  }
+
+  // Display enrichment only.  It runs on records which are already loaded, so a failed user or attachment read
+  // degrades the view instead of dropping members, and the partial failure is reported rather than swallowed.
+  private enrichTeamRecords(records: any[]) {
+    this.usersService.requestUserData();
+    const optional = (enrichment: Observable<any[]>) => enrichment.pipe(catchError(() => of(null)));
+    return forkJoin([
+      optional(this.usersService.usersListener(true).pipe(take(1))),
+      optional(this.couchService.findAllStrict('attachments'))
+    ]).pipe(map(([ users, attachments ]: any[]) => {
+      if (users === null || attachments === null) {
+        this.planetMessageService.showAlert($localize`Some team member details could not be loaded.`);
+      }
+      return records.map((record: any) => record.fromShelf === true ? record : ({
+        ...record,
+        userDoc: (users || []).find(
+          user => (user.doc.couchId || user._id) === record.userId && user.doc.planetCode === record.userPlanetCode
+        ),
+        attachmentDoc: (attachments || []).find(attachment => attachment._id === `${record.userId}@${record.userPlanetCode}`)
+      }));
+    }));
   }
 
   getTeamResources(linkDocs: any[]) {
@@ -370,7 +399,7 @@ export class TeamsService {
   }
 
   isTeamEmpty(team) {
-    return this.getTeamMembers(team).pipe(map((docs) => docs.length === 0));
+    return this.getActiveTeamMembershipRecords(team).pipe(map((records: any[]) => records.length === 0));
   }
 
   sendNotifications(type, members, notificationParams) {


### PR DESCRIPTION
## Summary

Add a new `findAllStrict()` method to `CouchService` that propagates query failures instead of silently returning empty results. Use this for authoritative membership reads in `TeamsService` to safely archive teams only when all membership sources have been confirmed empty, and separate enrichment concerns from core membership logic.

## Key Changes

- **CouchService**: Introduce `findAllStrict(db, query, opts)` that fails fast on any page of a paginated query, enabling callers to distinguish "no members found" from "query failed"
- **TeamsService**: 
  - Split `getTeamMembers()` into `getActiveTeamMembershipRecords()` (strict, authoritative) and `enrichTeamRecords()` (optional, display-only)
  - `isTeamEmpty()` now uses strict queries to confirm a team is truly empty before archival
  - `getTeamMembers()` still enriches with user and attachment data, but degraded failures (missing users/attachments) now show an alert instead of dropping members
  - Add `PlanetMessageService` dependency to report partial enrichment failures
- **Tests**: 
  - Add comprehensive `TeamsService membership safety` test suite covering team archival conditions, query failure propagation, and enrichment resilience
  - Add `CouchService paginated queries` test suite validating strict vs. lenient behavior and multi-page pagination

## Implementation Details

The strict path allows `TeamsService` to safely archive a team only after confirming:
1. No membership documents remain in the teams database
2. No shelf records reference the team
3. Both queries succeeded (not just returned empty)

Enrichment (user details, attachments) is now optional and runs after membership is confirmed, so a failed user or attachment service degrades the UI rather than losing team members from the view.

https://claude.ai/code/session_011FEKT1dpH51ZpP1hYdedst