### PR TITLE
dashboard: smoother courses cards dragging (fixes #10429)

### DIFF
--- a/src/app/dashboard/dashboard-tile.component.spec.ts
+++ b/src/app/dashboard/dashboard-tile.component.spec.ts
@@ -1,5 +1,6 @@
 import { ElementRef, EnvironmentInjector, runInInjectionContext } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
@@ -132,5 +133,38 @@ describe('DashboardTileComponent', () => {
     expect(coursesService.courseResignAdmission).toHaveBeenCalledWith('course-1', 'resign', 'Course 1');
     expect(dialogRef.close).toHaveBeenCalled();
     expect(messageService.showMessage).toHaveBeenCalled();
+  });
+
+  it('renders cover image and binds has-course-cover class for course cards with coverFileName', () => {
+    TestBed.configureTestingModule({
+      imports: [ DashboardTileComponent ],
+      providers: [
+        provideRouter([]),
+        { provide: CoursesService, useValue: {} },
+        { provide: DeviceInfoService, useValue: { watchDeviceType: vi.fn().mockReturnValue(of(undefined)) } },
+        { provide: MatDialog, useValue: {} },
+        { provide: PlanetMessageService, useValue: {} },
+        { provide: TeamsService, useValue: {} },
+        { provide: UserService, useValue: { get: vi.fn().mockReturnValue({ roles: [] }), shelf: { courseIds: [] }, userChange$: of({}) } }
+      ]
+    });
+    const fixture = TestBed.createComponent(DashboardTileComponent);
+    const component = fixture.componentInstance;
+    component.cardType = 'myCourses';
+    component.isLoading = false;
+    component.itemData = [
+      { _id: 'c1', title: 'Course with cover', coverFileName: 'cover.png' },
+      { _id: 'c2', title: 'Course without cover' }
+    ];
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.dashboard-item');
+    expect(items.length).toBe(2);
+    expect(items[0].classList.contains('has-course-cover')).toBe(true);
+    expect(items[1].classList.contains('has-course-cover')).toBe(false);
+
+    const coverImg = items[0].querySelector('.dashboard-course-cover img');
+    expect(coverImg).toBeTruthy();
+    expect(coverImg.getAttribute('src')).toContain('/courses/c1/cover.png');
   });
 });

--- a/src/app/dashboard/dashboard-tile.scss
+++ b/src/app/dashboard/dashboard-tile.scss
@@ -54,6 +54,10 @@
         grid-auto-columns: v.$dashboard-tile-width;
         transition: transform 0.5s;
 
+        &.cdk-drop-list-dragging .dashboard-item:not(.cdk-drag-placeholder) {
+          transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+        }
+
         .dashboard-item {
           grid-column-end: span 1;
           grid-row-end: 1;
@@ -65,6 +69,14 @@
           padding: 0;
           position: relative;
           word-break: break-word;
+
+          &.cdk-drag-placeholder {
+            opacity: 0.3;
+          }
+
+          &.cdk-drag-animating {
+            transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+          }
 
           > .dashboard-item-link {
             display: flex;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1085,6 +1085,59 @@ body {
     text-decoration: underline;
   }
 
+  // Dashboard drag & drop preview styles
+  .cdk-drag-preview.dashboard-item {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    background-color: v.$white;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+    word-break: break-word;
+
+    &.bg-grey {
+      background-color: v.$grey;
+    }
+
+    > .dashboard-item-link {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 1rem 0.5rem;
+    }
+
+    &.has-course-cover > .dashboard-item-link {
+      padding: 0.5rem;
+    }
+
+    .dashboard-course-cover img {
+      width: 48px;
+      height: 48px;
+      object-fit: cover;
+      border-radius: 4px;
+      border: 1px solid v.$grey;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    .dashboard-text {
+      display: -webkit-box;
+      width: calc(#{v.$dashboard-tile-width} - 1rem);
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .delete-item {
+      display: none;
+    }
+  }
+
   /* Custom scrollbar styles */
   ::-webkit-scrollbar {
     width: 13px;


### PR DESCRIPTION
Fixes #10429

### Description

Dragging a dashboard course card with a cover image creates an Angular CDK preview under `<body>`. The original card styles were nested beneath the component host, so they did not match
the hoisted preview. This allowed cover images to render at their intrinsic size and overflow the card.

### Changes

- Moved the shared dashboard-item layout into a top-level, component-scoped rule that matches both the original card and CDK’s cloned preview.
- Constrained course cover images and preserved card text, spacing, and alternating backgrounds while dragging.
- Used Material elevation for the preview instead of a hardcoded shadow.
- Hid the remove button from the preview.
- Added placeholder, sibling movement, and drop-return transitions.
- Let CDK preserve the source card’s measured dimensions instead of forcing preview sizing.
- Removed duplicated preview styles from the global stylesheet.

### Verification

- `npm run lint`
- `npm run build`
- `npx vitest run` — 57 test files and 398 tests passed

### Manual verification

- [ ] Course cover remains constrained while dragging
- [ ] Grey cards remain grey in the preview
- [ ] Preview animates into position when dropped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the appearance and consistency of dashboard items, including links, text truncation, and course covers.
  - Added visual elevation to draggable item previews.
  - Added smoother drag-and-drop transitions and clearer placeholder states.
  - Applied dashboard item styling more consistently across dashboard layouts.
  - Preserved appropriate spacing for empty links and visible focus outlines for improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->