### PR TITLE
state: improve error handling and resilience for database requests

### DIFF
--- a/src/app/shared/couchdb.service.spec.ts
+++ b/src/app/shared/couchdb.service.spec.ts
@@ -1,0 +1,20 @@
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+
+import { CouchService } from './couchdb.service';
+
+describe('CouchService', () => {
+  it('keeps the documents already fetched when a later page of a find request fails', () => {
+    const http = { post: vi.fn() };
+    http.post
+      .mockReturnValueOnce(of({ docs: [ { _id: 'resource-1' } ], bookmark: 'page-2' }))
+      .mockReturnValueOnce(throwError(new Error('offline')));
+    const service = new CouchService(http as any, { showAlert: vi.fn() } as any);
+    let docs: any[];
+
+    service.findAll('resources').subscribe((res: any[]) => docs = res);
+
+    expect(docs).toEqual([ { _id: 'resource-1' } ]);
+    expect(http.post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -123,9 +123,12 @@ export class CouchService {
   }
 
   private findAllRequest(db: string, query: any, opts: any) {
-    return this.post(db + '/_find', query, opts).pipe(
-      catchError(() => of({ docs: [], rows: [] })),
-      expand((res) => res.docs.length > 0 ? this.post(db + '/_find', { ...query, bookmark: res.bookmark }, opts) : empty())
+    // Each page is guarded so one failed request returns the pages already fetched rather than erroring the whole stream
+    const findRequest = (bookmark?: string) => this.post(
+      db + '/_find', bookmark === undefined ? query : { ...query, bookmark }, opts
+    ).pipe(catchError(() => of({ docs: [], rows: [] })));
+    return findRequest().pipe(
+      expand((res: any) => res.docs.length > 0 ? findRequest(res.bookmark) : empty())
     );
   }
 

--- a/src/app/shared/state.service.spec.ts
+++ b/src/app/shared/state.service.spec.ts
@@ -1,0 +1,54 @@
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+
+import { StateService } from './state.service';
+
+describe('StateService', () => {
+  it('notifies listeners and clears the pending flag when a database request fails', () => {
+    const couchService = { get: vi.fn().mockReturnValue(throwError(new Error('offline'))) };
+    const planetMessageService = { showAlert: vi.fn() };
+    const service = new StateService(couchService as any, planetMessageService as any);
+    const updates: any[] = [];
+    service.couchStateListener('courses').subscribe((res) => updates.push(res));
+
+    service.requestData('courses', 'parent');
+
+    expect(updates).toEqual([ { newData: [], db: 'courses', planetField: 'parent', inProgress: false, error: true } ]);
+    expect(planetMessageService.showAlert).toHaveBeenCalledTimes(1);
+
+    // A failure must not leave the database flagged as in progress, otherwise the view can never retry
+    service.requestData('courses', 'parent');
+
+    expect(couchService.get).toHaveBeenCalledTimes(2);
+    expect(planetMessageService.showAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('only alerts once when several databases on the same planet fail', () => {
+    const couchService = { get: vi.fn().mockReturnValue(throwError(new Error('offline'))) };
+    const planetMessageService = { showAlert: vi.fn() };
+    const service = new StateService(couchService as any, planetMessageService as any);
+
+    service.requestData('courses', 'parent');
+    service.requestData('tags', 'parent');
+
+    expect(planetMessageService.showAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores change rows without a document', () => {
+    const couchService = {
+      get: vi.fn().mockReturnValue(of({
+        last_seq: '5',
+        results: [ { doc: null }, { doc: { _id: '_design/courses' } }, { doc: { _id: 'course-1' } } ]
+      }))
+    };
+    const service = new StateService(couchService as any, { showAlert: vi.fn() } as any);
+    service.state.parent = { courses: { docs: [ { _id: 'course-0' } ], lastSeq: '1' } };
+    const updates: any[] = [];
+    service.couchStateListener('courses').subscribe((res) => updates.push(res));
+
+    service.requestData('courses', 'parent');
+
+    expect(updates[0].newData).toEqual([ { _id: 'course-0' }, { _id: 'course-1' } ]);
+    expect(updates[0].error).toBeUndefined();
+  });
+});

--- a/src/app/shared/state.service.ts
+++ b/src/app/shared/state.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { CouchService } from '../shared/couchdb.service';
+import { PlanetMessageService } from './planet-message.service';
 import { findDocuments } from '../shared/mangoQueries';
-import { Subject } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { map, switchMap, filter, catchError } from 'rxjs/operators';
 
 @Injectable({
@@ -12,6 +13,8 @@ export class StateService {
   state: any = { local: {}, parent: {} };
   private stateUpdated = new Subject<any>();
   private inProgress = { local: new Map(), parent: new Map() };
+  // Tracks which planets already alerted the user, so one outage does not stack a snackbar per database
+  private errorNotified = new Set<string>();
 
   get configuration(): any {
     const config = this.state.local.configurations?.docs[0] || {};
@@ -24,7 +27,8 @@ export class StateService {
   }
 
   constructor(
-    private couchService: CouchService
+    private couchService: CouchService,
+    private planetMessageService: PlanetMessageService
   ) {}
 
   requestBaseData() {
@@ -37,6 +41,7 @@ export class StateService {
   }
 
   requestData(db: string, planetField: string, sort?: { [key: string]: 'asc' | 'desc' }) {
+    this.inProgress[planetField] = this.inProgress[planetField] || new Map();
     if (this.inProgress[planetField].get(db) !== true) {
       this.inProgress[planetField].set(db, true);
       this.getCouchState(db, planetField, sort).subscribe(() => {});
@@ -56,14 +61,32 @@ export class StateService {
         const inProgress = isInitialFind && changes.length > 0;
         this.state[planetField][db].docs = newData;
         this.stateUpdated.next({ newData, db, planetField, inProgress });
-        this.inProgress[planetField].set(db, inProgress);
+        this.setInProgress(db, planetField, inProgress);
+        this.errorNotified.delete(planetField);
         return newData;
       }),
       catchError(() => {
-        this.inProgress[planetField].set(db, false);
-        return [];
+        // Always notify listeners, otherwise views waiting on this database keep their loading spinner forever
+        const docs = this.state[planetField][db].docs;
+        this.setInProgress(db, planetField, false);
+        this.stateUpdated.next({ newData: docs, db, planetField, inProgress: false, error: true });
+        this.notifyError(planetField);
+        return of(docs);
       })
     );
+  }
+
+  private setInProgress(db: string, planetField: string, inProgress: boolean) {
+    this.inProgress[planetField] = this.inProgress[planetField] || new Map();
+    this.inProgress[planetField].set(db, inProgress);
+  }
+
+  private notifyError(planetField: string) {
+    if (this.errorNotified.has(planetField)) {
+      return;
+    }
+    this.errorNotified.add(planetField);
+    this.planetMessageService.showAlert($localize`There was an error connecting to Planet`);
   }
 
   optsFromPlanetField(planetField: string) {
@@ -90,12 +113,14 @@ export class StateService {
       db + '/_changes?include_docs=true&since=' + (this.state[planetField][db].lastSeq || 'now'), opts
     ).pipe(map((res: any) => {
       this.state[planetField][db].lastSeq = res.last_seq;
-      return res.results.filter((r: any) => r.doc._id.indexOf('_design') === -1).map((r: any) => r.doc);
+      return (res.results || [])
+        .filter((r: any) => r.doc !== undefined && r.doc !== null && r.doc._id.indexOf('_design') === -1)
+        .map((r: any) => r.doc);
     }));
   }
 
   couchStateListener(db: string) {
-    return this.stateUpdated.pipe(filter((stateObj: { newData, db, planetField, inProgress }) => db === stateObj.db));
+    return this.stateUpdated.pipe(filter((stateObj: { newData, db, planetField, inProgress, error? }) => db === stateObj.db));
   }
 
   combineChanges(docs: any[], changesDocs: any[], sort) {


### PR DESCRIPTION
## Summary
Improves error handling in `StateService` and `CouchService` to prevent UI deadlocks when database requests fail, and adds comprehensive test coverage for failure scenarios.

## Key Changes

**StateService (`state.service.ts`)**
- Added `PlanetMessageService` dependency to notify users of connection errors
- Implemented error tracking via `errorNotified` Set to alert once per planet outage instead of per-database
- Modified `catchError` handler to:
  - Always emit state updates (with `error: true` flag) so listeners don't hang indefinitely
  - Clear the `inProgress` flag on failure to allow retries
  - Return existing docs instead of empty array to preserve UI state
- Extracted `setInProgress()` helper to ensure `inProgress` Map is initialized
- Added `notifyError()` method to deduplicate alerts across multiple failing databases on the same planet
- Fixed `getCouchStateChanges()` to filter out null/undefined docs and handle missing `results` array

**CouchService (`couchdb.service.ts`)**
- Refactored `findAllRequest()` to guard each pagination request independently
- Failed requests now return accumulated docs from previous pages instead of erroring the entire stream
- Prevents data loss when pagination fails mid-fetch

**Test Coverage**
- Added `StateService` spec with three test cases:
  - Verifies error notifications and `inProgress` flag clearing on failure
  - Confirms single alert per planet even with multiple failing databases
  - Validates filtering of null docs and design documents
- Added `CouchService` spec verifying partial results are preserved on pagination failure

## Implementation Details
- Error state is communicated via optional `error: true` property in state updates
- `errorNotified` Set uses `planetField` as key to deduplicate alerts per tier (local/parent)
- Null/undefined doc filtering prevents crashes from malformed CouchDB responses
- Pagination resilience uses `catchError` with `of()` to continue the stream rather than break it

https://claude.ai/code/session_01CsPP8K8AE6aXdyWbgfH84V