### PR TITLE
upgrade: add authorization, disk space check, and improved error handling

### DIFF
--- a/docker/planet/default.conf.template
+++ b/docker/planet/default.conf.template
@@ -78,6 +78,7 @@ server {
     fastcgi_read_timeout 900;
     fastcgi_param SCRIPT_FILENAME "$document_root/upgrade.sh";
     fastcgi_param PLANET_VERSION "$version";
+    fastcgi_param HTTP_COOKIE "$http_cookie";
     fastcgi_pass unix://run/fcgi.sock;
   }
 

--- a/docker/planet/nginx/storage.sh
+++ b/docker/planet/nginx/storage.sh
@@ -3,4 +3,6 @@ echo "HTTP/1.0 200 OK"
 echo "Content-type: text/plain"
 echo ""
 
-echo $(df -h / | tail -1 | awk '{print $4}')
+# Bytes available, so callers can compare against an image size instead of
+# parsing a human-readable string like "2.3G". df -P reports 1024-byte blocks.
+df -P / | awk 'END {print $4 * 1024}'

--- a/docker/planet/nginx/upgrade.sh
+++ b/docker/planet/nginx/upgrade.sh
@@ -1,20 +1,144 @@
 #!/bin/sh
-echo "HTTP/1.0 200 OK"
-echo "Content-type: text/plain"
-echo ""
 
-function upgrade {
-  curl --unix-socket /var/run/docker.sock -X POST "http://localhost/images/create?fromImage=$1"
+SOCKET=/var/run/docker.sock
+API=http://localhost
+COUCHDB=http://couchdb:5984
+REPO=treehouses/planet
+VARIANTS="planet db-init chatapi"
+
+respond() {
+  echo "HTTP/1.0 $1"
+  echo "Content-type: text/plain"
+  echo ""
 }
 
-function rename {
-  curl --unix-socket /var/run/docker.sock -X POST "http://localhost/images/$1/tag?repo=$2"
+# This endpoint can replace every image the host boots from, so it requires a
+# CouchDB server admin. The browser sends AuthSession on this origin and nginx
+# forwards it as HTTP_COOKIE.
+authorized() {
+  [ -n "$HTTP_COOKIE" ] || return 1
+  roles=$(curl -s -H "Cookie: $HTTP_COOKIE" "$COUCHDB/_session" | jq -r '.userCtx.roles | join(" ")' 2>/dev/null)
+  echo " $roles " | grep -q " _admin "
 }
 
-upgrade "treehouses/planet:$PLANET_VERSION"
-upgrade "treehouses/planet:db-init-$PLANET_VERSION"
-upgrade "treehouses/planet:chatapi-$PLANET_VERSION"
+if ! authorized; then
+  respond "403 Forbidden"
+  echo "RESULT: error upgrade requires a signed-in Planet administrator"
+  exit 0
+fi
 
-rename "treehouses/planet:$PLANET_VERSION" "treehouses/planet:local"
-rename "treehouses/planet:db-init-$PLANET_VERSION" "treehouses/planet:db-init-local"
-rename "treehouses/planet:chatapi-$PLANET_VERSION" "treehouses/planet:chatapi-local"
+respond "200 OK"
+
+if [ -z "$PLANET_VERSION" ]; then
+  echo "RESULT: error no version supplied"
+  exit 0
+fi
+
+source_image() {
+  case "$1" in
+    planet) echo "$REPO:$PLANET_VERSION" ;;
+    *) echo "$REPO:$1-$PLANET_VERSION" ;;
+  esac
+}
+
+local_image() {
+  case "$1" in
+    planet) echo "$REPO:local" ;;
+    *) echo "$REPO:$1-local" ;;
+  esac
+}
+
+previous_image() {
+  case "$1" in
+    planet) echo "$REPO:previous" ;;
+    *) echo "$REPO:$1-previous" ;;
+  esac
+}
+
+api_get() {
+  curl -s --unix-socket "$SOCKET" "$API$1"
+}
+
+api_post() {
+  curl -s --unix-socket "$SOCKET" -X POST "$API$1"
+}
+
+api_delete() {
+  curl -s -o /dev/null --unix-socket "$SOCKET" -X DELETE "$API$1"
+}
+
+image_id() {
+  api_get "/images/$1/json" | jq -r '.Id // empty' 2>/dev/null
+}
+
+# Docker answers 200 and streams progress as JSON even when a pull fails, so the
+# body decides the outcome rather than the status code. Without this a failed
+# pull was still retagged as :local and reported as a successful upgrade.
+pull() {
+  echo "Pulling $1"
+  # tee rather than capture: nginx times the upstream out after 900s of silence,
+  # and a large pull over a slow link needs the progress stream to keep flowing
+  # while still leaving the body available to inspect for failure.
+  progress=$(mktemp)
+  api_post "/images/create?fromImage=$1" | tee "$progress"
+  if grep -q '"errorDetail"' "$progress"; then
+    rm -f "$progress"
+    return 1
+  fi
+  rm -f "$progress"
+  [ -n "$(image_id "$1")" ]
+}
+
+tag() {
+  repo=${2%:*}
+  name=${2##*:}
+  api_post "/images/$1/tag?repo=$repo&tag=$name" > /dev/null
+}
+
+# Pull the whole set before moving any tag: a partial pull must never become the
+# version the host comes up on.
+for variant in $VARIANTS; do
+  image=$(source_image "$variant")
+  if ! pull "$image"; then
+    echo "RESULT: error could not pull $image"
+    exit 0
+  fi
+done
+
+# Keep the outgoing images reachable as :previous, both so a bad upgrade can be
+# rolled back and so the cleanup below does not read them as garbage.
+for variant in $VARIANTS; do
+  current=$(image_id "$(local_image "$variant")")
+  if [ -n "$current" ]; then
+    tag "$current" "$(previous_image "$variant")"
+  fi
+done
+
+for variant in $VARIANTS; do
+  tag "$(source_image "$variant")" "$(local_image "$variant")"
+done
+
+# An upgrade leaves the superseded version fully tagged, so without this every
+# upgrade permanently costs another copy of all three images on an SD card that
+# does not have the room. Only versioned treehouses/planet tags are considered,
+# and never an image that :local or :previous still points at.
+cleanup() {
+  keep=$(for variant in $VARIANTS; do
+    image_id "$(local_image "$variant")"
+    image_id "$(previous_image "$variant")"
+  done | sort -u | tr '\n' ' ')
+
+  api_get "/images/json" \
+    | jq -r --arg repo "$REPO" \
+        '.[] | .Id as $id | (.RepoTags // [])[] | select(startswith($repo + ":")) | "\($id) \(.)"' \
+    | while read -r id name; do
+        case " $keep " in *" $id "*) continue ;; esac
+        case "$name" in *:local|*-local|*:previous|*-previous) continue ;; esac
+        echo "Removing superseded image $name"
+        api_delete "/images/$name"
+      done
+}
+
+cleanup
+
+echo "RESULT: success"

--- a/src/app/upgrade/upgrade.component.ts
+++ b/src/app/upgrade/upgrade.component.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { CouchService } from '../shared/couchdb.service';
-import { catchError, switchMap } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { ManagerService } from '../manager-dashboard/manager.service';
 import { StateService } from '../shared/state.service';
@@ -49,6 +49,7 @@ export class UpgradeComponent {
   error = false;
   cleanOutput = '';
   timeoutTrials = 0;
+  requiredBytes = 450 * 1024 * 1024;
 
   constructor(
     private route: ActivatedRoute,
@@ -83,8 +84,9 @@ export class UpgradeComponent {
     this.getParentVersion().pipe(
       switchMap((pVersion: string) => {
         parentVersion = pVersion;
-        return this.syncService.openPasswordConfirmation();
+        return this.checkDiskSpace();
       }),
+      switchMap(() => this.syncService.openPasswordConfirmation()),
       switchMap((credentials: { name, password }) => this.managerService.updateCredentialsYml(credentials)),
       switchMap(() => this.managerService.addAdminLog('upgrade')),
       switchMap(() => {
@@ -95,23 +97,40 @@ export class UpgradeComponent {
     ).subscribe(result => this.handleResult(result), err => this.handleError(err));
   }
 
+  // The upgrade script ends with a RESULT line stating what actually happened.
+  // Scanning the log for error text instead used to report a failed pull as a
+  // successful upgrade, since Docker reports pull failures in a 200 response.
   handleResult(result) {
-    result.split('\n').forEach(line => {
+    const lines = result.split('\n');
+    const resultLine = lines.filter(line => line.startsWith('RESULT:')).pop() || '';
+    const failed = resultLine.startsWith('RESULT: error');
+
+    lines.forEach(line => {
+      if (line.startsWith('RESULT:')) {
+        return;
+      }
+
       if (line.includes('timeout') || line.includes('server misbehaving')) {
         this.addLine(line, 'upgrade_timeout');
         return;
       }
 
-      if (line.includes('invalid reference format')) {
-        this.handleError(line);
-        return;
-      }
-
-      this.addLine(line, 'upgrade_success');
+      this.addLine(line, failed ? 'upgrade_error' : 'upgrade_success');
     });
+
+    if (failed) {
+      this.handleError(resultLine.replace('RESULT: error', '').trim());
+      return;
+    }
 
     if (result.includes('timeout') || result.includes('server misbehaving')) {
       this.handleTimeout();
+      return;
+    }
+
+    // myPlanet upgrades run a different script which reports no RESULT line.
+    if (!resultLine && this.mode === 'planet') {
+      this.handleError('The server did not report an upgrade result.');
       return;
     }
 
@@ -164,13 +183,41 @@ export class UpgradeComponent {
 
   handleError(err) {
     this.addLine($localize`An error ocurred:`, 'upgrade_error');
-    JSON.stringify(err, null, 1).split('\n').forEach(line => {
+    // Errors reach here as a reason from the upgrade script, an Error, or an
+    // HttpErrorResponse whose body holds the server's explanation. Stringifying
+    // all three alike reduced the last two to an empty object.
+    const raw = typeof err === 'string' ? err : (err?.error || err?.message || err);
+    const detail = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 1);
+    detail.split('\n').forEach(line => {
       this.addLine(line, 'upgrade_error');
     });
     this.working = false;
     this.message = $localize`Start upgrade`;
     this.error = true;
     this.done = true;
+  }
+
+  // Every image is pulled before any tag moves and the superseded set is kept
+  // for rollback, so an upgrade needs more room than the installed footprint.
+  // 450MB is the size treehouses/cli already reserves for planet.
+  checkDiskSpace() {
+    if (environment.production !== true) {
+      return of(true);
+    }
+    return this.http.get(`${window.location.origin}/storage`, { responseType: 'text' }).pipe(
+      catchError(() => of('')),
+      map((free: string) => {
+        const freeBytes = parseInt(free.trim(), 10);
+        if (isNaN(freeBytes)) {
+          return true;
+        }
+        this.addLine(`Free space: ${freeBytes} bytes`);
+        if (freeBytes < this.requiredBytes) {
+          throw new Error(`Not enough free space to upgrade: ${freeBytes} bytes free, ${this.requiredBytes} needed`);
+        }
+        return true;
+      })
+    );
   }
 
   getParentVersion() {


### PR DESCRIPTION
## Summary

Significantly improves the upgrade process with authorization checks, disk space validation, and more robust error reporting. The upgrade script now requires admin credentials, validates available storage before pulling images, and reports upgrade outcomes via a structured `RESULT:` line rather than scanning logs for error keywords.

## Key Changes

**Backend (upgrade.sh)**
- Added authorization check requiring CouchDB admin role via HTTP_COOKIE
- Implemented atomic upgrade: pulls all images before retagging any, preventing partial upgrades from becoming the boot version
- Added cleanup logic to remove superseded images while preserving :local and :previous tags for rollback
- Replaced simple curl calls with helper functions (pull, tag, image_id) for better error handling
- Changed from scanning logs for errors to returning explicit `RESULT: success` or `RESULT: error <reason>` lines
- Pull failures now properly detected via JSON error markers instead of relying on HTTP status codes

**Frontend (upgrade.component.ts)**
- Added `checkDiskSpace()` method that queries `/storage` endpoint and validates 450MB availability before upgrade
- Integrated disk space check into upgrade pipeline before password confirmation
- Rewrote `handleResult()` to parse the `RESULT:` line instead of scanning for error keywords, fixing false positives from Docker's 200-response pull failures
- Improved `handleError()` to handle multiple error types (string, Error, HttpErrorResponse) without over-stringifying
- Added fallback error when myPlanet upgrade script reports no RESULT line

**Infrastructure**
- Updated `storage.sh` to return bytes instead of human-readable format, enabling programmatic comparison against image sizes
- Modified `default.conf.template` to forward `HTTP_COOKIE` to upgrade.sh for authorization checks

## Notable Implementation Details

- The upgrade script uses `tee` to stream pull progress while capturing output for error detection, preventing nginx's 900s upstream timeout on large pulls over slow links
- Images are kept as :previous during upgrade to enable rollback and prevent cleanup from treating them as garbage
- Disk space check only runs in production; dev builds skip it to avoid test environment friction
- Authorization leverages existing CouchDB session cookies forwarded by nginx, requiring no additional credential exchange

https://claude.ai/code/session_017vCHc4WWFdpKUkF8pmebkw