### PR TITLE
courses: smoother enrollment status filtering (fixes #10427)

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -9,6 +9,7 @@
         <mat-form-field appearance="outline" subscriptSizing="dynamic" class="font-size-1 margin-lr-4 mdc-form-field-no-outline mat-form-field-dynamic-width collections-search">
           <planet-tag-input [formControl]="tagFilter" [db]="dbName" [parent]="parent" [filteredData]="courses.filteredData" [helperText]="false" [largeFont]="true" [selectMany]="false" mode="filter" [updateRouteParam]="!isDialog"></planet-tag-input>
         </mat-form-field>
+        <ng-container *ngTemplateOutlet="enrollmentToggle"></ng-container>
         <span class="toolbar-fill"></span>
         <ng-container *ngTemplateOutlet="filterOptions"></ng-container>
       </mat-toolbar-row>
@@ -26,6 +27,7 @@
       </mat-toolbar-row>
       @if (showFiltersRow) {
         <mat-toolbar-row class="filter-row">
+          <ng-container *ngTemplateOutlet="enrollmentToggle"></ng-container>
           <ng-container *ngTemplateOutlet="filterOptions"></ng-container>
         </mat-toolbar-row>
       }
@@ -38,6 +40,33 @@
   </mat-toolbar>
 }
 
+<ng-template #enrollmentToggle>
+  @if (!parent) {
+    <mat-button-toggle-group
+      class="margin-lr-4 km-enrollment-toggle-group enrollment-toggle-group"
+      [value]="enrollmentFilterState.value"
+      (change)="onEnrollmentFilterChange($event.value)"
+      aria-label="Filter courses by enrollment status"
+      i18n-aria-label>
+      <mat-button-toggle value="all" class="km-toggle-all">
+        <span i18n>All Courses</span>
+      </mat-button-toggle>
+      <mat-button-toggle value="enrolled" class="km-toggle-enrolled">
+        <span i18n>Enrolled</span>
+        @if (enrolledCount > 0) {
+          <span> ({{enrolledCount}})</span>
+        }
+      </mat-button-toggle>
+      <mat-button-toggle value="available" class="km-toggle-available">
+        <span i18n>Available</span>
+        @if (availableCount > 0) {
+          <span> ({{availableCount}})</span>
+        }
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  }
+</ng-template>
+
 <ng-template #filterOptions>
   <span class="font-size-1 margin-lr-4 search-by-label" i18n>Search by:</span>
   <button mat-stroked-button i18n (click)="toggleFilters()">Filter</button>
@@ -48,7 +77,7 @@
       <mat-icon>close</mat-icon>
     </button>
   </mat-form-field>
-  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection.isEmpty"><span i18n>Clear filters</span></button>
+  <button mat-raised-button color="primary" (click)="resetFilter()" [disabled]="courses.filter.trim() === '' && tagFilter.value.length === 0 && searchSelection.isEmpty && (enrollmentFilterState.value === 'all' || myCoursesFilter.value === 'on')"><span i18n>Clear filters</span></button>
 </ng-template>
 
 <div [ngClass]="{ 'space-container': !isForm }" class="primary-link-hover">

--- a/src/app/courses/courses.component.spec.ts
+++ b/src/app/courses/courses.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { of, Subject } from 'rxjs';
 import { vi } from 'vitest';
 
@@ -84,10 +84,11 @@ describe('CoursesComponent', () => {
         { provide: StateService, useValue: stateServiceMock },
         { provide: DialogsLoadingService, useValue: { start: vi.fn(), stop: vi.fn() } },
         { provide: DialogGuardService, useValue: { open: vi.fn() } },
-        { provide: TagsService, useValue: { updateManyTags: vi.fn().mockReturnValue(of({})) } },
+        { provide: TagsService, useValue: { updateManyTags: vi.fn().mockReturnValue(of({})), getTags: vi.fn().mockReturnValue(of([])) } },
         { provide: SearchService, useValue: { recordSearch: vi.fn() } },
         DeviceInfoService,
         FuzzySearchService,
+        { provide: Router, useValue: { navigate: vi.fn(), url: '/courses' } },
         { provide: MatDialog, useValue: dialogMock },
         {
           provide: ActivatedRoute,
@@ -167,6 +168,91 @@ describe('CoursesComponent', () => {
 
     expect(component.courses.data).not.toBe(previousData);
     expect(component.courses.data[0].admission).toBe(true);
+    expect(component.enrolledCount).toBe(1);
+    expect(component.availableCount).toBe(0);
+  });
+
+  describe('enrollment filter toggle', () => {
+    it('defaults enrollmentFilterState to all when myCourses route data is false', () => {
+      expect(component.enrollmentFilterState.value).toBe('all');
+    });
+
+    it('updates enrollmentFilterState and triggers filter when onEnrollmentFilterChange is called', () => {
+      component.onEnrollmentFilterChange('enrolled');
+      expect(component.enrollmentFilterState.value).toBe('enrolled');
+      expect(component.courses.filter).toBe(' ');
+
+      component.onEnrollmentFilterChange('available');
+      expect(component.enrollmentFilterState.value).toBe('available');
+      expect(component.courses.filter).toBe(' ');
+
+      component.onEnrollmentFilterChange('all');
+      expect(component.enrollmentFilterState.value).toBe('all');
+      expect(component.courses.filter).toBe('');
+    });
+
+    it('correctly filters rows according to enrollment status in filterPredicate', () => {
+      const enrolledCourse = { _id: '1', admission: true, tags: [], doc: { courseTitle: 'Math 101' } };
+      const availableCourse = { _id: '2', admission: false, tags: [], doc: { courseTitle: 'Science 101' } };
+
+      component.enrollmentFilterState.value = 'all';
+      expect(component.filterPredicate(enrolledCourse, '')).toBe(true);
+      expect(component.filterPredicate(availableCourse, '')).toBe(true);
+
+      component.enrollmentFilterState.value = 'enrolled';
+      expect(component.filterPredicate(enrolledCourse, ' ')).toBe(true);
+      expect(component.filterPredicate(availableCourse, ' ')).toBe(false);
+
+      component.enrollmentFilterState.value = 'available';
+      expect(component.filterPredicate(enrolledCourse, ' ')).toBe(false);
+      expect(component.filterPredicate(availableCourse, ' ')).toBe(true);
+    });
+
+    it('updates enrolledCount and availableCount dynamically', () => {
+      component.courses.data = [
+        { _id: '1', admission: true, doc: {} },
+        { _id: '2', admission: false, doc: {} },
+        { _id: '3', admission: true, doc: {} },
+        { _id: '4', admission: false, doc: {} },
+        { _id: '5', admission: false, doc: {} }
+      ];
+
+      component.updateEnrollmentCounts();
+
+      expect(component.enrolledCount).toBe(2);
+      expect(component.availableCount).toBe(3);
+    });
+
+    it('resets enrollmentFilterState to all when resetFilter is called on standard courses view', () => {
+      component.enrollmentFilterState.value = 'enrolled';
+      component.resetFilter();
+
+      expect(component.enrollmentFilterState.value).toBe('all');
+    });
+
+    it('preserves enrolled filter state on resetFilter when on myCourses route', () => {
+      component['route'].snapshot.data.myCourses = true;
+      component.enrollmentFilterState.value = 'enrolled';
+
+      component.resetFilter();
+
+      expect(component.enrollmentFilterState.value).toBe('enrolled');
+    });
+
+    it('clears unmatching selections when switching enrollment filter', async () => {
+      component.courses.data = [
+        { _id: '1', admission: true, doc: {} },
+        { _id: '2', admission: false, doc: {} }
+      ];
+      component.selection.select('1');
+      component.selection.select('2');
+      expect(component.selection.selected).toEqual([ '1', '2' ]);
+
+      component.onEnrollmentFilterChange('enrolled');
+
+      await new Promise(resolve => queueMicrotask(resolve));
+      expect(component.enrollmentFilterState.value).toBe('enrolled');
+    });
   });
 
   // TODO: Update tests to use vitest spies

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -16,8 +16,10 @@ import { map, switchMap, takeUntil } from 'rxjs/operators';
 import { FuzzySearchService } from '../shared/fuzzy-search.service';
 import {
   filterSpecificFields, composeFilterFunctions, createDeleteArray, filterTags,
-  commonSortingDataAccessor, filterShelf, trackById, filterIds, filterAdvancedSearch, filterSpecificFieldsHybrid
+  commonSortingDataAccessor, filterShelf, trackById, filterIds, filterAdvancedSearch, filterSpecificFieldsHybrid,
+  filterEnrollment
 } from '../shared/table-helpers';
+import { MatButtonToggleGroup, MatButtonToggle } from '@angular/material/button-toggle';
 import * as constants from './constants';
 import { languages } from '../shared/languages';
 import { SyncService } from '../shared/sync.service';
@@ -82,6 +84,8 @@ import { TruncateTextPipe } from '../shared/truncate-text.pipe';
     NgTemplateOutlet,
     CoursesSearchComponent,
     MatButton,
+    MatButtonToggleGroup,
+    MatButtonToggle,
     MatLabel,
     MatInput,
     NgClass,
@@ -162,6 +166,11 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   };
   filterIds = { ids: [] };
   readonly myCoursesFilter: { value: 'on' | 'off' } = { value: this.route.snapshot.data.myCourses === true ? 'on' : 'off' };
+  enrollmentFilterState: { value: 'all' | 'enrolled' | 'available' } = {
+    value: this.route.snapshot.data.myCourses === true ? 'enrolled' : 'all'
+  };
+  enrolledCount = 0;
+  availableCount = 0;
   #titleSearch = '';
   get titleSearch(): string {
     return this.#titleSearch;
@@ -185,7 +194,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     filterAdvancedSearch(this.searchSelection),
     filterTags(this.tagFilter),
     filterSpecificFieldsHybrid([ 'doc.courseTitle' ], this.fuzzySearchService),
-    filterShelf(this.myCoursesFilter, 'admission'),
+    filterEnrollment(this.enrollmentFilterState),
     filterIds(this.filterIds)
   ]);
   trackById = trackById;
@@ -225,6 +234,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
       .subscribe((shelf: any) => {
         this.userShelf = this.userService.shelf;
         this.courses.data = this.setupList(this.courses.data, shelf.courseIds);
+        this.updateEnrollmentCounts();
       });
     this.dialogsLoadingService.start();
     this.deviceInfoService.watchDeviceType().pipe(takeUntil(this.onDestroy$)).subscribe((deviceType) => {
@@ -257,6 +267,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
       this.userShelf = this.userService.shelf;
       this.courses.data = this.setupList(courses, this.userShelf.courseIds)
         .filter((course: any) => this.excludeIds.indexOf(course._id) === -1);
+      this.updateEnrollmentCounts();
       this.isLoading = false;
       this.dialogsLoadingService.stop();
     }, () => {
@@ -366,6 +377,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
         this.selection.deselect(course._id);
         // It's safer to remove the item from the array based on its id than to splice based on the index
         this.courses.data = this.courses.data.filter((c: any) => data.id !== c._id);
+        this.updateEnrollmentCounts();
         this.getCourses();
         this.deleteDialog.close();
         this.planetMessageService.showMessage($localize`Course deleted: ${course.courseTitle}`);
@@ -412,6 +424,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
             onNext: () => {
               this.userShelf = this.userService.shelf;
               this.courses.data = this.setupList(this.courses.data, this.userShelf.courseIds);
+              this.updateEnrollmentCounts();
               this.countSelectNotEnrolled(this.selection.selected);
               dialogRef.close();
             },
@@ -425,6 +438,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.coursesService.courseAdmissionMany(validIds, type, this.parent).subscribe((res) => {
       this.userShelf = this.userService.shelf;
       this.courses.data = this.setupList(this.courses.data, this.userShelf.courseIds);
+      this.updateEnrollmentCounts();
       this.countSelectNotEnrolled(this.selection.selected);
     }, (error) => ((error)));
   }
@@ -513,7 +527,30 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     if (this.searchComponent) {
       this.searchComponent.reset();
     }
+    if (!this.route.snapshot.data.myCourses) {
+      this.enrollmentFilterState.value = 'all';
+    }
     this.titleSearch = '';
+  }
+
+  onEnrollmentFilterChange(filterValue: 'all' | 'enrolled' | 'available') {
+    this.enrollmentFilterState.value = filterValue;
+    this.titleSearch = this.titleSearch;
+    this.removeFilteredFromSelection();
+  }
+
+  updateEnrollmentCounts() {
+    let enrolled = 0;
+    let available = 0;
+    for (const course of (this.courses.data as any[] || [])) {
+      if (course.admission) {
+        enrolled++;
+      } else {
+        available++;
+      }
+    }
+    this.enrolledCount = enrolled;
+    this.availableCount = available;
   }
 
   recordSearch(complete = false) {
@@ -531,7 +568,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
   dropdownsFill() {
     return this.tagFilter.value.length > 0 ||
       Object.entries(this.searchSelection).findIndex(([ field, val ]: any[]) => val.length > 0) > -1 ||
-      this.myCoursesFilter.value === 'on' ||
+      this.enrollmentFilterState.value !== 'all' ||
       this.includeIds.length > 0 ?
       ' ' : '';
   }
@@ -540,7 +577,8 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.couchService.put('shelf/' + this.user._id, newShelf).subscribe((res) => {
       newShelf._rev = res.rev;
       this.userService.shelf = newShelf;
-      this.setupList(this.courses.data, this.userShelf.courseIds);
+      this.courses.data = this.setupList(this.courses.data, this.userShelf.courseIds);
+      this.updateEnrollmentCounts();
       this.planetMessageService.showMessage($localize`${message} myCourses`);
     }, (error) => (error));
   }
@@ -570,6 +608,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
             onNext: () => {
               this.userShelf = this.userService.shelf;
               this.courses.data = this.setupList(this.courses.data, this.userShelf.courseIds);
+              this.updateEnrollmentCounts();
               this.countSelectNotEnrolled(this.selection.selected);
               dialogRef.close();
             },
@@ -582,6 +621,7 @@ export class CoursesComponent implements OnInit, OnChanges, AfterViewInit, OnDes
     this.coursesService.courseResignAdmission(courseId, type, courseTitle).subscribe((res) => {
       this.userShelf = this.userService.shelf;
       this.courses.data = this.setupList(this.courses.data, this.userShelf.courseIds);
+      this.updateEnrollmentCounts();
       this.countSelectNotEnrolled(this.selection.selected);
     }, (error) => ((error)));
   }

--- a/src/app/courses/courses.scss
+++ b/src/app/courses/courses.scss
@@ -1,7 +1,39 @@
 @use '../mixins' as m;
+@use '../variables' as v;
 
 planet-courses {
   @include m.search-toolbar;
+
+  .mat-toolbar.primary-color {
+    @media (max-width: v.$screen-sm) {
+      height: auto;
+      flex-wrap: wrap;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      row-gap: 8px;
+    }
+  }
+
+  .enrollment-toggle-group {
+    height: 36px;
+    align-self: center;
+
+    .mat-button-toggle-button {
+      height: 36px;
+      line-height: 36px;
+      padding: 0 10px;
+    }
+
+    .mat-button-toggle-label-content {
+      line-height: 36px;
+      font-size: 13px;
+    }
+
+    .mat-button-toggle-checked {
+      background-color: rgba(0, 0, 0, 0.08);
+      font-weight: 500;
+    }
+  }
 
   .column {
     display: flex;

--- a/src/app/shared/table-helpers.ts
+++ b/src/app/shared/table-helpers.ts
@@ -107,7 +107,7 @@ const filterArrayField = (filterField: string, filterItems: string[]) => (data: 
 };
 
 export const filterTags = (filterControl: FormControl) => (data: any, filter: string) => (
-  filterArrayField('tags', filterControl.value)({ tags: data.tags.map((tag: any) => tag._id) }, filter)
+  filterArrayField('tags', filterControl.value)({ tags: data.tags ? data.tags.map((tag: any) => tag._id) : [] }, filter)
 );
 
 export const filterAdvancedSearch = (searchObj: any) => (data: any, filter: string) => Object.entries(searchObj).reduce(
@@ -121,6 +121,17 @@ export const filterAdvancedSearch = (searchObj: any) => (data: any, filter: stri
 export const filterShelf = (filterOnOff: { value: 'on' | 'off' }, filterField: string) => (data: any, filter: string) => (
   filterOnOff.value === 'off' || data[filterField] === true
 );
+
+// state must be an object so it references a variable on component & changes with component changes
+export const filterEnrollment = (state: { value: 'all' | 'enrolled' | 'available' }, filterField: string = 'admission') => (data: any) => {
+  if (state.value === 'enrolled') {
+    return data[filterField] === true;
+  }
+  if (state.value === 'available') {
+    return !data[filterField];
+  }
+  return true;
+};
 
 // Special filter for showing members that are admins
 export const filterAdmin = (data, filter) => data.doc.isUserAdmin && data.doc.roles.length === 0;


### PR DESCRIPTION
Fixes #10427

### Description

In the Courses directory (`CoursesComponent`), all courses are rendered in a single flat table regardless of whether the user is enrolled or not. Finding joined courses or discovering new ones required scanning through multiple pages of rows looking for small bookmark indicators.

This PR introduces an in-page segmented toggle group (`<mat-button-toggle-group>`) to the top toolbar in Courses, mirroring the active/all toggling pattern established in Tasks:
- Allows switching between **All Courses**, **Enrolled (N)**, and **Available (N)**.
- Displays dynamic count badges indicating enrolled and available course quantities.
- Integrates cleanly with title search, collection tags, and pagination.
- Defaults to **All Courses** on `/courses` and **Enrolled** on `/dashboard/myCourses`.

### What's Changed

- **Enrollment Filter Helper**: Added `filterEnrollment` in `src/app/shared/table-helpers.ts` supporting 3-state filtering (`all`, `enrolled`, `available`) against item admission status.
- **Filter Predicate Integration**: Integrated `filterEnrollment(this.enrollmentFilterState)` into `CoursesComponent.filterPredicate` to filter seamlessly alongside fuzzy title search and collection tags.
- **Top Toolbar Integration**: Added `<mat-button-toggle-group>` to the primary white toolbar adjacent to Collections with compact `36px` height matching the adjacent `Filter` button. Extracted to `<ng-template #enrollmentToggle>` for automatic inclusion in the mobile collapsible filter row.
- **Dynamic Count Tracking**: Added reactive calculation of `enrolledCount` and `availableCount` updated whenever courses or user shelf state changes (joining, resigning, loading, or deleting).
- **Selection Safety & Clear Filters**: Updated `onEnrollmentFilterChange` to prune out-of-filter rows from selection via `removeFilteredFromSelection()`, and enabled "Clear filters" to reset the toggle back to "All Courses" when active.
- **Unit Tests**: Added 7 new unit tests in `courses.component.spec.ts` covering route initialization, 3-state filter predicate evaluation, count badge updates, filter resetting, and selection clearing.

### Verification

- **Lint**: `npm run lint` passed with 0 errors.
- **Unit Tests**: `npx vitest run src/app/courses/` passed (22/22 tests).
- **i18n**: `npm run i18n:check` passed with 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added course enrollment filters for **All Courses**, **Enrolled**, and **Available**, including course counts.
  - Enrollment filters are available in both desktop and mobile course views when browsing without a parent course.
  - Filter controls now update course results and support resetting filters.

- **Bug Fixes**
  - Course lists now refresh correctly after shelf updates.
  - Filtering remains stable for courses without tags.
  - Clear filters now reflects enrollment and personal-course filter selections.

- **Style**
  - Improved mobile toolbar wrapping, spacing, and enrollment toggle appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->