### PR TITLE
achievements: add visibility controls for learner profile sections

### DIFF
--- a/src/app/users/users-achievements/users-achievements-update.component.html
+++ b/src/app/users/users-achievements/users-achievements-update.component.html
@@ -135,6 +135,14 @@
             <p class="warn-text-color mat-caption">{{ resumeUploadError }}</p>
           }
         </div>
+        <div class="visibility-section">
+          <p class="mat-hint mat-caption" i18n>Choose which sections to include when you print your achievements or when others view them</p>
+          <div class="visibility-options" formGroupName="visibility">
+            @for (section of sections; track section.key) {
+              <mat-checkbox [formControlName]="section.key">{{ section.label }}</mat-checkbox>
+            }
+          </div>
+        </div>
         <mat-checkbox formControlName="sendToNation" class="full-width achievements-checkbox" i18n>
           Allow your achievements to be shared with the nation
         </mat-checkbox>

--- a/src/app/users/users-achievements/users-achievements-update.component.ts
+++ b/src/app/users/users-achievements/users-achievements-update.component.ts
@@ -31,6 +31,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { SubmitDirective } from '../../shared/submit.directive';
 import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 import { FullNamePipe } from '../../shared/full-name.pipe';
+import { AchievementSection, achievementSectionKeys, achievementSections } from './users-achievements.constants';
 
 type DateValue = string | Date;
 type DateSortOrder = 'none' | 'asc' | 'desc';
@@ -54,6 +55,8 @@ interface LinkFormControls {
   url: FormControl<string>;
 }
 
+type VisibilityFormControls = { [section in AchievementSection]: FormControl<boolean> };
+
 interface EditFormControls {
   purpose: FormControl<string>;
   goals: FormControl<string>;
@@ -64,6 +67,7 @@ interface EditFormControls {
   otherInfo: FormArray<FormControl<any>>;
   sendToNation: FormControl<boolean>;
   dateSortOrder: FormControl<DateSortOrder>;
+  visibility: FormGroup<VisibilityFormControls>;
 }
 
 interface ProfileFormControls {
@@ -117,6 +121,7 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
   docInfo = { _id: this.user._id + '@' + this.configuration.code, _rev: undefined };
   readonly dbName = 'achievements';
   readonly resumeAttachmentKey = 'resume.pdf';
+  readonly sections = achievementSections;
   readonly maxResumeSizeMb = 512;
   achievementNotFound = false;
   editForm!: FormGroup<EditFormControls>;
@@ -172,7 +177,8 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
           goals: achievements.goals,
           achievementsHeader: achievements.achievementsHeader,
           sendToNation: achievements.sendToNation,
-          dateSortOrder: achievements.dateSortOrder || 'none'
+          dateSortOrder: achievements.dateSortOrder || 'none',
+          visibility: this.usersAchievementsService.visibility(achievements)
         });
         this.editForm.setControl('achievements', this.buildAchievementsFormArray(achievements.achievements));
         this.editForm.setControl('references', this.buildReferencesFormArray(achievements.references));
@@ -230,8 +236,18 @@ export class UsersAchievementsUpdateComponent implements OnInit, OnDestroy, CanC
       // Keeping older otherInfo property so we don't lose this info on database
       otherInfo: this.fb.array<FormControl<any>>([]),
       sendToNation: this.fb.control(false),
-      dateSortOrder: this.fb.control<DateSortOrder>('none')
+      dateSortOrder: this.fb.control<DateSortOrder>('none'),
+      visibility: this.createVisibilityForm()
     });
+  }
+
+  createVisibilityForm(): FormGroup<VisibilityFormControls> {
+    return this.fb.group<VisibilityFormControls>(
+      achievementSectionKeys.reduce(
+        (controls, key) => ({ ...controls, [key]: this.fb.control(true) }),
+        {} as VisibilityFormControls
+      )
+    );
   }
 
   createProfileForm() {

--- a/src/app/users/users-achievements/users-achievements-update.scss
+++ b/src/app/users/users-achievements/users-achievements-update.scss
@@ -32,6 +32,16 @@
     margin-bottom: 15px;
   }
 
+  .visibility-section {
+    margin-top: 15px;
+
+    .visibility-options {
+      display: flex;
+      flex-wrap: wrap;
+      column-gap: 1.5rem;
+    }
+  }
+
   a[mat-raised-button] mat-icon {
     vertical-align: middle;
   }

--- a/src/app/users/users-achievements/users-achievements.component.html
+++ b/src/app/users/users-achievements/users-achievements.component.html
@@ -49,7 +49,7 @@
             <div class="user-info">
               <planet-avatar [username]="userName" [planetCode]="userPlanetCode" imgClass="profile-image"></planet-avatar>
               <h2>{{ ((user | fullName) || user?.name) | truncateText:40 }}</h2>
-              @if (!publicView) {
+              @if (!publicView && isSectionVisible('personalInfo')) {
                 <div class="birth-info">
                   @if (user.birthDate) {
                     <span i18n>Birthdate: {{' ' + (user.birthDate | date:'mediumDate') + ' '}}</span>
@@ -59,31 +59,34 @@
                     }
                   </div>
                 }
-                @if (user.joinDate) {
+                @if (user.joinDate && isSectionVisible('personalInfo')) {
                   <div>
                     <span i18n>Member since: {{ user.joinDate | date:'mediumDate' }}</span>
                   </div>
                 }
               </div>
-              @if (achievements.purpose) {
+              @if (achievements.purpose && isSectionVisible('purpose')) {
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Purpose</h3>
+                  <ng-container *ngTemplateOutlet="hiddenLabel; context: { $implicit: 'purpose' }"></ng-container>
                   <planet-markdown [content]="achievements.purpose"></planet-markdown>
                 </div>
               }
-              @if (achievements.goals) {
+              @if (achievements.goals && isSectionVisible('goals')) {
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Goals</h3>
+                  <ng-container *ngTemplateOutlet="hiddenLabel; context: { $implicit: 'goals' }"></ng-container>
                   <planet-markdown [content]="achievements.goals"></planet-markdown>
                 </div>
               }
               <ng-container *planetBeta>
-                @if (certifications.length > 0) {
+                @if (certifications.length > 0 && isSectionVisible('certifications')) {
                   <div>
                     <mat-divider></mat-divider>
                     <h3 i18n>My Certifications</h3>
+                    <ng-container *ngTemplateOutlet="hiddenLabel; context: { $implicit: 'certifications' }"></ng-container>
                     <mat-list class="certs-list">
                       @for (certification of certifications; track certification) {
                         <mat-list-item>
@@ -94,10 +97,11 @@
                   </div>
                 }
               </ng-container>
-              @if (achievements?.links?.length > 0) {
+              @if (achievements?.links?.length > 0 && isSectionVisible('links')) {
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Links</h3>
+                  <ng-container *ngTemplateOutlet="hiddenLabel; context: { $implicit: 'links' }"></ng-container>
                   <mat-list>
                     @for (link of achievements.links; track link) {
                       <mat-list-item class="mat-list-item-word-wrap">
@@ -108,10 +112,11 @@
                   </mat-list>
                 </div>
               }
-              @if (achievements.achievementsHeader || achievements.achievements.length > 0) {
+              @if ((achievements.achievementsHeader || achievements.achievements.length > 0) && isSectionVisible('achievements')) {
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My Achievements</h3>
+                  <ng-container *ngTemplateOutlet="hiddenLabel; context: { $implicit: 'achievements' }"></ng-container>
                   <planet-markdown [content]="achievements.achievementsHeader"></planet-markdown>
                   <mat-list>
                     @for (achievement of achievements.achievements; track achievement; let i = $index) {
@@ -145,10 +150,11 @@
                   </mat-list>
                 </div>
               }
-              @if (achievements.references.length > 0) {
+              @if (achievements.references.length > 0 && isSectionVisible('references')) {
                 <div>
                   <mat-divider></mat-divider>
                   <h3 i18n>My References</h3>
+                  <ng-container *ngTemplateOutlet="hiddenLabel; context: { $implicit: 'references' }"></ng-container>
                   <mat-list class="references-list">
                     @for (reference of achievements.references; track reference) {
                       <mat-list-item class="mat-list-item-word-wrap">
@@ -183,3 +189,12 @@
       }
     </div>
   </div>
+
+<ng-template #hiddenLabel let-section>
+  @if (isSectionHidden(section)) {
+    <p class="achievement-hidden-label mat-caption">
+      <mat-icon inline="true">visibility_off</mat-icon>
+      <ng-container i18n>Only visible to you - not printed or shared</ng-container>
+    </p>
+  }
+</ng-template>

--- a/src/app/users/users-achievements/users-achievements.component.spec.ts
+++ b/src/app/users/users-achievements/users-achievements.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
@@ -13,11 +13,14 @@ import { PlanetMessageService } from '../../shared/planet-message.service';
 import { CoursesService } from '../../courses/courses.service';
 import { CertificationsService } from '../../manager-dashboard/certifications/certifications.service';
 import { PdfService } from '../../shared/pdf.service';
+import { achievementVisibility } from './users-achievements.constants';
 
 describe('UsersAchievementsComponent', () => {
   let component: UsersAchievementsComponent;
   let fixture: ComponentFixture<UsersAchievementsComponent>;
   let couchService;
+  let pdfService;
+  let usersAchievementsService;
 
   const couchServiceMock = {
     get: vi.fn().mockReturnValue(of({}))
@@ -36,8 +39,15 @@ describe('UsersAchievementsComponent', () => {
       providers: [
         { provide: CouchService, useValue: couchServiceMock },
         { provide: StateService, useValue: stateServiceMock },
-        { provide: UserService, useValue: { get: vi.fn().mockReturnValue({ _id: 'org.couchdb.user:local', name: 'local' }) } },
-        { provide: UsersAchievementsService, useValue: { getAchievements: vi.fn().mockReturnValue(of({})), isEmpty: vi.fn() } },
+        { provide: UserService, useValue: {
+          get: vi.fn().mockReturnValue({ _id: 'org.couchdb.user:local', name: 'local', planetCode: 'local_code' }),
+          isBetaEnabled: vi.fn().mockReturnValue(false)
+        } },
+        { provide: UsersAchievementsService, useValue: {
+          getAchievements: vi.fn().mockReturnValue(of({})),
+          isEmpty: vi.fn(),
+          visibility: vi.fn().mockReturnValue(achievementVisibility())
+        } },
         { provide: CoursesService, useValue: {
           coursesListener$: vi.fn().mockReturnValue(of([])),
           progressListener$: vi.fn().mockReturnValue(of([])),
@@ -46,7 +56,7 @@ describe('UsersAchievementsComponent', () => {
         { provide: CertificationsService, useValue: { getCertifications: vi.fn().mockReturnValue(of([])), isCourseCompleted: vi.fn() } },
         { provide: PdfService, useValue: { download: vi.fn() } },
         { provide: PlanetMessageService, useValue: { showAlert: vi.fn() } },
-        { provide: Router, useValue: { navigate: vi.fn() } },
+        provideRouter([]),
         { provide: ActivatedRoute, useValue: { snapshot: { data: {} }, paramMap: of({ get: () => null }) } },
         provideHttpClient(withInterceptorsFromDi())
       ]
@@ -54,6 +64,8 @@ describe('UsersAchievementsComponent', () => {
     fixture = TestBed.createComponent(UsersAchievementsComponent);
     component = fixture.componentInstance;
     couchService = TestBed.inject(CouchService);
+    pdfService = TestBed.inject(PdfService);
+    usersAchievementsService = TestBed.inject(UsersAchievementsService);
   });
 
   it('should create', () => {
@@ -109,6 +121,91 @@ describe('UsersAchievementsComponent', () => {
     it('should return local for a missing planet code even when the parent code is also missing', () => {
       stateServiceMock.configuration = { code: 'local_code', parentCode: undefined };
       expect(component.userRelationship(undefined)).toBe('local');
+    });
+  });
+
+  describe('section visibility', () => {
+    const pdfText = () => JSON.stringify(pdfService.download.mock.calls[0][0].content);
+
+    beforeEach(() => {
+      component.user = { name: 'local', firstName: 'Local', birthplace: 'Nairobi' };
+      component.achievements = {
+        purpose: 'My purpose',
+        goals: 'My goals',
+        achievements: [ { title: 'An achievement' } ],
+        links: [ { title: 'A link', url: 'https://example.com' } ],
+        references: [ { name: 'A reference' } ]
+      };
+      component.visibility = achievementVisibility({ goals: false, references: false });
+    });
+
+    it('should show every section by default', () => {
+      component.visibility = achievementVisibility();
+      expect(component.isSectionVisible('goals')).toBe(true);
+      expect(component.isSectionVisible('references')).toBe(true);
+    });
+
+    it('should hide sections the learner turned off from other viewers', () => {
+      component.ownAchievements = false;
+      expect(component.isSectionVisible('goals')).toBe(false);
+      expect(component.isSectionVisible('purpose')).toBe(true);
+    });
+
+    it('should still show hidden sections to the learner', () => {
+      component.ownAchievements = true;
+      expect(component.isSectionVisible('goals')).toBe(true);
+      expect(component.isSectionHidden('goals')).toBe(true);
+      expect(component.isSectionHidden('purpose')).toBe(false);
+    });
+
+    it('should not mark sections as hidden for other viewers', () => {
+      component.ownAchievements = false;
+      expect(component.isSectionHidden('goals')).toBe(false);
+    });
+
+    it('should leave hidden sections out of the printed achievements', () => {
+      component.generatePDF();
+      const content = pdfText();
+      expect(content).toContain('My purpose');
+      expect(content).toContain('An achievement');
+      expect(content).not.toContain('My goals');
+      expect(content).not.toContain('A reference');
+    });
+
+    it('should leave personal details out of the printed achievements when hidden', () => {
+      component.visibility = achievementVisibility({ personalInfo: false });
+      component.generatePDF();
+      expect(pdfText()).not.toContain('Nairobi');
+    });
+
+    it('should not link a hidden CV/Resume for other viewers', () => {
+      component.ownAchievements = false;
+      component.achievements = { _id: 'id', _attachments: { 'resume.pdf': {} } };
+      component.visibility = achievementVisibility({ resume: false });
+      expect(component.resumeUrl).toBe('');
+      component.visibility = achievementVisibility();
+      expect(component.resumeUrl).toContain('resume.pdf');
+    });
+  });
+  describe('hidden section label', () => {
+    const renderAchievements = (visibility) => {
+      usersAchievementsService.getAchievements.mockReturnValue(
+        of({ purpose: 'My purpose', goals: 'My goals', achievements: [], references: [], links: [] })
+      );
+      usersAchievementsService.isEmpty.mockReturnValue(false);
+      usersAchievementsService.visibility.mockReturnValue(achievementVisibility(visibility));
+      fixture.detectChanges();
+      component.isLoading = false;
+      fixture.detectChanges();
+      return fixture.nativeElement.querySelectorAll('.achievement-hidden-label');
+    };
+
+    it('should mark only the sections the learner hid on their own page', () => {
+      expect(renderAchievements({ goals: false }).length).toBe(1);
+    });
+
+    it('should not mark any section when everything is shared', () => {
+      expect(renderAchievements({}).length).toBe(0);
     });
   });
 });

--- a/src/app/users/users-achievements/users-achievements.component.ts
+++ b/src/app/users/users-achievements/users-achievements.component.ts
@@ -12,7 +12,7 @@ import { CoursesService } from '../../courses/courses.service';
 import { environment } from '../../../environments/environment';
 import { CertificationsService } from '../../manager-dashboard/certifications/certifications.service';
 import { PdfService } from '../../shared/pdf.service';
-import { NgClass, DatePipe, formatDate } from '@angular/common';
+import { NgClass, NgTemplateOutlet, DatePipe, formatDate } from '@angular/common';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconButton, MatAnchor } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -25,6 +25,7 @@ import { TruncateTextPipe } from '../../shared/truncate-text.pipe';
 import { AvatarComponent } from '../../shared/avatar.component';
 import { fullName } from '../../shared/utils';
 import { FullNamePipe } from '../../shared/full-name.pipe';
+import { AchievementSection, achievementVisibility, AchievementVisibility } from './users-achievements.constants';
 
 @Component({
   templateUrl: './users-achievements.component.html',
@@ -46,6 +47,7 @@ import { FullNamePipe } from '../../shared/full-name.pipe';
     MatListItemTitle,
     MatListItemMeta,
     NgClass,
+    NgTemplateOutlet,
     MatListItemLine,
     DatePipe,
     TruncateTextPipe,
@@ -64,6 +66,7 @@ export class UsersAchievementsComponent implements OnInit {
   ownAchievements = false;
   openAchievementIndex = -1;
   certifications: any[] = [];
+  visibility: AchievementVisibility = achievementVisibility();
   publicView = this.route.snapshot.data.requiresAuth === false && !this.userService.get()._id;
   isLoading = true;
 
@@ -124,6 +127,7 @@ export class UsersAchievementsComponent implements OnInit {
         this.achievementNotFound = true;
       } else {
         this.achievements = achievements;
+        this.visibility = this.usersAchievementsService.visibility(achievements);
       }
       if (this.publicView) {
         this.isLoading = false;
@@ -163,6 +167,16 @@ export class UsersAchievementsComponent implements OnInit {
     this.openAchievementIndex = this.openAchievementIndex === index ? -1 : index;
   }
 
+  // Learners always see their full achievements page; everyone else only sees the sections
+  // the learner chose to share, which is the same set that goes into the printed PDF.
+  isSectionVisible(section: AchievementSection): boolean {
+    return this.ownAchievements || this.visibility[section];
+  }
+
+  isSectionHidden(section: AchievementSection): boolean {
+    return this.ownAchievements && !this.visibility[section];
+  }
+
   isClickable(achievement): boolean {
     return (!!achievement.description && achievement.description.length > 0) || (!!achievement.link && achievement.link.length > 0);
   }
@@ -176,7 +190,8 @@ export class UsersAchievementsComponent implements OnInit {
 
 
   get resumeUrl() {
-    if (!this.achievements?._attachments?.[this.resumeAttachmentKey] || !this.achievements?._id) {
+    if (!this.achievements?._attachments?.[this.resumeAttachmentKey] || !this.achievements?._id ||
+      !this.isSectionVisible('resume')) {
       return '';
     }
     return `${environment.couchAddress}/${this.dbName}/${this.achievements._id}/${this.resumeAttachmentKey}`;
@@ -199,6 +214,7 @@ export class UsersAchievementsComponent implements OnInit {
   generatePDF() {
     const formattedBirthDate = this.user.birthDate ? formatDate(this.user.birthDate, 'mediumDate', this.localeId) : '';
     const formattedMemberSince = this.user.joinDate ? formatDate(this.user.joinDate, 'mediumDate', this.localeId) : '';
+    const showPersonalInfo = this.visibility.personalInfo;
     let contentArray = [
       {
         text: $localize`${this.user.firstName}'s achievements`,
@@ -208,9 +224,9 @@ export class UsersAchievementsComponent implements OnInit {
       {
         text: `
           ${fullName(this.user) || this.user.name}
-          ${formattedBirthDate ? $localize`Birthdate: ${formattedBirthDate}` : ''}
-          ${this.user.birthplace ? $localize`Birthplace: ${this.user.birthplace}` : ''}
-          ${formattedMemberSince ? $localize`Member since: ${formattedMemberSince}` : ''}
+          ${showPersonalInfo && formattedBirthDate ? $localize`Birthdate: ${formattedBirthDate}` : ''}
+          ${showPersonalInfo && this.user.birthplace ? $localize`Birthplace: ${this.user.birthplace}` : ''}
+          ${showPersonalInfo && formattedMemberSince ? $localize`Member since: ${formattedMemberSince}` : ''}
           `,
         alignment: 'center',
       },
@@ -219,7 +235,7 @@ export class UsersAchievementsComponent implements OnInit {
     const optionals = [];
     const sectionSpacer = { text: '', margin: [ 0, 10 ] };
 
-    if (this.achievements.purpose) {
+    if (this.visibility.purpose && this.achievements.purpose) {
       optionals.push(
         { text: $localize`My Purpose`, style: 'subHeader', alignment: 'center' },
         { text: this.achievements.purpose, alignment: 'left', margin: [ 20, 5 ] },
@@ -227,7 +243,7 @@ export class UsersAchievementsComponent implements OnInit {
       );
     }
 
-    if (this.achievements.goals) {
+    if (this.visibility.goals && this.achievements.goals) {
       optionals.push(
         { text: $localize`My Goals`, style: 'subHeader', alignment: 'center' },
         { text: this.achievements.goals, alignment: 'left', margin: [ 20, 5 ] },
@@ -235,7 +251,7 @@ export class UsersAchievementsComponent implements OnInit {
       );
     }
 
-    if (this.certifications && this.certifications.length > 0) {
+    if (this.visibility.certifications && this.certifications && this.certifications.length > 0) {
       optionals.push(
         { text: $localize`My Certifications`, style: 'subHeader', alignment: 'center' },
         ...this.certifications.map((certification) => [
@@ -245,7 +261,7 @@ export class UsersAchievementsComponent implements OnInit {
       );
     }
 
-    if (this.achievements.achievements && this.achievements.achievements.length > 0) {
+    if (this.visibility.achievements && this.achievements.achievements && this.achievements.achievements.length > 0) {
       optionals.push(
         { text: $localize`My Achievements`, style: 'subHeader', alignment: 'center' },
         ...this.achievements.achievements.map((achievement) => {
@@ -261,7 +277,7 @@ export class UsersAchievementsComponent implements OnInit {
       );
     }
 
-    if (this.achievements.links && this.achievements.links.length > 0) {
+    if (this.visibility.links && this.achievements.links && this.achievements.links.length > 0) {
       optionals.push(
         { text: $localize`My Links`, style: 'subHeader', alignment: 'center' },
         ...this.achievements.links.map((achievement) => [
@@ -272,7 +288,7 @@ export class UsersAchievementsComponent implements OnInit {
       );
     }
 
-    if (this.achievements.references && this.achievements.references.length > 0) {
+    if (this.visibility.references && this.achievements.references && this.achievements.references.length > 0) {
       optionals.push(
         { text: $localize`My References`, style: 'subHeader', alignment: 'center' },
         ...this.achievements.references.map((achievement) => [

--- a/src/app/users/users-achievements/users-achievements.constants.ts
+++ b/src/app/users/users-achievements/users-achievements.constants.ts
@@ -1,0 +1,25 @@
+export type AchievementSection =
+  'personalInfo' | 'purpose' | 'goals' | 'certifications' | 'achievements' | 'links' | 'references' | 'resume';
+
+export type AchievementVisibility = { [section in AchievementSection]: boolean };
+
+export const achievementSections: { key: AchievementSection, label: string }[] = [
+  { key: 'personalInfo', label: $localize`Personal Details` },
+  { key: 'purpose', label: $localize`My Purpose` },
+  { key: 'goals', label: $localize`My Goals` },
+  { key: 'certifications', label: $localize`My Certifications` },
+  { key: 'achievements', label: $localize`My Achievements` },
+  { key: 'links', label: $localize`My Links` },
+  { key: 'references', label: $localize`My References` },
+  { key: 'resume', label: $localize`CV/Resume` }
+];
+
+export const achievementSectionKeys: AchievementSection[] = achievementSections.map(({ key }) => key);
+
+// Sections are shown unless the learner has explicitly hidden them, so achievements saved
+// before this option existed keep showing everything.
+export const achievementVisibility = (visibility: Partial<AchievementVisibility> = {}): AchievementVisibility =>
+  achievementSectionKeys.reduce(
+    (sections, key) => ({ ...sections, [key]: visibility?.[key] !== false }),
+    {} as AchievementVisibility
+  );

--- a/src/app/users/users-achievements/users-achievements.scss
+++ b/src/app/users/users-achievements/users-achievements.scss
@@ -53,6 +53,15 @@
     margin: 2rem;
    }
 
+  .achievement-hidden-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    color: v.$grey-text;
+    margin: 0;
+  }
+
   .mat-mdc-list-base .mat-mdc-list-item {
     &.mat-mdc-list-item-word-wrap {
       height: initial;

--- a/src/app/users/users-achievements/users-achievements.service.ts
+++ b/src/app/users/users-achievements/users-achievements.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CouchService } from '../../shared/couchdb.service';
+import { AchievementVisibility, achievementVisibility } from './users-achievements.constants';
 
 @Injectable({
   providedIn: 'root'
@@ -15,6 +16,10 @@ export class UsersAchievementsService {
 
   getAchievements(id) {
     return this.couchService.get(this.dbName + '/' + id);
+  }
+
+  visibility(achievements: any = {}): AchievementVisibility {
+    return achievementVisibility(achievements?.visibility);
   }
 
   isEmpty(achievement) {


### PR DESCRIPTION
## Summary
Adds granular privacy controls allowing learners to choose which sections of their achievements profile are visible to others and included in printed PDFs. Learners always see their complete profile, but other viewers only see sections the learner has explicitly shared.

## Key Changes
- **New constants file** (`users-achievements.constants.ts`): Defines `AchievementSection` type, `AchievementVisibility` interface, and `achievementVisibility()` factory function that defaults all sections to visible (backward-compatible with pre-existing achievements)
- **Visibility form controls**: Added `visibility` FormGroup to the edit form in `UsersAchievementsUpdateComponent` with checkboxes for each section (personalInfo, purpose, goals, certifications, achievements, links, references, resume)
- **View-layer filtering**: 
  - Added `isSectionVisible()` method that returns true for own achievements or when section is shared
  - Added `isSectionHidden()` method to mark sections the learner has hidden (only shown to the learner themselves)
  - Updated template to conditionally render sections and display a "Only visible to you" label for hidden sections
- **PDF generation**: Modified `generatePDF()` to respect visibility settings, excluding hidden sections and personal details when `personalInfo` is disabled
- **Resume access**: Updated `resumeUrl` getter to check `isSectionVisible('resume')` before returning the attachment URL
- **Service integration**: Added `visibility()` method to `UsersAchievementsService` to extract visibility from stored achievements
- **Styling**: Added `.achievement-hidden-label` styles and `.visibility-section` layout for the new UI controls
- **Test coverage**: Comprehensive test suite covering visibility logic, PDF generation with hidden sections, and the hidden section label rendering

## Implementation Details
- Visibility defaults to all sections enabled for backward compatibility with existing achievements that lack a visibility property
- Learners see their full profile with visual indicators (icon + label) for hidden sections
- Other viewers see only shared sections; hidden sections are completely absent from their view
- The same visibility rules apply to both the web view and PDF export, ensuring consistency
- Added `NgTemplateOutlet` import to support the reusable hidden label template

https://claude.ai/code/session_01QSoqkgXvhRapTTqHY3AmGw