### PR TITLE
teams: smoother cover image handling (fixes #10424)

### DIFF
--- a/src/app/dashboard/dashboard-tile.component.html
+++ b/src/app/dashboard/dashboard-tile.component.html
@@ -37,7 +37,7 @@
               [ngClass]="{
                 'bg-grey': even,
                 'accordion-item': isAccordionMode,
-                'has-course-cover': cardType === 'myCourses' && item.coverFileName
+                'has-course-cover': (cardType === 'myCourses' || cardType === 'myTeams') && item.coverFileName
               }"
               cdkDrag
               [cdkDragDisabled]="cardType==='myLife' || isAccordionMode"
@@ -51,6 +51,11 @@
                 @if (cardType === 'myCourses' && item.coverFileName) {
                   <div class="dashboard-course-cover">
                     <img [src]="coverImageUrl(item)" alt="Course cover" i18n-alt>
+                  </div>
+                }
+                @if (cardType === 'myTeams' && item.coverFileName) {
+                  <div class="dashboard-course-cover">
+                    <img [src]="coverImageUrl(item)" alt="Team cover" i18n-alt>
                   </div>
                 }
                 @if (item.firstLine || item.badge) {

--- a/src/app/dashboard/dashboard-tile.component.spec.ts
+++ b/src/app/dashboard/dashboard-tile.component.spec.ts
@@ -96,6 +96,23 @@ describe('DashboardTileComponent', () => {
 
       expect(component.dashboardTextLines({ coverFileName: 'cover.png' })).toBe('none');
     });
+
+    it('measures team title lines and clamps when team has cover', () => {
+      component.cardType = 'myTeams';
+      component.courseTileLines = 2;
+      component.tileLines = 4;
+
+      expect(component.dashboardTextLines({ coverFileName: 'team-cover.png' })).toBe(2);
+      expect(component.dashboardTextLines({})).toBe(4);
+    });
+
+    it('builds coverImageUrl for myTeams and myCourses with respective dbs', () => {
+      component.cardType = 'myTeams';
+      expect(component.coverImageUrl({ _id: 't1', coverFileName: 'cover.png' })).toContain('/teams/t1/cover.png');
+
+      component.cardType = 'myCourses';
+      expect(component.coverImageUrl({ _id: 'c1', coverFileName: 'cover.png' })).toContain('/courses/c1/cover.png');
+    });
   });
 
   it('removes a dashboard course only after confirmation', () => {

--- a/src/app/dashboard/dashboard-tile.component.ts
+++ b/src/app/dashboard/dashboard-tile.component.ts
@@ -301,10 +301,11 @@ export class DashboardTileComponent implements AfterViewChecked, OnInit {
     if (this.isAccordionMode) {
       return 'none';
     }
-    return this.cardType === 'myCourses' && item.coverFileName ? this.courseTileLines : this.tileLines;
+    return (this.cardType === 'myCourses' || this.cardType === 'myTeams') && item.coverFileName ? this.courseTileLines : this.tileLines;
   }
 
   coverImageUrl(item: any): string {
-    return couchAttachmentUrl(environment.couchAddress, 'courses', item._id, item.coverFileName);
+    const db = this.cardType === 'myTeams' ? 'teams' : 'courses';
+    return couchAttachmentUrl(environment.couchAddress, db, item._id, item.coverFileName);
   }
 }

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -126,7 +126,7 @@
         }
         <!-- File Upload -->
         @if (field.type === 'file-upload') {
-          <div class="full-width">
+          <div class="full-width file-upload-wrapper">
             @if (field.placeholder) {
               <p class="mat-caption">{{ field.placeholder }}</p>
             }

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -56,6 +56,10 @@ import { UnsavedChangesPromptComponent } from '../unsaved-changes.component';
       display: block;
       height: 24px;
     }
+
+    .file-upload-wrapper {
+      margin-bottom: 20px;
+    }
   `],
   imports: [
     FormsModule,

--- a/src/app/teams/teams-view.component.html
+++ b/src/app/teams/teams-view.component.html
@@ -5,6 +5,9 @@
 <div class="space-container teams-view">
   <mat-toolbar class="primary-color font-size-1">
     @if (team !== undefined) {
+      @if (team?.coverFileName) {
+        <img class="team-toolbar-cover" [src]="coverImageUrl()" alt="Team cover" i18n-alt />
+      }
       <h3 class="margin-lr-3 ellipsis-title">
         {{team.name}} @if (mode==='enterprise') {
         <ng-container i18n>Office</ng-container>
@@ -112,6 +115,9 @@
       <ng-template mat-tab-label i18n>
           { mode, select, team {Plan} enterprise {Mission & Services} services {Services} }
         </ng-template>
+      @if (team?.coverFileName) {
+        <img class="team-cover" [src]="coverImageUrl()" alt="Team cover" i18n-alt />
+      }
       @if ((team?.description || team?.services || team?.rules)) {
         @if (team?.description && mode === 'enterprise') {
           <div class="mat-headline-6" i18n>What is your enterprise's Mission?</div>

--- a/src/app/teams/teams-view.component.spec.ts
+++ b/src/app/teams/teams-view.component.spec.ts
@@ -63,4 +63,14 @@ describe('TeamsViewComponent task projections', () => {
     expect(dialogsLoadingService.stop).toHaveBeenCalledTimes(1);
     expect(dialogRef.close).toHaveBeenCalled();
   });
+
+  it('builds a cover image URL when team has a cover file', () => {
+    const component: any = Object.create(TeamsViewComponent.prototype);
+    component.team = { _id: 'team-123', coverFileName: 'cover.jpg' };
+    expect(component.coverImageUrl()).toContain('teams/team-123/cover.jpg');
+
+    component.team = { _id: 'team-123' };
+    expect(component.coverImageUrl()).toBe('');
+  });
 });
+

--- a/src/app/teams/teams-view.component.ts
+++ b/src/app/teams/teams-view.component.ts
@@ -24,6 +24,7 @@ import { CustomValidators } from '../validators/custom-validators';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
 import { CoursesViewDetailDialogComponent } from '../courses/view-courses/courses-view-detail.component';
 import { enterpriseJoinAgreement, memberCompare, memberSort, requestDateCompare } from './teams.utils';
+import { couchAttachmentUrl } from '../shared/utils';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconAnchor, MatIconButton, MatButton, MatAnchor } from '@angular/material/button';
@@ -801,4 +802,12 @@ export class TeamsViewComponent implements OnInit, AfterViewChecked, OnDestroy {
     });
   }
 
+  coverImageUrl(): string {
+    if (!this.team?._id || !this.team?.coverFileName) {
+      return '';
+    }
+    return couchAttachmentUrl(environment.couchAddress, 'teams', this.team._id, this.team.coverFileName);
+  }
+
 }
+

--- a/src/app/teams/teams-view.scss
+++ b/src/app/teams/teams-view.scss
@@ -51,4 +51,22 @@
     margin-inline-start: 8px;
   }
 
+  .team-toolbar-cover {
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    object-fit: cover;
+    flex-shrink: 0;
+    margin-inline-end: 8px;
+  }
+
+  .team-cover {
+    display: block;
+    width: 180px;
+    height: 180px;
+    border-radius: 4px;
+    object-fit: cover;
+    margin-bottom: 1rem;
+  }
+
 }

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -65,6 +65,9 @@
         <mat-header-cell *matHeaderCellDef mat-sort-header="doc.name" i18n>Name</mat-header-cell>
         <mat-cell *matCellDef="let element">
           <h3 class="team-name">
+            @if (element.doc?.coverFileName) {
+              <img class="team-table-cover" [src]="coverImageUrl(element.doc)" alt="Team cover" i18n-alt />
+            }
             <a (click)="$event.stopPropagation(); teamClick(element.doc._id, element.doc.teamType)"
                (keydown.space)="$event.preventDefault(); $event.stopPropagation(); !$event.repeat && teamClick(element.doc._id, element.doc.teamType)"
                (keydown.enter)="$event.stopPropagation(); !$event.repeat && teamClick(element.doc._id, element.doc.teamType)"

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -20,6 +20,8 @@ import { DialogsLoadingService } from '../shared/dialogs/dialogs-loading.service
 import { StateService } from '../shared/state.service';
 import { DeviceInfoService, DeviceType } from '../shared/device-info.service';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
+import { environment } from '../../environments/environment';
+import { couchAttachmentUrl } from '../shared/utils';
 import { attachNamesToPlanets, codeToPlanetName } from '../manager-dashboard/reports/reports.utils';
 import { MatToolbar, MatToolbarRow } from '@angular/material/toolbar';
 import { NgTemplateOutlet, NgClass, DatePipe } from '@angular/common';
@@ -480,4 +482,12 @@ export class TeamsComponent implements OnInit, AfterViewInit {
     return team.doc.type === 'enterprise' ? $localize`enterprise` : $localize`team`;
   }
 
+  coverImageUrl(team: any): string {
+    if (!team?._id || !team?.coverFileName) {
+      return '';
+    }
+    return couchAttachmentUrl(environment.couchAddress, this.dbName, team._id, team.coverFileName);
+  }
+
 }
+

--- a/src/app/teams/teams.scss
+++ b/src/app/teams/teams.scss
@@ -31,6 +31,9 @@
 
   // Keep joined/type metadata visible by allowing long names to wrap.
   .team-name {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     max-width: 95%;
     overflow: hidden;
 
@@ -38,6 +41,14 @@
       outline: 2px solid v.$primary;
       outline-offset: -2px;
     }
+  }
+
+  .team-table-cover {
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    object-fit: cover;
+    flex-shrink: 0;
   }
 
   .highlighted {

--- a/src/app/teams/teams.service.spec.ts
+++ b/src/app/teams/teams.service.spec.ts
@@ -614,5 +614,55 @@ describe('TeamsService cover image handling', () => {
     expect(savedDoc.coverFileName).toBeUndefined();
     expect(savedDoc._attachments).toBeUndefined();
   });
+
+  it('creates a new team with an uploaded cover image, resolves new id/rev, and uploads attachment', async () => {
+    let callCount = 0;
+    const updateDocument = vi.fn((db, doc) => {
+      callCount++;
+      if (callCount === 1) {
+        return of({ id: 'brand-new-team-id', rev: '1-init' });
+      }
+      return of({ id: doc._id, rev: '2-final' });
+    });
+    const putAttachment = vi.fn().mockReturnValue(of({ ok: true }));
+    const get = vi.fn(() => of({
+      _id: 'brand-new-team-id',
+      _rev: '1-attached',
+      createdDate: '2026-09-10T18:00:00.000Z',
+      _attachments: { 'cover.png': { content_type: 'image/png', length: 1234, stub: true } }
+    }));
+    const { service } = createService({ updateDocument, putAttachment, get });
+
+    const newTeamData = { name: 'Brand New Team', type: 'team' };
+    const coverState = {
+      added: [ { file: new File([ 'data' ], 'cover.png', { type: 'image/png' }) } ],
+      retained: [],
+      removed: []
+    };
+
+    let result: any;
+    await new Promise<void>((resolve) => {
+      service.saveTeamWithCover(newTeamData, coverState, {}).subscribe((res) => {
+        result = res;
+        resolve();
+      });
+    });
+
+    expect(putAttachment).toHaveBeenCalledWith(
+      expect.stringContaining('teams/brand-new-team-id/'),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(putAttachment).toHaveBeenCalledWith(
+      expect.stringContaining('?rev=1-init'),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(get).toHaveBeenCalledWith('teams/brand-new-team-id');
+    expect(updateDocument).toHaveBeenCalledTimes(2);
+    expect(result._id).toBe('brand-new-team-id');
+    expect(result.coverFileName).toBeDefined();
+    expect(result._attachments).toBeDefined();
+  });
 });
 

--- a/src/app/teams/teams.service.spec.ts
+++ b/src/app/teams/teams.service.spec.ts
@@ -514,3 +514,105 @@ describe('TeamsService membership writes', () => {
     expect(error).not.toHaveBeenCalled();
   });
 });
+
+describe('TeamsService cover image handling', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const createService = (couchOverrides: any = {}) => {
+    const couchService = {
+      findAll: vi.fn().mockReturnValue(of([])),
+      get: vi.fn().mockReturnValue(of({})),
+      updateDocument: vi.fn((db, doc) => of({ id: doc._id || 'new-id', rev: '1-rev' })),
+      putAttachment: vi.fn().mockReturnValue(of({ ok: true })),
+      ...couchOverrides
+    };
+    const service = new TeamsService(
+      couchService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+    return { service, couchService };
+  };
+
+  it('extracts existing cover attachments properly', () => {
+    const { service } = createService();
+    const teamWithCover = {
+      _id: 'team-1',
+      coverFileName: 'cover.jpg',
+      _attachments: { 'cover.jpg': { content_type: 'image/jpeg', length: 5000 } }
+    };
+    const attachments = service.existingCoverAttachments(teamWithCover);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].name).toBe('cover.jpg');
+    expect(attachments[0].contentType).toBe('image/jpeg');
+    expect(attachments[0].size).toBe(5000);
+
+    expect(service.existingCoverAttachments({})).toEqual([]);
+  });
+
+  it('initializes coverAttachmentState with retained attachment', () => {
+    const { service } = createService();
+    const teamWithCover = {
+      _id: 'team-1',
+      coverFileName: 'cover.jpg',
+      _attachments: { 'cover.jpg': { content_type: 'image/jpeg', length: 5000 } }
+    };
+    const state = service.coverAttachmentState(teamWithCover);
+    expect(state.retained).toHaveLength(1);
+    expect(state.removed).toEqual([]);
+    expect(state.added).toEqual([]);
+  });
+
+  it('includes coverImage field in addTeamFields', () => {
+    const { service } = createService();
+    const fields = service.addTeamFields({ planetType: 'community' }, 'team');
+    const coverField = fields.find((f: any) => f.name === 'coverImage');
+    expect(coverField).toBeDefined();
+    expect(coverField.type).toBe('file-upload');
+  });
+
+  it('retains existing cover image when unchanged', () => {
+    const updateDocument = vi.fn((db, doc) => of({ id: doc._id, rev: '2-rev' }));
+    const { service } = createService({ updateDocument });
+    const originalTeam = {
+      _id: 'team-1',
+      coverFileName: 'original.png',
+      _attachments: { 'original.png': { content_type: 'image/png', length: 1234 } }
+    };
+    const coverState = {
+      retained: [ { name: 'original.png', contentType: 'image/png', url: '', size: 1234 } ],
+      removed: [],
+      added: []
+    };
+
+    service.saveTeamWithCover({ _id: 'team-1', name: 'Team' }, coverState, originalTeam).subscribe();
+
+    expect(updateDocument).toHaveBeenCalledWith('teams', expect.objectContaining({
+      _id: 'team-1',
+      name: 'Team',
+      coverFileName: 'original.png',
+      _attachments: { 'original.png': { content_type: 'image/png', length: 1234 } }
+    }));
+  });
+
+  it('removes coverFileName and attachment when cover is removed', () => {
+    const updateDocument = vi.fn((db, doc) => of({ id: doc._id, rev: '2-rev' }));
+    const { service } = createService({ updateDocument });
+    const originalTeam = {
+      _id: 'team-1',
+      coverFileName: 'original.png',
+      _attachments: { 'original.png': { content_type: 'image/png', length: 1234 } }
+    };
+    const coverState = { retained: [], removed: [], added: [] };
+
+    service.saveTeamWithCover({ _id: 'team-1', name: 'Team' }, coverState, originalTeam).subscribe();
+
+    const savedDoc = updateDocument.mock.calls[0][1];
+    expect(savedDoc.coverFileName).toBeUndefined();
+    expect(savedDoc._attachments).toBeUndefined();
+  });
+});
+

--- a/src/app/teams/teams.service.spec.ts
+++ b/src/app/teams/teams.service.spec.ts
@@ -664,5 +664,51 @@ describe('TeamsService cover image handling', () => {
     expect(result.coverFileName).toBeDefined();
     expect(result._attachments).toBeDefined();
   });
+
+  it('creates a new team when updateDocument returns CouchDB-style {_id, _rev} response', async () => {
+    let callCount = 0;
+    const updateDocument = vi.fn((db, doc) => {
+      callCount++;
+      if (callCount === 1) {
+        return of({ _id: 'couchdb-team-id', _rev: '1-couchdbrev' });
+      }
+      return of({ _id: doc._id, _rev: '2-couchdbrev' });
+    });
+    const putAttachment = vi.fn().mockReturnValue(of({ ok: true }));
+    const get = vi.fn(() => of({
+      _id: 'couchdb-team-id',
+      _rev: '1-attached',
+      createdDate: '2026-09-10T18:00:00.000Z',
+      _attachments: { 'cover.png': { content_type: 'image/png', length: 1234, stub: true } }
+    }));
+    const { service } = createService({ updateDocument, putAttachment, get });
+
+    const newTeamData = { name: 'CouchDB Team', type: 'team' };
+    const coverState = {
+      added: [ { file: new File([ 'data' ], 'cover.png', { type: 'image/png' }) } ],
+      retained: [],
+      removed: []
+    };
+
+    let result: any;
+    await new Promise<void>((resolve) => {
+      service.saveTeamWithCover(newTeamData, coverState, {}).subscribe((res) => {
+        result = res;
+        resolve();
+      });
+    });
+
+    expect(putAttachment).toHaveBeenCalledWith(
+      expect.stringContaining('teams/couchdb-team-id/'),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(putAttachment).toHaveBeenCalledWith(
+      expect.stringContaining('?rev=1-couchdbrev'),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(result._id).toBe('couchdb-team-id');
+  });
 });
 

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -1,16 +1,18 @@
 import { Injectable } from '@angular/core';
-import { of, empty, forkJoin, throwError } from 'rxjs';
+import { of, empty, forkJoin, throwError, from } from 'rxjs';
 import { switchMap, map, take } from 'rxjs/operators';
 import { CouchService } from '../shared/couchdb.service';
 import { UserService } from '../shared/user.service';
-import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
+import { DialogsFormService, DialogField } from '../shared/dialogs/dialogs-form.service';
 import { findDocuments } from '../shared/mangoQueries';
 import { CustomValidators } from '../validators/custom-validators';
 import { StateService } from '../shared/state.service';
 import { ValidatorService } from '../validators/validator.service';
 import { UsersService } from '../users/users.service';
 import { planetAndParentId } from '../manager-dashboard/reports/reports.utils';
-import { fullName, truncateText } from '../shared/utils';
+import { fullName, truncateText, normalizeImage, NormalizedImage, couchAttachmentUrl } from '../shared/utils';
+import { AttachmentInputState, ExistingAttachment } from '../shared/forms/file-upload.component';
+import { environment } from '../../environments/environment';
 
 const nameField = {
   type: 'textbox',
@@ -83,6 +85,7 @@ export class TeamsService {
     } : {};
     const formGroup = {
       ...nameControl,
+      coverImage: [ this.coverAttachmentState(team) ],
       description: team.description || '',
       services: team.services || '',
       rules: team.rules || '',
@@ -90,15 +93,20 @@ export class TeamsService {
       teamType: [ { value: team.teamType || 'local', disabled: team._id !== undefined } ],
       public: [ team.public || false ]
     };
-    return this.dialogsFormService.confirm(title, this.addTeamFields(configuration, type), formGroup, true)
+    return this.dialogsFormService.confirm(title, this.addTeamFields(configuration, type, team), formGroup, true)
       .pipe(
-        switchMap((response: any) => response !== undefined ?
-          this.updateTeam(
-            { limit: 12, status: 'active', createdDate: this.couchService.datePlaceholder, teamPlanetCode: configuration.code,
-              parentCode: configuration.parentCode, createdBy: userId, ...team, ...response, type }
-          ) :
-          empty()
-        ),
+        switchMap((response: any) => {
+          if (response === undefined) {
+            return empty();
+          }
+          const coverState: AttachmentInputState = response.coverImage || { retained: [], removed: [], added: [] };
+          delete response.coverImage;
+          const teamData = {
+            limit: 12, status: 'active', createdDate: this.couchService.datePlaceholder, teamPlanetCode: configuration.code,
+            parentCode: configuration.parentCode, createdBy: userId, ...team, ...response, type
+          };
+          return this.saveTeamWithCover(teamData, coverState, team);
+        }),
         switchMap((response) => !team._id ?
           this.toggleTeamMembership(response, false, { userId, userPlanetCode: configuration.code, isLeader: true }) :
           of(response)
@@ -106,8 +114,8 @@ export class TeamsService {
       );
   }
 
-  addTeamFields(configuration, type) {
-    const typeField = {
+  addTeamFields(configuration, type, team: any = {}) {
+    const typeField: DialogField = {
       type: 'selectbox',
       name: 'teamType',
       placeholder: $localize`Team Type`,
@@ -119,12 +127,112 @@ export class TeamsService {
         { value: 'local', name: $localize`Local team` }
       ]
     };
+    const coverField: DialogField = {
+      type: 'file-upload',
+      name: 'coverImage',
+      placeholder: $localize`Cover image`,
+      fileUpload: {
+        accept: 'image/*',
+        existingAttachments: this.existingCoverAttachments(team),
+        hint: $localize`Recommended: a square image. Covers are cropped to fit.`,
+        imagePreview: true,
+        maxFiles: 1,
+        multiple: false,
+        typePills: [ 'IMG' ]
+      }
+    };
     return [
       type === 'services' ? [] : nameField,
       type === 'enterprise' ? enterpriseDescField : descriptionField,
+      coverField,
       type === 'team' ? typeField : [],
       publicField
     ].flat();
+  }
+
+  existingCoverAttachments(team: any): ExistingAttachment[] {
+    const fileName = team?.coverFileName;
+    const attachment = team?._attachments?.[fileName];
+    return fileName && attachment ? [ {
+      name: fileName,
+      contentType: attachment.content_type,
+      url: couchAttachmentUrl(environment.couchAddress, this.dbName, team._id, fileName),
+      size: attachment.length
+    } ] : [];
+  }
+
+  coverAttachmentState(team: any): AttachmentInputState {
+    return {
+      retained: this.existingCoverAttachments(team),
+      removed: [],
+      added: []
+    };
+  }
+
+  saveTeamWithCover(team: any, coverState: AttachmentInputState, originalTeam: any = {}) {
+    const addedCover = coverState?.added?.[0];
+    const retainedCover = coverState?.retained?.[0];
+    const existingAttachmentNames = Object.keys(originalTeam?._attachments || {});
+
+    return (addedCover ? from(normalizeImage(addedCover.file, { usedNames: existingAttachmentNames })) : of(null)).pipe(
+      switchMap((normalizedCover: NormalizedImage | null) => {
+        if (normalizedCover) {
+          return this.saveTeamWithNewCover(team, normalizedCover, originalTeam);
+        }
+        const teamDoc = { ...team };
+        if (retainedCover && originalTeam?._attachments?.[retainedCover.name]) {
+          teamDoc.coverFileName = retainedCover.name;
+          teamDoc._attachments = { ...originalTeam._attachments };
+        } else {
+          const attachments = { ...(originalTeam?._attachments || {}) };
+          if (originalTeam?.coverFileName) {
+            delete attachments[originalTeam.coverFileName];
+          }
+          delete teamDoc.coverFileName;
+          if (Object.keys(attachments).length) {
+            teamDoc._attachments = attachments;
+          } else {
+            delete teamDoc._attachments;
+          }
+        }
+        return this.updateTeam(teamDoc);
+      })
+    );
+  }
+
+  private saveTeamWithNewCover(team: any, normalizedCover: NormalizedImage, originalTeam: any = {}) {
+    const existingTeamId = originalTeam._id || team._id;
+    const existingTeamRev = originalTeam._rev || team._rev;
+    const teamWithoutCover = { ...team };
+    delete teamWithoutCover.coverFileName;
+
+    const upload$ = existingTeamId && existingTeamRev ?
+      this.couchService.putAttachment(
+        `${this.dbName}/${existingTeamId}/${normalizedCover.fileName}?rev=${existingTeamRev}`,
+        normalizedCover.file, { headers: { 'Content-Type': normalizedCover.contentType } }
+      ).pipe(switchMap(() => this.couchService.get(`${this.dbName}/${existingTeamId}`))) :
+      this.updateTeam(teamWithoutCover).pipe(
+        switchMap((res: any) => this.couchService.putAttachment(
+          `${this.dbName}/${res.id}/${normalizedCover.fileName}?rev=${res.rev}`,
+          normalizedCover.file, { headers: { 'Content-Type': normalizedCover.contentType } }
+        ).pipe(switchMap(() => this.couchService.get(`${this.dbName}/${res.id}`))))
+      );
+
+    return upload$.pipe(
+      switchMap((uploadedDoc: any) => {
+        const attachments = { ...(uploadedDoc._attachments || {}) };
+        if (originalTeam?.coverFileName && originalTeam.coverFileName !== normalizedCover.fileName) {
+          delete attachments[originalTeam.coverFileName];
+        }
+        return this.updateTeam({
+          ...team,
+          _id: uploadedDoc._id,
+          _rev: uploadedDoc._rev,
+          coverFileName: normalizedCover.fileName,
+          _attachments: attachments
+        });
+      })
+    );
   }
 
   updateTeam(team: any) {

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -241,7 +241,13 @@ export class TeamsService {
   }
 
   updateTeam(team: any) {
-    return this.couchService.updateDocument(this.dbName, team).pipe(switchMap((res: any) => of({ ...team, _rev: res.rev, _id: res.id })));
+    return this.couchService.updateDocument(this.dbName, team).pipe(
+      switchMap((res: any) => of({
+        ...team,
+        _id: res._id || res.id || team._id,
+        _rev: res._rev || res.rev || team._rev
+      }))
+    );
   }
 
   requestToJoinTeam(team, user) {

--- a/src/app/teams/teams.service.ts
+++ b/src/app/teams/teams.service.ts
@@ -212,10 +212,14 @@ export class TeamsService {
         normalizedCover.file, { headers: { 'Content-Type': normalizedCover.contentType } }
       ).pipe(switchMap(() => this.couchService.get(`${this.dbName}/${existingTeamId}`))) :
       this.updateTeam(teamWithoutCover).pipe(
-        switchMap((res: any) => this.couchService.putAttachment(
-          `${this.dbName}/${res.id}/${normalizedCover.fileName}?rev=${res.rev}`,
-          normalizedCover.file, { headers: { 'Content-Type': normalizedCover.contentType } }
-        ).pipe(switchMap(() => this.couchService.get(`${this.dbName}/${res.id}`))))
+        switchMap((res: any) => {
+          const teamId = res._id || res.id;
+          const teamRev = res._rev || res.rev;
+          return this.couchService.putAttachment(
+            `${this.dbName}/${teamId}/${normalizedCover.fileName}?rev=${teamRev}`,
+            normalizedCover.file, { headers: { 'Content-Type': normalizedCover.contentType } }
+          ).pipe(switchMap(() => this.couchService.get(`${this.dbName}/${teamId}`)));
+        })
       );
 
     return upload$.pipe(
@@ -228,6 +232,7 @@ export class TeamsService {
           ...team,
           _id: uploadedDoc._id,
           _rev: uploadedDoc._rev,
+          ...(uploadedDoc.createdDate ? { createdDate: uploadedDoc.createdDate } : {}),
           coverFileName: normalizedCover.fileName,
           _attachments: attachments
         });


### PR DESCRIPTION
Fixes #10424

### Description

Teams and Enterprises previously lacked cover image support, unlike Courses which have cover image uploads, attachments, and thumbnail previews across the app.

This PR brings the cover image pattern from Courses over to Teams:
- Adds image upload and attachment handling to the team creation and edit dialog.
- Displays cover thumbnails across the Teams table and the team detail header toolbar.
- Shows the full cover image in the team's Plan tab.
- Supports team cover images on the dashboard's `myTeams` shelf cards.

### What's Changed

- **Attachment Lifecycle & Persistence**: Updated `TeamsService` to normalize uploaded images (`normalizeImage`), upload attachments to CouchDB via `putAttachment`, record `coverFileName`, and clean up superseded or removed attachments.
- **Form Field Integration**: Added a single-image upload field to `TeamsService.addTeamFields()`, placed below the Plan/Mission field with existing attachment preloading on edit.
- **Dialog Form Spacing**: Wrapped file upload form items in a `.file-upload-wrapper` with `margin-bottom: 20px` in `DialogsFormComponent`, providing balanced spacing between the Plan textarea, image dropzone, and team type selector.
- **Teams Views**: Added 36×36 cover thumbnails next to team names in the Teams directory table and in the team detail header toolbar, plus a 180×180 preview card in the Plan tab.
- **Dashboard Shelf Cards**: Updated `DashboardTileComponent` so `myTeams` cards resolve and display cover image attachments from the `teams` database.
- **Unit Tests**: Added tests covering image field definition, image attachment saving and removal, URL resolution, and dashboard shelf tile rendering.

### Verification

- **Lint**: `npm run lint` passed with 0 errors.
- **Unit Tests**: `npx vitest run src/app/teams/ src/app/dashboard/` passed (98/98 tests).
- **i18n**: `npm run i18n:check` passed with 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading, retaining, replacing, and removing team cover images.
  * Team covers now appear in team lists, team details, toolbar views, and Plan/Mission & Services sections.
  * Dashboard team tiles now display cover images with appropriate text layout limits.
  * Added accessible alternative text for team cover images.

* **Style**
  * Improved team cover image sizing, cropping, spacing, and alignment.
  * Added spacing below file-upload controls for clearer forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->