### PR TITLE
surveys: defer submission creation until first answer saved

### DIFF
--- a/src/app/exams/exams-view.component.spec.ts
+++ b/src/app/exams/exams-view.component.spec.ts
@@ -1,0 +1,126 @@
+import { FormBuilder } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+
+import { ExamsViewComponent } from './exams-view.component';
+
+describe('ExamsViewComponent', () => {
+  let couchService: any;
+  let submissionsService: any;
+  let planetMessageService: any;
+  let router: any;
+  let route: any;
+  let component: ExamsViewComponent;
+
+  const paramMapOf = (params: any) => ({
+    get: (key: string) => (params[key] !== undefined ? params[key] : null),
+    has: (key: string) => params[key] !== undefined
+  });
+
+  const createComponent = (params: any = {}) => {
+    route = {
+      snapshot: { data: { newUser: true }, params, paramMap: paramMapOf(params), url: [] }
+    };
+    return new ExamsViewComponent(
+      router,
+      route,
+      {} as any,
+      submissionsService,
+      { get: vi.fn().mockReturnValue({ name: 'user' }) } as any,
+      couchService,
+      planetMessageService,
+      {} as any,
+      { start: vi.fn(), stop: vi.fn() } as any,
+      new FormBuilder(),
+      {} as any
+    );
+  };
+
+  beforeEach(() => {
+    couchService = {
+      get: vi.fn((path: string) => of(
+        path.startsWith('teams/') ?
+          { _id: 'team-1', name: 'Team One', type: 'team' } :
+          { _id: 'survey-1', name: 'Survey 1', type: 'surveys', questions: [ { body: 'Q1' } ] }
+      ))
+    };
+    submissionsService = { openSubmission: vi.fn() };
+    planetMessageService = { showAlert: vi.fn() };
+    router = { navigate: vi.fn(), url: '/surveys/dispense' };
+  });
+
+  it('opens a survey for recording without creating a submission first', () => {
+    const params = { surveyId: 'survey-1', mode: 'take', questionNum: '1', surveyTeamId: 'team-1' };
+    component = createComponent(params);
+
+    component.setExam(paramMapOf(params));
+
+    expect(couchService.get).toHaveBeenCalledWith('exams/survey-1');
+    expect(couchService.get).toHaveBeenCalledWith('teams/team-1');
+    expect(submissionsService.openSubmission).toHaveBeenCalledWith({
+      parentId: 'survey-1',
+      parent: expect.objectContaining({ _id: 'survey-1' }),
+      user: {},
+      type: 'survey',
+      team: { _id: 'team-1', name: 'Team One', type: 'team' }
+    });
+    expect(component.title).toBe('Survey 1');
+  });
+
+  it('records a survey with no team when none is in the route', () => {
+    const params = { surveyId: 'survey-1', mode: 'take', questionNum: '1' };
+    component = createComponent(params);
+
+    component.setExam(paramMapOf(params));
+
+    expect(couchService.get).toHaveBeenCalledTimes(1);
+    expect(submissionsService.openSubmission).toHaveBeenCalledWith(expect.objectContaining({ team: undefined }));
+  });
+
+  it('alerts and leaves when the survey cannot be opened', () => {
+    const params = { surveyId: 'survey-1', mode: 'take', questionNum: '1' };
+    component = createComponent(params);
+    couchService.get.mockReturnValue(throwError(() => new Error('failed')));
+
+    component.setExam(paramMapOf(params));
+
+    expect(planetMessageService.showAlert).toHaveBeenCalledWith('There was a problem recording the survey.');
+    expect(submissionsService.openSubmission).not.toHaveBeenCalled();
+  });
+
+  it('continues a recording already under way instead of starting a second one', () => {
+    const params = { surveyId: 'survey-1', mode: 'take', questionNum: '1' };
+    component = createComponent(params);
+    submissionsService.submission = {
+      parentId: 'survey-1',
+      status: 'pending',
+      parent: { name: 'Survey 1', questions: [ { body: 'Q1' } ] }
+    };
+    submissionsService.resumeSubmission = vi.fn();
+
+    component.setExam(paramMapOf(params));
+
+    expect(submissionsService.resumeSubmission).toHaveBeenCalled();
+    expect(couchService.get).not.toHaveBeenCalled();
+    expect(submissionsService.openSubmission).not.toHaveBeenCalled();
+  });
+
+  it('adds the submission to the url once the first answer has created it', () => {
+    const params = { surveyId: 'survey-1', mode: 'take', questionNum: '1' };
+    component = createComponent(params);
+
+    expect(component.examParams()).toEqual(params);
+
+    component.submissionId = 'submission-1';
+
+    expect(component.examParams()).toEqual({ ...params, submissionId: 'submission-1', status: 'pending' });
+  });
+
+  it('keeps the url unchanged for a submission opened directly', () => {
+    const params = { submissionId: 'submission-1', mode: 'take', questionNum: '1' };
+    component = createComponent(params);
+    component.submissionId = 'submission-1';
+
+    expect(component.examParams()).toEqual(params);
+  });
+});

--- a/src/app/exams/exams-view.component.ts
+++ b/src/app/exams/exams-view.component.ts
@@ -210,6 +210,7 @@ export class ExamsViewComponent implements OnInit, OnDestroy, CanComponentDeacti
     this.examType = params.get('type') || this.examType;
     const courseId = params.get('id');
     const submissionId = params.get('submissionId');
+    const surveyId = params.get('surveyId');
     const mode = params.get('mode');
     this.mode = mode || this.mode;
     this.isFinished = false;
@@ -229,7 +230,38 @@ export class ExamsViewComponent implements OnInit, OnDestroy, CanComponentDeacti
       this.grade = mode === 'take' ? 0 : undefined;
       this.comment = undefined;
       this.submissionsService.openSubmission({ submissionId, status: params.get('status') });
+    } else if (surveyId) {
+      // No submission exists yet -- one is only written to the database once the first answer is
+      // saved, so opening a survey and leaving it never leaves an empty record behind
+      this.mode = mode || 'take';
+      this.grade = this.mode === 'take' ? 0 : undefined;
+      this.comment = undefined;
+      this.setRecordingSurvey(surveyId, params.get('surveyTeamId'));
     }
+  }
+
+  setRecordingSurvey(surveyId: string, teamId: string | null) {
+    const inProgress = this.submissionsService.submission;
+    // Moving back to a question of a recording already under way, which the browser can do from a
+    // url that predates the submission's id, has to keep the answers already given
+    if (inProgress && inProgress.parentId === surveyId && inProgress.status === 'pending') {
+      this.title = inProgress.parent.name;
+      this.setQuestion(inProgress.parent.questions);
+      this.submissionsService.resumeSubmission();
+      return;
+    }
+    this.isLoading = true;
+    forkJoin([
+      this.couchService.get(`exams/${surveyId}`),
+      teamId ? this.couchService.get(`teams/${teamId}`) : of(null)
+    ]).subscribe(([ survey, team ]: [ any, any ]) => {
+      this.title = survey.name;
+      this.setTakingExam(survey, survey._id, 'survey', team ? { _id: team._id, name: team.name, type: team.type } : undefined);
+    }, () => {
+      this.planetMessageService.showAlert($localize`There was a problem recording the survey.`);
+      this.isInternalNavigation = true;
+      this.goBack();
+    });
   }
 
   setExamPreview() {
@@ -318,8 +350,17 @@ export class ExamsViewComponent implements OnInit, OnDestroy, CanComponentDeacti
     // A zero direction keeps the same url, which the router skips without running the guard, so
     // flagging it would leave the next real exit unprompted
     this.isInternalNavigation = direction !== 0;
-    this.router.navigate([ { ...this.route.snapshot.params, questionNum: this.questionNum + direction } ], { relativeTo: this.route });
+    this.router.navigate([ { ...this.examParams(), questionNum: this.questionNum + direction } ], { relativeTo: this.route });
     this.isNewQuestion = true;
+  }
+
+  // A survey opened for recording starts without a submission id, so once the first answer creates
+  // the submission the url has to carry it or the next question would start a second submission
+  examParams() {
+    const params = this.route.snapshot.params;
+    return params.surveyId && this.submissionId ?
+      { ...params, submissionId: this.submissionId, status: 'pending' } :
+      params;
   }
 
   examComplete() {
@@ -346,14 +387,15 @@ export class ExamsViewComponent implements OnInit, OnDestroy, CanComponentDeacti
     this.isNewQuestion = true;
   }
 
-  setTakingExam(exam, parentId, type) {
+  setTakingExam(exam, parentId, type, team?: { _id: string, name: string, type: string }) {
     const user = this.route.snapshot.data.newUser === true ? {} : this.userService.get();
     this.setQuestion(exam.questions);
     this.submissionsService.openSubmission({
       parentId,
       parent: exam,
       user,
-      type });
+      type,
+      team });
   }
 
   setQuestion(questions: any[]) {
@@ -415,7 +457,7 @@ export class ExamsViewComponent implements OnInit, OnDestroy, CanComponentDeacti
           this.questionNum = nextUnansweredQuestion;
           this.isInternalNavigation = true;
           this.router.navigate([ {
-            ...this.route.snapshot.params,
+            ...this.examParams(),
             questionNum: this.questionNum
           } ], { relativeTo: this.route });
         }

--- a/src/app/submissions/submissions.service.ts
+++ b/src/app/submissions/submissions.service.ts
@@ -68,8 +68,8 @@ export class SubmissionsService {
     this.submission = this.submissions.find((submission) => submission._id === id);
   }
 
-  private newSubmission({ parentId, parent, user, type }) {
-    this.submission = this.createNewSubmission({ parentId, parent, user, type });
+  private newSubmission({ parentId, parent, user, type, team }: { parentId, parent, user, type, team? }) {
+    this.submission = this.createNewSubmission({ parentId, parent, user, type, team });
   }
 
   private createNewSubmission({ parentId, parent, user, type, sender, team }: { parentId, parent, user, type, sender?, team? }) {
@@ -87,7 +87,9 @@ export class SubmissionsService {
     return { source: configuration.code, parentCode: configuration.parentCode };
   }
 
-  openSubmission({ parentId = '', parent = '', user = { name: '' }, type = '', submissionId = '', status = 'pending' }: any) {
+  openSubmission(
+    { parentId = '', parent = '', user = { name: '' }, type = '', submissionId = '', status = 'pending', team = undefined }: any
+  ) {
     const selector = submissionId ? { _id: submissionId } : { parentId, 'user.name': user.name, 'parent._rev': parent._rev };
     const obs = user.name || submissionId ? this.couchService.post('submissions/_find', { selector }) : of({ docs: [] });
     obs.subscribe((res) => {
@@ -97,11 +99,17 @@ export class SubmissionsService {
       this.submission = res.docs.find(submission => submission.status === status || type === 'survey');
       if (this.submission === undefined) {
         attempts += 1;
-        this.newSubmission({ parentId, parent, user, type });
+        this.newSubmission({ parentId, parent, user, type, team });
       }
       this.submissionAttempts = attempts;
       this.submissionUpdated.next({ submission: this.submission, attempts, bestAttempt });
     });
+  }
+
+  // Re-emits the submission already in progress, so returning to a question of a survey that has
+  // not been saved under an id yet continues it rather than starting a second one
+  resumeSubmission() {
+    this.submissionUpdated.next({ submission: this.submission, attempts: this.submissionAttempts });
   }
 
   submitAnswer(answer, correct: boolean, index: number, isFinish = false) {
@@ -219,10 +227,6 @@ export class SubmissionsService {
         );
       })
     );
-  }
-
-  createSubmission(parent: any, type: string, user: any = {}, team?: { _id: string, name: string, type: string }) {
-    return this.couchService.updateDocument('submissions', this.createNewSubmission({ parentId: parent._id, parent, user, type, team }));
   }
 
   submissionName(user) {

--- a/src/app/surveys/surveys.component.spec.ts
+++ b/src/app/surveys/surveys.component.spec.ts
@@ -1,5 +1,5 @@
 import { FormBuilder } from '@angular/forms';
-import { of, Subject, throwError } from 'rxjs';
+import { of } from 'rxjs';
 import { vi } from 'vitest';
 
 import { SurveysComponent } from './surveys.component';
@@ -35,11 +35,11 @@ describe('SurveysComponent', () => {
 
   beforeEach(() => {
     couchService = {
-      get: vi.fn((path: string) => of({ _id: path.replace('teams/', ''), name: path, type: 'team' }))
+      get: vi.fn((path: string) => of({ _id: path.replace('teams/', ''), name: path, type: 'team' })),
+      post: vi.fn().mockReturnValue(of({})),
+      put: vi.fn().mockReturnValue(of({}))
     };
-    submissionsService = {
-      createSubmission: vi.fn().mockReturnValue(of({ id: 'submission-1' }))
-    };
+    submissionsService = {};
     planetMessageService = {
       showAlert: vi.fn()
     };
@@ -63,45 +63,30 @@ describe('SurveysComponent', () => {
     component = createComponent();
   });
 
-  it('fetches the current input team for each recording', () => {
+  it('sends the current input team along to each recording', () => {
     component.teamId = 'team-1';
     component.recordSurvey({ _id: 'survey-1', name: 'Survey 1' });
 
     component.teamId = 'team-2';
     component.recordSurvey({ _id: 'survey-2', name: 'Survey 2' });
 
-    expect(couchService.get).toHaveBeenNthCalledWith(1, 'teams/team-1');
-    expect(couchService.get).toHaveBeenNthCalledWith(2, 'teams/team-2');
-    expect(submissionsService.createSubmission).toHaveBeenNthCalledWith(
+    expect(router.navigate).toHaveBeenNthCalledWith(
       2,
-      { _id: 'survey-2', name: 'Survey 2' },
-      'survey',
-      {},
-      { _id: 'team-2', name: 'teams/team-2', type: 'team' }
+      [ 'surveys/dispense', expect.objectContaining({ surveyId: 'survey-2', surveyTeamId: 'team-2', mode: 'take' }) ],
+      expect.anything()
     );
   });
 
-  it('stops loading and shows an alert when recording fails', () => {
-    submissionsService.createSubmission.mockReturnValue(throwError(() => new Error('failed')));
-
+  it('leaves the submission to be created by the first saved answer', () => {
     component.recordSurvey({ _id: 'survey-1', name: 'Survey 1' });
 
-    expect(dialogsLoadingService.start).toHaveBeenCalled();
-    expect(dialogsLoadingService.stop).toHaveBeenCalled();
-    expect(planetMessageService.showAlert).toHaveBeenCalledWith('There was a problem recording the survey.');
-    expect(router.navigate).not.toHaveBeenCalled();
-  });
-
-  it('does not navigate after the component is destroyed during recording', () => {
-    const createSubmission$ = new Subject<any>();
-    submissionsService.createSubmission.mockReturnValue(createSubmission$);
-
-    component.recordSurvey({ _id: 'survey-1', name: 'Survey 1' });
-    component.ngOnDestroy();
-    createSubmission$.next({ id: 'submission-1' });
-
-    expect(dialogsLoadingService.stop).toHaveBeenCalled();
-    expect(router.navigate).not.toHaveBeenCalled();
+    expect(couchService.post).not.toHaveBeenCalled();
+    expect(couchService.put).not.toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(
+      [ 'dispense', expect.objectContaining({ questionNum: 1, surveyId: 'survey-1', mode: 'take' }) ],
+      expect.anything()
+    );
+    expect(router.navigate.mock.calls[0][0][1].surveyTeamId).toBeUndefined();
   });
 
   it('keeps the search input synchronized with the table filter', () => {

--- a/src/app/surveys/surveys.component.ts
+++ b/src/app/surveys/surveys.component.ts
@@ -502,32 +502,20 @@ export class SurveysComponent implements OnInit, AfterViewInit, OnDestroy {
     );
   }
 
-  private getRecordTeam(): Observable<any> {
-    const targetTeamId = this.teamId || this.routeTeamId;
-    if (!targetTeamId) {
-      return of(null);
-    }
-    return this.couchService.get('teams/' + targetTeamId);
-  }
-
+  // The submission is not created here: it is written once the first answer is saved, so opening a
+  // survey and abandoning it does not leave an empty pending submission behind
   recordSurvey(survey: any) {
-    this.dialogsLoadingService.start();
-    this.getRecordTeam().pipe(
-      switchMap((team: any) => {
-        const teamInfo = team ? { _id: team._id, name: team.name, type: team.type } : undefined;
-        const { teamIds, taken, courseTitle, course, ...surveyInfo } = survey;
-        return this.submissionsService.createSubmission(surveyInfo, 'survey', {}, teamInfo);
-      }),
-      takeUntil(this.onDestroy$),
-      finalize(() => this.dialogsLoadingService.stop())
-    ).subscribe((res: any) => {
-      this.router.navigate([
-        this.teamId ? 'surveys/dispense' : 'dispense',
-        { questionNum: 1, submissionId: res.id, status: 'pending', mode: 'take', snap: this.route.snapshot.url }
-      ], { relativeTo: this.route });
-    }, () => {
-      this.planetMessageService.showAlert($localize`There was a problem recording the survey.`);
-    });
+    const targetTeamId = this.teamId || this.routeTeamId;
+    this.router.navigate([
+      this.teamId ? 'surveys/dispense' : 'dispense',
+      {
+        questionNum: 1,
+        surveyId: survey._id,
+        mode: 'take',
+        snap: this.route.snapshot.url,
+        ...(targetTeamId ? { surveyTeamId: targetTeamId } : {})
+      }
+    ], { relativeTo: this.route });
   }
 
   toggleSurveyPublicAccess(survey: any) {


### PR DESCRIPTION
## Summary

Refactor survey recording to defer submission creation until the first answer is saved, eliminating empty pending submissions when users open a survey and abandon it without answering.

## Key Changes

- **ExamsViewComponent**: Added `setRecordingSurvey()` method to handle survey recording without pre-creating a submission. Surveys now start with a `surveyId` parameter instead of `submissionId`, and the submission ID is added to the URL once the first answer creates it via `examParams()`.
  - New `examParams()` method intelligently updates route parameters: adds `submissionId` and `status` once a submission exists for surveys opened via `surveyId`.
  - `setTakingExam()` now accepts an optional `team` parameter to associate recordings with teams.
  - Added `resumeSubmission()` call to continue in-progress recordings instead of starting duplicates.

- **SurveysComponent**: Simplified `recordSurvey()` to navigate directly to the exam view with `surveyId` and optional `surveyTeamId` parameters, removing the synchronous submission creation and associated loading UI.
  - Removed `getRecordTeam()` helper and `createSubmission` call.
  - Removed error handling and `DialogsLoadingService` usage (submission creation now happens asynchronously in the exam view).

- **SubmissionsService**: 
  - Updated `openSubmission()` signature to accept optional `team` parameter.
  - Added `resumeSubmission()` method to re-emit an in-progress submission without re-querying the database.
  - Removed `createSubmission()` method (no longer needed; submissions are created on first answer save).

- **Tests**: 
  - Added comprehensive `ExamsViewComponent` spec covering survey recording, team association, error handling, and URL parameter management.
  - Updated `SurveysComponent` spec to verify navigation with `surveyId`/`surveyTeamId` instead of submission creation.

## Implementation Details

- Surveys opened for recording now use a lazy submission pattern: the submission document is only written to CouchDB when the first answer is saved, preventing orphaned pending submissions.
- The URL evolves as the user progresses: starts with `surveyId`, gains `submissionId` and `status` after the first answer.
- Returning to a question of an in-progress survey (e.g., via browser back button) resumes the existing submission rather than creating a duplicate.
- Team information is fetched alongside the survey and passed through to the submission for proper association.

https://claude.ai/code/session_01FLjfHbpgrZwJowfPN3XbpC